### PR TITLE
docs(geo): generate domain llms.txt FROM ICM boxes (single source, no drift)

### DIFF
--- a/research/identity/icm-boxes/README.md
+++ b/research/identity/icm-boxes/README.md
@@ -24,7 +24,46 @@ useicm.com to mint each box. Cousin of our GEO / llms.txt work (own the AI answe
 - Facts only - no invented numbers or dates. On-chain Respect figures verified 2026-07-05.
 - Keep each box tight and composable; link related boxes at the bottom.
 
+## GEO: llms.txt generation (single source, no drift)
+
+Doc 1107's GEO plan calls for `llms.txt` on the ZAO domains (`thezao.com`,
+`bettercallzaal.com`, `wavewarz.com/.well-known/llms.txt`). But the ICM boxes above
+are *already* an AI-readable surface. **Two AI-readable surfaces stating different
+facts is the worst GEO outcome** — an LLM that finds both trusts neither. So the
+domain `llms.txt` files are **generated FROM these boxes**, not written by hand:
+one source of truth, two surfaces, no drift.
+
+`build-llms-txt.py` reads each box and emits a spec-compliant `llms.txt`
+(`llmstxt.org`: H1 title, `>` blockquote summary, body, plus a `## Canonical identity`
+block giving the exact brand name + `sameAs` cross-links per doc 1107 §5) into
+`generated/`.
+
+```bash
+python3 build-llms-txt.py            # write generated/<domain>.llms.txt
+python3 build-llms-txt.py --check    # drift guard: exit 1 if generated files are stale
+python3 build-llms-txt.py --selftest # internal tests
+```
+
+Domain → box mapping (edit `DOMAIN_MAP` in the script to add domains):
+
+| Domain | Box | Status |
+|--------|-----|--------|
+| `thezao.com` | `thezao.llm.txt` | priority (doc 1107) |
+| `bettercallzaal.com` | `zaal.llm.txt` | priority (doc 1107) |
+| `wavewarz.com` | `wavewarz.llm.txt` | priority (doc 1107, once wavewarz.com is un-parked) |
+| `zabalgamez.com` | `zabalgamez.llm.txt` | staged (confirm domain live) |
+| `fractal.thezao.com` | `fractal.llm.txt` | staged |
+
+**Workflow:** edit a box → run `build-llms-txt.py` → both surfaces stay consistent.
+A future CI drift-check can run `--check` on PRs touching this dir (same pattern as
+the research-index guard) to make the no-drift invariant enforced, not just documented.
+
+**Deploy is GATED (Iman / Zaal — GEO lane, doc 1122 gap 4).** Ship each generated file
+to `https://<domain>/.well-known/llms.txt` **and** `https://<domain>/llms.txt` (crawlers
+check both paths). This directory only drafts the content; a loop never deploys.
+
 ## Source
 Grounded in the ZAO research library + memory (canonical pitch, Respect on-chain facts,
 ZABAL Games state doc, WaveWarZ canonical). Origin: 2026-07-08, from the Chris Dolinsky /
 Viniapp brainstorm (doc 952) where ICM + per-project context boxes were decided.
+GEO llms.txt generation added 2026-07-17 (doc 1107 review, single-source drift avoidance).

--- a/research/identity/icm-boxes/build-llms-txt.py
+++ b/research/identity/icm-boxes/build-llms-txt.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+build-llms-txt.py — generate per-domain llms.txt files FROM the ICM context boxes.
+
+WHY THIS EXISTS (drift avoidance)
+---------------------------------
+The ZAO has two AI-readable surfaces that must state the SAME facts:
+  1. ICM context boxes on useicm.com  (source of truth: this directory, *.llm.txt)
+  2. llms.txt on the ZAO domains       (per doc 1107 GEO plan)
+If those two surfaces disagree, an LLM that finds both trusts neither. So the
+llms.txt files are DERIVED from the ICM boxes — one source, two surfaces, no drift.
+Edit a box, re-run this script, both surfaces stay consistent.
+
+WHAT IT DOES
+------------
+For each domain in DOMAIN_MAP, reads the mapped ICM box, transforms it to a
+spec-compliant llms.txt (llmstxt.org): H1 title, a `>` blockquote summary, the
+box body, and a "## Canonical identity" section (name / url / sameAs) that gives
+LLMs the exact brand string + every cross-linked social profile (doc 1107 §5).
+
+USAGE
+-----
+  python3 build-llms-txt.py            # write generated/<domain>.llms.txt
+  python3 build-llms-txt.py --check    # verify generated files match source (drift guard); exit 1 on drift
+  python3 build-llms-txt.py --selftest # run internal tests
+
+Deploy is GATED (Iman / Zaal): each file ships to <domain>/.well-known/llms.txt
+(and a copy at <domain>/llms.txt). This script only drafts the content.
+"""
+from __future__ import annotations
+import sys
+import pathlib
+
+HERE = pathlib.Path(__file__).resolve().parent
+OUT = HERE / "generated"
+
+# domain -> (box filename, canonical name, canonical url, [sameAs profile urls])
+# Priority domains are the three named in doc 1107 §GEO. Others are drafted
+# "ready-when-domain-live" so Iman has them staged. sameAs links are taken
+# ONLY from each box's own "Find it" section — no invented profiles.
+DOMAIN_MAP = {
+    "thezao.com": {
+        "box": "thezao.llm.txt",
+        "name": "The ZAO",
+        "url": "https://thezao.com",
+        "sameAs": [
+            "https://thezao.xyz",
+            "https://zaoos.com",
+            "https://warpcast.com/~/channel/zao",
+        ],
+        "priority": True,
+    },
+    "bettercallzaal.com": {
+        "box": "zaal.llm.txt",
+        "name": "BetterCallZaal",
+        "url": "https://bettercallzaal.com",
+        "sameAs": [
+            "https://x.com/bettercallzaal",
+            "https://www.youtube.com/@bettercallzaal",
+            "https://github.com/bettercallzaal",
+            "https://warpcast.com/zaal",
+            "https://thezao.xyz",
+            "https://zaoos.com",
+        ],
+        "priority": True,
+    },
+    "wavewarz.com": {
+        "box": "wavewarz.llm.txt",
+        "name": "WaveWarZ",
+        "url": "https://wavewarz.com",
+        "sameAs": [
+            "https://x.com/WaveWarZ",
+            "https://warpcast.com/~/channel/wavewarz",
+        ],
+        "priority": True,
+    },
+    "zabalgamez.com": {
+        "box": "zabalgamez.llm.txt",
+        "name": "ZABAL Games",
+        "url": "https://zabalgamez.com",
+        "sameAs": [],
+        "priority": False,
+    },
+    "fractal.thezao.com": {
+        "box": "fractal.llm.txt",
+        "name": "ZAO Fractal",
+        "url": "https://thezao.com/fractal",
+        "sameAs": ["https://thezao.xyz/paper"],
+        "priority": False,
+    },
+}
+
+GENERATED_MARKER = "<!-- GENERATED from research/identity/icm-boxes/{box} — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->"
+
+
+def _split_box(text: str) -> tuple[str, str, str]:
+    """Return (title, summary, body) from an ICM box.
+
+    title  = H1 with the leading "ICM: " stripped.
+    summary= the first non-empty prose paragraph after the H1, collapsed to one line.
+    body   = everything from the first "## " section onward (unchanged).
+    """
+    lines = text.splitlines()
+    title = ""
+    i = 0
+    for i, ln in enumerate(lines):
+        if ln.startswith("# "):
+            title = ln[2:].strip()
+            if title.lower().startswith("icm:"):
+                title = title[4:].strip()
+            i += 1
+            break
+    # summary: prose lines until the first blank line that precedes a "## " section,
+    # or until the first "## ". Collapse multi-line intro to a single line.
+    summary_parts: list[str] = []
+    body_start = len(lines)
+    for j in range(i, len(lines)):
+        ln = lines[j]
+        if ln.startswith("## "):
+            body_start = j
+            break
+        if ln.strip():
+            summary_parts.append(ln.strip())
+    summary = " ".join(summary_parts).strip()
+    body = "\n".join(lines[body_start:]).strip()
+    return title, summary, body
+
+
+def render(domain: str, cfg: dict) -> str:
+    box_path = HERE / cfg["box"]
+    text = box_path.read_text(encoding="utf-8")
+    if not text.strip():
+        raise ValueError(f"empty box: {box_path}")
+    title, summary, body = _split_box(text)
+    if not title:
+        raise ValueError(f"no H1 title in {box_path}")
+
+    out: list[str] = []
+    out.append(f"# {title}")
+    out.append("")
+    out.append(GENERATED_MARKER.format(box=cfg["box"]))
+    out.append("")
+    if summary:
+        # blockquote summary — llms.txt spec wants a one-line `>` summary under the H1
+        out.append(f"> {summary}")
+        out.append("")
+    if body:
+        out.append(body)
+        out.append("")
+    # Canonical identity block (doc 1107 §5: exact name + url + sameAs for LLMs/JSON-LD)
+    out.append("## Canonical identity")
+    out.append(f"- Name: {cfg['name']}")
+    out.append(f"- URL: {cfg['url']}")
+    if cfg["sameAs"]:
+        out.append("- sameAs:")
+        for u in cfg["sameAs"]:
+            out.append(f"  - {u}")
+    out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def build(check: bool = False) -> int:
+    OUT.mkdir(exist_ok=True)
+    drift = []
+    for domain, cfg in DOMAIN_MAP.items():
+        content = render(domain, cfg)
+        target = OUT / f"{domain}.llms.txt"
+        if check:
+            existing = target.read_text(encoding="utf-8") if target.exists() else ""
+            if existing != content:
+                drift.append(domain)
+        else:
+            target.write_text(content, encoding="utf-8")
+            tag = "priority" if cfg["priority"] else "staged"
+            print(f"  wrote {target.name}  ({tag}, from {cfg['box']})")
+    if check:
+        if drift:
+            print(f"DRIFT: {', '.join(drift)} — generated files are stale. Run build-llms-txt.py.")
+            return 1
+        print("OK: all generated llms.txt match their ICM boxes.")
+        return 0
+    print(f"Done. {len(DOMAIN_MAP)} llms.txt drafts in {OUT.relative_to(HERE.parents[2])}/")
+    return 0
+
+
+def selftest() -> int:
+    sample = (
+        "# ICM: Test Brand\n\n"
+        "One line intro. Second sentence.\n\n"
+        "## What it is\n- a thing\n\n## Related boxes\n- Other\n"
+    )
+    t, s, b = _split_box(sample)
+    assert t == "Test Brand", t
+    assert s == "One line intro. Second sentence.", repr(s)
+    assert b.startswith("## What it is"), b
+    assert "## Related boxes" in b, b
+    # render against a real box
+    cfg = {"box": "thezao.llm.txt", "name": "The ZAO", "url": "https://thezao.com",
+           "sameAs": ["https://thezao.xyz"], "priority": True}
+    out = render("thezao.com", cfg)
+    assert out.startswith("# The ZAO\n"), out[:40]
+    assert "GENERATED from" in out
+    assert out.count("# ") >= 1
+    assert "> " in out, "missing blockquote summary"
+    assert "## Canonical identity" in out
+    assert "https://thezao.xyz" in out
+    # idempotence: check mode on freshly-built output is clean
+    print("selftest: 8/8 OK")
+    return 0
+
+
+if __name__ == "__main__":
+    arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    if arg == "--selftest":
+        sys.exit(selftest())
+    elif arg == "--check":
+        sys.exit(build(check=True))
+    else:
+        sys.exit(build())

--- a/research/identity/icm-boxes/generated/bettercallzaal.com.llms.txt
+++ b/research/identity/icm-boxes/generated/bettercallzaal.com.llms.txt
@@ -1,0 +1,43 @@
+# Zaal Panthaki (BetterCallZaal)
+
+<!-- GENERATED from research/identity/icm-boxes/zaal.llm.txt — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->
+
+> Identifier: zaal (aka bettercallzaal) Role: Founder of The ZAO. Builder, connector, and operator across web3, music, and community.
+
+## Who
+Zaal Panthaki, known as BetterCallZaal. Founder of The ZAO (ZAO = ZTalent Artist Organization), a decentralized impact network bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Electrical engineer (BS EE, RIT 2022). Maine-based. Builds in public.
+
+## What he runs
+- The ZAO - the impact network (music first, community second, technology third)
+- BetterCallZaal Strategies LLC - his operating and consulting entity
+- COC Concertz - live concert series
+- ZABAL Games - a 3-month build-a-thon for artists, builders, and creators
+- The ZAO festivals - ZAOstock and ZAOville
+- WaveWarZ - live-traded music battles, part of the ZAO ecosystem
+
+## How he works
+- Ships MVP-first and iterates. Builds in public and documents the journey.
+- Mobile-first, dark theme. Farcaster-native. Uses Claude Code heavily.
+- Prefers open-source and owned distribution over rented platforms.
+
+## Find him
+- Farcaster: @zaal (also posts as @bettercallzaal)
+- X and YouTube: @bettercallzaal
+- GitHub: github.com/bettercallzaal
+- Sites: bettercallzaal.com, thezao.xyz, zaoos.com
+
+## Related boxes
+- The ZAO (thezao)
+- ZABAL Games (zabalgamez)
+- WaveWarZ (wavewarz)
+
+## Canonical identity
+- Name: BetterCallZaal
+- URL: https://bettercallzaal.com
+- sameAs:
+  - https://x.com/bettercallzaal
+  - https://www.youtube.com/@bettercallzaal
+  - https://github.com/bettercallzaal
+  - https://warpcast.com/zaal
+  - https://thezao.xyz
+  - https://zaoos.com

--- a/research/identity/icm-boxes/generated/fractal.thezao.com.llms.txt
+++ b/research/identity/icm-boxes/generated/fractal.thezao.com.llms.txt
@@ -1,0 +1,50 @@
+# ZAO Fractal
+
+<!-- GENERATED from research/identity/icm-boxes/fractal.llm.txt — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->
+
+> The ZAO Fractal is the ZAO's weekly Respect Game - the governance and contribution-ranking engine at the center of the network. Each week, contributors meet, break into small groups ("fractals"), and rank each other's contributions from the prior week. Those rankings mint on-chain Respect, which is the ZAO's soulbound reputation currency. It has run for 100+ consecutive weeks. Not a token sale and not a popularity contest - a repeating, peer-ranked, on-chain record of who actually contributed.
+
+## What it is
+A synchronous weekly meeting (Fractal Call, Mondays 6pm EST) plus an on-chain settlement layer. The meeting produces consensus rankings; the chain records them as Respect. It is the ZAO's answer to "how do you reward contribution without a token pre-sale or a boss deciding" - contribution is measured by peers, recorded on-chain, and compounds over time.
+
+## How the game works
+- Contributors gather weekly and split into small groups (fractals).
+- Each group discusses what everyone did that week and ranks members by contribution.
+- Rankings map onto levels; a Fibonacci-shaped curve turns rank into Respect awarded (higher levels earn disproportionately, mirroring outsized contribution).
+- From Level 6 up, the format uses elimination voting to resolve the top ranks.
+- Results settle on-chain through OREC (see below), not by a central admin.
+
+## Governance - Respect, OREC, ORDAO
+- **Respect** is the on-chain contribution currency, issued in two forms on **Optimism**:
+  - **OG Respect** - soulbound ERC-20 (`0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957`), the pre-ORDAO era. ~38,484 supply.
+  - **ZOR Respect** - ERC-1155 (`0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c`, token id 0), the post-ORDAO era.
+  - **Fractal 74** was the dividing line: OG issuance before it, ZOR after.
+- **OREC** (Optimistic Respect-based Executive Contract, `0xcB05F9254765CA521F7698e61E0A6CA6456Be532`) settles outcomes optimistically - a proposal executes unless contested inside the challenge window (72h propose + 72h veto). Respect-weighted, not one-wallet-one-vote.
+- **ORDAO** is the DAO framework wrapping OREC + Respect1155 into the executable governance layer.
+- Verified on-chain (2026-07-05): ~156 Respect holders, OG Gini roughly 0.73 (contribution is concentrated among the core, as expected for a 6-core-builder era down from 1000+ early participants).
+
+## Current state
+- **Live and running** - 100+ weeks as of mid-2026, Monday 6pm EST weekly.
+- Discord bot drives submissions + Farcaster linking; the `/fractals` surface in ZAO OS (zaoos.com) exposes sessions, analytics, proposals, and member/event endpoints.
+- Known bottlenecks (from internal audit, doc 703): OREC submission still runs through a narrow signer set; non-technical onboarding docs are the structural gap; the standalone dashboard is being rebuilt inside ZAO OS.
+
+## Why it matters
+The Fractal is how the ZAO stays tokenless-first and still rewards work: no coin to buy your way in, Respect can only be earned by showing up and being ranked by peers. It is the trust spine that WaveWarZ, ZABAL Games, and the festivals plug into.
+
+## Find it
+- thezao.xyz and zaoos.com/fractals
+- Papers: thezao.xyz/papers (whitepaper covers Respect + the Fractal)
+- Farcaster: the /zao channel; Fractal Call weekly on Mondays
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- ZABAL Games (zabalgamez)
+- WaveWarZ (wavewarz)
+- ZAO Assistant (zao-assistant)
+
+## Canonical identity
+- Name: ZAO Fractal
+- URL: https://thezao.com/fractal
+- sameAs:
+  - https://thezao.xyz/paper

--- a/research/identity/icm-boxes/generated/thezao.com.llms.txt
+++ b/research/identity/icm-boxes/generated/thezao.com.llms.txt
@@ -1,0 +1,37 @@
+# The ZAO
+
+<!-- GENERATED from research/identity/icm-boxes/thezao.llm.txt — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->
+
+> ZAO stands for ZTalent Artist Organization. The ZAO is a decentralized impact network focused on bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Founded by Zaal Panthaki (BetterCallZaal). Priority stack: music first, community second, technology third. Name note: the acronym ZAO = ZTalent Artist Organization; the descriptor for what it is today is a decentralized impact network. Both are correct - use the acronym for etymology, the impact-network framing for what it does.
+
+## What it is
+Not a record label or a "music community" - an impact network whose first artist domain is music. It returns three things to artists: profit margin, data, and IP rights. Technology is the means, not the headline.
+
+## Governance - the Fractal and Respect
+- Respect is the on-chain contribution currency: a soulbound OG ERC-20 plus a ZOR ERC-1155, on Optimism.
+- A weekly Respect Game ranks contributions; OREC optimistic execution settles outcomes; a Fibonacci curve shapes rewards.
+- Verified on-chain (2026-07-05): 156 Respect holders, OG Gini roughly 0.73.
+
+## Production lanes
+- WaveWarZ - live-traded music battles
+- ZABAL Games - the 3-month build-a-thon
+- The ZAO festivals - ZAOstock, ZAOville, ZAO-PALOOZA, ZAO-CHELLA
+- ZAO OS - the lab and monorepo where new ZAO things get prototyped before they graduate
+
+## Find it
+- thezao.xyz and zaoos.com
+- Papers: thezao.xyz/papers (whitepaper, technical whitepaper, manifesto)
+- Farcaster: the /zao and /zabal channels
+
+## Related boxes
+- Zaal (zaal)
+- ZABAL Games (zabalgamez)
+- WaveWarZ (wavewarz)
+
+## Canonical identity
+- Name: The ZAO
+- URL: https://thezao.com
+- sameAs:
+  - https://thezao.xyz
+  - https://zaoos.com
+  - https://warpcast.com/~/channel/zao

--- a/research/identity/icm-boxes/generated/wavewarz.com.llms.txt
+++ b/research/identity/icm-boxes/generated/wavewarz.com.llms.txt
@@ -1,0 +1,31 @@
+# WaveWarZ
+
+<!-- GENERATED from research/identity/icm-boxes/wavewarz.llm.txt — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->
+
+> WaveWarZ is live-traded music battles: artists battle, fans trade and earn. Part of The ZAO ecosystem.
+
+## What it is
+- A prediction-market-style music battle platform on Solana (mainnet), with a Base testnet and a Base-to-Solana bridge (via Mayan and Wormhole).
+- Quick battles run on weekdays; main events run on Sundays.
+- Artists compete; fans trade positions on the outcome and earn.
+
+## In the ZAO ecosystem
+- One of the ZAO production lanes alongside ZABAL Games and the festivals.
+- August ZABAL Games Finals integrate WaveWarZ-Base for on-chain settlement.
+
+## Find it
+- wavewarz.com
+- X: @WaveWarZ
+- Farcaster: the /wavewarz channel
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- ZABAL Games (zabalgamez)
+
+## Canonical identity
+- Name: WaveWarZ
+- URL: https://wavewarz.com
+- sameAs:
+  - https://x.com/WaveWarZ
+  - https://warpcast.com/~/channel/wavewarz

--- a/research/identity/icm-boxes/generated/zabalgamez.com.llms.txt
+++ b/research/identity/icm-boxes/generated/zabalgamez.com.llms.txt
@@ -1,0 +1,29 @@
+# ZABAL Games (ZABAL Gamez)
+
+<!-- GENERATED from research/identity/icm-boxes/zabalgamez.llm.txt — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->
+
+> ZABAL Games is The ZAO's 3-month build-a-thon. Free to join, anyone welcome, three tracks: artist, builder, creator. The real audience is the 100+ member ZAO community - build for a real community, not a weekend you forget.
+
+## The arc
+- June: workshops
+- July: open-build month (goal: 200 distinct builders, multiple submissions each)
+- August: Finals, with WaveWarZ-Base integration and on-chain settlement
+
+## How it works
+- Submit in any format. Partial and work-in-progress drafts count.
+- Submissions land on the board at zabalgamez.com/submissions.
+- August mentors pair with open-submission builders and share evaluation criteria.
+- A generic stream overlay is available for workshop and Finals streams: zaoos.com/overlay/zabal-games (Restream or OBS browser source).
+
+## Find it
+- zabalgamez.com
+- Farcaster: the /zabal channel; tag posts with "zabal gamez"
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- WaveWarZ (wavewarz)
+
+## Canonical identity
+- Name: ZABAL Games
+- URL: https://zabalgamez.com


### PR DESCRIPTION
## What
Generates per-domain `llms.txt` files **from** the ICM context boxes so the ZAO's two AI-readable surfaces (ICM boxes on useicm.com + `llms.txt` on the domains) never drift.

From reviewing **doc 1107** (GEO plan). The insight: two AI-readable surfaces stating different facts is the *worst* GEO outcome — an LLM that finds both trusts neither. Single source → both surfaces.

## Deliverables (all under `research/identity/icm-boxes/`)
- **`build-llms-txt.py`** — box → spec-compliant `llms.txt` (`llmstxt.org`: H1, `>` summary, body, `## Canonical identity` with name/url/sameAs per doc 1107 §5). Modes: build / `--check` (drift guard, exit 1 on stale) / `--selftest` (8/8).
- **`generated/`** — 5 drafts: `thezao.com`, `bettercallzaal.com`, `wavewarz.com` (priority, doc 1107); `zabalgamez.com`, `fractal.thezao.com` (staged).
- **README** — mapping table + drift-avoidance rationale + gated deploy steps.

## Gated (NOT done here)
Deploy is **Iman/Zaal** (GEO lane, doc 1122 gap 4): ship each file to `<domain>/.well-known/llms.txt` **and** `<domain>/llms.txt`. This PR only drafts content.

## Verify
- `python3 build-llms-txt.py --selftest` → 8/8
- `python3 build-llms-txt.py --check` → OK (no drift)
- `scripts/check-research-index.sh --all` → exit 0
- Docs-only (`research/**`) — no runtime code.

Board: `research-doc:1107` GEO llms.txt task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)