### PR TITLE
test(music+publish): listenbrainz, Last.fm, Discord — 44 cases

### DIFF
--- a/src/lib/music/__tests__/lastfm.test.ts
+++ b/src/lib/music/__tests__/lastfm.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { scrobble, updateNowPlaying, getAuthUrl, getSession } from '../lastfm';
+
+function mockFetch(status: number, body: unknown = {}) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+  });
+}
+
+function getRequestBody(): Record<string, string> {
+  const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+  return Object.fromEntries(new URLSearchParams(opts.body as string));
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+  process.env.LASTFM_API_KEY = 'test-key';
+  process.env.LASTFM_API_SECRET = 'test-secret';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.LASTFM_API_KEY;
+  delete process.env.LASTFM_API_SECRET;
+});
+
+describe('scrobble', () => {
+  it('POSTs to https://ws.audioscrobbler.com/2.0/', async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Artist', track: 'Track', timestamp: 1000, sk: 'sk-1' });
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://ws.audioscrobbler.com/2.0/');
+  });
+
+  it("sends method: 'track.scrobble' in body", async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Artist', track: 'Track', timestamp: 1000, sk: 'sk-1' });
+    expect(getRequestBody().method).toBe('track.scrobble');
+  });
+
+  it('includes artist, track, timestamp, sk from params', async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Portishead', track: 'Glory Box', timestamp: 9999, sk: 'sk-xyz' });
+    const body = getRequestBody();
+    expect(body.artist).toBe('Portishead');
+    expect(body.track).toBe('Glory Box');
+    expect(body.timestamp).toBe('9999');
+    expect(body.sk).toBe('sk-xyz');
+  });
+
+  it('includes album when provided', async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Artist', track: 'Track', album: 'Dummy', timestamp: 1000, sk: 'sk-1' });
+    expect(getRequestBody().album).toBe('Dummy');
+  });
+
+  it('omits album field when not provided', async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Artist', track: 'Track', timestamp: 1000, sk: 'sk-1' });
+    expect(getRequestBody()).not.toHaveProperty('album');
+  });
+
+  it("includes api_key: 'test-key' and format: 'json' in body", async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Artist', track: 'Track', timestamp: 1000, sk: 'sk-1' });
+    const body = getRequestBody();
+    expect(body.api_key).toBe('test-key');
+    expect(body.format).toBe('json');
+  });
+
+  it('includes api_sig as a 32-char hex string', async () => {
+    mockFetch(200, {});
+    await scrobble({ artist: 'Artist', track: 'Track', timestamp: 1000, sk: 'sk-1' });
+    const { api_sig } = getRequestBody();
+    expect(api_sig).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('throws "Last.fm API error 403:" on non-ok response', async () => {
+    mockFetch(403, {});
+    await expect(
+      scrobble({ artist: 'Artist', track: 'Track', timestamp: 1000, sk: 'sk-1' })
+    ).rejects.toThrow('Last.fm API error 403:');
+  });
+});
+
+describe('updateNowPlaying', () => {
+  it("sends method: 'track.updateNowPlaying' in body", async () => {
+    mockFetch(200, {});
+    await updateNowPlaying({ artist: 'Artist', track: 'Track', sk: 'sk-1' });
+    expect(getRequestBody().method).toBe('track.updateNowPlaying');
+  });
+});
+
+describe('getAuthUrl', () => {
+  it('returns URL containing api_key=test-key and encoded callback URL', () => {
+    const callback = 'https://example.com/callback?foo=bar';
+    const url = getAuthUrl(callback);
+    expect(url).toContain('api_key=test-key');
+    expect(url).toContain(encodeURIComponent(callback));
+  });
+});
+
+describe('getSession', () => {
+  it('returns result.session.key from the API response', async () => {
+    mockFetch(200, { session: { key: 'sk-abc' } });
+    const key = await getSession('token-123');
+    expect(key).toBe('sk-abc');
+  });
+});

--- a/src/lib/music/__tests__/listenbrainz.test.ts
+++ b/src/lib/music/__tests__/listenbrainz.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { submitListen, submitNowPlaying } from '../listenbrainz';
+
+vi.stubGlobal('fetch', vi.fn());
+
+const TOKEN = 'user-abc123';
+
+function mockFetch(status: number, body: unknown = { status: 'ok' }) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+function getCall() {
+  return (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+describe('submitListen', () => {
+  it('POSTs to https://api.listenbrainz.org/1/submit-listens', async () => {
+    mockFetch(200);
+    await submitListen({ artist: 'Artist', track: 'Track', timestamp: 1000, userToken: TOKEN });
+    const [url, init] = getCall();
+    expect(url).toBe('https://api.listenbrainz.org/1/submit-listens');
+    expect(init.method).toBe('POST');
+  });
+
+  it('includes Authorization: Token <userToken> header', async () => {
+    mockFetch(200);
+    await submitListen({ artist: 'Artist', track: 'Track', timestamp: 1000, userToken: TOKEN });
+    const [, init] = getCall();
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe(`Token ${TOKEN}`);
+  });
+
+  it('sends listen_type: "single" in body', async () => {
+    mockFetch(200);
+    await submitListen({ artist: 'Artist', track: 'Track', timestamp: 1000, userToken: TOKEN });
+    const [, init] = getCall();
+    const body = JSON.parse(init.body as string);
+    expect(body.listen_type).toBe('single');
+  });
+
+  it('body contains listened_at, artist_name, track_name from params', async () => {
+    mockFetch(200);
+    await submitListen({ artist: 'Test Artist', track: 'Test Track', timestamp: 1234567890, userToken: TOKEN });
+    const [, init] = getCall();
+    const body = JSON.parse(init.body as string);
+    const entry = body.payload[0];
+    expect(entry.listened_at).toBe(1234567890);
+    expect(entry.track_metadata.artist_name).toBe('Test Artist');
+    expect(entry.track_metadata.track_name).toBe('Test Track');
+  });
+
+  it('includes release_name in track_metadata when album is provided', async () => {
+    mockFetch(200);
+    await submitListen({ artist: 'Artist', track: 'Track', album: 'My Album', timestamp: 1000, userToken: TOKEN });
+    const [, init] = getCall();
+    const body = JSON.parse(init.body as string);
+    expect(body.payload[0].track_metadata.release_name).toBe('My Album');
+  });
+
+  it('omits release_name when album is absent', async () => {
+    mockFetch(200);
+    await submitListen({ artist: 'Artist', track: 'Track', timestamp: 1000, userToken: TOKEN });
+    const [, init] = getCall();
+    const body = JSON.parse(init.body as string);
+    expect(body.payload[0].track_metadata).not.toHaveProperty('release_name');
+  });
+
+  it('returns parsed JSON on success', async () => {
+    mockFetch(200, { status: 'ok' });
+    const result = await submitListen({ artist: 'Artist', track: 'Track', timestamp: 1000, userToken: TOKEN });
+    expect(result).toEqual({ status: 'ok' });
+  });
+
+  it('throws "ListenBrainz error 401: ..." on non-ok response', async () => {
+    mockFetch(401, { error: 'Unauthorized' });
+    await expect(
+      submitListen({ artist: 'Artist', track: 'Track', timestamp: 1000, userToken: 'bad-token' })
+    ).rejects.toThrow('ListenBrainz error 401:');
+  });
+});
+
+describe('submitNowPlaying', () => {
+  it('sends listen_type: "playing_now" in body', async () => {
+    mockFetch(200);
+    await submitNowPlaying({ artist: 'Artist', track: 'Track', userToken: TOKEN });
+    const [, init] = getCall();
+    const body = JSON.parse(init.body as string);
+    expect(body.listen_type).toBe('playing_now');
+  });
+
+  it('does NOT include listened_at in the payload (only track_metadata)', async () => {
+    mockFetch(200);
+    await submitNowPlaying({ artist: 'Artist', track: 'Track', userToken: TOKEN });
+    const [, init] = getCall();
+    const body = JSON.parse(init.body as string);
+    const entry = body.payload[0];
+    expect(entry).not.toHaveProperty('listened_at');
+    expect(entry).toHaveProperty('track_metadata');
+  });
+});

--- a/src/lib/publish/__tests__/discord.test.ts
+++ b/src/lib/publish/__tests__/discord.test.ts
@@ -1,0 +1,243 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildZaoEmbed, publishToDiscord } from '../discord';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WEBHOOK = 'https://discord.com/api/webhooks/123/token';
+
+function mockFetch(status: number, body: unknown = { id: 'msg-1' }) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+function getRequestBody(): Record<string, unknown> {
+  const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+  return JSON.parse(opts.body as string);
+}
+
+function getRequestUrl(): string {
+  const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+  return url;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+  delete process.env.DISCORD_WEBHOOK_URL;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.DISCORD_WEBHOOK_URL;
+});
+
+// ---------------------------------------------------------------------------
+// publishToDiscord
+// ---------------------------------------------------------------------------
+
+describe('publishToDiscord', () => {
+  it('returns not-configured error when no webhook URL is set', async () => {
+    const result = await publishToDiscord({ text: 'hello' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Discord not configured/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses DISCORD_WEBHOOK_URL env var when no override provided', async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    mockFetch(200);
+    const result = await publishToDiscord({ text: 'env-driven' });
+    expect(result.success).toBe(true);
+    expect(fetch).toHaveBeenCalledOnce();
+    const url = getRequestUrl();
+    expect(url).toContain(WEBHOOK);
+  });
+
+  it('prefers content.webhookUrl over env var', async () => {
+    process.env.DISCORD_WEBHOOK_URL = 'https://discord.com/api/webhooks/env/token';
+    mockFetch(200);
+    await publishToDiscord({ text: 'override', webhookUrl: WEBHOOK });
+    const url = getRequestUrl();
+    expect(url).toContain('webhooks/123/token');
+  });
+
+  it('appends ?wait=true to a plain webhook URL', async () => {
+    mockFetch(200);
+    await publishToDiscord({ text: 'hi', webhookUrl: WEBHOOK });
+    const url = getRequestUrl();
+    expect(url).toBe(`${WEBHOOK}?wait=true`);
+  });
+
+  it('appends &wait=true when webhook URL already has a query string', async () => {
+    const webhookWithQuery = `${WEBHOOK}?thread_id=abc`;
+    mockFetch(200);
+    await publishToDiscord({ text: 'hi', webhookUrl: webhookWithQuery });
+    const url = getRequestUrl();
+    expect(url).toBe(`${webhookWithQuery}&wait=true`);
+  });
+
+  it('returns success with messageId on 200 OK', async () => {
+    mockFetch(200, { id: 'abc-123' });
+    const result = await publishToDiscord({ text: 'good', webhookUrl: WEBHOOK });
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe('abc-123');
+  });
+
+  it('returns generic error message on non-ok response with no JSON body', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('not json at all'),
+      json: () => Promise.reject(new SyntaxError('bad json')),
+    });
+    const result = await publishToDiscord({ text: 'bad', webhookUrl: WEBHOOK });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Discord API error (400)');
+  });
+
+  it('returns Discord error message on non-ok response with JSON { message }', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve(JSON.stringify({ message: 'Unknown Webhook' })),
+      json: () => Promise.resolve({ message: 'Unknown Webhook' }),
+    });
+    const result = await publishToDiscord({ text: 'bad', webhookUrl: WEBHOOK });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Discord API error: Unknown Webhook');
+  });
+
+  it('returns error.message when fetch throws', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network down'));
+    const result = await publishToDiscord({ text: 'crash', webhookUrl: WEBHOOK });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('network down');
+  });
+
+  it('truncates text longer than 2000 chars at a word boundary', async () => {
+    mockFetch(200);
+    // Build a string >2000 chars with a clear word boundary near the limit
+    const prefix = 'word '.repeat(399); // 399 * 5 = 1995 chars
+    const longText = prefix + 'overflow extra words here';
+    await publishToDiscord({ text: longText, webhookUrl: WEBHOOK });
+    const body = getRequestBody();
+    const sent = body.content as string;
+    expect(sent.length).toBeLessThanOrEqual(2003); // maxLen + '...' (3)
+    expect(sent.endsWith('...')).toBe(true);
+    // Must not have split mid-word — every segment before '...' should end at a space boundary
+    const withoutEllipsis = sent.slice(0, -3);
+    expect(withoutEllipsis.endsWith(' ')).toBe(false); // trailing space is trimmed before '...'
+    expect(longText.startsWith(withoutEllipsis)).toBe(true);
+  });
+
+  it('sends username in payload when provided', async () => {
+    mockFetch(200);
+    await publishToDiscord({ text: 'hi', webhookUrl: WEBHOOK, username: 'ZAO Bot' });
+    const body = getRequestBody();
+    expect(body.username).toBe('ZAO Bot');
+  });
+
+  it('sends avatar_url in payload when avatarUrl provided', async () => {
+    mockFetch(200);
+    await publishToDiscord({
+      text: 'hi',
+      webhookUrl: WEBHOOK,
+      avatarUrl: 'https://example.com/avatar.png',
+    });
+    const body = getRequestBody();
+    expect(body.avatar_url).toBe('https://example.com/avatar.png');
+  });
+
+  it('omits embeds key when no embeds provided', async () => {
+    mockFetch(200);
+    await publishToDiscord({ text: 'plain text', webhookUrl: WEBHOOK });
+    const body = getRequestBody();
+    expect(Object.prototype.hasOwnProperty.call(body, 'embeds')).toBe(false);
+  });
+
+  it('omits embeds key when empty embeds array provided', async () => {
+    mockFetch(200);
+    await publishToDiscord({ text: 'plain text', webhookUrl: WEBHOOK, embeds: [] });
+    const body = getRequestBody();
+    expect(Object.prototype.hasOwnProperty.call(body, 'embeds')).toBe(false);
+  });
+
+  it('slices embeds to maximum 10 and includes them in payload', async () => {
+    mockFetch(200);
+    const embeds = Array.from({ length: 15 }, (_, i) => ({
+      title: `Embed ${i}`,
+      description: 'short',
+    }));
+    await publishToDiscord({ text: 'many embeds', webhookUrl: WEBHOOK, embeds });
+    const body = getRequestBody();
+    expect(Array.isArray(body.embeds)).toBe(true);
+    expect((body.embeds as unknown[]).length).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildZaoEmbed
+// ---------------------------------------------------------------------------
+
+describe('buildZaoEmbed', () => {
+  it('uses ZAO gold color (0xf5a623)', () => {
+    const embed = buildZaoEmbed({ title: 'T', description: 'D' });
+    expect(embed.color).toBe(0xf5a623);
+  });
+
+  it('uses default footer text when footerText is not provided', () => {
+    const embed = buildZaoEmbed({ title: 'T', description: 'D' });
+    expect(embed.footer?.text).toBe('Posted via ZAO OS');
+  });
+
+  it('accepts a custom footerText', () => {
+    const embed = buildZaoEmbed({ title: 'T', description: 'D', footerText: 'Custom Footer' });
+    expect(embed.footer?.text).toBe('Custom Footer');
+  });
+
+  it('truncates description longer than 4096 chars', () => {
+    const longDesc = 'a'.repeat(5000);
+    const embed = buildZaoEmbed({ title: 'T', description: longDesc });
+    expect((embed.description ?? '').length).toBeLessThanOrEqual(4099); // 4096 + '...'
+    expect(embed.description?.endsWith('...')).toBe(true);
+  });
+
+  it('includes image.url when imageUrl is provided', () => {
+    const embed = buildZaoEmbed({
+      title: 'T',
+      description: 'D',
+      imageUrl: 'https://example.com/img.png',
+    });
+    expect(embed.image?.url).toBe('https://example.com/img.png');
+  });
+
+  it('omits image when imageUrl is not provided', () => {
+    const embed = buildZaoEmbed({ title: 'T', description: 'D' });
+    expect(embed.image).toBeUndefined();
+  });
+
+  it('includes a timestamp as an ISO string', () => {
+    const before = Date.now();
+    const embed = buildZaoEmbed({ title: 'T', description: 'D' });
+    const after = Date.now();
+    expect(typeof embed.timestamp).toBe('string');
+    const ts = new Date(embed.timestamp!).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('includes url when provided', () => {
+    const embed = buildZaoEmbed({ title: 'T', description: 'D', url: 'https://zao.ai' });
+    expect(embed.url).toBe('https://zao.ai');
+  });
+});


### PR DESCRIPTION
## Summary
- `listenbrainz` (10): `submitListen` — POST URL, `Authorization: Token` header, `listen_type: 'single'`, `listened_at`/artist/track in body, optional `release_name`, JSON return, error throw. `submitNowPlaying` — `playing_now` type, no `listened_at` in payload.
- `lastfm` (11): `scrobble` — POST URL, method field, all params, optional album, `api_key`+`format` injection, `api_sig` as 32-char MD5 hex, 403 error throw. `updateNowPlaying` — method field. `getAuthUrl` — encoded callback. `getSession` — session key extraction.
- `discord` (23): `publishToDiscord` — not-configured return, env var + override resolution, `?wait=true`/`&wait=true` appending, success+messageId, generic error, JSON error message, fetch-throw recovery, 2000-char text truncation at word boundary, `username`/`avatar_url` in payload, embeds absent/empty/max-10. `buildZaoEmbed` — ZAO gold `0xf5a623`, default/custom footer, description truncation, image present/absent, ISO timestamp, url passthrough.

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)