### PR TITLE
test: stock/members pure fns + juke integration manifest (47 cases)

### DIFF
--- a/src/lib/spaces/__tests__/jukeIntegrationManifest.test.ts
+++ b/src/lib/spaces/__tests__/jukeIntegrationManifest.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  INTEGRATION_ARCHITECTURE_ASCII,
+  getJukeIntegrationManifest,
+  renderIntegrationMarkdown,
+} from '../jukeIntegrationManifest';
+
+// ---------------------------------------------------------------------------
+// INTEGRATION_ARCHITECTURE_ASCII
+// ---------------------------------------------------------------------------
+
+describe('INTEGRATION_ARCHITECTURE_ASCII', () => {
+  it('is a non-empty string', () => {
+    expect(typeof INTEGRATION_ARCHITECTURE_ASCII).toBe('string');
+    expect(INTEGRATION_ARCHITECTURE_ASCII.length).toBeGreaterThan(0);
+  });
+
+  it('references ZAO OS', () => {
+    expect(INTEGRATION_ARCHITECTURE_ASCII).toContain('ZAO OS');
+  });
+
+  it('references juke.audio', () => {
+    expect(INTEGRATION_ARCHITECTURE_ASCII).toContain('juke.audio');
+  });
+
+  it('describes the webhook path', () => {
+    expect(INTEGRATION_ARCHITECTURE_ASCII).toContain('webhooks');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getJukeIntegrationManifest
+// ---------------------------------------------------------------------------
+
+describe('getJukeIntegrationManifest', () => {
+  it('returns an object', () => {
+    const m = getJukeIntegrationManifest();
+    expect(typeof m).toBe('object');
+    expect(m).not.toBeNull();
+  });
+
+  it('has a version string', () => {
+    const { version } = getJukeIntegrationManifest();
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+  });
+
+  it('about.name is "The ZAO"', () => {
+    expect(getJukeIntegrationManifest().about.name).toBe('The ZAO');
+  });
+
+  it('about has required URL fields', () => {
+    const { about } = getJukeIntegrationManifest();
+    expect(typeof about.site).toBe('string');
+    expect(typeof about.farcaster).toBe('string');
+    expect(typeof about.juke_path_a_route).toBe('string');
+    expect(typeof about.juke_path_b_route).toBe('string');
+    expect(typeof about.public_status_route).toBe('string');
+  });
+
+  it('shipped is a non-empty array', () => {
+    const { shipped } = getJukeIntegrationManifest();
+    expect(Array.isArray(shipped)).toBe(true);
+    expect(shipped.length).toBeGreaterThan(0);
+  });
+
+  it('every shipped item has id, title, shippedAt, and files', () => {
+    for (const item of getJukeIntegrationManifest().shipped) {
+      expect(typeof item.id).toBe('string');
+      expect(typeof item.title).toBe('string');
+      expect(typeof item.shippedAt).toBe('string');
+      expect(Array.isArray(item.files)).toBe(true);
+      expect(item.files.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('shipped IDs are all unique', () => {
+    const ids = getJukeIntegrationManifest().shipped.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('open_asks is a non-empty array', () => {
+    const { open_asks } = getJukeIntegrationManifest();
+    expect(Array.isArray(open_asks)).toBe(true);
+    expect(open_asks.length).toBeGreaterThan(0);
+  });
+
+  it('every open_ask has priority in p0/p1/p2', () => {
+    for (const ask of getJukeIntegrationManifest().open_asks) {
+      expect(['p0', 'p1', 'p2']).toContain(ask.priority);
+    }
+  });
+
+  it('every open_ask has id, title, reason, blocks', () => {
+    for (const ask of getJukeIntegrationManifest().open_asks) {
+      expect(typeof ask.id).toBe('string');
+      expect(typeof ask.title).toBe('string');
+      expect(typeof ask.reason).toBe('string');
+      expect(typeof ask.blocks).toBe('string');
+    }
+  });
+
+  it('conventions is a non-empty array of strings', () => {
+    const { conventions } = getJukeIntegrationManifest();
+    expect(Array.isArray(conventions)).toBe(true);
+    expect(conventions.length).toBeGreaterThan(0);
+    for (const c of conventions) {
+      expect(typeof c).toBe('string');
+    }
+  });
+
+  it('contact has zao_dev, general, and partnership fields', () => {
+    const { contact } = getJukeIntegrationManifest();
+    expect(typeof contact.zao_dev).toBe('string');
+    expect(typeof contact.general).toBe('string');
+    expect(typeof contact.partnership).toBe('string');
+  });
+
+  it('juke_release_feed starts with https://', () => {
+    expect(getJukeIntegrationManifest().juke_release_feed).toMatch(/^https:\/\//);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderIntegrationMarkdown
+// ---------------------------------------------------------------------------
+
+describe('renderIntegrationMarkdown', () => {
+  it('returns a non-empty string', () => {
+    const manifest = getJukeIntegrationManifest();
+    const md = renderIntegrationMarkdown(manifest);
+    expect(typeof md).toBe('string');
+    expect(md.length).toBeGreaterThan(0);
+  });
+
+  it('contains ## About section', () => {
+    const md = renderIntegrationMarkdown(getJukeIntegrationManifest());
+    expect(md).toContain('## About');
+  });
+
+  it('contains ## Shipped section', () => {
+    const md = renderIntegrationMarkdown(getJukeIntegrationManifest());
+    expect(md).toContain('## Shipped');
+  });
+
+  it('contains ## Open Asks section', () => {
+    const md = renderIntegrationMarkdown(getJukeIntegrationManifest());
+    expect(md).toContain('## Open Asks');
+  });
+
+  it('contains ## Conventions section', () => {
+    const md = renderIntegrationMarkdown(getJukeIntegrationManifest());
+    expect(md).toContain('## Conventions');
+  });
+
+  it('includes the manifest version', () => {
+    const manifest = getJukeIntegrationManifest();
+    const md = renderIntegrationMarkdown(manifest);
+    expect(md).toContain(manifest.version);
+  });
+
+  it('includes the Architecture section when ASCII is embedded', () => {
+    const md = renderIntegrationMarkdown(getJukeIntegrationManifest());
+    expect(md).toContain('## Architecture');
+  });
+
+  it('renders optional stats when provided', () => {
+    const manifest = getJukeIntegrationManifest();
+    const md = renderIntegrationMarkdown(manifest, { active_spaces: 3, total_webhooks: 42 });
+    expect(md).toContain('## Live Stats');
+    expect(md).toContain('active_spaces: 3');
+    expect(md).toContain('total_webhooks: 42');
+  });
+
+  it('omits Live Stats section when no stats provided', () => {
+    const md = renderIntegrationMarkdown(getJukeIntegrationManifest());
+    expect(md).not.toContain('## Live Stats');
+  });
+});

--- a/src/lib/stock/__tests__/members.test.ts
+++ b/src/lib/stock/__tests__/members.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { parseLinks, slugify } from '../members';
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+
+describe('slugify', () => {
+  it('returns empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+
+  it('lowercases the name', () => {
+    expect(slugify('ZAO')).toBe('zao');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(slugify('Zaal Panthaki')).toBe('zaal-panthaki');
+  });
+
+  it('collapses multiple spaces into a single hyphen', () => {
+    expect(slugify('hello   world')).toBe('hello-world');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(slugify('  ZAO  ')).toBe('zao');
+  });
+
+  it('strips special characters (punctuation other than hyphens)', () => {
+    expect(slugify("Don't Stop!")).toBe('dont-stop');
+  });
+
+  it('preserves existing hyphens', () => {
+    expect(slugify('pre-existing')).toBe('pre-existing');
+  });
+
+  it('preserves digits', () => {
+    expect(slugify('Agent007')).toBe('agent007');
+  });
+
+  it('handles a mixed real name', () => {
+    expect(slugify('ZAO OS')).toBe('zao-os');
+  });
+
+  it('strips parentheses and brackets', () => {
+    expect(slugify('member (admin)')).toBe('member-admin');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLinks
+// ---------------------------------------------------------------------------
+
+describe('parseLinks', () => {
+  it('returns empty array for empty string', () => {
+    expect(parseLinks('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(parseLinks('   ')).toEqual([]);
+  });
+
+  it('parses a URL with protocol as-is', () => {
+    const result = parseLinks('https://thezao.com');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ href: 'https://thezao.com', display: 'https://thezao.com' });
+  });
+
+  it('prepends https:// to a bare domain', () => {
+    const result = parseLinks('example.com');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ href: 'https://example.com', display: 'example.com' });
+  });
+
+  it('converts an email to a mailto: href', () => {
+    const result = parseLinks('zaal@thezao.com');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ href: 'mailto:zaal@thezao.com', display: 'zaal@thezao.com' });
+  });
+
+  it('converts a @handle to an x.com profile link', () => {
+    const result = parseLinks('@zaal');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ href: 'https://x.com/zaal', display: '@zaal' });
+  });
+
+  it('splits on spaces', () => {
+    const result = parseLinks('https://a.com https://b.com');
+    expect(result).toHaveLength(2);
+  });
+
+  it('splits on commas', () => {
+    const result = parseLinks('https://a.com,https://b.com');
+    expect(result).toHaveLength(2);
+  });
+
+  it('splits on semicolons', () => {
+    const result = parseLinks('https://a.com;https://b.com');
+    expect(result).toHaveLength(2);
+  });
+
+  it('handles mixed types in one string', () => {
+    const result = parseLinks('@alice user@example.com https://zaoos.com');
+    expect(result).toHaveLength(3);
+    expect(result[0].href).toBe('https://x.com/alice');
+    expect(result[1].href).toBe('mailto:user@example.com');
+    expect(result[2].href).toBe('https://zaoos.com');
+  });
+
+  it('preserves display text as the original token', () => {
+    const result = parseLinks('@alice');
+    expect(result[0].display).toBe('@alice');
+  });
+});


### PR DESCRIPTION
## Test coverage added

**47 cases across 2 modules — all pure functions and constants, no source changes.**

### `src/lib/stock/__tests__/members.test.ts` (21 cases)

**`slugify`** (10 cases): empty string, lowercase, space→hyphen, multiple spaces collapse, trim whitespace, strip punctuation (!, ', parentheses), preserve existing hyphens, preserve digits, mixed real name

**`parseLinks`** (11 cases): empty/whitespace→[], URL with protocol preserved, bare domain→https:// prepended, email→mailto: href, @handle→x.com href, space/comma/semicolon splitting, mixed types in one string, display preserves original token

### `src/lib/spaces/__tests__/jukeIntegrationManifest.test.ts` (26 cases)

**`INTEGRATION_ARCHITECTURE_ASCII`** (4): non-empty, contains 'ZAO OS', contains 'juke.audio', contains 'webhooks'

**`getJukeIntegrationManifest()`** (13): returns object, version string, about.name='The ZAO', about URL fields, shipped non-empty + required fields + unique IDs, open_asks non-empty + priority in p0/p1/p2 + required fields, conventions non-empty strings, contact has 3 fields, juke_release_feed starts https://

**`renderIntegrationMarkdown()`** (9): returns non-empty string, contains ## About/Shipped/Open Asks/Conventions/Architecture sections, includes manifest version, renders Live Stats section with stats data, omits Live Stats when none provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)