### PR TITLE
test(music+library): Tidal client + Minimax summarizer — 24 cases

### DIFF
--- a/src/lib/library/__tests__/minimax.test.ts
+++ b/src/lib/library/__tests__/minimax.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnv = vi.hoisted(() => ({
+  MINIMAX_API_KEY: 'test-key' as string | undefined,
+  MINIMAX_API_URL: undefined as string | undefined,
+  MINIMAX_MODEL: undefined as string | undefined,
+}));
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+import { generateResearchSummary } from '../minimax';
+
+function mockFetch(ok: boolean, status: number, body: unknown) {
+  const bodyStr = JSON.stringify(body);
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(bodyStr),
+    json: () => Promise.resolve(body),
+  });
+}
+
+function successBody(summary: string) {
+  return { choices: [{ message: { content: summary } }] };
+}
+
+describe('generateResearchSummary', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    mockEnv.MINIMAX_API_KEY = 'test-key';
+    mockEnv.MINIMAX_API_URL = undefined;
+    mockEnv.MINIMAX_MODEL = undefined;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns { summary: null, error: "Minimax not configured" } when MINIMAX_API_KEY is undefined', async () => {
+    mockEnv.MINIMAX_API_KEY = undefined;
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'Minimax not configured' });
+  });
+
+  it('returns { summary, error: null } from choices[0].message.content on success', async () => {
+    mockFetch(true, 200, successBody('This is a summary.'));
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: 'This is a summary.', error: null });
+  });
+
+  it('falls back to data.reply when choices is absent', async () => {
+    mockFetch(true, 200, { reply: 'Reply summary.' });
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: 'Reply summary.', error: null });
+  });
+
+  it('returns { summary: null, error: "No summary in Minimax response" } when both choices and reply absent', async () => {
+    mockFetch(true, 200, {});
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'No summary in Minimax response' });
+  });
+
+  it('returns { summary: null, error: "Minimax API error: 500" } on HTTP 500', async () => {
+    mockFetch(false, 500, { message: 'Internal Server Error' });
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'Minimax API error: 500' });
+  });
+
+  it('returns { summary: null, error: "Minimax: quota exceeded" } when base_resp.status_code !== 0', async () => {
+    mockFetch(true, 200, { base_resp: { status_code: 1000, status_msg: 'quota exceeded' } });
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'Minimax: quota exceeded' });
+  });
+
+  it('returns { summary: null, error: "Minimax: model not found" } when data.error.message is set', async () => {
+    mockFetch(true, 200, { error: { message: 'model not found', type: 'invalid_request_error' } });
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'Minimax: model not found' });
+  });
+
+  it('returns { summary: null, error: "Minimax request failed" } when fetch throws', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network failure'));
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'Minimax request failed' });
+  });
+
+  it('strips <think>...</think> tags from summary before returning', async () => {
+    mockFetch(true, 200, successBody('<think>internal reasoning here</think>\nActual summary text.'));
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: 'Actual summary text.', error: null });
+  });
+
+  it('returns { summary: null, error: "Minimax returned only reasoning tokens" } when summary is only <think> content', async () => {
+    mockFetch(true, 200, successBody('<think>only reasoning, no real answer</think>'));
+    const result = await generateResearchSummary('some content');
+    expect(result).toEqual({ summary: null, error: 'Minimax returned only reasoning tokens' });
+  });
+
+  it('uses MINIMAX_API_URL as endpoint when set', async () => {
+    mockEnv.MINIMAX_API_URL = 'https://custom.api.example.com/v1/chat/completions';
+    mockFetch(true, 200, successBody('ok'));
+    await generateResearchSummary('some content');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://custom.api.example.com/v1/chat/completions',
+      expect.any(Object),
+    );
+  });
+
+  it('uses MINIMAX_MODEL in request body when set', async () => {
+    mockEnv.MINIMAX_MODEL = 'MiniMax-CustomModel';
+    mockFetch(true, 200, successBody('ok'));
+    await generateResearchSummary('some content');
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe('MiniMax-CustomModel');
+  });
+});

--- a/src/lib/music/__tests__/tidal.test.ts
+++ b/src/lib/music/__tests__/tidal.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let searchTidal: (query: string, limit?: number) => Promise<any[]>;
+let getTidalTrack: (id: string) => Promise<any | null>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.stubGlobal('fetch', vi.fn());
+  process.env.TIDAL_CLIENT_ID = 'client-id';
+  process.env.TIDAL_CLIENT_SECRET = 'client-secret';
+  const mod = await import('../tidal');
+  searchTidal = mod.searchTidal;
+  getTidalTrack = mod.getTidalTrack;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.TIDAL_CLIENT_ID;
+  delete process.env.TIDAL_CLIENT_SECRET;
+});
+
+function mockFetchSequence(...responses: Array<{ ok: boolean; status?: number; body: unknown }>) {
+  let call = 0;
+  (fetch as ReturnType<typeof vi.fn>).mockImplementation(() => {
+    const r = responses[call++] ?? responses[responses.length - 1];
+    return Promise.resolve({
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 400),
+      json: () => Promise.resolve(r.body),
+      text: () => Promise.resolve(''),
+    });
+  });
+}
+
+const TOKEN_RESP = { ok: true, body: { access_token: 'tok123', expires_in: 3600 } };
+
+describe('searchTidal', () => {
+  it('returns [] when TIDAL_CLIENT_ID is missing', async () => {
+    delete process.env.TIDAL_CLIENT_ID;
+    const result = await searchTidal('some query');
+    expect(result).toEqual([]);
+    expect(fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when TIDAL_CLIENT_SECRET is missing', async () => {
+    delete process.env.TIDAL_CLIENT_SECRET;
+    const result = await searchTidal('some query');
+    expect(result).toEqual([]);
+    expect(fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when token request fails (non-ok)', async () => {
+    mockFetchSequence({ ok: false, status: 401, body: {} });
+    const result = await searchTidal('some query');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when search request fails (non-ok)', async () => {
+    mockFetchSequence(TOKEN_RESP, { ok: false, status: 500, body: {} });
+    const result = await searchTidal('some query');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when fetch throws an error', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'));
+    const result = await searchTidal('some query');
+    expect(result).toEqual([]);
+  });
+
+  it('maps data.tracks to TidalTrack array using mapTrack', async () => {
+    const rawTrack = {
+      id: 42,
+      title: 'Glory Box',
+      artists: [{ name: 'Portishead' }],
+      album: { title: 'Dummy', imageCover: [{ url: 'https://img.example.com/cover.jpg' }] },
+      duration: 310,
+    };
+    mockFetchSequence(TOKEN_RESP, { ok: true, body: { tracks: [rawTrack] } });
+
+    const result = await searchTidal('Glory Box');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: '42',
+      title: 'Glory Box',
+      artist: 'Portishead',
+      album: 'Dummy',
+      url: 'https://tidal.com/browse/track/42',
+    });
+  });
+
+  it('returns [] when data.tracks is absent', async () => {
+    mockFetchSequence(TOKEN_RESP, { ok: true, body: {} });
+    const result = await searchTidal('no tracks here');
+    expect(result).toEqual([]);
+  });
+
+  it('reuses token on second call (fetch called 3 times total for 2 searches)', async () => {
+    const track = {
+      id: 1,
+      title: 'Track One',
+      artists: [{ name: 'Artist One' }],
+      album: { title: 'Album One' },
+      duration: 200,
+    };
+    // Sequence: token fetch, first search, second search (no second token fetch)
+    mockFetchSequence(
+      TOKEN_RESP,
+      { ok: true, body: { tracks: [track] } },
+      { ok: true, body: { tracks: [track] } },
+    );
+
+    await searchTidal('first query');
+    await searchTidal('second query');
+
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
+  });
+});
+
+describe('getTidalTrack', () => {
+  it('returns null when credentials are missing', async () => {
+    delete process.env.TIDAL_CLIENT_ID;
+    const result = await getTidalTrack('123');
+    expect(result).toBeNull();
+    expect(fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('returns null when track request fails (non-ok)', async () => {
+    mockFetchSequence(TOKEN_RESP, { ok: false, status: 404, body: {} });
+    const result = await getTidalTrack('999');
+    expect(result).toBeNull();
+  });
+
+  it('returns correctly mapped TidalTrack with top-level fields', async () => {
+    const rawTrack = {
+      id: 77,
+      title: 'Sour Times',
+      artists: [{ name: 'Portishead' }],
+      album: { title: 'Dummy', imageCover: [{ url: 'https://img.example.com/sour.jpg' }] },
+      duration: 255,
+    };
+    mockFetchSequence(TOKEN_RESP, { ok: true, body: rawTrack });
+
+    const result = await getTidalTrack('77');
+
+    expect(result).toMatchObject({
+      id: '77',
+      title: 'Sour Times',
+      artist: 'Portishead',
+      album: 'Dummy',
+      artworkUrl: 'https://img.example.com/sour.jpg',
+      duration: 255,
+      url: 'https://tidal.com/browse/track/77',
+    });
+  });
+
+  it('falls back to raw.attributes fields when top-level fields are absent', async () => {
+    const rawTrack = {
+      data: { id: '55' },
+      attributes: {
+        title: 'Roads',
+        artists: [{ name: 'Portishead' }],
+        duration: 300,
+      },
+    };
+    mockFetchSequence(TOKEN_RESP, { ok: true, body: rawTrack });
+
+    const result = await getTidalTrack('55');
+
+    expect(result).toMatchObject({
+      id: '55',
+      title: 'Roads',
+      artist: 'Portishead',
+      duration: 300,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `tidal` (12): `searchTidal` — credentials guard (no fetch without creds), token-fetch failure → `[]`, search non-ok → `[]`, fetch-throw → `[]`, `data.tracks` mapping (id/title/artist/album/url), no-tracks-key → `[]`, token cache reuse (3 fetches for 2 calls, not 4). `getTidalTrack` — credentials guard, non-ok → null, top-level field mapping, `attributes` fallback. Used `vi.resetModules()` + dynamic import per test to isolate module-level `cachedToken`.
- `minimax` (12): no-key guard, `choices[0].message.content` happy path, `data.reply` fallback, missing-summary error, HTTP 500 error, `base_resp.status_code !== 0` error, `data.error.message` shape, fetch-throw recovery, `<think>…</think>` tag stripping, reasoning-only error, custom `MINIMAX_API_URL`, custom `MINIMAX_MODEL`.

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)