### PR TITLE
test(agents/empire-builder): 24 vitest cases for token constants

### DIFF
--- a/src/lib/agents/__tests__/types.test.ts
+++ b/src/lib/agents/__tests__/types.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { BASE_CHAIN_ID, BURN_ADDRESS, BURN_PCT, TOKENS, ZABAL_STAKING_CONTRACT } from '../types';
+
+// Valid Ethereum address: 0x followed by exactly 40 hex chars
+const ETH_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+describe('TOKENS', () => {
+  it('has exactly 4 token addresses', () => {
+    expect(Object.keys(TOKENS)).toHaveLength(4);
+  });
+
+  it('includes ZABAL, SANG, WETH, USDC keys', () => {
+    expect(Object.keys(TOKENS)).toEqual(expect.arrayContaining(['ZABAL', 'SANG', 'WETH', 'USDC']));
+  });
+
+  it('ZABAL is a valid Ethereum address', () => {
+    expect(TOKENS.ZABAL).toMatch(ETH_ADDRESS);
+  });
+
+  it('SANG is a valid Ethereum address', () => {
+    expect(TOKENS.SANG).toMatch(ETH_ADDRESS);
+  });
+
+  it('WETH is the canonical Base WETH address', () => {
+    expect(TOKENS.WETH).toBe('0x4200000000000000000000000000000000000006');
+  });
+
+  it('USDC is the canonical Base USDC address', () => {
+    expect(TOKENS.USDC).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+  });
+
+  it('all token addresses are distinct', () => {
+    const addrs = Object.values(TOKENS).map((a) => a.toLowerCase());
+    expect(new Set(addrs).size).toBe(addrs.length);
+  });
+});
+
+describe('BASE_CHAIN_ID', () => {
+  it('is 8453 (Base mainnet)', () => {
+    expect(BASE_CHAIN_ID).toBe(8453);
+  });
+});
+
+describe('BURN_ADDRESS', () => {
+  it('is the canonical dead address', () => {
+    expect(BURN_ADDRESS).toBe('0x000000000000000000000000000000000000dEaD');
+  });
+
+  it('is a valid Ethereum address', () => {
+    expect(BURN_ADDRESS).toMatch(ETH_ADDRESS);
+  });
+});
+
+describe('BURN_PCT', () => {
+  it('is 0.01 (1%)', () => {
+    expect(BURN_PCT).toBe(0.01);
+  });
+
+  it('is a positive finite number', () => {
+    expect(Number.isFinite(BURN_PCT)).toBe(true);
+    expect(BURN_PCT).toBeGreaterThan(0);
+    expect(BURN_PCT).toBeLessThan(1);
+  });
+});
+
+describe('ZABAL_STAKING_CONTRACT', () => {
+  it('is a string (env var or empty fallback)', () => {
+    expect(typeof ZABAL_STAKING_CONTRACT).toBe('string');
+  });
+});

--- a/src/lib/empire-builder/__tests__/config.test.ts
+++ b/src/lib/empire-builder/__tests__/config.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  EMPIRE_BUILDER_BASE_URL,
+  EMPIRE_BUILDER_CACHE_TTL_MS,
+  EMPIRE_BUILDER_FETCH_TIMEOUT_MS,
+  ZABAL_EMPIRE_ADDRESS,
+  ZABAL_TOKEN_ADDRESS,
+} from '../config';
+import { TOKENS } from '../../agents/types';
+
+const ETH_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+describe('ZABAL_TOKEN_ADDRESS', () => {
+  it('matches agents/types TOKENS.ZABAL (consistency)', () => {
+    expect(ZABAL_TOKEN_ADDRESS).toBe(TOKENS.ZABAL);
+  });
+
+  it('is a valid Ethereum address', () => {
+    expect(ZABAL_TOKEN_ADDRESS).toMatch(ETH_ADDRESS);
+  });
+});
+
+describe('ZABAL_EMPIRE_ADDRESS', () => {
+  it('is a valid Ethereum address', () => {
+    expect(ZABAL_EMPIRE_ADDRESS).toMatch(ETH_ADDRESS);
+  });
+
+  it('is distinct from ZABAL_TOKEN_ADDRESS', () => {
+    expect(ZABAL_EMPIRE_ADDRESS.toLowerCase()).not.toBe(ZABAL_TOKEN_ADDRESS.toLowerCase());
+  });
+});
+
+describe('EMPIRE_BUILDER_BASE_URL', () => {
+  it('is the Empire Builder API base URL', () => {
+    expect(EMPIRE_BUILDER_BASE_URL).toBe('https://empirebuilder.world/api');
+  });
+
+  it('starts with https://', () => {
+    expect(EMPIRE_BUILDER_BASE_URL).toMatch(/^https:\/\//);
+  });
+
+  it('does not end with a trailing slash', () => {
+    expect(EMPIRE_BUILDER_BASE_URL).not.toMatch(/\/$/);
+  });
+});
+
+describe('EMPIRE_BUILDER_CACHE_TTL_MS', () => {
+  it('is 60 seconds (60_000 ms)', () => {
+    expect(EMPIRE_BUILDER_CACHE_TTL_MS).toBe(60_000);
+  });
+
+  it('is a positive integer', () => {
+    expect(Number.isInteger(EMPIRE_BUILDER_CACHE_TTL_MS)).toBe(true);
+    expect(EMPIRE_BUILDER_CACHE_TTL_MS).toBeGreaterThan(0);
+  });
+});
+
+describe('EMPIRE_BUILDER_FETCH_TIMEOUT_MS', () => {
+  it('is 8000 ms', () => {
+    expect(EMPIRE_BUILDER_FETCH_TIMEOUT_MS).toBe(8000);
+  });
+
+  it('is less than the cache TTL (timeout shorter than cache)', () => {
+    expect(EMPIRE_BUILDER_FETCH_TIMEOUT_MS).toBeLessThan(EMPIRE_BUILDER_CACHE_TTL_MS);
+  });
+});


### PR DESCRIPTION
## What

Tests for pure constant modules:
- `src/lib/agents/types.ts` — on-chain token addresses, chain ID, burn config
- `src/lib/empire-builder/config.ts` — ZABAL empire addresses + API config

## Coverage (24 cases)

| File | Cases |
|---|---|
| `agents/__tests__/types.test.ts` | 13 |
| `empire-builder/__tests__/config.test.ts` | 11 |

### agents/types.test.ts
- TOKENS: 4 keys (ZABAL/SANG/WETH/USDC), all valid ETH addresses, all distinct, canonical Base WETH + USDC values spot-checked
- BASE_CHAIN_ID = 8453 (Base mainnet)
- BURN_ADDRESS = canonical dead address (valid ETH addr)
- BURN_PCT = 0.01, positive finite, in (0, 1)
- ZABAL_STAKING_CONTRACT is a string (env var or empty fallback)

### empire-builder/config.test.ts
- ZABAL_TOKEN_ADDRESS matches `TOKENS.ZABAL` from agents/types (cross-module consistency guard)
- ZABAL_EMPIRE_ADDRESS valid ETH address, distinct from token address
- EMPIRE_BUILDER_BASE_URL exact value, https prefix, no trailing slash
- EMPIRE_BUILDER_CACHE_TTL_MS = 60_000 ms, positive integer
- EMPIRE_BUILDER_FETCH_TIMEOUT_MS = 8000, less than cache TTL

Test-only PR — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)