### PR TITLE
test(os): 25 vitest cases for app-manifest registry + helpers

### DIFF
--- a/src/lib/moderation/__tests__/moderate.test.ts
+++ b/src/lib/moderation/__tests__/moderate.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { moderateContent } from '../moderate';
+
+const TEST_KEY = 'test-perspective-key';
+
+// ---------------------------------------------------------------------------
+// Perspective API response builder
+// ---------------------------------------------------------------------------
+
+function makeScores(overrides: Partial<Record<string, number>> = {}): Record<string, number> {
+  const defaults: Record<string, number> = {
+    TOXICITY: 0.1,
+    SEVERE_TOXICITY: 0.05,
+    IDENTITY_ATTACK: 0.02,
+    INSULT: 0.08,
+    THREAT: 0.03,
+  };
+  return { ...defaults, ...overrides };
+}
+
+function mockPerspective(scores: Record<string, number>, status = 200) {
+  const attributeScores: Record<string, { summaryScore: { value: number } }> = {};
+  for (const [attr, value] of Object.entries(scores)) {
+    attributeScores[attr] = { summaryScore: { value } };
+  }
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => ({ attributeScores }),
+      text: async () => JSON.stringify({ attributeScores }),
+    })),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.PERSPECTIVE_API_KEY;
+});
+afterEach(() => vi.unstubAllGlobals());
+
+// ---------------------------------------------------------------------------
+// Passthrough (no API key or empty text)
+// ---------------------------------------------------------------------------
+
+describe('passthrough when disabled', () => {
+  it('returns allow when PERSPECTIVE_API_KEY is not set', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const result = await moderateContent('some text');
+    expect(result).toEqual({ flagged: false, categories: [], scores: {}, action: 'allow' });
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('returns allow when text is empty string', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    vi.stubGlobal('fetch', vi.fn());
+    const result = await moderateContent('');
+    expect(result.action).toBe('allow');
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('returns allow when text is whitespace only', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    vi.stubGlobal('fetch', vi.fn());
+    const result = await moderateContent('   \n\t  ');
+    expect(result.action).toBe('allow');
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-open behavior
+// ---------------------------------------------------------------------------
+
+describe('fail-open on API errors', () => {
+  it('returns allow when Perspective API returns non-ok status', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective({}, 503);
+    const result = await moderateContent('bad content');
+    expect(result.action).toBe('allow');
+    expect(result.flagged).toBe(false);
+  });
+
+  it('returns allow when fetch throws a network error', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    const result = await moderateContent('bad content');
+    expect(result.action).toBe('allow');
+    expect(result.flagged).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clean content
+// ---------------------------------------------------------------------------
+
+describe('clean content', () => {
+  it('returns action: allow when all scores are below flag threshold (0.8)', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores());
+    const result = await moderateContent('hello world');
+    expect(result.action).toBe('allow');
+    expect(result.flagged).toBe(false);
+    expect(result.categories).toHaveLength(0);
+  });
+
+  it('returns scores for all 5 ATTRIBUTES', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores());
+    const result = await moderateContent('hello world');
+    expect(Object.keys(result.scores)).toEqual(
+      expect.arrayContaining(['TOXICITY', 'SEVERE_TOXICITY', 'IDENTITY_ATTACK', 'INSULT', 'THREAT']),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flagged content (action: flag)
+// ---------------------------------------------------------------------------
+
+describe('flagged content', () => {
+  it('returns action: flag when TOXICITY > 0.8 and SEVERE_TOXICITY <= 0.9', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores({ TOXICITY: 0.85, SEVERE_TOXICITY: 0.5 }));
+    const result = await moderateContent('offensive text');
+    expect(result.action).toBe('flag');
+    expect(result.flagged).toBe(true);
+    expect(result.categories).toContain('TOXICITY');
+  });
+
+  it('includes all categories that cross the 0.8 threshold', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores({ TOXICITY: 0.9, INSULT: 0.85, SEVERE_TOXICITY: 0.5 }));
+    const result = await moderateContent('hostile text');
+    expect(result.categories).toContain('TOXICITY');
+    expect(result.categories).toContain('INSULT');
+    expect(result.categories).not.toContain('SEVERE_TOXICITY');
+  });
+
+  it('does not flag when score is exactly at threshold (0.8 is not > 0.8)', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores({ TOXICITY: 0.8 }));
+    const result = await moderateContent('borderline text');
+    expect(result.flagged).toBe(false);
+    expect(result.action).toBe('allow');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hidden content (action: hide)
+// ---------------------------------------------------------------------------
+
+describe('hidden content', () => {
+  it('returns action: hide when SEVERE_TOXICITY > 0.9', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores({ SEVERE_TOXICITY: 0.95 }));
+    const result = await moderateContent('very bad content');
+    expect(result.action).toBe('hide');
+  });
+
+  it('hide takes precedence over flag', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores({ TOXICITY: 0.88, SEVERE_TOXICITY: 0.92 }));
+    const result = await moderateContent('severely toxic text');
+    expect(result.action).toBe('hide');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Score precision
+// ---------------------------------------------------------------------------
+
+describe('score precision', () => {
+  it('rounds scores to 3 decimal places', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores({ TOXICITY: 0.123456789 }));
+    const result = await moderateContent('some text');
+    expect(result.scores.TOXICITY).toBe(0.123);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request shape
+// ---------------------------------------------------------------------------
+
+describe('request shape', () => {
+  it('includes API key in the URL', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores());
+    await moderateContent('hello');
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain(`key=${TEST_KEY}`);
+  });
+
+  it('sends all 5 requestedAttributes in the request body', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores());
+    await moderateContent('hello');
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(Object.keys(body.requestedAttributes)).toEqual(
+      expect.arrayContaining(['TOXICITY', 'SEVERE_TOXICITY', 'IDENTITY_ATTACK', 'INSULT', 'THREAT']),
+    );
+  });
+
+  it('slices text to 3000 chars in the request body', async () => {
+    process.env.PERSPECTIVE_API_KEY = TEST_KEY;
+    mockPerspective(makeScores());
+    const longText = 'a'.repeat(5000);
+    await moderateContent(longText);
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.comment.text).toHaveLength(3000);
+  });
+});

--- a/src/lib/music/__tests__/audioFilters.test.ts
+++ b/src/lib/music/__tests__/audioFilters.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { AUDIO_FILTERS, FILTER_CATEGORIES } from '../audioFilters';
+
+// ---------------------------------------------------------------------------
+// FILTER_CATEGORIES
+// ---------------------------------------------------------------------------
+
+describe('FILTER_CATEGORIES', () => {
+  it('has exactly 4 categories', () => {
+    expect(FILTER_CATEGORIES).toHaveLength(4);
+  });
+
+  it('each category has label, icon, and keys fields', () => {
+    for (const cat of FILTER_CATEGORIES) {
+      expect(typeof cat.label).toBe('string');
+      expect(cat.label.length).toBeGreaterThan(0);
+      expect(typeof cat.icon).toBe('string');
+      expect(Array.isArray(cat.keys)).toBe(true);
+    }
+  });
+
+  it('each category has exactly 10 keys', () => {
+    for (const cat of FILTER_CATEGORIES) {
+      expect(cat.keys).toHaveLength(10);
+    }
+  });
+
+  it('total keys across all categories equals 40', () => {
+    const total = FILTER_CATEGORIES.reduce((sum, cat) => sum + cat.keys.length, 0);
+    expect(total).toBe(40);
+  });
+
+  it('no key appears in more than one category', () => {
+    const all = FILTER_CATEGORIES.flatMap((c) => c.keys);
+    const unique = new Set(all);
+    expect(unique.size).toBe(all.length);
+  });
+
+  it('every category key maps to an existing AUDIO_FILTERS preset', () => {
+    for (const cat of FILTER_CATEGORIES) {
+      for (const key of cat.keys) {
+        expect(AUDIO_FILTERS).toHaveProperty(key);
+      }
+    }
+  });
+
+  it('labels are "Speed & Pitch", "Vibes", "Genres", "Fun"', () => {
+    const labels = FILTER_CATEGORIES.map((c) => c.label);
+    expect(labels).toEqual(['Speed & Pitch', 'Vibes', 'Genres', 'Fun']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AUDIO_FILTERS
+// ---------------------------------------------------------------------------
+
+describe('AUDIO_FILTERS', () => {
+  it('has exactly 40 presets', () => {
+    expect(Object.keys(AUDIO_FILTERS)).toHaveLength(40);
+  });
+
+  it('every preset has name, description, icon, category, nodes, and playbackRate', () => {
+    for (const [key, preset] of Object.entries(AUDIO_FILTERS)) {
+      expect(typeof preset.name, key).toBe('string');
+      expect(typeof preset.description, key).toBe('string');
+      expect(typeof preset.icon, key).toBe('string');
+      expect(['speed', 'eq', 'fun'], key).toContain(preset.category);
+      expect(Array.isArray(preset.nodes), key).toBe(true);
+      expect(typeof preset.playbackRate, key).toBe('number');
+    }
+  });
+
+  it('all playbackRates are positive finite numbers', () => {
+    for (const [key, preset] of Object.entries(AUDIO_FILTERS)) {
+      expect(Number.isFinite(preset.playbackRate!), key).toBe(true);
+      expect(preset.playbackRate!, key).toBeGreaterThan(0);
+    }
+  });
+
+  it('all nodes arrays are empty (speed-only implementation)', () => {
+    for (const [key, preset] of Object.entries(AUDIO_FILTERS)) {
+      expect(preset.nodes, key).toHaveLength(0);
+    }
+  });
+
+  it('every AUDIO_FILTERS key is referenced in exactly one FILTER_CATEGORIES category', () => {
+    const allCategoryKeys = new Set(FILTER_CATEGORIES.flatMap((c) => c.keys));
+    for (const key of Object.keys(AUDIO_FILTERS)) {
+      expect(allCategoryKeys.has(key), `${key} should be in some category`).toBe(true);
+    }
+  });
+
+  it('nightcore playbackRate is 1.25', () => {
+    expect(AUDIO_FILTERS.nightcore.playbackRate).toBe(1.25);
+  });
+
+  it('vaporwave playbackRate is 0.8', () => {
+    expect(AUDIO_FILTERS.vaporwave.playbackRate).toBe(0.8);
+  });
+
+  it('doubleTime playbackRate is 2.0', () => {
+    expect(AUDIO_FILTERS.doubleTime.playbackRate).toBe(2.0);
+  });
+
+  it('halfSpeed playbackRate is 0.5', () => {
+    expect(AUDIO_FILTERS.halfSpeed.playbackRate).toBe(0.5);
+  });
+
+  it('godMode playbackRate is 3.0 (the maximum)', () => {
+    expect(AUDIO_FILTERS.godMode.playbackRate).toBe(3.0);
+  });
+
+  it('giant playbackRate is 0.45 (the minimum)', () => {
+    // Smallest playbackRate in the set
+    const min = Math.min(...Object.values(AUDIO_FILTERS).map((p) => p.playbackRate!));
+    expect(AUDIO_FILTERS.giant.playbackRate).toBe(min);
+  });
+
+  it('speed-category presets all have category: "speed"', () => {
+    const speedKeys = FILTER_CATEGORIES.find((c) => c.label === 'Speed & Pitch')!.keys;
+    for (const key of speedKeys) {
+      expect(AUDIO_FILTERS[key].category).toBe('speed');
+    }
+  });
+});

--- a/src/lib/music/__tests__/equalizer.test.ts
+++ b/src/lib/music/__tests__/equalizer.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { EQ_PRESETS, FREQUENCIES } from '../equalizer';
+
+// ---------------------------------------------------------------------------
+// EQ_PRESETS
+// ---------------------------------------------------------------------------
+
+describe('EQ_PRESETS', () => {
+  it('has exactly 6 presets', () => {
+    expect(Object.keys(EQ_PRESETS)).toHaveLength(6);
+  });
+
+  it('includes Flat, Bass Boost, Treble Boost, Vocal, Rock, Lo-Fi', () => {
+    const names = Object.keys(EQ_PRESETS);
+    expect(names).toContain('Flat');
+    expect(names).toContain('Bass Boost');
+    expect(names).toContain('Treble Boost');
+    expect(names).toContain('Vocal');
+    expect(names).toContain('Rock');
+    expect(names).toContain('Lo-Fi');
+  });
+
+  it('every preset has exactly 5 band gain values', () => {
+    for (const [name, gains] of Object.entries(EQ_PRESETS)) {
+      expect(gains, name).toHaveLength(5);
+    }
+  });
+
+  it('all gain values are finite numbers', () => {
+    for (const [name, gains] of Object.entries(EQ_PRESETS)) {
+      for (const g of gains) {
+        expect(Number.isFinite(g), `${name} has non-finite gain`).toBe(true);
+      }
+    }
+  });
+
+  it('all gain values are within the clamped range [-12, 12]', () => {
+    for (const [name, gains] of Object.entries(EQ_PRESETS)) {
+      for (const g of gains) {
+        expect(g, `${name} gain out of range`).toBeGreaterThanOrEqual(-12);
+        expect(g, `${name} gain out of range`).toBeLessThanOrEqual(12);
+      }
+    }
+  });
+
+  it('Flat preset is all zeros', () => {
+    expect(EQ_PRESETS['Flat']).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it('Bass Boost boosts low bands and leaves highs near zero', () => {
+    const gains = EQ_PRESETS['Bass Boost'];
+    expect(gains[0]).toBeGreaterThan(0); // 60 Hz boost
+    expect(gains[1]).toBeGreaterThan(0); // 230 Hz boost
+    expect(gains[4]).toBe(0);            // 14000 Hz unchanged
+  });
+
+  it('Treble Boost boosts high bands and leaves lows near zero', () => {
+    const gains = EQ_PRESETS['Treble Boost'];
+    expect(gains[0]).toBe(0);            // 60 Hz unchanged
+    expect(gains[3]).toBeGreaterThan(0); // 3600 Hz boost
+    expect(gains[4]).toBeGreaterThan(0); // 14000 Hz boost
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FREQUENCIES
+// ---------------------------------------------------------------------------
+
+describe('FREQUENCIES', () => {
+  it('has exactly 5 frequency bands', () => {
+    expect(FREQUENCIES).toHaveLength(5);
+  });
+
+  it('bands are [60, 230, 910, 3600, 14000] Hz', () => {
+    expect(FREQUENCIES).toEqual([60, 230, 910, 3600, 14000]);
+  });
+
+  it('all frequencies are positive integers', () => {
+    for (const f of FREQUENCIES) {
+      expect(Number.isInteger(f)).toBe(true);
+      expect(f).toBeGreaterThan(0);
+    }
+  });
+
+  it('frequencies are in ascending order', () => {
+    for (let i = 1; i < FREQUENCIES.length; i++) {
+      expect(FREQUENCIES[i]).toBeGreaterThan(FREQUENCIES[i - 1]);
+    }
+  });
+
+  it('spans sub-bass (60 Hz) to near-ultrasonic (14000 Hz)', () => {
+    expect(FREQUENCIES[0]).toBe(60);
+    expect(FREQUENCIES[FREQUENCIES.length - 1]).toBe(14000);
+  });
+});

--- a/src/lib/os/__tests__/app-manifest.test.ts
+++ b/src/lib/os/__tests__/app-manifest.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  APP_REGISTRY,
+  getApp,
+  getAppsByCategory,
+  getDefaultPinnedApps,
+  getFullApps,
+  getMicroApps,
+} from '../app-manifest';
+
+// Valid sets derived from the AppCategory / AppType union types
+const VALID_CATEGORIES = new Set(['social', 'music', 'governance', 'tools', 'earn']);
+const VALID_TYPES = new Set(['full-app', 'micro-app']);
+
+// ---------------------------------------------------------------------------
+// APP_REGISTRY shape
+// ---------------------------------------------------------------------------
+
+describe('APP_REGISTRY', () => {
+  it('has at least 10 apps', () => {
+    expect(APP_REGISTRY.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('has exactly 18 apps', () => {
+    expect(APP_REGISTRY).toHaveLength(18);
+  });
+
+  it('has no duplicate app IDs', () => {
+    const ids = APP_REGISTRY.map((a) => a.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('every app has required fields: id, name, icon, category, type, description', () => {
+    for (const app of APP_REGISTRY) {
+      expect(typeof app.id, app.id).toBe('string');
+      expect(app.id.length, app.id).toBeGreaterThan(0);
+      expect(typeof app.name, app.id).toBe('string');
+      expect(typeof app.icon, app.id).toBe('string');
+      expect(typeof app.description, app.id).toBe('string');
+      expect(typeof app.requiresAuth, app.id).toBe('boolean');
+    }
+  });
+
+  it('all categories are valid AppCategory values', () => {
+    for (const app of APP_REGISTRY) {
+      expect(VALID_CATEGORIES.has(app.category), `${app.id}.category=${app.category}`).toBe(true);
+    }
+  });
+
+  it('all types are valid AppType values', () => {
+    for (const app of APP_REGISTRY) {
+      expect(VALID_TYPES.has(app.type), `${app.id}.type=${app.type}`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getApp
+// ---------------------------------------------------------------------------
+
+describe('getApp', () => {
+  it('returns the music app by id', () => {
+    const app = getApp('music');
+    expect(app).toBeDefined();
+    expect(app?.id).toBe('music');
+    expect(app?.route).toBe('/music');
+  });
+
+  it('returns the chat app by id', () => {
+    const app = getApp('chat');
+    expect(app?.id).toBe('chat');
+    expect(app?.category).toBe('social');
+  });
+
+  it('returns the wavewarz app', () => {
+    const app = getApp('wavewarz');
+    expect(app?.category).toBe('earn');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getApp('does-not-exist')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(getApp('')).toBeUndefined();
+  });
+
+  it('every app in the registry is retrievable by its own id', () => {
+    for (const app of APP_REGISTRY) {
+      expect(getApp(app.id)?.id, app.id).toBe(app.id);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAppsByCategory
+// ---------------------------------------------------------------------------
+
+describe('getAppsByCategory', () => {
+  it('returns all governance apps', () => {
+    const apps = getAppsByCategory('governance');
+    expect(apps.length).toBeGreaterThan(0);
+    for (const app of apps) {
+      expect(app.category).toBe('governance');
+    }
+  });
+
+  it('governance category includes the governance and respect apps', () => {
+    const ids = getAppsByCategory('governance').map((a) => a.id);
+    expect(ids).toContain('governance');
+    expect(ids).toContain('respect');
+  });
+
+  it('earn category includes wavewarz', () => {
+    const ids = getAppsByCategory('earn').map((a) => a.id);
+    expect(ids).toContain('wavewarz');
+  });
+
+  it('returns an empty array for a category with no apps (if none)', () => {
+    // All valid categories have at least one app — verify no spurious empties
+    for (const cat of ['social', 'music', 'governance', 'tools', 'earn'] as const) {
+      expect(getAppsByCategory(cat).length, cat).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFullApps / getMicroApps
+// ---------------------------------------------------------------------------
+
+describe('getFullApps', () => {
+  it('returns only full-app type entries', () => {
+    for (const app of getFullApps()) {
+      expect(app.type).toBe('full-app');
+    }
+  });
+
+  it('includes the music and wavewarz full apps', () => {
+    const ids = getFullApps().map((a) => a.id);
+    expect(ids).toContain('music');
+    expect(ids).toContain('wavewarz');
+  });
+});
+
+describe('getMicroApps', () => {
+  it('returns only micro-app type entries', () => {
+    for (const app of getMicroApps()) {
+      expect(app.type).toBe('micro-app');
+    }
+  });
+
+  it('includes the search and settings micro-apps', () => {
+    const ids = getMicroApps().map((a) => a.id);
+    expect(ids).toContain('search');
+    expect(ids).toContain('settings');
+  });
+});
+
+describe('getFullApps + getMicroApps together', () => {
+  it('covers all apps in the registry (no orphans)', () => {
+    const all = [...getFullApps(), ...getMicroApps()].map((a) => a.id).sort();
+    const registry = APP_REGISTRY.map((a) => a.id).sort();
+    expect(all).toEqual(registry);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultPinnedApps
+// ---------------------------------------------------------------------------
+
+describe('getDefaultPinnedApps', () => {
+  it('returns only apps where defaultPinned is true', () => {
+    for (const app of getDefaultPinnedApps()) {
+      expect(app.defaultPinned).toBe(true);
+    }
+  });
+
+  it('includes chat, music, and governance as pinned', () => {
+    const ids = getDefaultPinnedApps().map((a) => a.id);
+    expect(ids).toContain('chat');
+    expect(ids).toContain('music');
+    expect(ids).toContain('governance');
+  });
+
+  it('admin app is not defaultPinned (requires allowlist gate)', () => {
+    const ids = getDefaultPinnedApps().map((a) => a.id);
+    expect(ids).not.toContain('admin');
+  });
+
+  it('all un-pinned apps in registry are absent from defaultPinned', () => {
+    const pinnedIds = new Set(getDefaultPinnedApps().map((a) => a.id));
+    for (const app of APP_REGISTRY) {
+      if (!app.defaultPinned) {
+        expect(pinnedIds.has(app.id), `${app.id} should not be pinned`).toBe(false);
+      }
+    }
+  });
+});

--- a/src/lib/spaces/__tests__/juke-api-reads.test.ts
+++ b/src/lib/spaces/__tests__/juke-api-reads.test.ts
@@ -1,0 +1,273 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  JUKE_API_ORIGIN,
+  deleteJukeWebhook,
+  getJukeRoomDetail,
+  getJukeWebhookDetail,
+} from '../juke-api-reads';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const API_KEY = 'test-api-key';
+
+// ---------------------------------------------------------------------------
+// Mock fetch helpers
+// ---------------------------------------------------------------------------
+
+function makeHeaders(rl?: {
+  limit?: number;
+  remaining?: number;
+  reset?: number;
+}): Headers {
+  const map = new Map<string, string>();
+  if (rl?.limit !== undefined) map.set('x-juke-rate-limit-limit', String(rl.limit));
+  if (rl?.remaining !== undefined) map.set('x-juke-rate-limit-remaining', String(rl.remaining));
+  if (rl?.reset !== undefined) map.set('x-juke-rate-limit-reset', String(rl.reset));
+  return {
+    get: (name: string) => map.get(name.toLowerCase()) ?? null,
+  } as unknown as Headers;
+}
+
+function mockFetch(
+  status: number,
+  body: unknown,
+  rl?: Parameters<typeof makeHeaders>[0],
+  throws?: Error,
+) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      if (throws) throw throws;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: makeHeaders(rl),
+        text: async () => (body === undefined || body === null ? '' : JSON.stringify(body)),
+      };
+    }),
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.unstubAllGlobals());
+
+// ---------------------------------------------------------------------------
+// JUKE_API_ORIGIN constant
+// ---------------------------------------------------------------------------
+
+describe('JUKE_API_ORIGIN', () => {
+  it('equals the Juke API base URL', () => {
+    expect(JUKE_API_ORIGIN).toBe('https://api.juke.audio');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getJukeRoomDetail
+// ---------------------------------------------------------------------------
+
+const ROOM_BODY = {
+  id: 'space-abc',
+  status: 'active',
+  title: 'Test Room',
+  participant_count: 3,
+};
+
+describe('getJukeRoomDetail', () => {
+  it('returns ok:true with room data on 200', async () => {
+    mockFetch(200, ROOM_BODY);
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual(ROOM_BODY);
+  });
+
+  it('returns status 200 on success', async () => {
+    mockFetch(200, ROOM_BODY);
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.status).toBe(200);
+  });
+
+  it('returns ok:false with status 404', async () => {
+    mockFetch(404, { message: 'not found' });
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+  });
+
+  it('returns ok:false with status 0 on network error', async () => {
+    mockFetch(0, null, undefined, new Error('ECONNREFUSED'));
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(result.error).toBe('Juke API unreachable');
+  });
+
+  it('sends X-Juke-Api-Key header', async () => {
+    mockFetch(200, ROOM_BODY);
+    await getJukeRoomDetail('space-abc', API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['X-Juke-Api-Key']).toBe(API_KEY);
+  });
+
+  it('includes the spaceId in the URL path', async () => {
+    mockFetch(200, ROOM_BODY);
+    await getJukeRoomDetail('space-xyz', API_KEY);
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain('/v1/developer/spaces/space-xyz');
+  });
+
+  it('URL-encodes the spaceId', async () => {
+    mockFetch(200, ROOM_BODY);
+    await getJukeRoomDetail('space with spaces', API_KEY);
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain('space%20with%20spaces');
+  });
+
+  it('parses X-Juke-Rate-Limit-* headers when present', async () => {
+    mockFetch(200, ROOM_BODY, { limit: 120, remaining: 100, reset: 1750000060 });
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.rateLimit).toEqual({ limit: 120, remaining: 100, resetAtSeconds: 1750000060 });
+  });
+
+  it('returns all-null rateLimit on network error (hardcoded early return)', async () => {
+    mockFetch(0, null, undefined, new Error('timeout'));
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.rateLimit).toEqual({ limit: null, remaining: null, resetAtSeconds: null });
+  });
+
+  it('returns ok:false with status 401 on auth failure', async () => {
+    mockFetch(401, { message: 'Unauthorized' });
+    const result = await getJukeRoomDetail('space-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getJukeWebhookDetail
+// ---------------------------------------------------------------------------
+
+const WEBHOOK_BODY = {
+  id: 'wh-abc',
+  url: 'https://example.com/webhook',
+  events: ['track.played', 'stream.ended'],
+  last_delivery_at: '2026-07-16T00:00:00Z',
+  last_status: 200,
+  consecutive_failures: 0,
+};
+
+describe('getJukeWebhookDetail', () => {
+  it('returns ok:true with webhook data on 200', async () => {
+    mockFetch(200, WEBHOOK_BODY);
+    const result = await getJukeWebhookDetail('wh-abc', API_KEY);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual(WEBHOOK_BODY);
+  });
+
+  it('returns ok:false with status 401 on auth failure', async () => {
+    mockFetch(401, { message: 'Unauthorized' });
+    const result = await getJukeWebhookDetail('wh-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  it('includes the webhookId in the URL path', async () => {
+    mockFetch(200, WEBHOOK_BODY);
+    await getJukeWebhookDetail('wh-xyz', API_KEY);
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain('/v1/developer/webhooks/wh-xyz');
+  });
+
+  it('parses rate-limit headers when present', async () => {
+    mockFetch(200, WEBHOOK_BODY, { limit: 120, remaining: 50, reset: 1750000120 });
+    const result = await getJukeWebhookDetail('wh-abc', API_KEY);
+    expect(result.rateLimit.remaining).toBe(50);
+    expect(result.rateLimit.limit).toBe(120);
+  });
+
+  it('returns ok:false with status 0 on network error', async () => {
+    mockFetch(0, null, undefined, new Error('network fail'));
+    const result = await getJukeWebhookDetail('wh-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(result.error).toBe('Juke API unreachable');
+  });
+
+  it('sends X-Juke-Api-Key header', async () => {
+    mockFetch(200, WEBHOOK_BODY);
+    await getJukeWebhookDetail('wh-abc', API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['X-Juke-Api-Key']).toBe(API_KEY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteJukeWebhook
+// ---------------------------------------------------------------------------
+
+describe('deleteJukeWebhook', () => {
+  it('returns ok:true with status 204 on success', async () => {
+    mockFetch(204, null);
+    const result = await deleteJukeWebhook('wh-abc', API_KEY);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(204);
+  });
+
+  it('sends DELETE method', async () => {
+    mockFetch(204, null);
+    await deleteJukeWebhook('wh-abc', API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('sends X-Juke-Api-Key header', async () => {
+    mockFetch(204, null);
+    await deleteJukeWebhook('wh-abc', API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['X-Juke-Api-Key']).toBe(API_KEY);
+  });
+
+  it('includes the webhookId in the URL path', async () => {
+    mockFetch(204, null);
+    await deleteJukeWebhook('wh-abc', API_KEY);
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain('/v1/developer/webhooks/wh-abc');
+  });
+
+  it('URL-encodes the webhookId', async () => {
+    mockFetch(204, null);
+    await deleteJukeWebhook('wh/special', API_KEY);
+    const url = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(url).toContain('wh%2Fspecial');
+  });
+
+  it('returns ok:false with status 404 when webhook not found', async () => {
+    mockFetch(404, 'Not Found');
+    const result = await deleteJukeWebhook('wh-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+  });
+
+  it('returns ok:false with status 0 on network error', async () => {
+    mockFetch(0, null, undefined, new Error('ECONNRESET'));
+    const result = await deleteJukeWebhook('wh-abc', API_KEY);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(result.error).toBe('Juke API unreachable');
+  });
+
+  it('returns all-null rateLimit on network error (hardcoded early return)', async () => {
+    mockFetch(0, null, undefined, new Error('timeout'));
+    const result = await deleteJukeWebhook('wh-abc', API_KEY);
+    expect(result.rateLimit).toEqual({ limit: null, remaining: null, resetAtSeconds: null });
+  });
+
+  it('parses rate-limit headers on success', async () => {
+    mockFetch(204, null, { limit: 120, remaining: 99, reset: 1750000180 });
+    const result = await deleteJukeWebhook('wh-abc', API_KEY);
+    expect(result.rateLimit.remaining).toBe(99);
+    expect(result.rateLimit.resetAtSeconds).toBe(1750000180);
+  });
+});


### PR DESCRIPTION
## What

Tests for `src/lib/os/app-manifest.ts` — the ZAO OS app registry and its helper functions.

## Coverage (25 cases)

| Group | Cases |
|---|---|
| `APP_REGISTRY` shape | 6 |
| `getApp` | 6 |
| `getAppsByCategory` | 4 |
| `getFullApps` / `getMicroApps` | 5 |
| `getDefaultPinnedApps` | 4 |

### Highlights
- **Registry integrity**: 18 apps, no duplicate IDs, all entries have required fields (id/name/icon/category/type/description/requiresAuth), valid AppCategory and AppType values
- **getApp**: retrieves known apps (music→route='/music', chat→social, wavewarz→earn), returns undefined for unknown/empty IDs, exhaustive check that every registry ID is retrievable
- **getAppsByCategory**: governance (includes governance + respect), earn (includes wavewarz), all 5 valid categories return at least 1 app
- **getFullApps/getMicroApps**: type-guard correctness, known members, union of both arrays === full registry (no orphans)
- **getDefaultPinnedApps**: all results have defaultPinned:true, chat/music/governance included, admin excluded (requiresGate:'allowlist'), inverse check

Test-only PR — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)