### PR TITLE
test(spaces): streamHelpers + juke-partner-token mint (34 cases)

### DIFF
--- a/src/lib/spaces/__tests__/juke-partner-token.test.ts
+++ b/src/lib/spaces/__tests__/juke-partner-token.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mintPartnerToken } from '../juke-partner-token';
+
+const API_KEY = 'juke-api-key-test';
+
+const GOOD_RESPONSE = {
+  token: 'eyJhbGciOiJIUzI1NiJ9.test',
+  fid: 42,
+  expires_at: '2026-07-17T00:00:00Z',
+  partner_app_id: 'zao-os',
+};
+
+function mockFetch(status: number, body: unknown, throws?: Error) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      if (throws) throw throws;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      };
+    }),
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.unstubAllGlobals());
+
+// ---------------------------------------------------------------------------
+// fid validation
+// ---------------------------------------------------------------------------
+
+describe('fid validation', () => {
+  it('returns error when fid is 0', async () => {
+    const result = await mintPartnerToken(API_KEY, { fid: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/positive integer/i);
+    }
+  });
+
+  it('returns error when fid is negative', async () => {
+    const result = await mintPartnerToken(API_KEY, { fid: -1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+  });
+
+  it('returns error when fid is Infinity', async () => {
+    const result = await mintPartnerToken(API_KEY, { fid: Infinity });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TTL clamping
+// ---------------------------------------------------------------------------
+
+describe('TTL clamping', () => {
+  it('clamps ttlSeconds below 60 to 60', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    await mintPartnerToken(API_KEY, { fid: 42, ttlSeconds: 30 });
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.ttl_seconds).toBe(60);
+  });
+
+  it('clamps ttlSeconds above 600 to 600', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    await mintPartnerToken(API_KEY, { fid: 42, ttlSeconds: 900 });
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.ttl_seconds).toBe(600);
+  });
+
+  it('defaults ttlSeconds to 300 when not provided', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    await mintPartnerToken(API_KEY, { fid: 42 });
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.ttl_seconds).toBe(300);
+  });
+
+  it('passes ttlSeconds through when within [60, 600]', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    await mintPartnerToken(API_KEY, { fid: 42, ttlSeconds: 120 });
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.ttl_seconds).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success path
+// ---------------------------------------------------------------------------
+
+describe('success path', () => {
+  it('returns ok:true with data on 200', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    const result = await mintPartnerToken(API_KEY, { fid: 42 });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual(GOOD_RESPONSE);
+  });
+
+  it('sends fid in request body', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    await mintPartnerToken(API_KEY, { fid: 7 });
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.fid).toBe(7);
+  });
+
+  it('sends X-Juke-Api-Key header', async () => {
+    mockFetch(200, GOOD_RESPONSE);
+    await mintPartnerToken(API_KEY, { fid: 42 });
+    const headers = (vi.mocked(fetch).mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers['X-Juke-Api-Key']).toBe(API_KEY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+describe('error paths', () => {
+  it('returns ok:false on HTTP 401', async () => {
+    mockFetch(401, { message: 'Unauthorized' });
+    const result = await mintPartnerToken(API_KEY, { fid: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(401);
+  });
+
+  it('returns ok:false with status 502 on network error', async () => {
+    mockFetch(0, null, new Error('network timeout'));
+    const result = await mintPartnerToken(API_KEY, { fid: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toContain('network timeout');
+    }
+  });
+
+  it('returns ok:false when response body has no token', async () => {
+    mockFetch(200, { expires_at: '2026-07-17T00:00:00Z' }); // missing token
+    const result = await mintPartnerToken(API_KEY, { fid: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(502);
+  });
+
+  it('returns ok:false when expires_at is missing', async () => {
+    mockFetch(200, { token: 'abc' }); // missing expires_at
+    const result = await mintPartnerToken(API_KEY, { fid: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(502);
+  });
+});

--- a/src/lib/spaces/__tests__/streamHelpers.test.ts
+++ b/src/lib/spaces/__tests__/streamHelpers.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { createGuestUser, createStreamUser, generateCallId, generateSlug } from '../streamHelpers';
+
+// ---------------------------------------------------------------------------
+// generateSlug
+// ---------------------------------------------------------------------------
+
+describe('generateSlug', () => {
+  it('lowercases and converts spaces to hyphens', () => {
+    const slug = generateSlug('My Awesome Session');
+    expect(slug).toMatch(/^my-awesome-session-[a-z0-9]{4}$/);
+  });
+
+  it('strips special characters', () => {
+    const slug = generateSlug('Hello! World & Co.');
+    expect(slug).toMatch(/^hello-world-co-[a-z0-9]{4}$/);
+  });
+
+  it('collapses multiple hyphens', () => {
+    const slug = generateSlug('A  B---C');
+    expect(slug).toMatch(/^a-b-c-[a-z0-9]{4}$/);
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    const slug = generateSlug('!leading and trailing!');
+    expect(slug).toMatch(/^leading-and-trailing-[a-z0-9]{4}$/);
+  });
+
+  it('truncates base to 60 chars before appending suffix', () => {
+    const long = 'a'.repeat(70);
+    const slug = generateSlug(long);
+    // base is 60 chars + '-' + 4 suffix chars = 65
+    expect(slug.length).toBeLessThanOrEqual(65);
+  });
+
+  it('always appends a 4-char alphanumeric suffix', () => {
+    const slug = generateSlug('test');
+    const parts = slug.split('-');
+    const suffix = parts[parts.length - 1];
+    expect(suffix).toMatch(/^[a-z0-9]{4}$/);
+  });
+
+  it('produces different slugs for the same title (random suffix)', () => {
+    const a = generateSlug('same title');
+    const b = generateSlug('same title');
+    // With overwhelming probability the 4-char random suffixes differ
+    // (fails ~1 in 36^4 ≈ 1.7M runs)
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCallId
+// ---------------------------------------------------------------------------
+
+describe('generateCallId', () => {
+  it('returns a non-empty string', () => {
+    expect(typeof generateCallId()).toBe('string');
+    expect(generateCallId().length).toBeGreaterThan(0);
+  });
+
+  it('returns a UUID when crypto.randomUUID is available', () => {
+    // Node 20 always has crypto.randomUUID — expect UUID format
+    expect(generateCallId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('produces unique ids on successive calls', () => {
+    expect(generateCallId()).not.toBe(generateCallId());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createStreamUser
+// ---------------------------------------------------------------------------
+
+describe('createStreamUser', () => {
+  it('maps fid to string id', () => {
+    const user = createStreamUser({ fid: 42, displayName: 'Alice', username: 'alice' });
+    expect(user.id).toBe('42');
+  });
+
+  it('uses displayName as name when present', () => {
+    const user = createStreamUser({ fid: 1, displayName: 'Alice Real', username: 'alice' });
+    expect(user.name).toBe('Alice Real');
+  });
+
+  it('falls back to username when displayName is empty string', () => {
+    const user = createStreamUser({ fid: 1, displayName: '', username: 'alice' });
+    expect(user.name).toBe('alice');
+  });
+
+  it('sets image from pfpUrl when provided', () => {
+    const user = createStreamUser({
+      fid: 1,
+      displayName: 'Alice',
+      username: 'alice',
+      pfpUrl: 'https://example.com/pfp.png',
+    });
+    expect(user.image).toBe('https://example.com/pfp.png');
+  });
+
+  it('omits image when pfpUrl is null', () => {
+    const user = createStreamUser({ fid: 1, displayName: 'Alice', username: 'alice', pfpUrl: null });
+    expect(user.image).toBeUndefined();
+  });
+
+  it('omits image when pfpUrl is not provided', () => {
+    const user = createStreamUser({ fid: 1, displayName: 'Alice', username: 'alice' });
+    expect(user.image).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createGuestUser
+// ---------------------------------------------------------------------------
+
+describe('createGuestUser', () => {
+  it('returns type: guest', () => {
+    expect(createGuestUser().type).toBe('guest');
+  });
+
+  it('returns name: "Guest Listener"', () => {
+    expect(createGuestUser().name).toBe('Guest Listener');
+  });
+
+  it('id starts with "guest_"', () => {
+    expect(createGuestUser().id).toMatch(/^guest_/);
+  });
+
+  it('produces unique ids on successive calls', () => {
+    expect(createGuestUser().id).not.toBe(createGuestUser().id);
+  });
+});


### PR DESCRIPTION
## What
34 new test cases covering two spaces modules.

**`streamHelpers.test.ts` (20 cases):**
- `generateSlug`: lowercase+hyphenate, strip special chars, collapse multi-hyphens, trim leading/trailing hyphens, 60-char base truncation, 4-char alphanumeric suffix always present, uniqueness across calls
- `generateCallId`: non-empty string, UUID format (Node 20 crypto.randomUUID path), uniqueness
- `createStreamUser`: fid→string id, displayName vs username fallback, pfpUrl present/null/absent
- `createGuestUser`: type='guest', name='Guest Listener', id starts with 'guest_', uniqueness

**`juke-partner-token.test.ts` (14 cases):**
- fid validation: 0 / negative / Infinity → `{ ok: false, status: 400 }`
- TTL clamping: <60→60, >600→600, default 300, pass-through for valid values
- Success: `ok:true` with full data, fid sent in body, `X-Juke-Api-Key` header present
- Errors: HTTP 401, network throw → 502 with message, missing token → 502, missing expires_at → 502

## Test run
```
✓ streamHelpers.test.ts         20/20
✓ juke-partner-token.test.ts    14/14
Total: 34/34 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)