### PR TITLE
chore(ci): add push-to-main trigger on research-index guard

### DIFF
--- a/.github/workflows/research-index.yml
+++ b/.github/workflows/research-index.yml
@@ -6,8 +6,19 @@ name: Research index guard
 # merge time to catch it - happened with docs 1076, 1174, and 1176, each found and
 # repaired only later by a manual `--all` audit. This runs that full --all audit on
 # every PR that touches research/, so an unindexed doc fails CI before it can merge.
+#
+# The push trigger below re-runs --all AFTER every merge into main so that a
+# squash-merge that drops a folder-index row (conflict between two agents both
+# appending to the same README) shows as a failing check on main rather than
+# silently becoming a gap discovered only on the next PR.
 on:
   pull_request:
+    paths:
+      - 'research/**'
+      - 'scripts/check-research-index.sh'
+  push:
+    branches:
+      - main
     paths:
       - 'research/**'
       - 'scripts/check-research-index.sh'


### PR DESCRIPTION
## Summary
- Root cause: squash-merge drops folder-index README rows when two agents both append to the same file concurrently. CI on the PR branch passes (the row was present), but the merged state on main is broken.
- Fix: add `push: branches: [main]` trigger to `research-index.yml` so `check-research-index.sh --all` re-runs after every merge into main. A broken index becomes a visible failing check on main instead of a silent gap discovered only during the next PR.
- Catches the 5 hand-repair cases from 2026-07-17 (docs 1076, 1174, 1176, 1177, cross-platform/1170).

## Companion action (Zaal-gated)
Enable **"Require branches to be up to date before merging"** in repo Settings → Branch protection for `main`. This prevents the conflict from occurring in the first place by forcing merge branches to rebase before they can be merged.

## Test plan
- [ ] CI passes on this PR (no workflow syntax errors)
- [ ] After merge, any push to main that touches `research/**` triggers the guard job

🤖 Generated with [Claude Code](https://claude.com/claude-code)