### PR TITLE
test(validation): Zod schemas — full + library suites (86 cases)

### DIFF
--- a/src/lib/validation/__tests__/library-schemas.test.ts
+++ b/src/lib/validation/__tests__/library-schemas.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  LIBRARY_TAGS,
+  libraryCommentSchema,
+  libraryDeleteSchema,
+  librarySubmitSchema,
+  libraryVoteSchema,
+} from '../library-schemas';
+
+// ---------------------------------------------------------------------------
+// LIBRARY_TAGS
+// ---------------------------------------------------------------------------
+
+describe('LIBRARY_TAGS', () => {
+  it('has exactly 8 tags', () => {
+    expect(LIBRARY_TAGS.length).toBe(8);
+  });
+
+  it('includes expected categories', () => {
+    expect(LIBRARY_TAGS).toContain('Music');
+    expect(LIBRARY_TAGS).toContain('Governance');
+    expect(LIBRARY_TAGS).toContain('AI');
+    expect(LIBRARY_TAGS).toContain('Other');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// librarySubmitSchema
+// ---------------------------------------------------------------------------
+
+describe('librarySubmitSchema', () => {
+  it('accepts a minimal valid submission (just input)', () => {
+    expect(librarySubmitSchema.safeParse({ input: 'https://example.com' }).success).toBe(true);
+  });
+
+  it('accepts all optional fields', () => {
+    expect(
+      librarySubmitSchema.safeParse({
+        input: 'some topic',
+        note: 'interesting',
+        tags: ['Music', 'AI'],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects empty input string', () => {
+    expect(librarySubmitSchema.safeParse({ input: '' }).success).toBe(false);
+  });
+
+  it('rejects whitespace-only input (trim then min 1)', () => {
+    expect(librarySubmitSchema.safeParse({ input: '   ' }).success).toBe(false);
+  });
+
+  it('rejects input over 2000 chars', () => {
+    expect(librarySubmitSchema.safeParse({ input: 'a'.repeat(2001) }).success).toBe(false);
+  });
+
+  it('rejects note over 1000 chars', () => {
+    expect(
+      librarySubmitSchema.safeParse({ input: 'topic', note: 'n'.repeat(1001) }).success,
+    ).toBe(false);
+  });
+
+  it('rejects tags array with more than 3 items', () => {
+    expect(
+      librarySubmitSchema.safeParse({
+        input: 'topic',
+        tags: ['Music', 'AI', 'Tech', 'Culture'],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects an invalid tag value', () => {
+    expect(
+      librarySubmitSchema.safeParse({ input: 'topic', tags: ['InvalidTag' as never] }).success,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// libraryVoteSchema
+// ---------------------------------------------------------------------------
+
+describe('libraryVoteSchema', () => {
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts upvote', () => {
+    expect(libraryVoteSchema.safeParse({ entry_id: uuid, vote_type: 'up' }).success).toBe(true);
+  });
+
+  it('accepts downvote', () => {
+    expect(libraryVoteSchema.safeParse({ entry_id: uuid, vote_type: 'down' }).success).toBe(true);
+  });
+
+  it('rejects non-UUID entry_id', () => {
+    expect(libraryVoteSchema.safeParse({ entry_id: 'not-a-uuid', vote_type: 'up' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects invalid vote_type', () => {
+    expect(
+      libraryVoteSchema.safeParse({ entry_id: uuid, vote_type: 'neutral' as never }).success,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// libraryCommentSchema
+// ---------------------------------------------------------------------------
+
+describe('libraryCommentSchema', () => {
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts a valid comment', () => {
+    expect(
+      libraryCommentSchema.safeParse({ entry_id: uuid, body: 'Great resource!' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects empty body (min 1)', () => {
+    expect(libraryCommentSchema.safeParse({ entry_id: uuid, body: '' }).success).toBe(false);
+  });
+
+  it('rejects whitespace-only body (trim then min 1)', () => {
+    expect(libraryCommentSchema.safeParse({ entry_id: uuid, body: '   ' }).success).toBe(false);
+  });
+
+  it('rejects body over 500 chars', () => {
+    expect(
+      libraryCommentSchema.safeParse({ entry_id: uuid, body: 'b'.repeat(501) }).success,
+    ).toBe(false);
+  });
+
+  it('accepts body of exactly 500 chars', () => {
+    expect(
+      libraryCommentSchema.safeParse({ entry_id: uuid, body: 'b'.repeat(500) }).success,
+    ).toBe(true);
+  });
+
+  it('rejects non-UUID entry_id', () => {
+    expect(
+      libraryCommentSchema.safeParse({ entry_id: 'abc', body: 'Hello' }).success,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// libraryDeleteSchema
+// ---------------------------------------------------------------------------
+
+describe('libraryDeleteSchema', () => {
+  it('accepts a valid UUID', () => {
+    expect(
+      libraryDeleteSchema.safeParse({ entry_id: '550e8400-e29b-41d4-a716-446655440000' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a non-UUID string', () => {
+    expect(libraryDeleteSchema.safeParse({ entry_id: 'not-a-uuid' }).success).toBe(false);
+  });
+
+  it('rejects missing entry_id', () => {
+    expect(libraryDeleteSchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/src/lib/validation/__tests__/schemas.test.ts
+++ b/src/lib/validation/__tests__/schemas.test.ts
@@ -1,0 +1,434 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  allowlistEntrySchema,
+  castHashSchema,
+  castTextSchema,
+  channelIdSchema,
+  communityIssueSchema,
+  createProposalSchema,
+  csvRowSchema,
+  hideMessageSchema,
+  proposalCategorySchema,
+  proposalCommentSchema,
+  proposalVoteSchema,
+  removeAllowlistSchema,
+  sendMessageSchema,
+} from '../schemas';
+
+// ---------------------------------------------------------------------------
+// castTextSchema
+// ---------------------------------------------------------------------------
+describe('castTextSchema', () => {
+  it('accepts a valid string', () => {
+    expect(castTextSchema.safeParse('hello').success).toBe(true);
+  });
+
+  it('rejects an empty string (min 1)', () => {
+    expect(castTextSchema.safeParse('').success).toBe(false);
+  });
+
+  it('accepts a string of exactly 1024 characters (max boundary)', () => {
+    expect(castTextSchema.safeParse('a'.repeat(1024)).success).toBe(true);
+  });
+
+  it('rejects a string of 1025 characters (exceeds max)', () => {
+    expect(castTextSchema.safeParse('a'.repeat(1025)).success).toBe(false);
+  });
+
+  it('rejects a whitespace-only string (trim then min 1)', () => {
+    expect(castTextSchema.safeParse('   ').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// channelIdSchema
+// ---------------------------------------------------------------------------
+describe('channelIdSchema', () => {
+  it('accepts a simple lowercase word', () => {
+    expect(channelIdSchema.safeParse('music').success).toBe(true);
+  });
+
+  it('accepts hyphenated lowercase channel id', () => {
+    expect(channelIdSchema.safeParse('hip-hop').success).toBe(true);
+  });
+
+  it('rejects uppercase letters and spaces', () => {
+    expect(channelIdSchema.safeParse('My Channel').success).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(channelIdSchema.safeParse('').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// castHashSchema
+// ---------------------------------------------------------------------------
+describe('castHashSchema', () => {
+  it('accepts a valid 0x-prefixed 40-hex-char hash', () => {
+    expect(castHashSchema.safeParse('0x' + 'a'.repeat(40)).success).toBe(true);
+  });
+
+  it('accepts a valid 0x-prefixed 64-hex-char hash', () => {
+    expect(castHashSchema.safeParse('0x' + 'f'.repeat(64)).success).toBe(true);
+  });
+
+  it('accepts uppercase hex chars (case-insensitive)', () => {
+    expect(castHashSchema.safeParse('0x' + 'ABCDEF1234'.repeat(4)).success).toBe(true);
+  });
+
+  it('rejects a hash without 0x prefix', () => {
+    expect(castHashSchema.safeParse('a'.repeat(40)).success).toBe(false);
+  });
+
+  it('rejects a hash shorter than 40 hex chars', () => {
+    expect(castHashSchema.safeParse('0x' + 'a'.repeat(39)).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendMessageSchema
+// ---------------------------------------------------------------------------
+describe('sendMessageSchema', () => {
+  it('accepts minimal valid input (just text)', () => {
+    expect(sendMessageSchema.safeParse({ text: 'Hello world' }).success).toBe(true);
+  });
+
+  it('accepts text with a single valid embedUrl', () => {
+    const result = sendMessageSchema.safeParse({
+      text: 'Check this out',
+      embedUrls: ['https://example.com/image.png'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects embedUrls array with more than 2 entries', () => {
+    const result = sendMessageSchema.safeParse({
+      text: 'Too many urls',
+      embedUrls: [
+        'https://example.com/1',
+        'https://example.com/2',
+        'https://example.com/3',
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects crossPostChannels array with more than 3 entries', () => {
+    const result = sendMessageSchema.safeParse({
+      text: 'Cross posting everywhere',
+      crossPostChannels: ['music', 'art', 'tech', 'gaming'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid URL in embedUrls', () => {
+    const result = sendMessageSchema.safeParse({
+      text: 'Bad embed',
+      embedUrls: ['not-a-url'],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hideMessageSchema
+// ---------------------------------------------------------------------------
+describe('hideMessageSchema', () => {
+  const validHash = '0x' + 'a'.repeat(40);
+
+  it('accepts a valid castHash', () => {
+    expect(hideMessageSchema.safeParse({ castHash: validHash }).success).toBe(true);
+  });
+
+  it('accepts when reason is omitted (optional)', () => {
+    expect(hideMessageSchema.safeParse({ castHash: validHash }).success).toBe(true);
+  });
+
+  it('rejects when reason exceeds 500 characters', () => {
+    const result = hideMessageSchema.safeParse({
+      castHash: validHash,
+      reason: 'x'.repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// csvRowSchema
+// ---------------------------------------------------------------------------
+describe('csvRowSchema', () => {
+  it('accepts a valid CSV row', () => {
+    const result = csvRowSchema.safeParse({
+      ign: 'PlayerOne',
+      wallet_address: '0x' + 'a'.repeat(40),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty ign', () => {
+    const result = csvRowSchema.safeParse({
+      ign: '',
+      wallet_address: '0x' + 'a'.repeat(40),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects wallet_address without 0x prefix', () => {
+    const result = csvRowSchema.safeParse({
+      ign: 'PlayerOne',
+      wallet_address: 'a'.repeat(40),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects wallet_address with wrong length', () => {
+    const result = csvRowSchema.safeParse({
+      ign: 'PlayerOne',
+      wallet_address: '0x' + 'a'.repeat(39),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// communityIssueSchema
+// ---------------------------------------------------------------------------
+describe('communityIssueSchema', () => {
+  const validIssue = {
+    title: 'Something is broken',
+    description: 'The login button does not work on mobile devices.',
+    type: 'bug' as const,
+    priority: 'high' as const,
+  };
+
+  it('accepts a fully valid issue', () => {
+    expect(communityIssueSchema.safeParse(validIssue).success).toBe(true);
+  });
+
+  it('rejects a title under 5 characters', () => {
+    const result = communityIssueSchema.safeParse({ ...validIssue, title: 'Bug' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a description under 10 characters', () => {
+    const result = communityIssueSchema.safeParse({ ...validIssue, description: 'Short' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid type enum value', () => {
+    const result = communityIssueSchema.safeParse({ ...validIssue, type: 'complaint' });
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults priority to "medium" when omitted', () => {
+    const { priority: _p, ...withoutPriority } = validIssue;
+    const parsed = communityIssueSchema.parse(withoutPriority);
+    expect(parsed.priority).toBe('medium');
+  });
+
+  it('accepts priority "high" explicitly', () => {
+    const result = communityIssueSchema.safeParse({ ...validIssue, priority: 'high' });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allowlistEntrySchema
+// ---------------------------------------------------------------------------
+describe('allowlistEntrySchema', () => {
+  it('passes the refine when only fid is provided', () => {
+    expect(allowlistEntrySchema.safeParse({ fid: 12345 }).success).toBe(true);
+  });
+
+  it('passes the refine when only wallet_address is provided', () => {
+    expect(
+      allowlistEntrySchema.safeParse({ wallet_address: '0x' + 'a'.repeat(40) }).success,
+    ).toBe(true);
+  });
+
+  it('fails the refine when neither fid nor wallet_address is provided', () => {
+    expect(allowlistEntrySchema.safeParse({ real_name: 'Alice' }).success).toBe(false);
+  });
+
+  it('passes when both fid and wallet_address are provided', () => {
+    const result = allowlistEntrySchema.safeParse({
+      fid: 42,
+      wallet_address: '0x' + 'b'.repeat(40),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeAllowlistSchema
+// ---------------------------------------------------------------------------
+describe('removeAllowlistSchema', () => {
+  it('accepts a valid UUID', () => {
+    const result = removeAllowlistSchema.safeParse({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-UUID string', () => {
+    const result = removeAllowlistSchema.safeParse({ id: 'not-a-uuid' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when id field is missing', () => {
+    const result = removeAllowlistSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// proposalCategorySchema
+// ---------------------------------------------------------------------------
+describe('proposalCategorySchema', () => {
+  it.each(['general', 'technical', 'community', 'governance', 'treasury', 'wavewarz', 'social'])(
+    'accepts valid category: %s',
+    (category) => {
+      expect(proposalCategorySchema.safeParse(category).success).toBe(true);
+    },
+  );
+
+  it('rejects an invalid category', () => {
+    expect(proposalCategorySchema.safeParse('politics').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createProposalSchema
+// ---------------------------------------------------------------------------
+describe('createProposalSchema', () => {
+  const futureDate = new Date(Date.now() + 86400000).toISOString();
+
+  it('accepts a minimal valid proposal', () => {
+    const result = createProposalSchema.safeParse({
+      title: 'Fund the hackathon',
+      description: 'We need money for the event',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults category to "general" when omitted', () => {
+    const parsed = createProposalSchema.parse({
+      title: 'My proposal',
+      description: 'Describing the proposal here',
+    });
+    expect(parsed.category).toBe('general');
+  });
+
+  it('accepts a valid future closes_at ISO date', () => {
+    const result = createProposalSchema.safeParse({
+      title: 'Timed proposal',
+      description: 'Closes in the future',
+      closes_at: futureDate,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects closes_at in the past', () => {
+    const pastDate = new Date(Date.now() - 86400000).toISOString();
+    const result = createProposalSchema.safeParse({
+      title: 'Past proposal',
+      description: 'Already closed',
+      closes_at: pastDate,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty title', () => {
+    const result = createProposalSchema.safeParse({
+      title: '',
+      description: 'Has description',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a title over 200 characters', () => {
+    const result = createProposalSchema.safeParse({
+      title: 'T'.repeat(201),
+      description: 'Has description',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid publish_image_url', () => {
+    const result = createProposalSchema.safeParse({
+      title: 'Image proposal',
+      description: 'Testing image url',
+      publish_image_url: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// proposalCommentSchema
+// ---------------------------------------------------------------------------
+describe('proposalCommentSchema', () => {
+  const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts a valid comment', () => {
+    const result = proposalCommentSchema.safeParse({
+      proposal_id: validUuid,
+      body: 'This is a great proposal!',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty body', () => {
+    const result = proposalCommentSchema.safeParse({
+      proposal_id: validUuid,
+      body: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a body over 2000 characters', () => {
+    const result = proposalCommentSchema.safeParse({
+      proposal_id: validUuid,
+      body: 'x'.repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-UUID proposal_id', () => {
+    const result = proposalCommentSchema.safeParse({
+      proposal_id: 'bad-id',
+      body: 'Valid body',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// proposalVoteSchema
+// ---------------------------------------------------------------------------
+describe('proposalVoteSchema', () => {
+  const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  it.each(['for', 'against', 'abstain'])('accepts valid vote: %s', (vote) => {
+    const result = proposalVoteSchema.safeParse({ proposal_id: validUuid, vote });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid vote value', () => {
+    const result = proposalVoteSchema.safeParse({
+      proposal_id: validUuid,
+      vote: 'maybe',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-UUID proposal_id', () => {
+    const result = proposalVoteSchema.safeParse({
+      proposal_id: 'not-a-uuid',
+      vote: 'for',
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
86 new test cases covering all Zod validation schemas across two modules.

**`schemas.test.ts` (63 cases)** — 13 schema suites:
- `castTextSchema`: trim, min 1, max 1024, whitespace-only guard
- `channelIdSchema`: valid/invalid regex patterns
- `castHashSchema`: 0x+40-64 hex chars, case-insensitive, length guards
- `sendMessageSchema`: minimal, embedUrls max-2, crossPostChannels max-3, invalid URL
- `hideMessageSchema`, `csvRowSchema`, `communityIssueSchema` (with priority default)
- `allowlistEntrySchema`: `.refine()` — fid||wallet_address required
- `removeAllowlistSchema`, `proposalCategorySchema`, `createProposalSchema`, `proposalCommentSchema`, `proposalVoteSchema` (for/against/abstain)

**`library-schemas.test.ts` (23 cases)** — 5 schema suites:
- `LIBRARY_TAGS`: length=8, expected categories present
- `librarySubmitSchema`: whitespace trim guard, tag array max-3, invalid tag
- `libraryVoteSchema`: up/down valid, non-UUID and invalid vote_type rejected
- `libraryCommentSchema`: empty/whitespace guard, 500-char boundary, non-UUID
- `libraryDeleteSchema`: valid UUID, non-UUID, missing field

## Notes
- No mocking — pure Zod validation
- Discovered schemas.ts has more schemas than initially scoped (proposal series) — all covered

## Test run
```
✓ schemas.test.ts          63/63
✓ library-schemas.test.ts  23/23
Total: 86/86 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)