### PR TITLE
test: portal destinations, songjam constants, platform detection (47 cases)

### DIFF
--- a/src/lib/os/__tests__/platform.test.ts
+++ b/src/lib/os/__tests__/platform.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { getPlatform, isAndroid, isIOS, isNative } from '../platform';
+
+// In the node test environment, typeof window === 'undefined', so getPlatform()
+// returns 'web' via the early-return path and never sets the module-level cache.
+// All four functions are therefore deterministic here.
+
+// ---------------------------------------------------------------------------
+// getPlatform (node / SSR path)
+// ---------------------------------------------------------------------------
+
+describe('getPlatform (node env)', () => {
+  it('returns "web" when window is undefined (SSR / node)', () => {
+    expect(getPlatform()).toBe('web');
+  });
+
+  it('returns "web" on a second call (consistent, no stale cache)', () => {
+    expect(getPlatform()).toBe('web');
+    expect(getPlatform()).toBe('web');
+  });
+
+  it('return value is one of the valid Platform literals', () => {
+    const result = getPlatform();
+    expect(['web', 'ios', 'android']).toContain(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isNative
+// ---------------------------------------------------------------------------
+
+describe('isNative (node env)', () => {
+  it('returns false when platform is "web"', () => {
+    expect(isNative()).toBe(false);
+  });
+
+  it('result is consistent with getPlatform() !== "ios" && !== "android"', () => {
+    const platform = getPlatform();
+    const expected = platform === 'ios' || platform === 'android';
+    expect(isNative()).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isIOS
+// ---------------------------------------------------------------------------
+
+describe('isIOS (node env)', () => {
+  it('returns false when platform is "web"', () => {
+    expect(isIOS()).toBe(false);
+  });
+
+  it('result is consistent with getPlatform() === "ios"', () => {
+    expect(isIOS()).toBe(getPlatform() === 'ios');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAndroid
+// ---------------------------------------------------------------------------
+
+describe('isAndroid (node env)', () => {
+  it('returns false when platform is "web"', () => {
+    expect(isAndroid()).toBe(false);
+  });
+
+  it('result is consistent with getPlatform() === "android"', () => {
+    expect(isAndroid()).toBe(getPlatform() === 'android');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutual exclusion guard
+// ---------------------------------------------------------------------------
+
+describe('platform mutual exclusion', () => {
+  it('isIOS and isAndroid are not both true', () => {
+    expect(isIOS() && isAndroid()).toBe(false);
+  });
+
+  it('isNative is true iff at least one of isIOS or isAndroid is true', () => {
+    expect(isNative()).toBe(isIOS() || isAndroid());
+  });
+});

--- a/src/lib/portal/__tests__/destinations.test.ts
+++ b/src/lib/portal/__tests__/destinations.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { PORTALS, getPortalById } from '../destinations';
+
+const HEX_COLOR = /^#[0-9a-fA-F]{3,8}$/;
+const VALID_IDS = ['music', 'social', 'build', 'earn', 'govern', 'vip'] as const;
+
+// ---------------------------------------------------------------------------
+// PORTALS constant
+// ---------------------------------------------------------------------------
+
+describe('PORTALS', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(PORTALS)).toBe(true);
+    expect(PORTALS.length).toBeGreaterThan(0);
+  });
+
+  it('has exactly 6 portals', () => {
+    expect(PORTALS).toHaveLength(6);
+  });
+
+  it('includes all expected portal IDs', () => {
+    const ids = PORTALS.map((p) => p.id);
+    for (const id of VALID_IDS) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it('every portal has required fields: id, title, subtitle, icon, glowColor, locked, destinations', () => {
+    for (const portal of PORTALS) {
+      expect(typeof portal.id).toBe('string');
+      expect(typeof portal.title).toBe('string');
+      expect(typeof portal.subtitle).toBe('string');
+      expect(typeof portal.icon).toBe('string');
+      expect(typeof portal.glowColor).toBe('string');
+      expect(typeof portal.locked).toBe('boolean');
+      expect(Array.isArray(portal.destinations)).toBe(true);
+    }
+  });
+
+  it('every portal glowColor is a hex color string', () => {
+    for (const portal of PORTALS) {
+      expect(portal.glowColor).toMatch(HEX_COLOR);
+    }
+  });
+
+  it('every portal has at least one destination', () => {
+    for (const portal of PORTALS) {
+      expect(portal.destinations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every destination has name, url, description, and external fields', () => {
+    for (const portal of PORTALS) {
+      for (const dest of portal.destinations) {
+        expect(typeof dest.name).toBe('string');
+        expect(typeof dest.url).toBe('string');
+        expect(typeof dest.description).toBe('string');
+        expect(typeof dest.external).toBe('boolean');
+      }
+    }
+  });
+
+  it('all portal IDs are unique', () => {
+    const ids = PORTALS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(PORTALS.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lock state
+// ---------------------------------------------------------------------------
+
+describe('PORTALS lock state', () => {
+  it('vip portal is locked', () => {
+    const vip = PORTALS.find((p) => p.id === 'vip');
+    expect(vip?.locked).toBe(true);
+  });
+
+  it('vip portal has gateType "allowlist"', () => {
+    const vip = PORTALS.find((p) => p.id === 'vip');
+    expect(vip?.gateType).toBe('allowlist');
+  });
+
+  it('all non-vip portals are unlocked', () => {
+    for (const portal of PORTALS.filter((p) => p.id !== 'vip')) {
+      expect(portal.locked).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spot content checks
+// ---------------------------------------------------------------------------
+
+describe('PORTALS spot content', () => {
+  it('music portal includes a WaveWarZ destination', () => {
+    const music = PORTALS.find((p) => p.id === 'music');
+    const names = music?.destinations.map((d) => d.name) ?? [];
+    expect(names.some((n) => n.toLowerCase().includes('wavewarz'))).toBe(true);
+  });
+
+  it('earn portal includes an Empire Builder destination', () => {
+    const earn = PORTALS.find((p) => p.id === 'earn');
+    const names = earn?.destinations.map((d) => d.name) ?? [];
+    expect(names.some((n) => n.toLowerCase().includes('empire'))).toBe(true);
+  });
+
+  it('govern portal includes a ZOUNZ destination', () => {
+    const govern = PORTALS.find((p) => p.id === 'govern');
+    const names = govern?.destinations.map((d) => d.name) ?? [];
+    expect(names.some((n) => n.toLowerCase().includes('zounz'))).toBe(true);
+  });
+
+  it('vip portal includes an internal (external: false) destination', () => {
+    const vip = PORTALS.find((p) => p.id === 'vip');
+    const hasInternal = vip?.destinations.some((d) => d.external === false) ?? false;
+    expect(hasInternal).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPortalById
+// ---------------------------------------------------------------------------
+
+describe('getPortalById', () => {
+  it('returns the music portal by id', () => {
+    const result = getPortalById('music');
+    expect(result?.id).toBe('music');
+  });
+
+  it('returns the vip portal by id', () => {
+    const result = getPortalById('vip');
+    expect(result?.id).toBe('vip');
+    expect(result?.locked).toBe(true);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getPortalById('nonexistent')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(getPortalById('')).toBeUndefined();
+  });
+
+  it('can retrieve every portal by its id', () => {
+    for (const id of VALID_IDS) {
+      expect(getPortalById(id)?.id).toBe(id);
+    }
+  });
+});

--- a/src/lib/spaces/__tests__/songjam.test.ts
+++ b/src/lib/spaces/__tests__/songjam.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  SONGJAM_IFRAME_ALLOW,
+  SONGJAM_IFRAME_SANDBOX,
+  SONGJAM_SPACE_DESCRIPTION,
+  SONGJAM_SPACE_LABEL,
+  SONGJAM_SPACE_URL,
+} from '../songjam';
+
+// ---------------------------------------------------------------------------
+// SONGJAM_SPACE_URL
+// ---------------------------------------------------------------------------
+
+describe('SONGJAM_SPACE_URL', () => {
+  it('is the exact www.songjam.space/zabal URL', () => {
+    expect(SONGJAM_SPACE_URL).toBe('https://www.songjam.space/zabal');
+  });
+
+  it('uses the www subdomain (required by Permissions-Policy exact-match)', () => {
+    expect(SONGJAM_SPACE_URL).toContain('www.songjam.space');
+  });
+
+  it('targets the /zabal community path', () => {
+    expect(SONGJAM_SPACE_URL).toContain('/zabal');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SONGJAM_SPACE_LABEL
+// ---------------------------------------------------------------------------
+
+describe('SONGJAM_SPACE_LABEL', () => {
+  it('is "ZABAL Live"', () => {
+    expect(SONGJAM_SPACE_LABEL).toBe('ZABAL Live');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SONGJAM_SPACE_DESCRIPTION
+// ---------------------------------------------------------------------------
+
+describe('SONGJAM_SPACE_DESCRIPTION', () => {
+  it('is a non-empty string', () => {
+    expect(typeof SONGJAM_SPACE_DESCRIPTION).toBe('string');
+    expect(SONGJAM_SPACE_DESCRIPTION.length).toBeGreaterThan(0);
+  });
+
+  it('mentions Songjam', () => {
+    expect(SONGJAM_SPACE_DESCRIPTION.toLowerCase()).toContain('songjam');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SONGJAM_IFRAME_ALLOW
+// ---------------------------------------------------------------------------
+
+describe('SONGJAM_IFRAME_ALLOW', () => {
+  it('includes microphone permission', () => {
+    expect(SONGJAM_IFRAME_ALLOW).toContain('microphone');
+  });
+
+  it('includes camera permission', () => {
+    expect(SONGJAM_IFRAME_ALLOW).toContain('camera');
+  });
+
+  it('includes autoplay permission', () => {
+    expect(SONGJAM_IFRAME_ALLOW).toContain('autoplay');
+  });
+
+  it('includes fullscreen permission', () => {
+    expect(SONGJAM_IFRAME_ALLOW).toContain('fullscreen');
+  });
+
+  it('includes clipboard-write permission', () => {
+    expect(SONGJAM_IFRAME_ALLOW).toContain('clipboard-write');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SONGJAM_IFRAME_SANDBOX
+// ---------------------------------------------------------------------------
+
+describe('SONGJAM_IFRAME_SANDBOX', () => {
+  it('includes allow-scripts', () => {
+    expect(SONGJAM_IFRAME_SANDBOX).toContain('allow-scripts');
+  });
+
+  it('includes allow-same-origin', () => {
+    expect(SONGJAM_IFRAME_SANDBOX).toContain('allow-same-origin');
+  });
+
+  it('includes allow-popups', () => {
+    expect(SONGJAM_IFRAME_SANDBOX).toContain('allow-popups');
+  });
+
+  it('includes allow-forms', () => {
+    expect(SONGJAM_IFRAME_SANDBOX).toContain('allow-forms');
+  });
+
+  it('includes allow-top-navigation-by-user-activation', () => {
+    expect(SONGJAM_IFRAME_SANDBOX).toContain('allow-top-navigation-by-user-activation');
+  });
+});


### PR DESCRIPTION
## Test coverage added

**47 cases across 3 modules — all pure constants and functions, no source changes.**

### `src/lib/portal/__tests__/destinations.test.ts` (20 cases)
- `PORTALS`: 6 portals, required fields (id/title/subtitle/icon/glowColor/locked/destinations), unique IDs, hex glowColors, non-empty destinations
- Lock state: vip locked + gateType='allowlist', all others unlocked
- Spot content: WaveWarZ in music, Empire Builder in earn, ZOUNZ in govern, internal destination in vip
- `getPortalById`: all 6 IDs retrievable, unknown/empty → undefined

### `src/lib/spaces/__tests__/songjam.test.ts` (16 cases)
- `SONGJAM_SPACE_URL` = `'https://www.songjam.space/zabal'` (exact, www required for Permissions-Policy)
- `SONGJAM_SPACE_LABEL` = `'ZABAL Live'`
- `SONGJAM_SPACE_DESCRIPTION` non-empty, mentions Songjam
- `SONGJAM_IFRAME_ALLOW`: microphone, camera, autoplay, fullscreen, clipboard-write
- `SONGJAM_IFRAME_SANDBOX`: allow-scripts, allow-same-origin, allow-popups, allow-forms, allow-top-navigation-by-user-activation

### `src/lib/os/__tests__/platform.test.ts` (11 cases)
- `getPlatform()` returns `'web'` in node/SSR env (window undefined → early return, no cache set)
- `isNative()` → false, `isIOS()` → false, `isAndroid()` → false
- Mutual exclusion: isIOS && isAndroid never both true; isNative === isIOS || isAndroid

🤖 Generated with [Claude Code](https://claude.com/claude-code)