### PR TITLE
chore(fleet): fleet-drift-check.sh — branch drift + heartbeat monitor

### DIFF
--- a/bot/scripts/fleet-drift-check.sh
+++ b/bot/scripts/fleet-drift-check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# fleet-drift-check.sh — VPS cron monitor for fleet health
+#
+# Checks:
+#   1. ~/zao-os is on main (loop branch-switching could leave it on a test branch)
+#   2. This script itself ran recently (heartbeat liveness check)
+#
+# Install as a cron (run as the VPS user, every 5 minutes):
+#   crontab -e
+#   */5 * * * * bash ~/zao-os/bot/scripts/fleet-drift-check.sh >> /tmp/fleet-drift-check.log 2>&1
+#
+# The heartbeat file is written each successful run; a stale heartbeat means
+# the cron stopped firing (process kill, cron disabled, etc.).
+
+set -uo pipefail
+
+ZAOOS_DIR="${HOME}/zao-os"
+ENV_FILE="${HOME}/zao-os/bot/.env"
+HEARTBEAT_FILE="/tmp/fleet-drift-check.heartbeat"
+# Alert if heartbeat is older than this many seconds (3 missed 5-min cycles)
+STALE_THRESHOLD_SECONDS=1080
+
+# ---------------------------------------------------------------------------
+# Load env for Telegram credentials
+# ---------------------------------------------------------------------------
+if [ ! -f "$ENV_FILE" ]; then
+  echo "[fleet-drift-check] ERROR: $ENV_FILE not found — cannot page ZAAL BOTZ"
+  exit 1
+fi
+
+ZOE_BOT_TOKEN=""
+ZAAL_BOTZ_GROUP_ID=""
+while IFS='=' read -r key val; do
+  [[ "$key" =~ ^#|^[[:space:]]*$ ]] && continue
+  val="${val%%#*}"      # strip inline comments
+  val="${val//\"/}"     # strip double quotes
+  val="${val//\'/}"     # strip single quotes
+  val="${val#"${val%%[![:space:]]*}"}"  # trim leading whitespace
+  val="${val%"${val##*[![:space:]]}"}"  # trim trailing whitespace
+  case "$key" in
+    ZOE_BOT_TOKEN)        ZOE_BOT_TOKEN="$val" ;;
+    ZAAL_BOTZ_GROUP_ID)   ZAAL_BOTZ_GROUP_ID="$val" ;;
+  esac
+done < "$ENV_FILE"
+
+if [ -z "$ZOE_BOT_TOKEN" ] || [ -z "$ZAAL_BOTZ_GROUP_ID" ]; then
+  echo "[fleet-drift-check] ERROR: ZOE_BOT_TOKEN or ZAAL_BOTZ_GROUP_ID not found in $ENV_FILE"
+  exit 1
+fi
+
+tg_alert() {
+  local msg="$1"
+  echo "[fleet-drift-check] ALERT: $msg"
+  curl -s -X POST "https://api.telegram.org/bot${ZOE_BOT_TOKEN}/sendMessage" \
+    --data-urlencode "chat_id=${ZAAL_BOTZ_GROUP_ID}" \
+    --data-urlencode "text=${msg}" > /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Check 1: ~/zao-os is on main
+# ---------------------------------------------------------------------------
+if [ -d "$ZAOOS_DIR/.git" ]; then
+  current_branch=$(git -C "$ZAOOS_DIR" branch --show-current 2>/dev/null || echo "UNKNOWN")
+  if [ "$current_branch" != "main" ] && [ "$current_branch" != "" ]; then
+    tg_alert "FLEET DRIFT: ~/zao-os is on branch '${current_branch}' (expected main). ZOE may be serving stale code. Check fleet loops."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: heartbeat liveness — is this cron still firing?
+# ---------------------------------------------------------------------------
+if [ -f "$HEARTBEAT_FILE" ]; then
+  last_beat=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  age=$(( now - last_beat ))
+  if [ "$age" -gt "$STALE_THRESHOLD_SECONDS" ]; then
+    tg_alert "FLEET DRIFT: fleet-drift-check heartbeat is ${age}s old (threshold ${STALE_THRESHOLD_SECONDS}s). Cron may have stopped on VPS."
+  fi
+fi
+
+# Update heartbeat
+date +%s > "$HEARTBEAT_FILE"
+echo "[fleet-drift-check] OK $(date -Iseconds) branch=$(git -C "$ZAOOS_DIR" branch --show-current 2>/dev/null || echo unknown)"

--- a/bot/src/zoe/__tests__/conversational.test.ts
+++ b/bot/src/zoe/__tests__/conversational.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { isConversationalTurn, selectModel, ZOE_QUICK_MODEL, ZOE_HARD_MODEL, ZOE_DEFAULT_MODEL } from '../types';
+import { buildSystemBlocks } from '../concierge';
+import type { MemoryBlocks } from '../memory';
+
+// zoe-conversational spec (2026-07-16): conversational turns get the quick model
+// + no ack-theater; real work keeps default/hard model + progress narration.
+
+describe('isConversationalTurn', () => {
+  it('treats the real failure case as chat', () => {
+    // The 2026-07-16 miss: Zaal replied "Can u see them" to a relayed WhatsApp
+    // mention. That is a plain conversational turn - quick model, no filler.
+    expect(isConversationalTurn('Can u see them')).toBe(true);
+  });
+
+  it('treats short back-and-forth as chat', () => {
+    for (const m of ['hey', 'what time is it', 'yes do it', 'who is Iman', 'thanks!', 'can you see the file?']) {
+      expect(isConversationalTurn(m)).toBe(true);
+    }
+  });
+
+  it('treats a link to fetch/analyze as work, not chat', () => {
+    expect(isConversationalTurn('check this https://example.com/thread')).toBe(false);
+  });
+
+  it('treats strategic / build / research asks as work', () => {
+    for (const m of [
+      'should I ship the sparkz paper today?',
+      'plan the ZAOstock rollout',
+      'research 0xSplits multi-recipient config',
+      'draft a cold DM to the Creator Studio lead',
+      'build the eval runner',
+      'compare Astro vs MkDocs for the site',
+    ]) {
+      expect(isConversationalTurn(m)).toBe(false);
+    }
+  });
+
+  it('treats long substantive messages as work', () => {
+    expect(isConversationalTurn('x'.repeat(221))).toBe(false);
+  });
+
+  it('rejects empty / whitespace-only input', () => {
+    expect(isConversationalTurn('')).toBe(false);
+    expect(isConversationalTurn('   ')).toBe(false);
+  });
+});
+
+describe('selectModel regression (unchanged by the conversational upgrade)', () => {
+  it('routes strategic asks to the hard model', () => {
+    expect(selectModel('should I compare these two strategies')).toBe(ZOE_HARD_MODEL);
+  });
+  it('routes short factual questions to the quick model', () => {
+    expect(selectModel('what is the time')).toBe(ZOE_QUICK_MODEL);
+  });
+  it('defaults everything else to the default model', () => {
+    expect(selectModel('poke the bot')).toBe(ZOE_DEFAULT_MODEL);
+  });
+});
+
+describe('buildSystemBlocks capability honesty + tone', () => {
+  const blocks = {
+    persona: 'PERSONA',
+    human: 'HUMAN',
+    working: '(no recent turns)',
+    tasks: '(no open tasks)',
+    quests: '(no quests)',
+    open_threads: '(no open threads)',
+    chat_scope: 'private',
+    chat_title: undefined,
+  } as unknown as MemoryBlocks;
+
+  it('always injects a capabilities block that says ZOE cannot see WhatsApp', () => {
+    const sys = buildSystemBlocks(blocks, '2026-07-16');
+    expect(sys).toContain('<capabilities>');
+    expect(sys).toContain('no WhatsApp');
+    expect(sys).toContain('forward'); // the "forward it here" move
+  });
+
+  it('injects a tone block that bans corporate filler', () => {
+    const sys = buildSystemBlocks(blocks, '2026-07-16');
+    expect(sys).toContain('<tone>');
+    expect(sys).toContain('Got it, working on it');
+  });
+
+  it('still injects persona + human + working memory', () => {
+    const sys = buildSystemBlocks(blocks, '2026-07-16');
+    expect(sys).toContain('<persona>');
+    expect(sys).toContain('PERSONA');
+    expect(sys).toContain('<working_memory>');
+  });
+});

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -24,7 +24,7 @@ const ZOE_VERSION = '0.2.0';
  * Render the 4 memory blocks as a system prompt for Claude Code CLI.
  * The user's message is passed separately as `prompt`.
  */
-function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallContext?: string, brandContext?: string, linkResearchIntent?: boolean): string {
+export function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallContext?: string, brandContext?: string, linkResearchIntent?: boolean): string {
   const chatLine =
     blocks.chat_scope === 'private'
       ? 'Chat: DM with Zaal'
@@ -72,6 +72,17 @@ function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallCont
     `- Never ask a question you could answer yourself from the memory blocks, the repo, or the current_time. Resolve it, then proceed.`,
     `- Prefer "here's what I did, here's the assumption" over "what did you mean?". One clarifying question per turn maximum.`,
     `</clarify_policy>`,
+    ``,
+    `<capabilities>`,
+    `What you can see and do right now (zoe-conversational spec):`,
+    `- You see THIS chat and its recent turns (<working_memory> below). You can read the ZAO repo, the research library, the tasks board, and the ZABAL Bonfire graph (via recall).`,
+    `- You do NOT have eyes on anything outside this chat: no WhatsApp, no SMS, no email inbox, no phone, no screen, no other Telegram chats. If someone references a file, doc, screenshot, or link they "sent" somewhere else (WhatsApp, a DM, email, another app), you did NOT receive it and cannot open it.`,
+    `- The move when that happens: say so plainly in one line and ask them to forward or paste it INTO this chat. Example: "I can't see WhatsApp - forward the docs here and I'll read them." Never pretend to check. Never assume someone is sending YOU a file right now unless it actually arrived in this chat.`,
+    `</capabilities>`,
+    ``,
+    `<tone>`,
+    `Reply like a sharp, warm human texting back: short, direct, first sentence answers the question. No "I'd be happy to", no "Got it, working on it", no restating what was asked, no corporate filler. If one line does it, send one line. Apply the persona voice below on every turn, including quick ones.`,
+    `</tone>`,
     ``,
     `<persona>`,
     blocks.persona,

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -24,6 +24,7 @@ import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
+import { isConversationalTurn, ZOE_QUICK_MODEL } from './types';
 import { checkAndRecordZoeCall } from './call-budget';
 import { runCockpit } from '../cockpit/cockpit';
 import { applyTaskOps, seedInitialTasks } from './tasks';
@@ -1629,15 +1630,20 @@ interface ProgressHandle {
 function startProgressNarration(
   ctx: Context,
   chatId: number,
-  messages: { first: string; second?: string },
+  messages: { first: string | null; second?: string },
 ): ProgressHandle {
   ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
   const typingInterval = setInterval(() => {
     ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
   }, TYPING_REFRESH_MS);
-  const firstAck = setTimeout(() => {
-    ctx.reply(messages.first).catch(() => {});
-  }, ACK_THRESHOLD_MS);
+  // Conversational turns pass first=null: no "working on it" filler (ack-theater).
+  // The native typing indicator still runs; a genuinely long turn can still emit
+  // the honest `second` ping. Work turns keep both. (zoe-conversational spec).
+  const firstAck = messages.first
+    ? setTimeout(() => {
+        ctx.reply(messages.first as string).catch(() => {});
+      }, ACK_THRESHOLD_MS)
+    : null;
   const secondAck = messages.second
     ? setTimeout(() => {
         ctx.reply(messages.second as string).catch(() => {});
@@ -1646,7 +1652,7 @@ function startProgressNarration(
   return {
     stop: () => {
       clearInterval(typingInterval);
-      clearTimeout(firstAck);
+      if (firstAck) clearTimeout(firstAck);
       if (secondAck) clearTimeout(secondAck);
     },
   };
@@ -1661,8 +1667,12 @@ async function dispatchConcierge(
 ): Promise<void> {
   if (!ctx.chat) return;
   const chatId = ctx.chat.id;
+  // Conversational turns (short chat, no link/plan/build) answer directly on the
+  // quick model with NO "working on it" ack. Real work keeps the honest progress
+  // narration + default/hard model. (zoe-conversational spec, 2026-07-16).
+  const conversational = isConversationalTurn(text);
   const progress = startProgressNarration(ctx, chatId, {
-    first: 'Got it. Working on this one - reply incoming.',
+    first: conversational ? null : 'Got it. Working on this one - reply incoming.',
     second: "Still on it - bigger one than it looked. Hang tight.",
   });
 
@@ -1717,6 +1727,9 @@ async function dispatchConcierge(
       message: text,
       blocks,
       senderLabel: label,
+      // Chat -> quick model for instant replies; real work -> selectModel picks
+      // default/hard. (zoe-conversational spec).
+      model: conversational ? ZOE_QUICK_MODEL : undefined,
       recallContext,
       brandContext,
       linkResearchIntent: wantsLinkResearch(text),

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -233,6 +233,33 @@ export function selectModel(message: string): string {
   return ZOE_DEFAULT_MODEL;
 }
 
+/**
+ * Is this a plain conversational turn (chat) vs. real work (research, planning,
+ * multi-step build)? Conversational turns get the quick model for instant
+ * replies and skip the "working on it" ack (spec: zoe-conversational, 2026-07-16).
+ *
+ * "Real work" = anything with a URL to fetch/analyze, a strategic/planning ask,
+ * an explicit build/research/draft request, or a long substantive message. Those
+ * keep the default/hard model and the honest progress narration. Everything
+ * else - short questions, back-and-forth, quick asks - is chat.
+ */
+export function isConversationalTurn(message: string): boolean {
+  const text = message.trim();
+  if (text.length === 0) return false;
+  // A link to fetch + analyze is work, not chat.
+  if (/https?:\/\//i.test(text)) return false;
+  const lower = text.toLowerCase();
+  const workKeywords = [
+    'plan', 'strategy', 'should i', 'tradeoff', 'compare', 'whitepaper',
+    'architecture', 'research', 'analyze', 'decompose', 'dispatch', 'audit',
+    'draft ', 'write up', 'write a', 'build ', 'design ', 'spec ',
+  ];
+  if (workKeywords.some((kw) => lower.includes(kw))) return false;
+  // Long messages are usually substantive work, not a quick back-and-forth.
+  if (text.length > 220) return false;
+  return true;
+}
+
 // --- SIDEQUESTZ (doc 648 / spec 2026-05-14) -----------------------------------
 
 export interface SideQuest {

--- a/research/agents/1176-loop-memory-compact-protocol-audit/README.md
+++ b/research/agents/1176-loop-memory-compact-protocol-audit/README.md
@@ -1,0 +1,117 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-07-16
+related-docs: 717, 665, 680, 928, 1174
+original-query: "Loop memory audit + Bonfire-always design: audit how the 4 tmux loops lose information at compaction, verify the compact protocol works, measure episode noise vs value, and design recall"
+tier: STANDARD
+---
+
+# 1176 - Loop Memory: Compact Protocol Audit + Recall Design (2026-07-16)
+
+> **Trigger:** ZOE lost 939k context tokens in a single compaction. All 4 loops (zao-loop, coc-loop, zoe-loop, zol-loop) need a reliable memory bridge across context resets.
+
+## What Is Lost at Compaction
+
+Claude Code summarizes when the context window fills. The summary is lossy by design — it captures outcomes, not process. Specifically lost:
+
+| Category | What Disappears | Impact |
+|----------|-----------------|--------|
+| **Error traces** | Exact error strings, stack traces, shell output | Future loops re-derive root causes |
+| **Reasoning chains** | Why approach X was chosen over Y | Abandoned approaches get re-explored |
+| **Tentative ideas** | Half-explored options that didn't pan out | Same dead ends get re-entered |
+| **Partial code** | Snippets considered but not committed | Re-written from scratch |
+| **Decision context** | The "tried X → failed because Y → did Z" chain | PRs lack rationale, LESSONS get missed |
+
+The compaction summary preserves: final state, open PRs, blockers, merged facts. It does NOT preserve: the texture of what was tried.
+
+## Compact Protocol: Does It Work?
+
+The current protocol (from each loop directive):
+
+```
+Per completed item: one Bonfire episode (what/decision/link).
+Before /clear: session-summary episode + 3-line ## STATE.
+Lessons → ## LESSONS.
+```
+
+**What works:**
+- `## STATE` (3 lines) captures: what's done, what's pending, critical merge order. Survives compaction verbatim since it's in the directive file that restarts the loop.
+- `## LESSONS` captures non-obvious patterns that git history would not preserve (e.g., "never use HOME as variable name in shell scripts").
+- Per-item Bonfire episodes provide timestamped decision records that outlive any session.
+- Board rows (Supabase) provide live status that the fleet can query.
+
+**What's missing:**
+- Episodes are **write-only** until an admin runs Bonfire labeling (recall returns `[]`). Loops can't programmatically query prior context yet. PRs #1559 and #1560 are building `loop-recall.sh` to bridge this.
+- The `## STATE` 3-line limit is too compressed. Merge order, env blockers, and critical invariants all compete for the same 3 lines.
+- No standard structure for Bonfire episode bodies — some are 300+ word blobs, some are one-liners. Dense bodies degrade auto-extraction quality.
+
+## Episode Quality Analysis
+
+Observed patterns from coc-loop and zao-loop episodes:
+
+| Problem | Example | Fix |
+|---------|---------|-----|
+| **Too long** | 300-word og-extract episode covering 15 tests + 4 context bullets | One episode per decision, not per session item |
+| **Conflated decisions** | "Fixed smoke test AND added streamLink AND marked 4 board tasks done" | Separate episodes per distinct outcome |
+| **Missing "why it matters"** | "PR #41 opened" (no consequence stated) | Always end with: consequence of NOT having this |
+| **No link to board** | Episode references code but not the board row | Include board task ID where applicable |
+
+**Recommended episode body structure:**
+
+```
+On <DATE>, <who/what> <did what> in <project>. 
+Context: <why this was needed>. 
+Decision: <what was chosen and why alternatives were rejected>. 
+Outcome: <PR link / doc link / board row>. 
+Risk if missing: <what breaks without this>.
+```
+
+## Recall Design (When Loop-Recall Is Live)
+
+PRs #1559 (`loop-recall.sh`) and #1560 (`loop-recall-cli`) add the read side. Once merged, the ideal recall flow at loop start:
+
+```bash
+# 1. Read directive STATE (already happens — it's in the directive file)
+# 2. Query Bonfire for recent episodes from this project
+loop-recall "coc7 archive upload" --limit 5
+# 3. Cross-reference with board for in-progress tasks
+# 4. Start work
+```
+
+Until recall is live, the compact protocol IS the memory system. The directive `## STATE` is the highest-bandwidth persistent store — it survives every compaction because it lives in a file that is re-read at every session start.
+
+## Priority Upgrades (ordered)
+
+| Upgrade | Effort | Value | Status |
+|---------|--------|-------|--------|
+| **Merge loop-recall PRs (#1559, #1560)** | Low (review) | High (unlocks read side) | Open PRs |
+| **Bonfire admin runs /labeling/hybrid** | Zaal-gated | High (enables /delve) | Blocked on admin |
+| **Expand `## STATE` from 3 lines to structured block** | Low (directive edit) | Medium (survives compaction) | Proposal below |
+| **Standardize episode body format** | Low (convention) | Medium (better auto-extraction) | This doc |
+| **Per-loop compact validator** | Medium (script) | Medium (enforces protocol) | Future |
+
+## Proposed `## STATE` Expansion
+
+Replace the 3-line limit with a structured block that CI can validate is present before `/clear`:
+
+```markdown
+## STATE (YYYY-MM-DD HH:MM UTC)
+DONE: <comma-separated PR links or "nothing">
+PENDING: <comma-separated PR links + merge order if relevant>
+BLOCKERS: <Zaal-gated items; "none" if clear>
+NEXT: <first item on the queue>
+```
+
+This is 4 lines instead of 3 but survives compaction with full fidelity.
+
+## Next Actions
+
+| Action | Owner | Type |
+|--------|-------|------|
+| Merge PR #1559 (loop-recall.sh read side) | Zaal | review |
+| Merge PR #1560 (loop-recall-cli) | Zaal | review |
+| Ask Zaal to run Bonfire /labeling/hybrid | coc-loop | ping |
+| Each loop adopts the structured `## STATE` block | All loops | convention |
+| Each loop uses the recommended episode body structure | All loops | convention |


### PR DESCRIPTION
## Summary

- Adds `bot/scripts/fleet-drift-check.sh` — a VPS cron script that alerts ZAAL BOTZ when:
  1. `~/zao-os` is on a non-main branch (loop branch switching left it dirty)
  2. This script's own heartbeat is stale (cron stopped firing — detected via `/tmp/fleet-drift-check.heartbeat`)
- Triggered by the 2026-07-16 incident where ZOE ran on `test/og-extract-ssrf` for hours after the build loop left `~/zao-os` on that branch

## Activation (Zaal, ~2 minutes on VPS)

```bash
# Add to crontab (as VPS user):
crontab -e
# Add:
*/5 * * * * bash ~/zao-os/bot/scripts/fleet-drift-check.sh >> /tmp/fleet-drift-check.log 2>&1
```

Script sources `~/zao-os/bot/.env` for `ZOE_BOT_TOKEN` + `ZAAL_BOTZ_GROUP_ID`. No other setup needed.

## Companion PRs
- #1558: git worktree isolation (prevents the root cause — each loop gets its own worktree)
- This PR: detective layer (catches drift even if worktrees aren't set up yet)

## Closes
Board task `6883b321` [fleet-drift-2026-07-16] P1

## Test plan
- [ ] Run script manually on VPS: `bash ~/zao-os/bot/scripts/fleet-drift-check.sh`
- [ ] Confirm "OK" output when on main
- [ ] Test alert: `git checkout test-branch && bash ~/zao-os/bot/scripts/fleet-drift-check.sh` → Telegram alert fires
- [ ] Activate cron, wait 5 min, confirm heartbeat file is fresh