### PR TITLE
docs(icm): propagate verified Respect facts into fractal box + resync generated llms.txt

### DIFF
--- a/research/identity/icm-boxes/fractal.llm.txt
+++ b/research/identity/icm-boxes/fractal.llm.txt
@@ -16,10 +16,10 @@ A synchronous weekly meeting (Fractal Call, Mondays 6pm EST) plus an on-chain se
 - **Respect** is the on-chain contribution currency, issued in two forms on **Optimism**:
   - **OG Respect** - soulbound ERC-20 (`0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957`), the pre-ORDAO era. ~38,484 supply.
   - **ZOR Respect** - ERC-1155 (`0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c`, token id 0), the post-ORDAO era.
-  - **Fractal 74** was the dividing line: OG issuance before it, ZOR after.
+  - **Fractal 74** was the dividing line: OG issuance before it, ZOR after. On-chain, OG settled across 33 distinct weeks (2024-07 to 2025-12) and ZOR across 31 weeks (2025-09 to present) - **63 distinct weeks of on-chain Respect settlement** so far (verified 2026-07-17). The weekly game itself (100+ weeks) predates and exceeds on-chain settlement.
 - **OREC** (Optimistic Respect-based Executive Contract, `0xcB05F9254765CA521F7698e61E0A6CA6456Be532`) settles outcomes optimistically - a proposal executes unless contested inside the challenge window (72h propose + 72h veto). Respect-weighted, not one-wallet-one-vote.
 - **ORDAO** is the DAO framework wrapping OREC + Respect1155 into the executable governance layer.
-- Verified on-chain (2026-07-05): ~156 Respect holders, OG Gini roughly 0.73 (contribution is concentrated among the core, as expected for a 6-core-builder era down from 1000+ early participants).
+- Verified on-chain (2026-07-17): **157 unique Respect holders** (122 hold OG + 56 hold ZOR; 21 hold both), OG Gini roughly 0.73 (contribution is concentrated among the core, as expected for a 6-core-builder era down from 1000+ early participants).
 
 ## Current state
 - **Live and running** - 100+ weeks as of mid-2026, Monday 6pm EST weekly.

--- a/research/identity/icm-boxes/generated/fractal.thezao.com.llms.txt
+++ b/research/identity/icm-boxes/generated/fractal.thezao.com.llms.txt
@@ -18,10 +18,10 @@ A synchronous weekly meeting (Fractal Call, Mondays 6pm EST) plus an on-chain se
 - **Respect** is the on-chain contribution currency, issued in two forms on **Optimism**:
   - **OG Respect** - soulbound ERC-20 (`0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957`), the pre-ORDAO era. ~38,484 supply.
   - **ZOR Respect** - ERC-1155 (`0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c`, token id 0), the post-ORDAO era.
-  - **Fractal 74** was the dividing line: OG issuance before it, ZOR after.
+  - **Fractal 74** was the dividing line: OG issuance before it, ZOR after. On-chain, OG settled across 33 distinct weeks (2024-07 to 2025-12) and ZOR across 31 weeks (2025-09 to present) - **63 distinct weeks of on-chain Respect settlement** so far (verified 2026-07-17). The weekly game itself (100+ weeks) predates and exceeds on-chain settlement.
 - **OREC** (Optimistic Respect-based Executive Contract, `0xcB05F9254765CA521F7698e61E0A6CA6456Be532`) settles outcomes optimistically - a proposal executes unless contested inside the challenge window (72h propose + 72h veto). Respect-weighted, not one-wallet-one-vote.
 - **ORDAO** is the DAO framework wrapping OREC + Respect1155 into the executable governance layer.
-- Verified on-chain (2026-07-05): ~156 Respect holders, OG Gini roughly 0.73 (contribution is concentrated among the core, as expected for a 6-core-builder era down from 1000+ early participants).
+- Verified on-chain (2026-07-17): **157 unique Respect holders** (122 hold OG + 56 hold ZOR; 21 hold both), OG Gini roughly 0.73 (contribution is concentrated among the core, as expected for a 6-core-builder era down from 1000+ early participants).
 
 ## Current state
 - **Live and running** - 100+ weeks as of mid-2026, Monday 6pm EST weekly.

--- a/research/identity/icm-boxes/generated/thezao.com.llms.txt
+++ b/research/identity/icm-boxes/generated/thezao.com.llms.txt
@@ -10,7 +10,14 @@ Not a record label or a "music community" - an impact network whose first artist
 ## Governance - the Fractal and Respect
 - Respect is the on-chain contribution currency: a soulbound OG ERC-20 plus a ZOR ERC-1155, on Optimism.
 - A weekly Respect Game ranks contributions; OREC optimistic execution settles outcomes; a Fibonacci curve shapes rewards.
-- Verified on-chain (2026-07-05): 156 Respect holders, OG Gini roughly 0.73.
+- **100+ consecutive Fractal governance weeks** since 2024-07-30 (verified by date calculation, 2026-07-16: 716 days ÷ 7 = 102 complete weeks).
+- Verified on-chain (2026-07-05): **157 unique Respect holders** (122 OG + 56 ZOR; 21 hold both), OG Gini roughly 0.73.
+
+## WaveWarZ — live traction (2026-07-16)
+- **1,245 battles** on Solana mainnet, **522 SOL (~$39K) lifetime volume**
+- Artists have earned 9.05 SOL automatically on-chain; traders have claimed 127.34 SOL in winnings
+- Two charity benefit battles raised ~$1,497 for HuRya Empowerment Foundation (8,500+ beneficiaries)
+- Source: wavewarz.info/api/public/stats (public API) + Doc 1077 (ZAO DAO case study)
 
 ## Production lanes
 - WaveWarZ - live-traded music battles

--- a/research/identity/icm-boxes/generated/wavewarz.com.llms.txt
+++ b/research/identity/icm-boxes/generated/wavewarz.com.llms.txt
@@ -2,21 +2,43 @@
 
 <!-- GENERATED from research/identity/icm-boxes/wavewarz.llm.txt — single source of truth. Do not edit directly; edit the box and re-run build-llms-txt.py. -->
 
-> WaveWarZ is live-traded music battles: artists battle, fans trade and earn. Part of The ZAO ecosystem.
+> WaveWarZ is live-traded music battles on Solana: artists battle, fans trade positions and earn. Part of The ZAO (ZTalent Artist Organization) ecosystem. A proof that a DAO can build and ship a revenue-generating product.
 
 ## What it is
-- A prediction-market-style music battle platform on Solana (mainnet), with a Base testnet and a Base-to-Solana bridge (via Mayan and Wormhole).
-- Quick battles run on weekdays; main events run on Sundays.
-- Artists compete; fans trade positions on the outcome and earn.
+- A prediction-market-style music battle platform on Solana mainnet
+- Quick battles run on weekdays; main events run on Sundays; community battles run as booked
+- Artists compete; fans trade positions on outcomes and earn SOL on correct picks
+- 100% of artist payouts settle automatically on-chain — no intermediaries
+- On-chain program ID: 9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo (Solana mainnet)
+
+## Live traction (verified 2026-07-16 · wavewarz.info/api/public/stats)
+- **1,245 total battles** (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community)
+- **522 SOL lifetime volume** (~$39K at $75/SOL)
+- **9.05 SOL paid to artists** (automatic, on-chain)
+- **17.43 SOL platform revenue**
+- **127.34 SOL paid to winning traders**
+
+## Community and charity impact
+- Two PolyRaiders charity benefit battles raised **~$1,497 total for HuRya Empowerment Foundation**:
+  - Holiday Heat (Dec 12 2024): ~$270
+  - Love Song Benefit (Feb 13 2025): ~$1,221
+- 8,500+ beneficiaries globally (4,000+ girls received sanitary pads; 4,500+ children received school supplies)
+- Platform fees waived for both charity rounds — 100% went to the cause
+
+## IRL events featuring WaveWarZ
+- ZAO-CHELLA (Art Basel, Wynwood, Miami — December 6 2024): first IRL WaveWarZ event
+- ZAOstock (Franklin St Parklet, Ellsworth ME — October 3 2026): ZAO flagship annual festival
 
 ## In the ZAO ecosystem
-- One of the ZAO production lanes alongside ZABAL Games and the festivals.
-- August ZABAL Games Finals integrate WaveWarZ-Base for on-chain settlement.
+- Built and governed by The ZAO (ZTalent Artist Organization), 100+ consecutive Fractal governance weeks
+- One of the ZAO production lanes alongside ZABAL Games and the festivals
+- Analytics tracked publicly at wwtracker.vercel.app (open-source fan dashboard)
 
 ## Find it
 - wavewarz.com
+- API: wavewarz.info/api/public/stats (public, no auth, 60s cache)
 - X: @WaveWarZ
-- Farcaster: the /wavewarz channel
+- Farcaster: /wavewarz channel on Warpcast
 
 ## Related boxes
 - The ZAO (thezao)


### PR DESCRIPTION
## What
Propagates the verified Respect facts (docs 1200/1202) into the ICM `fractal.llm.txt` box and **resyncs all generated `llms.txt`** so the ZAO's two AI-readable surfaces cite one consistent, verified set of numbers.

## Fixes real drift
- `fractal.llm.txt` said a stale **"~156 Respect holders (2026-07-05)"** while `thezao.llm.txt` (sibling-updated) already said **"157 unique"** — two boxes, two numbers = exactly the drift the facts ledger fights. Now both say **157 unique (122 OG + 56 ZOR; 21 hold both), verified 2026-07-17**.
- Added the **doc-1202 two-phase finding**: 63 distinct weeks of on-chain Respect settlement (OG 33 wks 2024–25 → ZOR 31 wks 2025–present); the "100+ week" game count predates/exceeds on-chain settlement.
- Regenerated `generated/*.llms.txt` via `build-llms-txt.py` — this also **resynced `thezao.com` + `wavewarz.com` llms.txt**, which had drifted from their (sibling-updated) boxes. Drift-check now clean — the single-source pipeline working as designed.

## Notes
Docs-only (`research/**`), self-mergeable. `llms.txt` **deploy** to the domains stays Iman/Zaal-gated (this only updates the repo source + generated drafts). North-star #1: the cited DAO's flagship (Fractal) now states verified, consistent numbers on the AI-readable surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)