### PR TITLE
test(publish+push+spaces): x splitIntoThread, vapid push, juke webhook HMAC (51 cases)

### DIFF
--- a/src/lib/publish/__tests__/x.test.ts
+++ b/src/lib/publish/__tests__/x.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that touch the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('twitter-api-v2', () => ({
+  TwitterApi: vi.fn().mockImplementation(() => ({})),
+}));
+
+// vi.hoisted ensures mockENV is created before the module factory below runs.
+const mockENV = vi.hoisted(() => ({
+  X_API_KEY: '',
+  X_API_SECRET: '',
+  X_ACCESS_TOKEN: '',
+  X_ACCESS_SECRET: '',
+}));
+
+vi.mock('@/lib/env', () => ({ ENV: mockENV }));
+
+// ---------------------------------------------------------------------------
+// Subject under test
+// ---------------------------------------------------------------------------
+
+import { splitIntoThread, getXClient } from '@/lib/publish/x';
+
+// ---------------------------------------------------------------------------
+// Constants (mirror the module)
+// ---------------------------------------------------------------------------
+
+const CAST_URL = 'https://warpcast.com/thezao/0xdeadbeef'; // 23 chars when t.co-ified
+const FIRST_MAX = 256; // 280 - 23 - 1
+
+// ---------------------------------------------------------------------------
+// splitIntoThread
+// ---------------------------------------------------------------------------
+
+describe('splitIntoThread', () => {
+  // 1. Short text (well under 256 chars) — single element with castUrl appended
+  it('returns single-element array when text fits within 256 chars', () => {
+    const text = 'Hello, world!';
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(`${text} ${CAST_URL}`);
+  });
+
+  // 2. Text exactly 256 chars — still fits, returns single element
+  it('returns single-element array when text is exactly 256 chars (borderline)', () => {
+    const text = 'a'.repeat(FIRST_MAX);
+    expect(text.length).toBe(256);
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(`${text} ${CAST_URL}`);
+  });
+
+  // 3. Text 257 chars (one over limit) — splits into two chunks
+  it('produces two chunks when text is 257 chars (one over first-chunk limit)', () => {
+    const text = 'a'.repeat(FIRST_MAX + 1); // no spaces → hard cut at 256
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(2);
+    // First chunk: first 256 chars + ' ' + castUrl
+    expect(result[0]).toBe(`${'a'.repeat(256)} ${CAST_URL}`);
+    // Second chunk: remainder
+    expect(result[1]).toBe('a');
+  });
+
+  // 4. castUrl always appended to first chunk only
+  it('appends castUrl to the first chunk only (never to subsequent chunks)', () => {
+    const text = 'word '.repeat(100).trim(); // >256 chars, multiple words
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result[0]).toContain(CAST_URL);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).not.toContain(CAST_URL);
+    }
+  });
+
+  // 5. Word-boundary break: last space before 256 is used
+  it('breaks at the last word boundary before 256 chars', () => {
+    // Build text: 250 'a' chars, a space, then more chars to push over 256
+    const prefix = 'a'.repeat(250);
+    const suffix = 'b'.repeat(20);
+    const text = `${prefix} ${suffix}`; // space at index 250, total 271 chars
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(2);
+    // First chunk should break at the space (index 250), not at 256
+    expect(result[0]).toBe(`${prefix} ${CAST_URL}`);
+    expect(result[1]).toBe(suffix);
+  });
+
+  // 6. No-space text longer than 256 — hard cut at 256
+  it('hard-cuts at 256 when there are no spaces in a long text', () => {
+    const text = 'z'.repeat(300);
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(`${'z'.repeat(256)} ${CAST_URL}`);
+    expect(result[1]).toBe('z'.repeat(44));
+  });
+
+  // 7. Three-chunk scenario: text long enough to need 3 tweets
+  it('produces three chunks for text spanning 3 tweets', () => {
+    // ~700 chars with spaces to force 3 splits
+    const segment = 'word '.repeat(56).trim(); // 56*5-1 = 279 chars each, no natural break at 256
+    const text = `${segment} ${segment} ${segment}`; // well over 256+280+280
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result.length).toBeGreaterThanOrEqual(3);
+    // First chunk always ends with castUrl
+    expect(result[0].endsWith(CAST_URL)).toBe(true);
+    // First chunk text portion (before " <castUrl>") must be ≤ FIRST_MAX (256)
+    const firstTextPart = result[0].slice(0, result[0].length - 1 - CAST_URL.length);
+    expect(firstTextPart.length).toBeLessThanOrEqual(FIRST_MAX);
+    // Subsequent chunks are standalone ≤ 280 chars each
+    result.slice(1).forEach((chunk) => {
+      expect(chunk.length).toBeLessThanOrEqual(280);
+    });
+  });
+
+  // 8. Subsequent chunks are standalone (no trailing castUrl, no leading noise)
+  it('subsequent chunks contain only text content with no trailing castUrl', () => {
+    const text = 'hello '.repeat(60).trim(); // forces multiple chunks
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result.length).toBeGreaterThan(1);
+    result.slice(1).forEach((chunk) => {
+      expect(chunk).not.toContain(CAST_URL);
+      expect(chunk.trim()).toBe(chunk); // no leading/trailing whitespace
+    });
+  });
+
+  // 9. Empty text → single element " <castUrl>" (space + url, as per implementation)
+  it('handles empty text — returns single element with space+castUrl', () => {
+    const result = splitIntoThread('', CAST_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(` ${CAST_URL}`);
+  });
+
+  // 10. First chunk text portion never exceeds FIRST_MAX (256) chars
+  it('first chunk text portion never exceeds 256 chars (regardless of castUrl length)', () => {
+    // Use text with no spaces so we get a hard cut at exactly 256
+    const text = 'x'.repeat(500);
+    const result = splitIntoThread(text, CAST_URL);
+    // The first chunk is "<256 chars> <castUrl>" — strip the " <castUrl>" suffix
+    const textPart = result[0].slice(0, result[0].length - 1 - CAST_URL.length);
+    expect(textPart.length).toBeLessThanOrEqual(FIRST_MAX);
+    // And verify the structure
+    expect(result[0].endsWith(` ${CAST_URL}`)).toBe(true);
+  });
+
+  // 11. Multiple word boundaries near 256 — picks the LAST space before limit
+  it('picks the last available space before 256 when multiple spaces exist near boundary', () => {
+    // Spaces at 240 and 248, text extends to 270
+    const part1 = 'a'.repeat(240);
+    const part2 = 'b'.repeat(7);
+    const part3 = 'c'.repeat(22);
+    const text = `${part1} ${part2} ${part3}`; // spaces at 240 and 248, total 272
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(2);
+    // Last space before 256 is at index 248 → first chunk is "aaa...aaa bbbbbbb"
+    expect(result[0]).toBe(`${part1} ${part2} ${CAST_URL}`);
+    expect(result[1]).toBe(part3);
+  });
+
+  // 12. Single chunk: first chunk length is at most FIRST_MAX (256) + space + castUrl len
+  it('single-chunk result is correctly formatted as "<text> <castUrl>"', () => {
+    const text = 'Short enough text';
+    const result = splitIntoThread(text, CAST_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatch(/^.+ https?:\/\//);
+    expect(result[0]).toBe(`${text} ${CAST_URL}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getXClient
+// ---------------------------------------------------------------------------
+
+describe('getXClient', () => {
+  // Reset mocked env fields before each test
+  function setEnv(overrides: Partial<typeof mockENV>) {
+    mockENV.X_API_KEY = overrides.X_API_KEY ?? '';
+    mockENV.X_API_SECRET = overrides.X_API_SECRET ?? '';
+    mockENV.X_ACCESS_TOKEN = overrides.X_ACCESS_TOKEN ?? '';
+    mockENV.X_ACCESS_SECRET = overrides.X_ACCESS_SECRET ?? '';
+  }
+
+  // 1. All 4 env vars missing → null
+  it('returns null when all four env vars are missing', () => {
+    setEnv({});
+    expect(getXClient()).toBeNull();
+  });
+
+  // 2. Partial env vars (3 of 4) → null
+  it('returns null when only three of four env vars are set (missing X_ACCESS_SECRET)', () => {
+    setEnv({
+      X_API_KEY: 'key',
+      X_API_SECRET: 'secret',
+      X_ACCESS_TOKEN: 'token',
+      // X_ACCESS_SECRET intentionally omitted
+    });
+    expect(getXClient()).toBeNull();
+  });
+
+  it('returns null when only three of four env vars are set (missing X_API_KEY)', () => {
+    setEnv({
+      // X_API_KEY intentionally omitted
+      X_API_SECRET: 'secret',
+      X_ACCESS_TOKEN: 'token',
+      X_ACCESS_SECRET: 'access-secret',
+    });
+    expect(getXClient()).toBeNull();
+  });
+
+  // 3. All 4 env vars set → returns non-null TwitterApi instance
+  it('returns a non-null client when all four env vars are set', () => {
+    setEnv({
+      X_API_KEY: 'key',
+      X_API_SECRET: 'secret',
+      X_ACCESS_TOKEN: 'token',
+      X_ACCESS_SECRET: 'access-secret',
+    });
+    const client = getXClient();
+    expect(client).not.toBeNull();
+  });
+});

--- a/src/lib/push/__tests__/vapid.test.ts
+++ b/src/lib/push/__tests__/vapid.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Static mocks declared before any dynamic import so vi.mock hoisting works.
+vi.mock('web-push', () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type VapidModule = typeof import('../vapid');
+
+async function loadModule(): Promise<VapidModule> {
+  return import('../vapid');
+}
+
+async function getWebpush() {
+  const wp = (await import('web-push')).default;
+  return wp as {
+    setVapidDetails: ReturnType<typeof vi.fn>;
+    sendNotification: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function getLogger() {
+  const { logger } = await import('@/lib/logger');
+  return logger as { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
+}
+
+const SUBSCRIPTION = {
+  endpoint: 'https://push.example.com/sub/123',
+  keys: { p256dh: 'p256dh-key', auth: 'auth-key' },
+};
+
+const PAYLOAD = { title: 'Hello', body: 'World' };
+
+// ---------------------------------------------------------------------------
+// describe: getVapidPublicKey
+// ---------------------------------------------------------------------------
+
+describe('getVapidPublicKey', () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    vi.resetModules();
+  });
+
+  it('returns the NEXT_PUBLIC_VAPID_PUBLIC_KEY env var value', async () => {
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'pk-test-abc';
+    process.env.VAPID_PRIVATE_KEY = 'sk-test-xyz';
+    const { getVapidPublicKey } = await loadModule();
+    expect(getVapidPublicKey()).toBe('pk-test-abc');
+  });
+
+  it('returns empty string when NEXT_PUBLIC_VAPID_PUBLIC_KEY is not set', async () => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    const { getVapidPublicKey } = await loadModule();
+    expect(getVapidPublicKey()).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: webpush.setVapidDetails — module init
+// ---------------------------------------------------------------------------
+
+describe('webpush.setVapidDetails at module init', () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    delete process.env.VAPID_SUBJECT;
+    vi.resetModules();
+  });
+
+  it('is called with subject, public key, and private key when both keys are set', async () => {
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'pk-init';
+    process.env.VAPID_PRIVATE_KEY = 'sk-init';
+    process.env.VAPID_SUBJECT = 'mailto:test@example.com';
+    await loadModule();
+    const wp = await getWebpush();
+    expect(wp.setVapidDetails).toHaveBeenCalledWith('mailto:test@example.com', 'pk-init', 'sk-init');
+  });
+
+  it('is NOT called when keys are missing', async () => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    const wp = await getWebpush();
+    wp.setVapidDetails.mockClear();
+    await loadModule();
+    expect(wp.setVapidDetails).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: sendPushNotification — VAPID keys configured
+// ---------------------------------------------------------------------------
+
+describe('sendPushNotification (VAPID keys configured)', () => {
+  let sendPushNotification: VapidModule['sendPushNotification'];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'pk-test';
+    process.env.VAPID_PRIVATE_KEY = 'sk-test';
+    const mod = await loadModule();
+    sendPushNotification = mod.sendPushNotification;
+    // Reset sendNotification mock state so each test starts clean
+    const wp = await getWebpush();
+    wp.sendNotification.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+  });
+
+  it('returns true when webpush.sendNotification resolves', async () => {
+    const wp = await getWebpush();
+    wp.sendNotification.mockResolvedValue(undefined);
+    const result = await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(result).toBe(true);
+  });
+
+  it('passes JSON.stringify(payload) to webpush.sendNotification', async () => {
+    const wp = await getWebpush();
+    wp.sendNotification.mockResolvedValue(undefined);
+    await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(wp.sendNotification).toHaveBeenCalledWith(SUBSCRIPTION, JSON.stringify(PAYLOAD));
+  });
+
+  it('returns false on 404 statusCode (expired subscription)', async () => {
+    const wp = await getWebpush();
+    wp.sendNotification.mockRejectedValue({ statusCode: 404 });
+    const result = await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(result).toBe(false);
+  });
+
+  it('logs info message on 404 statusCode', async () => {
+    const wp = await getWebpush();
+    wp.sendNotification.mockRejectedValue({ statusCode: 404 });
+    const log = await getLogger();
+    log.info.mockClear();
+    await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(log.info).toHaveBeenCalledWith('[push] Subscription expired or invalid, should be removed');
+  });
+
+  it('returns false on 410 statusCode (gone subscription)', async () => {
+    const wp = await getWebpush();
+    wp.sendNotification.mockRejectedValue({ statusCode: 410 });
+    const result = await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(result).toBe(false);
+  });
+
+  it('returns false on other errors without throwing', async () => {
+    const wp = await getWebpush();
+    wp.sendNotification.mockRejectedValue(new Error('Network failure'));
+    await expect(sendPushNotification(SUBSCRIPTION, PAYLOAD)).resolves.toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describe: sendPushNotification — NO VAPID keys
+// ---------------------------------------------------------------------------
+
+describe('sendPushNotification (NO VAPID keys)', () => {
+  let sendPushNotification: VapidModule['sendPushNotification'];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    const mod = await loadModule();
+    sendPushNotification = mod.sendPushNotification;
+    const wp = await getWebpush();
+    wp.sendNotification.mockReset();
+  });
+
+  it('returns false immediately without calling webpush.sendNotification', async () => {
+    const wp = await getWebpush();
+    const result = await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(result).toBe(false);
+    expect(wp.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('logs a warn message when keys are not configured', async () => {
+    const log = await getLogger();
+    log.warn.mockClear();
+    await sendPushNotification(SUBSCRIPTION, PAYLOAD);
+    expect(log.warn).toHaveBeenCalledWith('[push] VAPID keys not configured — skipping push notification');
+  });
+});

--- a/src/lib/spaces/__tests__/jukeWebhookVerify.test.ts
+++ b/src/lib/spaces/__tests__/jukeWebhookVerify.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+import { createHash, createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { parseJukeSignature, verifyJukeWebhook } from '../jukeWebhookVerify';
+
+// ---------------------------------------------------------------------------
+// parseJukeSignature
+// ---------------------------------------------------------------------------
+
+describe('parseJukeSignature', () => {
+  it('returns null for null input', () => {
+    expect(parseJukeSignature(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(parseJukeSignature(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseJukeSignature('')).toBeNull();
+  });
+
+  it('parses a valid header', () => {
+    expect(parseJukeSignature('t=1750000000,v1=abc123def')).toEqual({
+      ts: 1750000000,
+      v1: 'abc123def',
+    });
+  });
+
+  it('is order-insensitive (v1 before t)', () => {
+    expect(parseJukeSignature('v1=hexvalue,t=1750000001')).toEqual({
+      ts: 1750000001,
+      v1: 'hexvalue',
+    });
+  });
+
+  it('ignores unknown keys', () => {
+    expect(parseJukeSignature('t=1750000002,v1=hexval,extra=ignored')).toEqual({
+      ts: 1750000002,
+      v1: 'hexval',
+    });
+  });
+
+  it('returns null when t is not a number', () => {
+    expect(parseJukeSignature('t=notanumber,v1=abc')).toBeNull();
+  });
+
+  it('returns null when v1 is missing', () => {
+    expect(parseJukeSignature('t=1750000003')).toBeNull();
+  });
+
+  it('returns null when t is missing', () => {
+    expect(parseJukeSignature('v1=hexvalue')).toBeNull();
+  });
+
+  it('trims whitespace around key=value pairs', () => {
+    expect(parseJukeSignature(' t=1750000004 , v1=trimmed ')).toEqual({
+      ts: 1750000004,
+      v1: 'trimmed',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyJukeWebhook — helper to build a valid HMAC signature
+// ---------------------------------------------------------------------------
+
+function makeSignature(secret: string, ts: number, rawBody: string): string {
+  const message = `${ts}.${rawBody}`;
+  const v1 = createHmac('sha256', secret).update(message).digest('hex');
+  return `t=${ts},v1=${v1}`;
+}
+
+const NOW = 1750000000; // stable reference timestamp
+const SECRET = 'test-secret-key';
+const BODY = '{"event":"track.played","data":{}}';
+
+// ---------------------------------------------------------------------------
+// verifyJukeWebhook — guard cases
+// ---------------------------------------------------------------------------
+
+describe('verifyJukeWebhook guards', () => {
+  it('returns error when secret is empty', () => {
+    const result = verifyJukeWebhook(BODY, makeSignature(SECRET, NOW, BODY), '', NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/not configured/i);
+  });
+
+  it('returns error when header is null', () => {
+    const result = verifyJukeWebhook(BODY, null, SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/malformed/i);
+  });
+
+  it('returns error when header is undefined', () => {
+    const result = verifyJukeWebhook(BODY, undefined, SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/malformed/i);
+  });
+
+  it('rejects a timestamp older than 5 minutes', () => {
+    const oldTs = NOW - 5 * 60 - 1;
+    const result = verifyJukeWebhook(BODY, makeSignature(SECRET, oldTs, BODY), SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/replay window/i);
+  });
+
+  it('rejects a timestamp more than 5 minutes in the future', () => {
+    const futureTs = NOW + 5 * 60 + 1;
+    const result = verifyJukeWebhook(BODY, makeSignature(SECRET, futureTs, BODY), SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/replay window/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyJukeWebhook — valid signature cases
+// ---------------------------------------------------------------------------
+
+describe('verifyJukeWebhook valid signatures', () => {
+  it('returns ok:true for a correct signature (raw secret)', () => {
+    const header = makeSignature(SECRET, NOW, BODY);
+    const result = verifyJukeWebhook(BODY, header, SECRET, NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ts).toBe(NOW);
+      expect(result.matchedVariant).toBe('raw');
+    }
+  });
+
+  it('signatureHash is SHA-256 of the v1 hex string', () => {
+    const header = makeSignature(SECRET, NOW, BODY);
+    const result = verifyJukeWebhook(BODY, header, SECRET, NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const v1 = parseJukeSignature(header)!.v1;
+      const expectedHash = createHash('sha256').update(v1).digest('hex');
+      expect(result.signatureHash).toBe(expectedHash);
+    }
+  });
+
+  it('accepts ts within 5 minutes (boundary)', () => {
+    const borderTs = NOW - 5 * 60; // exactly at boundary
+    const result = verifyJukeWebhook(BODY, makeSignature(SECRET, borderTs, BODY), SECRET, NOW);
+    expect(result.ok).toBe(true);
+  });
+
+  it('verifies with whsec_ prefix using no-whsec variant', () => {
+    const whsecSecret = `whsec_${SECRET}`;
+    // The key used for HMAC should be SECRET (the part after "whsec_")
+    const v1 = createHmac('sha256', SECRET).update(`${NOW}.${BODY}`).digest('hex');
+    const header = `t=${NOW},v1=${v1}`;
+    const result = verifyJukeWebhook(BODY, header, whsecSecret, NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.matchedVariant).toBe('no-whsec');
+  });
+
+  it('verifies with whsec_app_key using no-whsec-noapp variant', () => {
+    const innerKey = 'the-actual-key';
+    const whsecSecret = `whsec_app_${innerKey}`;
+    const v1 = createHmac('sha256', innerKey).update(`${NOW}.${BODY}`).digest('hex');
+    const header = `t=${NOW},v1=${v1}`;
+    const result = verifyJukeWebhook(BODY, header, whsecSecret, NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.matchedVariant).toBe('no-whsec-noapp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyJukeWebhook — mismatch cases
+// ---------------------------------------------------------------------------
+
+describe('verifyJukeWebhook mismatch', () => {
+  it('returns ok:false for wrong secret', () => {
+    const header = makeSignature('wrong-secret', NOW, BODY);
+    const result = verifyJukeWebhook(BODY, header, SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/mismatch/i);
+      expect(result.debug).toBeDefined();
+    }
+  });
+
+  it('returns ok:false when body is tampered', () => {
+    const header = makeSignature(SECRET, NOW, BODY);
+    const result = verifyJukeWebhook('{"tampered":true}', header, SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/mismatch/i);
+  });
+
+  it('debug block includes secretFp and bodyLen', () => {
+    const header = makeSignature('wrong', NOW, BODY);
+    const result = verifyJukeWebhook(BODY, header, SECRET, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.debug) {
+      expect(result.debug.secretLen).toBe(SECRET.length);
+      expect(result.debug.bodyLen).toBe(BODY.length);
+      expect(result.debug.secretFp).toHaveLength(12);
+    }
+  });
+});


### PR DESCRIPTION
## What
51 new test cases across three modules with non-trivial logic.

**`x.test.ts` (16 cases):**
- `splitIntoThread` pure function: single-chunk (short text + castUrl), 256-char borderline, word-boundary split, no-space hard-cut at 256, 3-chunk long text, castUrl on first chunk only, empty text edge case
- `getXClient`: null when any of 4 OAuth env vars missing (3 variants), non-null when all present

**`vapid.test.ts` (12 cases):**
- `getVapidPublicKey`: reads env var, returns `''` when unset
- `webpush.setVapidDetails`: called at module init when keys present, not called when absent
- `sendPushNotification` (keys configured): true on success, JSON.stringify payload passed, false on 404/410 (expired sub), false on other errors without throwing
- `sendPushNotification` (no keys): false immediately, logs warn, never calls sendNotification
- Uses `vi.resetModules()` + dynamic import per group to isolate module-level constants

**`jukeWebhookVerify.test.ts` (23 cases):**
- `parseJukeSignature`: null/undefined/empty, valid parse, order-insensitive (v1 before t), unknown keys ignored, non-numeric t, missing t or v1, whitespace trim
- `verifyJukeWebhook` guards: empty secret, null/undefined header, replay window (>5min old, >5min future)
- Valid signatures: raw secret (`matchedVariant='raw'`), signatureHash=SHA256(v1), boundary (exactly 5min), `whsec_` prefix, `whsec_app_key` prefix
- Mismatch: wrong secret with debug block, tampered body, debug fields (secretFp length 12, bodyLen correct)

## Notes
- `jukeWebhookVerify` accepts injectable `now` parameter — no time mocking needed
- `splitIntoThread`: `TCO_LENGTH=23` controls text budget, not actual output length (castUrl appended verbatim)

## Test run
```
✓ x.test.ts                16/16
✓ vapid.test.ts            12/12
✓ jukeWebhookVerify.test.ts 23/23
Total: 51/51 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)