### PR TITLE
test(music+publish): audioFilterState, auto-cast, x-insights — 27 cases

### DIFF
--- a/src/lib/music/__tests__/audioFilterState.test.ts
+++ b/src/lib/music/__tests__/audioFilterState.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getActiveFilterKey, setActiveFilterKey } from '../audioFilterState';
+
+describe('audioFilterState', () => {
+  beforeEach(() => {
+    setActiveFilterKey(null);
+  });
+
+  it('returns null initially after reset', () => {
+    expect(getActiveFilterKey()).toBeNull();
+  });
+
+  it('returns the key after setActiveFilterKey is called', () => {
+    setActiveFilterKey('reverb');
+    expect(getActiveFilterKey()).toBe('reverb');
+  });
+
+  it('returns null after setting a key then resetting to null', () => {
+    setActiveFilterKey('reverb');
+    setActiveFilterKey(null);
+    expect(getActiveFilterKey()).toBeNull();
+  });
+
+  it('overwrites the previous key when a new key is set', () => {
+    setActiveFilterKey('reverb');
+    setActiveFilterKey('echo');
+    expect(getActiveFilterKey()).toBe('echo');
+  });
+
+  it('is idempotent when the same key is set twice', () => {
+    setActiveFilterKey('reverb');
+    setActiveFilterKey('reverb');
+    expect(getActiveFilterKey()).toBe('reverb');
+  });
+
+  it('works with a non-simple key string like filter-123-abc', () => {
+    setActiveFilterKey('filter-123-abc');
+    expect(getActiveFilterKey()).toBe('filter-123-abc');
+  });
+});

--- a/src/lib/publish/__tests__/auto-cast.test.ts
+++ b/src/lib/publish/__tests__/auto-cast.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPostCast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/farcaster/neynar', () => ({ postCast: mockPostCast }));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { autoCastToZao } from '../auto-cast';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.ZAO_OFFICIAL_SIGNER_UUID;
+  delete process.env.ZAO_OFFICIAL_NEYNAR_API_KEY;
+});
+
+describe('autoCastToZao', () => {
+  it('returns null when ZAO_OFFICIAL_SIGNER_UUID is missing', async () => {
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    const result = await autoCastToZao('hello');
+    expect(result).toBeNull();
+    expect(mockPostCast).not.toHaveBeenCalled();
+  });
+
+  it('returns null when ZAO_OFFICIAL_NEYNAR_API_KEY is missing', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    const result = await autoCastToZao('hello');
+    expect(result).toBeNull();
+    expect(mockPostCast).not.toHaveBeenCalled();
+  });
+
+  it('returns null when both env vars are missing', async () => {
+    const result = await autoCastToZao('hello');
+    expect(result).toBeNull();
+    expect(mockPostCast).not.toHaveBeenCalled();
+  });
+
+  it('passes short text (≤ 320 chars) through unchanged', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    const text = 'a'.repeat(320);
+    mockPostCast.mockResolvedValue({ cast: { hash: 'hash-abc' } });
+
+    await autoCastToZao(text);
+
+    expect(mockPostCast).toHaveBeenCalledWith(
+      'signer-uuid',
+      text,
+      'zao',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'api-key',
+    );
+  });
+
+  it('truncates text > 320 chars to exactly 320 chars (319 + ellipsis)', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    const text = 'b'.repeat(321);
+    mockPostCast.mockResolvedValue({ cast: { hash: 'hash-abc' } });
+
+    await autoCastToZao(text);
+
+    const calledText = mockPostCast.mock.calls[0][1] as string;
+    expect(calledText).toHaveLength(320);
+    expect(calledText.endsWith('…')).toBe(true);
+    expect(calledText.slice(0, 319)).toBe('b'.repeat(319));
+  });
+
+  it('returns the cast hash on success', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    mockPostCast.mockResolvedValue({ cast: { hash: 'cast-hash-123' } });
+
+    const result = await autoCastToZao('hello');
+
+    expect(result).toBe('cast-hash-123');
+  });
+
+  it('returns null when result.cast is undefined', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    mockPostCast.mockResolvedValue({ cast: undefined });
+
+    const result = await autoCastToZao('hello');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when postCast throws', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    mockPostCast.mockRejectedValue(new Error('network error'));
+
+    const result = await autoCastToZao('hello');
+
+    expect(result).toBeNull();
+  });
+
+  it('passes embedUrl as [embedUrl] when provided', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    mockPostCast.mockResolvedValue({ cast: { hash: 'hash-xyz' } });
+
+    await autoCastToZao('hello', 'https://example.com/post');
+
+    expect(mockPostCast).toHaveBeenCalledWith(
+      'signer-uuid',
+      'hello',
+      'zao',
+      undefined,
+      undefined,
+      ['https://example.com/post'],
+      undefined,
+      'api-key',
+    );
+  });
+
+  it('passes undefined embedUrls when no embedUrl given', async () => {
+    process.env.ZAO_OFFICIAL_SIGNER_UUID = 'signer-uuid';
+    process.env.ZAO_OFFICIAL_NEYNAR_API_KEY = 'api-key';
+    mockPostCast.mockResolvedValue({ cast: { hash: 'hash-xyz' } });
+
+    await autoCastToZao('hello');
+
+    expect(mockPostCast).toHaveBeenCalledWith(
+      'signer-uuid',
+      'hello',
+      'zao',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'api-key',
+    );
+  });
+});

--- a/src/lib/publish/__tests__/x-insights.test.ts
+++ b/src/lib/publish/__tests__/x-insights.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetXClient = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/publish/x', () => ({
+  getXClient: mockGetXClient,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { fetchXInsights } from '@/lib/publish/x-insights';
+
+describe('fetchXInsights', () => {
+  const mockSingleTweet = vi.fn();
+  const mockClient = { v2: { singleTweet: mockSingleTweet } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 1. Throws when client is not configured
+  it('throws when getXClient() returns null', async () => {
+    mockGetXClient.mockReturnValue(null);
+
+    await expect(fetchXInsights('123')).rejects.toThrow('X client not configured');
+  });
+
+  // 2. Returns zeroed XMetrics when public_metrics is undefined
+  it('returns all-zero XMetrics when public_metrics is undefined on the tweet', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({ data: {} });
+
+    const result = await fetchXInsights('456');
+
+    expect(result).toEqual({
+      views: 0,
+      likes: 0,
+      replies: 0,
+      reposts: 0,
+      quotes: 0,
+      bookmarks: 0,
+    });
+  });
+
+  // 3. Maps impression_count → views
+  it('maps impression_count to views', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 42,
+          like_count: 0,
+          reply_count: 0,
+          retweet_count: 0,
+          quote_count: 0,
+          bookmark_count: 0,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet1');
+    expect(result.views).toBe(42);
+  });
+
+  // 4. Maps like_count → likes
+  it('maps like_count to likes', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 0,
+          like_count: 7,
+          reply_count: 0,
+          retweet_count: 0,
+          quote_count: 0,
+          bookmark_count: 0,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet2');
+    expect(result.likes).toBe(7);
+  });
+
+  // 5. Maps reply_count → replies
+  it('maps reply_count to replies', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 0,
+          like_count: 0,
+          reply_count: 3,
+          retweet_count: 0,
+          quote_count: 0,
+          bookmark_count: 0,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet3');
+    expect(result.replies).toBe(3);
+  });
+
+  // 6. Maps retweet_count → reposts
+  it('maps retweet_count to reposts', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 0,
+          like_count: 0,
+          reply_count: 0,
+          retweet_count: 5,
+          quote_count: 0,
+          bookmark_count: 0,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet4');
+    expect(result.reposts).toBe(5);
+  });
+
+  // 7. Maps quote_count → quotes
+  it('maps quote_count to quotes', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 0,
+          like_count: 0,
+          reply_count: 0,
+          retweet_count: 0,
+          quote_count: 2,
+          bookmark_count: 0,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet5');
+    expect(result.quotes).toBe(2);
+  });
+
+  // 8. Maps bookmark_count → bookmarks
+  it('maps bookmark_count to bookmarks', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 0,
+          like_count: 0,
+          reply_count: 0,
+          retweet_count: 0,
+          quote_count: 0,
+          bookmark_count: 9,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet6');
+    expect(result.bookmarks).toBe(9);
+  });
+
+  // 9. Full happy-path: all 6 fields populated correctly
+  it('returns all 6 fields correctly on a full public_metrics response', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          impression_count: 1000,
+          like_count: 50,
+          reply_count: 10,
+          retweet_count: 20,
+          quote_count: 5,
+          bookmark_count: 15,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet-full');
+
+    expect(result).toEqual({
+      views: 1000,
+      likes: 50,
+      replies: 10,
+      reposts: 20,
+      quotes: 5,
+      bookmarks: 15,
+    });
+  });
+
+  // 10. Returns zeroed metrics when singleTweet throws (API error recovery)
+  it('returns zeroed metrics when singleTweet throws an API error', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockRejectedValue(new Error('API rate limit exceeded'));
+
+    const result = await fetchXInsights('tweet-err');
+
+    expect(result).toEqual({
+      views: 0,
+      likes: 0,
+      replies: 0,
+      reposts: 0,
+      quotes: 0,
+      bookmarks: 0,
+    });
+  });
+
+  // Bonus: missing individual fields default to 0 via ?? operator
+  it('defaults missing impression_count to views: 0', async () => {
+    mockGetXClient.mockReturnValue(mockClient);
+    mockSingleTweet.mockResolvedValue({
+      data: {
+        public_metrics: {
+          // impression_count intentionally omitted
+          like_count: 1,
+          reply_count: 0,
+          retweet_count: 0,
+          quote_count: 0,
+          bookmark_count: 0,
+        },
+      },
+    });
+
+    const result = await fetchXInsights('tweet-no-impressions');
+    expect(result.views).toBe(0);
+    expect(result.likes).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `audioFilterState` (6 cases): shared singleton state — initial null, set/get round-trip, overwrite, idempotent set, null reset, hyphenated key
- `auto-cast` (10 cases): env-var null guard (missing signer, missing apiKey, both missing), 320-char truncation with U+2026 ellipsis, cast-hash passthrough, null on missing `cast`, null on throw, embedUrl wiring, undefined embedUrls when not provided
- `x-insights` (11 cases): null-client throws, all 6 `public_metrics` → `XMetrics` field mappings, `?? 0` defaults, zeroed return when `public_metrics` absent, zeroed return on API error

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)