### PR TITLE
test(music+publish): Audius URL resolver + Bluesky publisher — 25 cases

### DIFF
--- a/src/lib/music/__tests__/audius.test.ts
+++ b/src/lib/music/__tests__/audius.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAudiusPlaylist,
+  getAudiusStreamUrl,
+  getAudiusTrack,
+  resolveAudiusUrl,
+  searchAudiusTracks,
+} from '../audius';
+
+vi.stubGlobal('fetch', vi.fn());
+
+// Always reference via the global so we pick up re-stubs in afterEach
+function getMockFetch() {
+  return fetch as ReturnType<typeof vi.fn>;
+}
+
+function mockRedirect(status: number, location: string) {
+  getMockFetch().mockResolvedValueOnce({
+    ok: false,
+    status,
+    headers: { get: (h: string) => (h === 'location' ? location : null) },
+  });
+}
+
+function mockJson(body: unknown) {
+  getMockFetch().mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockFail(status = 404) {
+  getMockFetch().mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // Re-establish the stub so subsequent tests can still use getMockFetch()
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+// ---------------------------------------------------------------------------
+// resolveAudiusUrl
+// ---------------------------------------------------------------------------
+
+describe('resolveAudiusUrl', () => {
+  it('returns { type: "track", data } when redirect location contains /tracks/', async () => {
+    const trackData = { id: 'track-id', title: 'Song' };
+    mockRedirect(302, 'https://discoveryprovider.audius.co/v1/tracks/track-id?app_name=ZAO-OS');
+    mockJson({ data: trackData });
+
+    const result = await resolveAudiusUrl('https://audius.co/artist/song');
+    expect(result).toEqual({ type: 'track', data: trackData });
+  });
+
+  it('returns { type: "playlist", data } when redirect location contains /playlists/', async () => {
+    const playlistData = { id: 'playlist-id', playlist_name: 'My Playlist', tracks: [] };
+    mockRedirect(
+      302,
+      'https://discoveryprovider.audius.co/v1/playlists/playlist-id?app_name=ZAO-OS',
+    );
+    // getAudiusPlaylist -> audiusFetch -> fetch
+    mockJson({ data: playlistData });
+
+    const result = await resolveAudiusUrl('https://audius.co/artist/playlist/my-playlist');
+    expect(result).toEqual({ type: 'playlist', data: playlistData });
+  });
+
+  it('returns { type: "user", data } when redirect location contains /users/', async () => {
+    const userData = { id: 'user-id', handle: 'artist', track_count: 5, name: 'Artist Name' };
+    mockRedirect(302, 'https://discoveryprovider.audius.co/v1/users/user-id?app_name=ZAO-OS');
+    // audiusFetch -> fetch
+    mockJson({ data: userData });
+
+    const result = await resolveAudiusUrl('https://audius.co/artist');
+    expect(result).toEqual({ type: 'user', data: userData });
+  });
+
+  it('returns null when 3xx response has no location header', async () => {
+    getMockFetch().mockResolvedValueOnce({
+      ok: false,
+      status: 302,
+      headers: { get: () => null },
+    });
+
+    const result = await resolveAudiusUrl('https://audius.co/artist/song');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when redirect target fetch returns non-ok', async () => {
+    mockRedirect(302, 'https://discoveryprovider.audius.co/v1/tracks/track-id');
+    mockFail(404);
+
+    const result = await resolveAudiusUrl('https://audius.co/artist/song');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fetch throws a network error', async () => {
+    getMockFetch().mockRejectedValueOnce(new Error('network'));
+
+    const result = await resolveAudiusUrl('https://audius.co/artist/song');
+    expect(result).toBeNull();
+  });
+
+  it('detects playlist type from direct response shape with playlist_name', async () => {
+    const playlistData = { id: 'pl-1', playlist_name: 'Direct Playlist' };
+    getMockFetch().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: playlistData }),
+    });
+
+    const result = await resolveAudiusUrl('https://audius.co/artist/playlist');
+    expect(result).toEqual({ type: 'playlist', data: playlistData });
+  });
+
+  it('detects user type from direct response shape with handle + track_count', async () => {
+    const userData = { id: 'u-1', handle: 'djcool', track_count: 10, name: 'DJ Cool' };
+    getMockFetch().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: userData }),
+    });
+
+    const result = await resolveAudiusUrl('https://audius.co/djcool');
+    expect(result).toEqual({ type: 'user', data: userData });
+  });
+
+  it('detects track type from direct response shape (no playlist_name, no handle+track_count)', async () => {
+    const trackData = { id: 't-1', title: 'Beat Drop' };
+    getMockFetch().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: trackData }),
+    });
+
+    const result = await resolveAudiusUrl('https://audius.co/djcool/beat-drop');
+    expect(result).toEqual({ type: 'track', data: trackData });
+  });
+
+  it('follows unknown redirect location and returns playlist when response has playlist_name', async () => {
+    const playlistData = { id: 'pl-unknown', playlist_name: 'Fallback Playlist', tracks: [] };
+    // Redirect to an unknown path (not /tracks/, /playlists/, or /users/)
+    mockRedirect(302, 'https://discoveryprovider.audius.co/v1/resolve?url=something');
+    // audiusFetch called for the fallback follow — returns { data: playlistData }
+    mockJson({ data: playlistData });
+
+    const result = await resolveAudiusUrl('https://audius.co/unknown');
+    expect(result).toEqual({ type: 'playlist', data: playlistData });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAudiusTracks
+// ---------------------------------------------------------------------------
+
+describe('searchAudiusTracks', () => {
+  it('returns tracks array on success', async () => {
+    const trackData = [{ id: 'abc', title: 'Found Track' }];
+    mockJson({ data: trackData });
+
+    const result = await searchAudiusTracks('found track');
+    expect(result).toEqual(trackData);
+  });
+
+  it('returns [] on network error', async () => {
+    getMockFetch().mockRejectedValueOnce(new Error('network'));
+
+    const result = await searchAudiusTracks('anything');
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAudiusStreamUrl
+// ---------------------------------------------------------------------------
+
+describe('getAudiusStreamUrl', () => {
+  it('returns URL containing /tracks/${trackId}/stream and app_name=ZAO-OS', () => {
+    const trackId = 'abc123';
+    const url = getAudiusStreamUrl(trackId);
+    expect(url).toContain(`/tracks/${trackId}/stream`);
+    expect(url).toContain('app_name=ZAO-OS');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAudiusTrack
+// ---------------------------------------------------------------------------
+
+describe('getAudiusTrack', () => {
+  it('returns null on non-ok response', async () => {
+    mockFail(404);
+
+    const result = await getAudiusTrack('nonexistent-id');
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAudiusPlaylist
+// ---------------------------------------------------------------------------
+
+describe('getAudiusPlaylist', () => {
+  it('extracts first element when API returns an array', async () => {
+    const playlist1 = { id: 'pl-1', playlist_name: 'First' };
+    const playlist2 = { id: 'pl-2', playlist_name: 'Second' };
+    mockJson({ data: [playlist1, playlist2] });
+
+    const result = await getAudiusPlaylist('pl-1');
+    expect(result).toEqual(playlist1);
+  });
+});

--- a/src/lib/publish/__tests__/bluesky.test.ts
+++ b/src/lib/publish/__tests__/bluesky.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before any import of the module under test
+// ---------------------------------------------------------------------------
+const mockAgent = vi.hoisted(() => ({
+  login: vi.fn().mockResolvedValue(undefined),
+  post: vi.fn().mockResolvedValue({ uri: 'at://did:plc:abc/app.bsky.feed.post/rkey123', cid: 'cid123' }),
+  uploadBlob: vi.fn().mockResolvedValue({ data: { blob: { ref: 'blob-ref' } } }),
+}));
+const MockAtpAgent = vi.hoisted(() => vi.fn(() => mockAgent));
+const mockDetectFacets = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const MockRichText = vi.hoisted(() => vi.fn(() => ({
+  detectFacets: mockDetectFacets,
+  text: 'mocked text',
+  facets: [],
+})));
+
+vi.mock('@atproto/api', () => ({
+  AtpAgent: MockAtpAgent,
+  RichText: MockRichText,
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic import handles — reset per test to bust the module-level agentCache
+// ---------------------------------------------------------------------------
+let isBlueskyConfigured: () => boolean;
+let publishToBluesky: (content: any) => Promise<any>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn());
+  process.env.BLUESKY_HANDLE = 'test.bsky.social';
+  process.env.BLUESKY_APP_PASSWORD = 'test-password';
+  const mod = await import('../bluesky');
+  isBlueskyConfigured = mod.isBlueskyConfigured;
+  publishToBluesky = mod.publishToBluesky;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.BLUESKY_HANDLE;
+  delete process.env.BLUESKY_APP_PASSWORD;
+});
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+function makeContent(overrides: Partial<{
+  text: string;
+  images: string[];
+  embeds: string[];
+  castHash: string;
+  castUrl: string;
+  attribution: string;
+}> = {}) {
+  return {
+    text: 'Hello world',
+    images: [],
+    embeds: [],
+    castHash: '0xabc',
+    castUrl: 'https://warpcast.com/~/123',
+    attribution: 'via ZAO OS',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isBlueskyConfigured (3 tests)
+// ---------------------------------------------------------------------------
+describe('isBlueskyConfigured', () => {
+  it('returns true when both BLUESKY_HANDLE and BLUESKY_APP_PASSWORD are set', () => {
+    expect(isBlueskyConfigured()).toBe(true);
+  });
+
+  it('returns false when BLUESKY_HANDLE is missing', () => {
+    delete process.env.BLUESKY_HANDLE;
+    expect(isBlueskyConfigured()).toBe(false);
+  });
+
+  it('returns false when BLUESKY_APP_PASSWORD is missing', () => {
+    delete process.env.BLUESKY_APP_PASSWORD;
+    expect(isBlueskyConfigured()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publishToBluesky (7 tests)
+// ---------------------------------------------------------------------------
+describe('publishToBluesky', () => {
+  it('calls agent.login with BLUESKY_HANDLE and BLUESKY_APP_PASSWORD', async () => {
+    await publishToBluesky(makeContent());
+    expect(mockAgent.login).toHaveBeenCalledWith({
+      identifier: 'test.bsky.social',
+      password: 'test-password',
+    });
+  });
+
+  it('returns { uri, cid, postUrl } with postUrl containing handle and rkey from uri', async () => {
+    const result = await publishToBluesky(makeContent());
+    expect(result.uri).toBe('at://did:plc:abc/app.bsky.feed.post/rkey123');
+    expect(result.cid).toBe('cid123');
+    expect(result.postUrl).toBe('https://bsky.app/profile/test.bsky.social/post/rkey123');
+  });
+
+  it('fetches image URL, calls uploadBlob, and includes images embed when content.images is non-empty', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      headers: { get: (h: string) => h === 'content-type' ? 'image/jpeg' : null },
+    });
+
+    const result = await publishToBluesky(makeContent({ images: ['https://example.com/img.jpg'] }));
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com/img.jpg', expect.objectContaining({ signal: expect.anything() }));
+    expect(mockAgent.uploadBlob).toHaveBeenCalledTimes(1);
+
+    const postCall = mockAgent.post.mock.calls[0][0];
+    expect(postCall.embed).toMatchObject({ $type: 'app.bsky.embed.images' });
+    expect(postCall.embed.images).toHaveLength(1);
+    void result;
+  });
+
+  it('skips an image and does not call uploadBlob when image fetch returns non-ok', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: false,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      headers: { get: () => null },
+    });
+
+    await publishToBluesky(makeContent({ images: ['https://example.com/bad.jpg'] }));
+
+    expect(mockAgent.uploadBlob).not.toHaveBeenCalled();
+    const postCall = mockAgent.post.mock.calls[0][0];
+    expect(postCall.embed).toBeUndefined();
+  });
+
+  it('uses external embed with first embed URL when no images but content.embeds is non-empty', async () => {
+    await publishToBluesky(makeContent({ embeds: ['https://example.com/link'] }));
+
+    const postCall = mockAgent.post.mock.calls[0][0];
+    expect(postCall.embed).toMatchObject({
+      $type: 'app.bsky.embed.external',
+      external: { uri: 'https://example.com/link', title: '', description: '' },
+    });
+  });
+
+  it('passes no embed to agent.post when neither images nor embeds are present', async () => {
+    await publishToBluesky(makeContent());
+
+    const postCall = mockAgent.post.mock.calls[0][0];
+    expect(postCall.embed).toBeUndefined();
+  });
+
+  it('slices images to max 4 even when 5 are provided', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      headers: { get: (h: string) => h === 'content-type' ? 'image/jpeg' : null },
+    });
+
+    const fiveImages = [
+      'https://example.com/img1.jpg',
+      'https://example.com/img2.jpg',
+      'https://example.com/img3.jpg',
+      'https://example.com/img4.jpg',
+      'https://example.com/img5.jpg',
+    ];
+
+    await publishToBluesky(makeContent({ images: fiveImages }));
+
+    expect(mockAgent.uploadBlob).toHaveBeenCalledTimes(4);
+    const postCall = mockAgent.post.mock.calls[0][0];
+    expect(postCall.embed.images).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary
- `audius` (15): `resolveAudiusUrl` — redirect type detection (`/tracks/`, `/playlists/`, `/users/`), no-location null, redirect target failure null, fetch-throw null, direct response shape detection (`playlist_name` → playlist, `handle+track_count` → user, else → track), fallback redirect with shape detection. `searchAudiusTracks` — success array, error/network → `[]`. `getAudiusStreamUrl` — URL contains `/stream` and `app_name=ZAO-OS`. `getAudiusTrack` — non-ok → null. `getAudiusPlaylist` — array response extracts first element.
- `bluesky` (10): `isBlueskyConfigured` — env var presence. `publishToBluesky` — `agent.login` credentials, `uri/cid/postUrl` return (with rkey extraction), image fetch+upload+embed, skip failed image, external embed fallback, no embed when empty, max-4 image slice. Uses `vi.resetModules()` + dynamic import to isolate module-level `agentCache`.

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)