### PR TITLE
test(publish): hive AES-GCM crypto + broadcast allSettled (23 cases)

### DIFF
--- a/src/lib/publish/__tests__/broadcast.test.ts
+++ b/src/lib/publish/__tests__/broadcast.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPublishToTelegram = vi.hoisted(() => vi.fn());
+const mockPublishToDiscord = vi.hoisted(() => vi.fn());
+const mockBuildZaoEmbed = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/publish/telegram', () => ({ publishToTelegram: mockPublishToTelegram }));
+vi.mock('@/lib/publish/discord', () => ({
+  publishToDiscord: mockPublishToDiscord,
+  buildZaoEmbed: mockBuildZaoEmbed,
+}));
+
+import { broadcastToChannels } from '../broadcast';
+
+const TELEGRAM_TOKEN = 'tg-token-abc';
+const DISCORD_URL = 'https://discord.com/api/webhooks/123/abc';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBuildZaoEmbed.mockReturnValue({ title: 'embed', description: '' });
+  // Default: both configured. Tests that need a missing var explicitly delete it.
+  process.env.TELEGRAM_BOT_TOKEN = TELEGRAM_TOKEN;
+  process.env.DISCORD_WEBHOOK_URL = DISCORD_URL;
+});
+
+afterEach(() => {
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.DISCORD_WEBHOOK_URL;
+});
+
+// ---------------------------------------------------------------------------
+// Platform guards
+// ---------------------------------------------------------------------------
+
+describe('platform guards', () => {
+  it('skips Telegram when TELEGRAM_BOT_TOKEN is not set', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    const result = await broadcastToChannels({ text: 'hi' });
+    expect(mockPublishToTelegram).not.toHaveBeenCalled();
+    expect(result.telegram).toEqual({ success: false, error: 'Telegram not configured' });
+  });
+
+  it('skips Discord when DISCORD_WEBHOOK_URL is not set', async () => {
+    delete process.env.DISCORD_WEBHOOK_URL;
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    const result = await broadcastToChannels({ text: 'hi' });
+    expect(mockPublishToDiscord).not.toHaveBeenCalled();
+    expect(result.discord).toEqual({ success: false, error: 'Discord not configured' });
+  });
+
+  it('skips both when neither env var is set', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.DISCORD_WEBHOOK_URL;
+    const result = await broadcastToChannels({ text: 'hi' });
+    expect(mockPublishToTelegram).not.toHaveBeenCalled();
+    expect(mockPublishToDiscord).not.toHaveBeenCalled();
+    expect(result.telegram.success).toBe(false);
+    expect(result.discord.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Both succeed
+// ---------------------------------------------------------------------------
+
+describe('both platforms succeed', () => {
+  it('returns success: true for both', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    const result = await broadcastToChannels({ text: 'test message' });
+    expect(result.telegram).toEqual({ success: true, error: undefined });
+    expect(result.discord).toEqual({ success: true, error: undefined });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Promise.allSettled isolation
+// ---------------------------------------------------------------------------
+
+describe('promise.allSettled isolation', () => {
+  it('Telegram rejection does not prevent Discord success', async () => {
+    mockPublishToTelegram.mockRejectedValue(new Error('tg network error'));
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    const result = await broadcastToChannels({ text: 'hi' });
+    expect(result.telegram).toEqual({ success: false, error: 'tg network error' });
+    expect(result.discord).toEqual({ success: true, error: undefined });
+  });
+
+  it('Discord rejection does not prevent Telegram success', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockRejectedValue(new Error('discord 503'));
+    const result = await broadcastToChannels({ text: 'hi' });
+    expect(result.telegram).toEqual({ success: true, error: undefined });
+    expect(result.discord).toEqual({ success: false, error: 'discord 503' });
+  });
+
+  it('forwards error string from platform failure result', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: false, error: 'rate limited' });
+    mockPublishToDiscord.mockResolvedValue({ success: false, error: 'webhook gone' });
+    const result = await broadcastToChannels({ text: 'hi' });
+    expect(result.telegram.error).toBe('rate limited');
+    expect(result.discord.error).toBe('webhook gone');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// castHash link appended
+// ---------------------------------------------------------------------------
+
+describe('castHash link appending', () => {
+  it('appends Farcaster link to Telegram text when castHash is present', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    await broadcastToChannels({ text: 'New post', castHash: 'abc123' });
+    const telegramCall = mockPublishToTelegram.mock.calls[0][0];
+    expect(telegramCall.text).toContain('warpcast.com/~/conversations/abc123');
+  });
+
+  it('appends default ZAO OS link when no castHash', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    await broadcastToChannels({ text: 'New post' });
+    const telegramCall = mockPublishToTelegram.mock.calls[0][0];
+    expect(telegramCall.text).toContain('zaoos.com');
+    expect(telegramCall.text).not.toContain('warpcast');
+  });
+
+  it('uses options.url instead of default zaoos.com', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    await broadcastToChannels({ text: 'hi', url: 'https://custom.site' });
+    const telegramCall = mockPublishToTelegram.mock.calls[0][0];
+    expect(telegramCall.text).toContain('custom.site');
+    expect(telegramCall.text).not.toContain('zaoos.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Discord embed vs plain text routing
+// ---------------------------------------------------------------------------
+
+describe('discord embed vs plain text', () => {
+  it('sends embed when title is provided', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    await broadcastToChannels({ text: 'body', title: 'My Title' });
+    const discordCall = mockPublishToDiscord.mock.calls[0][0];
+    expect(discordCall.text).toBe('');
+    expect(discordCall.embeds).toBeDefined();
+    expect(discordCall.embeds!.length).toBe(1);
+    expect(mockBuildZaoEmbed).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'My Title', description: expect.stringContaining('body') }),
+    );
+  });
+
+  it('sends plain text when no title is provided', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    await broadcastToChannels({ text: 'just text' });
+    const discordCall = mockPublishToDiscord.mock.calls[0][0];
+    expect(discordCall.embeds).toBeUndefined();
+    expect(discordCall.text).toBe('just text');
+  });
+});

--- a/src/lib/publish/__tests__/hive.test.ts
+++ b/src/lib/publish/__tests__/hive.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@hiveio/dhive', () => ({
+  Client: vi.fn().mockImplementation(() => ({ broadcast: { comment: vi.fn() } })),
+  PrivateKey: { fromString: vi.fn((s: string) => s) },
+}));
+
+import { decryptPostingKey, encryptPostingKey, getHiveClient } from '../hive';
+
+const SECRET = 'test-session-secret-32-bytes!!';
+
+beforeEach(() => {
+  process.env.SESSION_SECRET = SECRET;
+});
+
+afterEach(() => {
+  delete process.env.SESSION_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// encryptPostingKey
+// ---------------------------------------------------------------------------
+
+describe('encryptPostingKey', () => {
+  it('returns a string with exactly 3 colon-separated segments', () => {
+    const result = encryptPostingKey('5KhivePk...');
+    expect(result.split(':').length).toBe(3);
+  });
+
+  it('throws when SESSION_SECRET is not set', () => {
+    delete process.env.SESSION_SECRET;
+    expect(() => encryptPostingKey('key')).toThrow('SESSION_SECRET is not set');
+  });
+
+  it('produces a different ciphertext on every call (random IV)', () => {
+    const a = encryptPostingKey('same-key');
+    const b = encryptPostingKey('same-key');
+    expect(a).not.toBe(b);
+  });
+
+  it('all three segments are non-empty base64 strings', () => {
+    const [iv, authTag, ciphertext] = encryptPostingKey('key123').split(':');
+    const b64 = /^[A-Za-z0-9+/=]+$/;
+    expect(iv).toMatch(b64);
+    expect(authTag).toMatch(b64);
+    expect(ciphertext).toMatch(b64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decryptPostingKey
+// ---------------------------------------------------------------------------
+
+describe('decryptPostingKey', () => {
+  it('round-trips a posting key', () => {
+    const original = '5KhivePkExampleWIFKey';
+    const encrypted = encryptPostingKey(original);
+    expect(decryptPostingKey(encrypted)).toBe(original);
+  });
+
+  it('round-trips an empty string', () => {
+    const encrypted = encryptPostingKey('');
+    expect(decryptPostingKey(encrypted)).toBe('');
+  });
+
+  it('throws when SESSION_SECRET is not set', () => {
+    const encrypted = encryptPostingKey('key');
+    delete process.env.SESSION_SECRET;
+    expect(() => decryptPostingKey(encrypted)).toThrow('SESSION_SECRET is not set');
+  });
+
+  it('throws on invalid format — too few segments', () => {
+    expect(() => decryptPostingKey('onlytwoparts:xyz')).toThrow('Invalid encrypted key format');
+  });
+
+  it('throws on invalid format — too many segments', () => {
+    expect(() => decryptPostingKey('a:b:c:d')).toThrow('Invalid encrypted key format');
+  });
+
+  it('throws when decrypting with a different SESSION_SECRET (auth tag mismatch)', () => {
+    const encrypted = encryptPostingKey('5Khive');
+    process.env.SESSION_SECRET = 'a-completely-different-secret!';
+    expect(() => decryptPostingKey(encrypted)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHiveClient
+// ---------------------------------------------------------------------------
+
+describe('getHiveClient', () => {
+  it('returns a Client instance', async () => {
+    const { Client } = await import('@hiveio/dhive');
+    const client = getHiveClient();
+    expect(Client).toHaveBeenCalled();
+    expect(client).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What
23 new test cases across two previously-untested publish modules.

**`hive.test.ts` (11 cases)** — AES-256-GCM crypto functions:
- `encryptPostingKey`: 3-segment base64 output, random IV uniqueness, SESSION_SECRET guard
- `decryptPostingKey`: round-trip (key + empty string), bad-format throws (2 shapes), wrong-secret auth-tag mismatch
- `getHiveClient`: Client instantiation

**`broadcast.test.ts` (12 cases)** — broadcastToChannels orchestration:
- Platform guards: skip Telegram, skip Discord, skip both
- `Promise.allSettled` isolation: each platform failure is independent, error string forwarded
- `castHash` → Farcaster link appended; `options.url` overrides default zaoos.com
- Discord embed-vs-plain-text routing based on title presence

## Notes
- `@hiveio/dhive` mocked — avoids blockchain network calls at test time
- `publishToTelegram` / `publishToDiscord` / `buildZaoEmbed` all mocked via `vi.hoisted()`
- Caught `setTelegram(undefined)` default-parameter gotcha: JS default args activate on explicit `undefined`, so `delete process.env.X` is used directly instead

## Test run
```
✓ hive.test.ts    11/11 passed
✓ broadcast.test.ts 12/12 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)