### PR TITLE
test(publish): Telegram + Threads publishers — 28 cases

### DIFF
--- a/src/lib/publish/__tests__/telegram.test.ts
+++ b/src/lib/publish/__tests__/telegram.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { escapeMarkdownV2, publishToTelegram } from '../telegram';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(ok: boolean, data: unknown) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: ok as any,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function getBody(): Record<string, unknown> {
+  const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+  return JSON.parse(opts.body as string);
+}
+
+function getUrl(): string {
+  return (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+  process.env.TELEGRAM_BOT_TOKEN = 'test-token';
+  process.env.TELEGRAM_CHAT_ID = '-1001234';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_CHAT_ID;
+});
+
+// ---------------------------------------------------------------------------
+// escapeMarkdownV2
+// ---------------------------------------------------------------------------
+
+describe('escapeMarkdownV2', () => {
+  it('escapes underscore', () => {
+    expect(escapeMarkdownV2('hello_world')).toBe('hello\\_world');
+  });
+
+  it('escapes asterisk', () => {
+    expect(escapeMarkdownV2('*bold*')).toBe('\\*bold\\*');
+  });
+
+  it('escapes period', () => {
+    expect(escapeMarkdownV2('v1.0.0')).toBe('v1\\.0\\.0');
+  });
+
+  it('leaves plain alphanumeric text unchanged', () => {
+    expect(escapeMarkdownV2('HelloWorld123')).toBe('HelloWorld123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publishToTelegram
+// ---------------------------------------------------------------------------
+
+describe('publishToTelegram', () => {
+  it('returns not-configured error when TELEGRAM_BOT_TOKEN is missing', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    const result = await publishToTelegram({ text: 'hello' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Telegram not configured/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns not-configured error when TELEGRAM_CHAT_ID is missing', async () => {
+    delete process.env.TELEGRAM_CHAT_ID;
+    const result = await publishToTelegram({ text: 'hello' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Telegram not configured/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses content.chatId override instead of env var', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 1 } });
+    await publishToTelegram({ text: 'hi', chatId: '-9999999' });
+    const body = getBody();
+    expect(body.chat_id).toBe('-9999999');
+  });
+
+  it('text-only: calls sendMessage endpoint', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 1 } });
+    await publishToTelegram({ text: 'hello' });
+    expect(getUrl()).toContain('/sendMessage');
+  });
+
+  it('with imageUrl: calls sendPhoto endpoint', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 2 } });
+    await publishToTelegram({ text: 'caption', imageUrl: 'https://example.com/img.png' });
+    expect(getUrl()).toContain('/sendPhoto');
+  });
+
+  it('truncates caption to 1024 chars for sendPhoto', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 3 } });
+    const longText = 'word '.repeat(300); // 1500 chars
+    await publishToTelegram({ text: longText, imageUrl: 'https://example.com/img.png' });
+    const body = getBody();
+    expect((body.caption as string).length).toBeLessThanOrEqual(1027); // 1024 + '...'
+    expect((body.caption as string).endsWith('...')).toBe(true);
+  });
+
+  it('does not truncate text under 4096 chars for sendMessage', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 4 } });
+    const shortText = 'hello world';
+    await publishToTelegram({ text: shortText });
+    const body = getBody();
+    expect(body.text).toBe(shortText);
+  });
+
+  it('returns { success: true, messageId: 42 } on success', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 42 } });
+    const result = await publishToTelegram({ text: 'hi' });
+    expect(result).toEqual({ success: true, messageId: 42 });
+  });
+
+  it('returns API error description when ok: false', async () => {
+    mockFetch(true, { ok: false, description: 'Bad Request' });
+    const result = await publishToTelegram({ text: 'hi' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Telegram API error: Bad Request');
+  });
+
+  it('returns error.message when fetch throws', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'));
+    const result = await publishToTelegram({ text: 'hi' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('network error');
+  });
+
+  it('sends parse_mode HTML when content.parseMode is HTML', async () => {
+    mockFetch(true, { ok: true, result: { message_id: 5 } });
+    await publishToTelegram({ text: 'hi', parseMode: 'HTML' });
+    const body = getBody();
+    expect(body.parse_mode).toBe('HTML');
+  });
+});

--- a/src/lib/publish/__tests__/threads.test.ts
+++ b/src/lib/publish/__tests__/threads.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoist mock env before module imports
+// ---------------------------------------------------------------------------
+
+const mockEnv = vi.hoisted(() => ({
+  THREADS_ACCESS_TOKEN: 'token123' as string | undefined,
+  THREADS_USER_ID: 'user456' as string | undefined,
+}));
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+import { isThreadsConfigured, publishToThreads, refreshThreadsToken } from '../threads';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContent(
+  overrides: Partial<{ text: string; images: string[]; embeds: string[] }> = {},
+) {
+  return {
+    text: 'Hello Threads',
+    images: [],
+    embeds: [],
+    castHash: '0xabc',
+    castUrl: 'https://warpcast.com/~/123',
+    attribution: 'via ZAO OS',
+    ...overrides,
+  };
+}
+
+function mockTwoStepFetch(containerId = 'container-123', postId = 'post-456') {
+  (fetch as ReturnType<typeof vi.fn>)
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: containerId }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: postId }),
+    });
+}
+
+function getCallUrl(callIndex: number): string {
+  const calls = (fetch as ReturnType<typeof vi.fn>).mock.calls;
+  return calls[callIndex][0] as string;
+}
+
+function getCallBody(callIndex: number): URLSearchParams {
+  const calls = (fetch as ReturnType<typeof vi.fn>).mock.calls;
+  return calls[callIndex][1].body as URLSearchParams;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+  mockEnv.THREADS_ACCESS_TOKEN = 'token123';
+  mockEnv.THREADS_USER_ID = 'user456';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// isThreadsConfigured
+// ---------------------------------------------------------------------------
+
+describe('isThreadsConfigured', () => {
+  it('returns true when both token and userId are set', () => {
+    mockEnv.THREADS_ACCESS_TOKEN = 'token123';
+    mockEnv.THREADS_USER_ID = 'user456';
+    expect(isThreadsConfigured()).toBe(true);
+  });
+
+  it('returns false when either token or userId is missing', () => {
+    mockEnv.THREADS_ACCESS_TOKEN = undefined;
+    mockEnv.THREADS_USER_ID = 'user456';
+    expect(isThreadsConfigured()).toBe(false);
+
+    mockEnv.THREADS_ACCESS_TOKEN = 'token123';
+    mockEnv.THREADS_USER_ID = undefined;
+    expect(isThreadsConfigured()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publishToThreads
+// ---------------------------------------------------------------------------
+
+describe('publishToThreads', () => {
+  it('throws "Threads not configured" when token is missing', async () => {
+    mockEnv.THREADS_ACCESS_TOKEN = undefined;
+    await expect(publishToThreads(makeContent())).rejects.toThrow('Threads not configured');
+  });
+
+  it('throws "Threads not configured" when userId is missing', async () => {
+    mockEnv.THREADS_USER_ID = undefined;
+    await expect(publishToThreads(makeContent())).rejects.toThrow('Threads not configured');
+  });
+
+  it('Step 1: POSTs to /{THREADS_USER_ID}/threads endpoint', async () => {
+    mockTwoStepFetch();
+    await publishToThreads(makeContent());
+    const url = getCallUrl(0);
+    expect(url).toContain('/user456/threads');
+  });
+
+  it('text-only post: sends media_type=TEXT in container params', async () => {
+    mockTwoStepFetch();
+    await publishToThreads(makeContent({ images: [] }));
+    const body = getCallBody(0);
+    expect(body.get('media_type')).toBe('TEXT');
+    expect(body.get('image_url')).toBeNull();
+  });
+
+  it('image post: sends media_type=IMAGE and image_url in container params', async () => {
+    mockTwoStepFetch();
+    const imageUrl = 'https://example.com/photo.jpg';
+    await publishToThreads(makeContent({ images: [imageUrl] }));
+    const body = getCallBody(0);
+    expect(body.get('media_type')).toBe('IMAGE');
+    expect(body.get('image_url')).toBe(imageUrl);
+  });
+
+  it('Step 2: POSTs to /{THREADS_USER_ID}/threads_publish with creation_id=container-123', async () => {
+    mockTwoStepFetch('container-123', 'post-456');
+    await publishToThreads(makeContent());
+    const url = getCallUrl(1);
+    expect(url).toContain('/user456/threads_publish');
+    const body = getCallBody(1);
+    expect(body.get('creation_id')).toBe('container-123');
+  });
+
+  it('returns { postId, postUrl } with correct values', async () => {
+    mockTwoStepFetch('container-123', 'post-456');
+    const result = await publishToThreads(makeContent());
+    expect(result.postId).toBe('post-456');
+    expect(result.postUrl).toBe('https://www.threads.net/@thezao/post/post-456');
+  });
+
+  it('throws with error message when container creation fails', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: { message: 'Invalid token' } }),
+    });
+    await expect(publishToThreads(makeContent())).rejects.toThrow('Invalid token');
+  });
+
+  it('throws when publish step returns non-ok response', async () => {
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'container-123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: { message: 'Server error' } }),
+      });
+    await expect(publishToThreads(makeContent())).rejects.toThrow('Threads publish failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshThreadsToken
+// ---------------------------------------------------------------------------
+
+describe('refreshThreadsToken', () => {
+  it('returns data.access_token from the refresh response', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ access_token: 'new-token-xyz', expires_in: 5183944 }),
+    });
+    const token = await refreshThreadsToken();
+    expect(token).toBe('new-token-xyz');
+  });
+
+  it('throws "Threads token refresh failed" on non-ok response', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ error: { message: 'Expired token' } }),
+    });
+    await expect(refreshThreadsToken()).rejects.toThrow('Threads token refresh failed');
+  });
+});


### PR DESCRIPTION
## Summary
- `telegram` (15): `escapeMarkdownV2` — `_`, `*`, `.` escaping, plain text passthrough. `publishToTelegram` — missing-token/chatId guards, `chatId` override, `sendMessage` vs `sendPhoto` routing, 1024-char caption vs 4096-char text truncation, success+messageId, `ok:false` error, fetch-throw error, `parse_mode: 'HTML'` forwarding.
- `threads` (13): `isThreadsConfigured` — both set/either missing. `publishToThreads` — missing-token/userId throws, container POST endpoint, `TEXT` media_type, `IMAGE`+image_url, publish POST with `creation_id`, postUrl format, container/publish failure throws. `refreshThreadsToken` — `access_token` returned, non-ok throws.

**Test-only PR — auto-merge eligible.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)