### PR TITLE
fix(test): recall options arg is object not number

### DIFF
--- a/src/lib/__tests__/memory-recall.test.ts
+++ b/src/lib/__tests__/memory-recall.test.ts
@@ -112,7 +112,7 @@ describe('getUserMemoryContext', () => {
     expect(mockRecall).toHaveBeenCalledWith(
       '42',
       'recent activity preferences interactions',
-      expect.any(Number),
+      expect.objectContaining({ limit: expect.any(Number) }),
     );
   });
 });


### PR DESCRIPTION
## Summary

- `getUserMemoryContext` calls `hindsight.recall(fid, query, { limit })` — third arg is `{ limit: N }` (an options object), not a bare number
- PR #1576 auto-merged before CI finished; broken assertion landed on main
- Fix: `expect.any(Number)` → `expect.objectContaining({ limit: expect.any(Number) })`

## Test plan
- [ ] CI test run passes for `src/lib/__tests__/memory-recall.test.ts` (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)