### PR TITLE
test(music): arweave buildMusicTags + isArweaveConfigured — 17 cases

### DIFF
--- a/src/lib/music/__tests__/arweave.test.ts
+++ b/src/lib/music/__tests__/arweave.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// @ardrive/turbo-sdk has a broken bs58 subpath in its ESM build — mock it so
+// the module can load without requiring the broken transitive dep.
+vi.mock('@ardrive/turbo-sdk', () => ({
+  TurboFactory: { authenticated: vi.fn() },
+}));
+
+import { buildMusicTags, isArweaveConfigured, LICENSE_PRESETS } from '../arweave';
+
+// ---------------------------------------------------------------------------
+// isArweaveConfigured
+// ---------------------------------------------------------------------------
+
+describe('isArweaveConfigured', () => {
+  beforeEach(() => { delete process.env.ARWEAVE_WALLET_KEY; });
+  afterEach(() => { delete process.env.ARWEAVE_WALLET_KEY; });
+
+  it('returns false when ARWEAVE_WALLET_KEY is not set', () => {
+    expect(isArweaveConfigured()).toBe(false);
+  });
+
+  it('returns true when ARWEAVE_WALLET_KEY is set', () => {
+    process.env.ARWEAVE_WALLET_KEY = '{"kty":"RSA"}';
+    expect(isArweaveConfigured()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildMusicTags — required fields
+// ---------------------------------------------------------------------------
+
+describe('buildMusicTags required fields', () => {
+  it('includes App-Name: ZAO-OS', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'App-Name', value: 'ZAO-OS' });
+  });
+
+  it('includes App-Version: 1.0.0', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'App-Version', value: '1.0.0' });
+  });
+
+  it('includes Type: music-track', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'Type', value: 'music-track' });
+  });
+
+  it('includes Title and Artist from opts', () => {
+    const tags = buildMusicTags({ title: 'My Track', artist: 'ZAO Band', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'Title', value: 'My Track' });
+    expect(tags).toContainEqual({ name: 'Artist', value: 'ZAO Band' });
+  });
+
+  it('includes License UDL tx ID', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    const licenseTag = tags.find((t) => t.name === 'License');
+    expect(licenseTag?.value).toMatch(/^[a-zA-Z0-9_-]{43}$/); // Arweave tx ID format
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildMusicTags — optional fields
+// ---------------------------------------------------------------------------
+
+describe('buildMusicTags optional fields', () => {
+  it('includes Genre when provided', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', genre: 'Hip-Hop', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'Genre', value: 'Hip-Hop' });
+  });
+
+  it('omits Genre when not provided', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    expect(tags.every((t) => t.name !== 'Genre')).toBe(true);
+  });
+
+  it('includes Description when provided', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', description: 'A great song', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'Description', value: 'A great song' });
+  });
+
+  it('includes Thumbnail (coverTxId) when provided', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', coverTxId: 'arweave-tx-abc', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'Thumbnail', value: 'arweave-tx-abc' });
+  });
+
+  it('omits Thumbnail when coverTxId not provided', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    expect(tags.every((t) => t.name !== 'Thumbnail')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildMusicTags — license presets
+// ---------------------------------------------------------------------------
+
+describe('buildMusicTags license presets', () => {
+  it('open preset: Commercial-Use=Allowed, Derivation=Allowed', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'open' });
+    expect(tags).toContainEqual({ name: 'Commercial-Use', value: 'Allowed' });
+    expect(tags).toContainEqual({ name: 'Derivation', value: 'Allowed' });
+  });
+
+  it('community preset: Commercial-Use=Allowed-With-Credit', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'community' });
+    expect(tags).toContainEqual({ name: 'Commercial-Use', value: 'Allowed-With-Credit' });
+    expect(tags).toContainEqual({ name: 'Derivation', value: 'Allowed-With-Credit' });
+  });
+
+  it('collectible preset: Derivation=Allowed-With-RevenueShare-25%', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'collectible' });
+    expect(tags).toContainEqual({ name: 'Derivation', value: 'Allowed-With-RevenueShare-25%' });
+  });
+
+  it('premium preset: Commercial-Use=Disallowed, has Access-Fee', () => {
+    const tags = buildMusicTags({ title: 'Song', artist: 'Artist', licensePreset: 'premium' });
+    expect(tags).toContainEqual({ name: 'Commercial-Use', value: 'Disallowed' });
+    expect(tags).toContainEqual({ name: 'Access-Fee', value: 'One-Time-0.001' });
+  });
+
+  it('LICENSE_PRESETS export has all 4 keys', () => {
+    expect(Object.keys(LICENSE_PRESETS)).toEqual(
+      expect.arrayContaining(['community', 'collectible', 'premium', 'open']),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Tests pure exports from `src/lib/music/arweave.ts` — skips `uploadToArweave` which requires the Turbo SDK (broken `bs58` ESM subpath). Mocks `@ardrive/turbo-sdk` so the module loads cleanly.

- `isArweaveConfigured` (2): false without env var, true when set
- `buildMusicTags` required fields (5): `App-Name`, `App-Version`, `Type`, `Title`+`Artist`, `License` UDL tx ID (43-char Arweave format)
- Optional fields (5): `Genre` present/absent, `Description`, `Thumbnail` (coverTxId) present/absent
- License presets (5): `open` (Allowed), `community` (Allowed-With-Credit), `collectible` (RevenueShare-25%), `premium` (Disallowed + Access-Fee), `LICENSE_PRESETS` has all 4 keys

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)