### PR TITLE
test(music+publish): songlink resolver + Threads insights — 22 cases

### DIFF
--- a/src/lib/music/__tests__/songlink.test.ts
+++ b/src/lib/music/__tests__/songlink.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { resolveMusicLinks, buildUniversalCard, RateLimitError } from '../songlink';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface SonglinkResponse {
+  entityUniqueId: string;
+  pageUrl: string;
+  entitiesByUniqueId: Record<
+    string,
+    {
+      id: string;
+      title?: string;
+      artistName?: string;
+      thumbnailUrl?: string;
+      apiProvider?: string;
+      platforms?: string[];
+    }
+  >;
+  linksByPlatform: Record<string, { url: string; entityUniqueId: string }>;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResponse(overrides = {}): SonglinkResponse {
+  return {
+    entityUniqueId: 'SPOTIFY::track::123',
+    pageUrl: 'https://song.link/test',
+    entitiesByUniqueId: {
+      'SPOTIFY::track::123': {
+        id: '123',
+        title: 'Test Song',
+        artistName: 'Test Artist',
+        thumbnailUrl: 'https://thumb.jpg',
+      },
+    },
+    linksByPlatform: {
+      spotify: { url: 'https://spotify.com/track/123', entityUniqueId: 'SPOTIFY::track::123' },
+    },
+    ...overrides,
+  };
+}
+
+function mockFetch(status: number, body: unknown) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── resolveMusicLinks ─────────────────────────────────────────────────────────
+
+describe('resolveMusicLinks', () => {
+  it('returns parsed response on 200 OK', async () => {
+    const response = makeResponse();
+    mockFetch(200, response);
+
+    const result = await resolveMusicLinks('https://spotify.com/track/123');
+
+    expect(result).toEqual(response);
+  });
+
+  it('throws RateLimitError on HTTP 429', async () => {
+    mockFetch(429, {});
+
+    await expect(resolveMusicLinks('https://spotify.com/track/123')).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof RateLimitError && (err as RateLimitError).name === 'RateLimitError',
+    );
+  });
+
+  it('throws Error with message containing "500" on HTTP 500', async () => {
+    mockFetch(500, {});
+
+    await expect(resolveMusicLinks('https://spotify.com/track/123')).rejects.toThrow('500');
+  });
+
+  it('encodes the music URL in the query string', async () => {
+    const inputUrl = 'https://spotify.com/track/123?si=abc&dl_branch=1';
+    mockFetch(200, makeResponse());
+
+    await resolveMusicLinks(inputUrl);
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain(encodeURIComponent(inputUrl));
+  });
+
+  it('passes User-Agent: ZAO-OS/1.0 header', async () => {
+    mockFetch(200, makeResponse());
+
+    await resolveMusicLinks('https://spotify.com/track/123');
+
+    const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect((calledOptions.headers as Record<string, string>)['User-Agent']).toBe('ZAO-OS/1.0');
+  });
+});
+
+// ── buildUniversalCard ────────────────────────────────────────────────────────
+
+describe('buildUniversalCard', () => {
+  it('returns title/artist/thumbnail from the primary entity', () => {
+    const response = makeResponse();
+    const card = buildUniversalCard(response);
+
+    expect(card.title).toBe('Test Song');
+    expect(card.artist).toBe('Test Artist');
+    expect(card.thumbnail).toBe('https://thumb.jpg');
+  });
+
+  it('falls back to scanning all entities when primary entity has no title or thumbnail', () => {
+    const response = makeResponse({
+      entityUniqueId: 'SPOTIFY::track::123',
+      entitiesByUniqueId: {
+        // Primary entity exists but lacks title + thumbnail
+        'SPOTIFY::track::123': { id: '123', artistName: 'Primary Artist' },
+        // Secondary entity has the missing fields
+        'APPLE::track::456': {
+          id: '456',
+          title: 'Fallback Title',
+          artistName: 'Fallback Artist',
+          thumbnailUrl: 'https://fallback-thumb.jpg',
+        },
+      },
+    });
+
+    const card = buildUniversalCard(response);
+
+    expect(card.title).toBe('Fallback Title');
+    // artist comes from primary entity since it has artistName
+    expect(card.artist).toBe('Primary Artist');
+    expect(card.thumbnail).toBe('https://fallback-thumb.jpg');
+  });
+
+  it('returns empty strings when no entity has metadata', () => {
+    const response = makeResponse({
+      entitiesByUniqueId: {},
+    });
+
+    const card = buildUniversalCard(response);
+
+    expect(card.title).toBe('');
+    expect(card.artist).toBe('');
+    expect(card.thumbnail).toBe('');
+  });
+
+  it('ignores non-ZAO platform keys in linksByPlatform', () => {
+    const response = makeResponse({
+      linksByPlatform: {
+        spotify: { url: 'https://spotify.com/track/123', entityUniqueId: 'SPOTIFY::track::123' },
+        amazonMusic: { url: 'https://music.amazon.com/track/123', entityUniqueId: 'AMAZON::track::123' },
+        deezer: { url: 'https://deezer.com/track/123', entityUniqueId: 'DEEZER::track::123' },
+      },
+    });
+
+    const card = buildUniversalCard(response);
+    const platformKeys = card.platforms.map((p) => p.platform);
+
+    expect(platformKeys).toContain('spotify');
+    expect(platformKeys).not.toContain('amazonMusic');
+    expect(platformKeys).not.toContain('deezer');
+  });
+
+  it('returns platforms in ZAO priority order: audius, spotify, appleMusic', () => {
+    const response = makeResponse({
+      linksByPlatform: {
+        appleMusic: { url: 'https://music.apple.com/track/123', entityUniqueId: 'APPLE::track::123' },
+        spotify: { url: 'https://spotify.com/track/123', entityUniqueId: 'SPOTIFY::track::123' },
+        audius: { url: 'https://audius.co/track/123', entityUniqueId: 'AUDIUS::track::123' },
+      },
+    });
+
+    const card = buildUniversalCard(response);
+    const platformKeys = card.platforms.map((p) => p.platform);
+
+    expect(platformKeys[0]).toBe('audius');
+    expect(platformKeys[1]).toBe('spotify');
+    expect(platformKeys[2]).toBe('appleMusic');
+  });
+
+  it('returns empty platforms array when none of the ZAO platforms are present', () => {
+    const response = makeResponse({
+      linksByPlatform: {
+        amazonMusic: { url: 'https://music.amazon.com/track/123', entityUniqueId: 'AMAZON::track::123' },
+      },
+    });
+
+    const card = buildUniversalCard(response);
+
+    expect(card.platforms).toEqual([]);
+  });
+
+  it('returns pageUrl from the response', () => {
+    const response = makeResponse({ pageUrl: 'https://song.link/my-song' });
+
+    const card = buildUniversalCard(response);
+
+    expect(card.pageUrl).toBe('https://song.link/my-song');
+  });
+});

--- a/src/lib/publish/__tests__/threads-insights.test.ts
+++ b/src/lib/publish/__tests__/threads-insights.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnv = vi.hoisted(() => ({ THREADS_ACCESS_TOKEN: 'test-token' as string | undefined }));
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+import { fetchThreadsInsights } from '../threads-insights';
+
+function mockFetch(status: number, body: unknown) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function makeBody(metrics: Partial<Record<string, number>>) {
+  return {
+    data: Object.entries(metrics).map(([name, value]) => ({
+      name,
+      values: [{ value }],
+    })),
+  };
+}
+
+describe('fetchThreadsInsights', () => {
+  beforeEach(() => {
+    mockEnv.THREADS_ACCESS_TOKEN = 'test-token';
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // 1. Throws when THREADS_ACCESS_TOKEN is undefined
+  it('throws when THREADS_ACCESS_TOKEN is undefined', async () => {
+    mockEnv.THREADS_ACCESS_TOKEN = undefined;
+
+    await expect(fetchThreadsInsights('thread-abc')).rejects.toThrow(
+      'missing THREADS_ACCESS_TOKEN',
+    );
+  });
+
+  // 2. All 5 metrics populated correctly from API response
+  it('returns all 5 metrics correctly from a full API response', async () => {
+    mockFetch(200, makeBody({ views: 100, likes: 50, replies: 10, reposts: 5, quotes: 2 }));
+
+    const result = await fetchThreadsInsights('thread-full');
+
+    expect(result).toEqual({
+      views: 100,
+      likes: 50,
+      replies: 10,
+      reposts: 5,
+      quotes: 2,
+    });
+  });
+
+  // 3. Partial metrics: only some fields present → missing ones remain 0
+  it('returns 0 for metrics absent from the API response', async () => {
+    mockFetch(200, makeBody({ views: 999, likes: 7 }));
+
+    const result = await fetchThreadsInsights('thread-partial');
+
+    expect(result).toEqual({
+      views: 999,
+      likes: 7,
+      replies: 0,
+      reposts: 0,
+      quotes: 0,
+    });
+  });
+
+  // 4. Empty data array → all zeros returned
+  it('returns all-zero metrics when data array is empty', async () => {
+    mockFetch(200, { data: [] });
+
+    const result = await fetchThreadsInsights('thread-empty');
+
+    expect(result).toEqual({ views: 0, likes: 0, replies: 0, reposts: 0, quotes: 0 });
+  });
+
+  // 5. Unknown metric name in response data → ignored
+  it('ignores unknown metric names from the API response', async () => {
+    mockFetch(200, makeBody({ views: 10, unknown_metric: 99 }));
+
+    const result = await fetchThreadsInsights('thread-unknown');
+
+    expect(result).toEqual({ views: 10, likes: 0, replies: 0, reposts: 0, quotes: 0 });
+    expect(result).not.toHaveProperty('unknown_metric');
+  });
+
+  // 6. API error (HTTP 401) with JSON error body → returns zeroed metrics
+  it('returns zeroed metrics on a 401 error with JSON error body', async () => {
+    mockFetch(401, { error: { message: 'permission denied' } });
+
+    const result = await fetchThreadsInsights('thread-401');
+
+    expect(result).toEqual({ views: 0, likes: 0, replies: 0, reposts: 0, quotes: 0 });
+  });
+
+  // 7. API error where json() throws → returns zeroed metrics
+  it('returns zeroed metrics when the error response json() throws', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not json')),
+    });
+
+    const result = await fetchThreadsInsights('thread-bad-json');
+
+    expect(result).toEqual({ views: 0, likes: 0, replies: 0, reposts: 0, quotes: 0 });
+  });
+
+  // 8. values[0] missing/undefined on a metric → defaults to 0
+  it('defaults to 0 when values array is empty for a metric', async () => {
+    mockFetch(200, {
+      data: [
+        { name: 'views', values: [] },
+        { name: 'likes', values: [{ value: 3 }] },
+      ],
+    });
+
+    const result = await fetchThreadsInsights('thread-missing-values');
+
+    expect(result.views).toBe(0);
+    expect(result.likes).toBe(3);
+  });
+
+  // 9. Access token is included in the request URL query string
+  it('includes access_token in the fetch URL query string', async () => {
+    mockFetch(200, { data: [] });
+
+    await fetchThreadsInsights('thread-token-check');
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('access_token=test-token');
+  });
+
+  // 10. Thread ID is correctly embedded in the URL path
+  it('embeds the thread ID in the fetch URL path', async () => {
+    mockFetch(200, { data: [] });
+
+    const threadId = 'my-thread-id-xyz';
+    await fetchThreadsInsights(threadId);
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain(`/${threadId}/insights`);
+  });
+});


### PR DESCRIPTION
## Summary
- `songlink` (12 cases): `resolveMusicLinks` — 200 OK parse, `RateLimitError` on 429, `Error` on 500, URL encoding, User-Agent header; `buildUniversalCard` — primary entity metadata, fallback entity scan, empty entity handling, non-ZAO platform filtering, ZAO priority order (audius→spotify→appleMusic→…), empty platforms, pageUrl passthrough
- `threads-insights` (10 cases): missing-token throws, all 5 metrics correctly mapped, partial metrics default to 0, empty `data` all-zeros, unknown metric names ignored, HTTP 401 → zeroed metrics, `json()` throws → zeroed metrics, `values[0]` missing → 0, `access_token` in URL, `threadId` in URL path

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)