### PR TITLE
test(music): formatDuration + curationWeight — 16 cases + fix two bugs

### DIFF
--- a/src/lib/music/__tests__/curationWeight.test.ts
+++ b/src/lib/music/__tests__/curationWeight.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { curationWeight } from '../curationWeight';
+
+describe('curationWeight', () => {
+  it('returns 1 for 0 Respect (minimum weight)', () => {
+    expect(curationWeight(0)).toBe(1);
+  });
+
+  it('returns 1 for negative scores (clamped to minimum)', () => {
+    expect(curationWeight(-100)).toBe(1);
+  });
+
+  it('returns log2(respect + 1) for positive scores', () => {
+    // 1 Respect → log2(2) = 1.0 (minimum clamp does not apply)
+    expect(curationWeight(1)).toBeCloseTo(1.0, 5);
+    // 3 Respect → log2(4) = 2.0
+    expect(curationWeight(3)).toBeCloseTo(2.0, 5);
+    // 7 Respect → log2(8) = 3.0
+    expect(curationWeight(7)).toBeCloseTo(3.0, 5);
+    // 15 Respect → log2(16) = 4.0
+    expect(curationWeight(15)).toBeCloseTo(4.0, 5);
+  });
+
+  it('returns ~8.97 for 500 Respect and ~9.97 for 1000 Respect', () => {
+    expect(curationWeight(500)).toBeCloseTo(Math.log2(501), 3); // ~8.97
+    expect(curationWeight(1000)).toBeCloseTo(Math.log2(1001), 3); // ~9.97
+  });
+
+  it('weight increases monotonically with Respect', () => {
+    const scores = [0, 10, 100, 500, 1000, 5000];
+    for (let i = 1; i < scores.length; i++) {
+      expect(curationWeight(scores[i])).toBeGreaterThan(curationWeight(scores[i - 1]));
+    }
+  });
+
+  it('minimum weight is always 1 (log2(1) = 0 is clamped)', () => {
+    // 0 Respect: log2(0+1) = 0 → clamped to 1
+    expect(curationWeight(0)).toBe(1);
+  });
+});

--- a/src/lib/music/__tests__/formatDuration.test.ts
+++ b/src/lib/music/__tests__/formatDuration.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { formatDuration } from '../formatDuration';
+
+describe('formatDuration', () => {
+  it('formats a round minute', () => {
+    expect(formatDuration(60_000)).toBe('1:00');
+  });
+
+  it('formats seconds with zero-padding', () => {
+    expect(formatDuration(65_000)).toBe('1:05');
+    expect(formatDuration(9_000)).toBe('0:09');
+  });
+
+  it('formats a typical song duration (3:45)', () => {
+    expect(formatDuration(225_000)).toBe('3:45');
+  });
+
+  it('formats a long track (>60 minutes)', () => {
+    expect(formatDuration(3_720_000)).toBe('62:00');
+  });
+
+  it('formats exactly 0ms as 0:00', () => {
+    expect(formatDuration(0)).toBe('0:00');
+  });
+
+  it('returns 0:00 for negative values', () => {
+    expect(formatDuration(-1000)).toBe('0:00');
+  });
+
+  it('returns 0:00 for NaN', () => {
+    expect(formatDuration(NaN)).toBe('0:00');
+  });
+
+  it('returns 0:00 for Infinity', () => {
+    expect(formatDuration(Infinity)).toBe('0:00');
+  });
+
+  it('truncates millisecond remainder (floors to seconds)', () => {
+    // 61 999ms → 1 minute 1 second → 1:01, NOT 1:02
+    expect(formatDuration(61_999)).toBe('1:01');
+  });
+
+  it('seconds always two digits', () => {
+    expect(formatDuration(10_000)).toBe('0:10');
+    expect(formatDuration(59_000)).toBe('0:59');
+  });
+});

--- a/src/lib/music/curationWeight.ts
+++ b/src/lib/music/curationWeight.ts
@@ -2,8 +2,9 @@
  * Calculate curation weight for a user based on their Respect score.
  * Weight = log2(respect + 1), minimum 1.
  * A member with 0 Respect has weight 1 (their likes still count).
- * A member with 500 Respect has weight ~9.97.
+ * A member with 1000 Respect has weight ~9.97.
  */
 export function curationWeight(respectScore: number): number {
+  if (respectScore <= 0) return 1;
   return Math.max(1, Math.log2(respectScore + 1));
 }


### PR DESCRIPTION
## Summary

- Tests `src/lib/music/formatDuration.ts` (10 cases) and `src/lib/music/curationWeight.ts` (6 cases)
- Two bugs found and fixed:

**Bug 1 — curationWeight negative input returns NaN:**
`Math.max(1, Math.log2(-99 + 1))` → `Math.max(1, NaN)` → `NaN` (JavaScript). The function doc says "minimum 1" but negative inputs silently broke this. Fix: guard `if (respectScore <= 0) return 1`.

**Bug 2 — wrong doc example:**
Doc comment claimed "A member with 500 Respect has weight ~9.97" but `log2(501) ≈ 8.97`. Weight of ~9.97 is at 1000 Respect (`log2(1001)`). Corrected.

## Test plan
- [ ] CI `Test` check passes (16/16 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)