### PR TITLE
test(autocliper+wavewarz): config constants + WaveWarZ data integrity (28 cases)

### DIFF
--- a/src/lib/autocliper/__tests__/config.test.ts
+++ b/src/lib/autocliper/__tests__/config.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// postizConfig
+// ---------------------------------------------------------------------------
+describe('postizConfig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.POSTIZ_API_KEY;
+    delete process.env.POSTIZ_API_URL;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    delete process.env.POSTIZ_API_KEY;
+    delete process.env.POSTIZ_API_URL;
+  });
+
+  it('platforms has all 4 values in order', async () => {
+    const { postizConfig } = await import('../config');
+    expect(postizConfig.platforms).toEqual(['warpcast', 'x', 'bluesky', 'discord']);
+  });
+
+  it('rateLimitPerHour is 90', async () => {
+    const { postizConfig } = await import('../config');
+    expect(postizConfig.rateLimitPerHour).toBe(90);
+  });
+
+  it('baseUrl defaults to the postiz public v1 URL when POSTIZ_API_URL is unset', async () => {
+    const { postizConfig } = await import('../config');
+    expect(postizConfig.baseUrl).toBe('https://api.postiz.com/public/v1');
+  });
+
+  it('baseUrl uses POSTIZ_API_URL when set', async () => {
+    process.env.POSTIZ_API_URL = 'https://custom.postiz.internal/v2';
+    const { postizConfig } = await import('../config');
+    expect(postizConfig.baseUrl).toBe('https://custom.postiz.internal/v2');
+  });
+
+  it('apiKey is undefined when POSTIZ_API_KEY is unset', async () => {
+    const { postizConfig } = await import('../config');
+    expect(postizConfig.apiKey).toBeUndefined();
+  });
+
+  it('apiKey is set when POSTIZ_API_KEY is provided', async () => {
+    process.env.POSTIZ_API_KEY = 'test-key-abc123';
+    const { postizConfig } = await import('../config');
+    expect(postizConfig.apiKey).toBe('test-key-abc123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clipperConfig
+// ---------------------------------------------------------------------------
+describe('clipperConfig', () => {
+  it('videoMaxSizeMB is 500', async () => {
+    const { clipperConfig } = await import('../config');
+    expect(clipperConfig.videoMaxSizeMB).toBe(500);
+  });
+
+  it('supportedFormats includes mp4, mov, webm, mkv', async () => {
+    const { clipperConfig } = await import('../config');
+    expect(clipperConfig.supportedFormats).toContain('mp4');
+    expect(clipperConfig.supportedFormats).toContain('mov');
+    expect(clipperConfig.supportedFormats).toContain('webm');
+    expect(clipperConfig.supportedFormats).toContain('mkv');
+  });
+
+  it('transcriptionProvider is whisper', async () => {
+    const { clipperConfig } = await import('../config');
+    expect(clipperConfig.transcriptionProvider).toBe('whisper');
+  });
+
+  it('defaultAspectRatio is 9:16', async () => {
+    const { clipperConfig } = await import('../config');
+    expect(clipperConfig.defaultAspectRatio).toBe('9:16');
+  });
+
+  it('captionMaxChars is 300', async () => {
+    const { clipperConfig } = await import('../config');
+    expect(clipperConfig.captionMaxChars).toBe(300);
+  });
+
+  it('captionMustMention is /wavewarz', async () => {
+    const { clipperConfig } = await import('../config');
+    expect(clipperConfig.captionMustMention).toBe('/wavewarz');
+  });
+});

--- a/src/lib/wavewarz/__tests__/constants.test.ts
+++ b/src/lib/wavewarz/__tests__/constants.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  INTELLIGENCE_BASE,
+  RESPECT_THRESHOLD,
+  SPOTLIGHT_TIERS,
+  WAVEWARZ_WALLETS,
+} from '../constants';
+
+// ---------------------------------------------------------------------------
+// SPOTLIGHT_TIERS
+// ---------------------------------------------------------------------------
+describe('SPOTLIGHT_TIERS', () => {
+  it('has exactly 3 tiers', () => {
+    expect(SPOTLIGHT_TIERS).toHaveLength(3);
+  });
+
+  it('each entry has tier, label, and minWins', () => {
+    for (const entry of SPOTLIGHT_TIERS) {
+      expect(entry).toHaveProperty('tier');
+      expect(entry).toHaveProperty('label');
+      expect(entry).toHaveProperty('minWins');
+      expect(typeof entry.tier).toBe('string');
+      expect(typeof entry.label).toBe('string');
+      expect(typeof entry.minWins).toBe('number');
+    }
+  });
+
+  it('contains the expected tier identifiers', () => {
+    const tierIds = SPOTLIGHT_TIERS.map((t) => t.tier);
+    expect(tierIds).toContain('rising_star');
+    expect(tierIds).toContain('veteran');
+    expect(tierIds).toContain('legend');
+  });
+
+  it('minWins values are in strictly ascending order', () => {
+    for (let i = 1; i < SPOTLIGHT_TIERS.length; i++) {
+      expect(SPOTLIGHT_TIERS[i].minWins).toBeGreaterThan(SPOTLIGHT_TIERS[i - 1].minWins);
+    }
+  });
+
+  it('rising_star has minWins of 3', () => {
+    const tier = SPOTLIGHT_TIERS.find((t) => t.tier === 'rising_star');
+    expect(tier?.minWins).toBe(3);
+  });
+
+  it('veteran has minWins of 10', () => {
+    const tier = SPOTLIGHT_TIERS.find((t) => t.tier === 'veteran');
+    expect(tier?.minWins).toBe(10);
+  });
+
+  it('legend has minWins of 25', () => {
+    const tier = SPOTLIGHT_TIERS.find((t) => t.tier === 'legend');
+    expect(tier?.minWins).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RESPECT_THRESHOLD
+// ---------------------------------------------------------------------------
+describe('RESPECT_THRESHOLD', () => {
+  it('is a number greater than 0', () => {
+    expect(typeof RESPECT_THRESHOLD).toBe('number');
+    expect(RESPECT_THRESHOLD).toBeGreaterThan(0);
+  });
+
+  it('is 1000', () => {
+    expect(RESPECT_THRESHOLD).toBe(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INTELLIGENCE_BASE
+// ---------------------------------------------------------------------------
+describe('INTELLIGENCE_BASE', () => {
+  it('is a string starting with https://', () => {
+    expect(typeof INTELLIGENCE_BASE).toBe('string');
+    expect(INTELLIGENCE_BASE.startsWith('https://')).toBe(true);
+  });
+
+  it('is a valid URL', () => {
+    expect(() => new URL(INTELLIGENCE_BASE)).not.toThrow();
+  });
+
+  it('points to the wavewarz intelligence host', () => {
+    expect(INTELLIGENCE_BASE).toBe('https://wavewarz-intelligence.vercel.app');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WAVEWARZ_WALLETS
+// ---------------------------------------------------------------------------
+describe('WAVEWARZ_WALLETS', () => {
+  it('has exactly 43 entries', () => {
+    expect(WAVEWARZ_WALLETS).toHaveLength(43);
+  });
+
+  it('every entry has a non-empty wallet string', () => {
+    for (const entry of WAVEWARZ_WALLETS) {
+      expect(typeof entry.wallet).toBe('string');
+      expect(entry.wallet.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every entry has a non-empty name string', () => {
+    for (const entry of WAVEWARZ_WALLETS) {
+      expect(typeof entry.name).toBe('string');
+      expect(entry.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every entry has exactly { wallet, name } shape', () => {
+    for (const entry of WAVEWARZ_WALLETS) {
+      expect(Object.keys(entry).sort()).toEqual(['name', 'wallet']);
+    }
+  });
+});


### PR DESCRIPTION
## What
28 test cases verifying configuration constants and WaveWarZ data integrity.

**`config.test.ts` (12 cases):**
- `postizConfig`: platforms has all 4 values in order, rateLimitPerHour=90, baseUrl default when POSTIZ_API_URL unset, baseUrl override via env, apiKey absent/present
- `clipperConfig`: videoMaxSizeMB=500, all 4 supportedFormats, transcriptionProvider='whisper', defaultAspectRatio='9:16', captionMaxChars=300, captionMustMention='/wavewarz'
- Uses `vi.resetModules()` + dynamic import to isolate module-level env reads

**`constants.test.ts` (16 cases):**
- `SPOTLIGHT_TIERS`: exactly 3 tiers, each has tier/label/minWins, expected IDs, minWins strictly ascending, exact values 3/10/25
- `RESPECT_THRESHOLD`: positive number, equals 1000
- `INTELLIGENCE_BASE`: starts with https://, valid URL, correct value
- `WAVEWARZ_WALLETS`: length 43, non-empty wallet strings, non-empty name strings, `{wallet, name}` shape

**Why constants matter:** WAVEWARZ_WALLETS has 43 entries used for on-chain queries — a silent off-by-one or shape mismatch would break the leaderboard. SPOTLIGHT_TIERS ascending check prevents future reordering bugs.

## Test run
```
✓ config.test.ts      12/12
✓ constants.test.ts   16/16
Total: 28/28 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)