### PR TITLE
test: crm CANONICAL_CATEGORIES + pure fns + curationWeight (36 cases)

### DIFF
--- a/src/lib/crm/__tests__/types.test.ts
+++ b/src/lib/crm/__tests__/types.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  CANONICAL_CATEGORIES,
+  deriveContactSlug,
+  hasStableContactKey,
+  slugify,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// CANONICAL_CATEGORIES
+// ---------------------------------------------------------------------------
+
+describe('CANONICAL_CATEGORIES', () => {
+  it('has exactly 11 entries', () => {
+    expect(CANONICAL_CATEGORIES).toHaveLength(11);
+  });
+
+  it('all entries are strings', () => {
+    for (const c of CANONICAL_CATEGORIES) {
+      expect(typeof c).toBe('string');
+    }
+  });
+
+  it('includes "Musician"', () => {
+    expect(CANONICAL_CATEGORIES).toContain('Musician');
+  });
+
+  it('includes "Developer / Tech"', () => {
+    expect(CANONICAL_CATEGORIES).toContain('Developer / Tech');
+  });
+
+  it('includes "Other" as a catch-all', () => {
+    expect(CANONICAL_CATEGORIES).toContain('Other');
+  });
+
+  it('has no duplicate entries', () => {
+    expect(new Set(CANONICAL_CATEGORIES).size).toBe(CANONICAL_CATEGORIES.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// slugify (CRM version — different from stock/members slugify)
+// ---------------------------------------------------------------------------
+
+describe('slugify', () => {
+  it('returns empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+
+  it('lowercases the input', () => {
+    expect(slugify('ZAAL')).toBe('zaal');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(slugify('  hello  ')).toBe('hello');
+  });
+
+  it('strips a leading @ (social handle → slug)', () => {
+    expect(slugify('@zaal')).toBe('zaal');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(slugify('hello world')).toBe('hello-world');
+  });
+
+  it('replaces runs of special characters with a single hyphen', () => {
+    expect(slugify('foo!!!bar')).toBe('foo-bar');
+  });
+
+  it('replaces dots with hyphens', () => {
+    expect(slugify('foo.bar')).toBe('foo-bar');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(slugify('_abc_')).toBe('abc');
+  });
+
+  it('slices the result to 64 characters', () => {
+    const long = 'a'.repeat(100);
+    expect(slugify(long).length).toBeLessThanOrEqual(64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveContactSlug
+// ---------------------------------------------------------------------------
+
+describe('deriveContactSlug', () => {
+  it('falls back to name when no other key is provided', () => {
+    expect(deriveContactSlug({ name: 'Zaal Panthaki' })).toBe('zaal-panthaki');
+  });
+
+  it('prefers explicit slug over other identifiers', () => {
+    expect(
+      deriveContactSlug({ slug: 'my-slug', farcaster_handle: 'other', name: 'Name' }),
+    ).toBe('my-slug');
+  });
+
+  it('prefers farcaster_handle over x_handle and name', () => {
+    expect(
+      deriveContactSlug({ farcaster_handle: 'zaalfc', x_handle: 'zaalx', name: 'Name' }),
+    ).toBe('zaalfc');
+  });
+
+  it('prefers x_handle over github_handle and name', () => {
+    expect(
+      deriveContactSlug({ x_handle: 'zaalx', github_handle: 'zaalgh', name: 'Name' }),
+    ).toBe('zaalx');
+  });
+
+  it('falls back to github_handle when no slug/farcaster/x', () => {
+    expect(deriveContactSlug({ github_handle: 'zaalgh', name: 'Name' })).toBe('zaalgh');
+  });
+
+  it('strips @ from a handle when slugifying', () => {
+    expect(deriveContactSlug({ farcaster_handle: '@thezao', name: 'Name' })).toBe('thezao');
+  });
+
+  it('returns a non-empty string for any valid input', () => {
+    const result = deriveContactSlug({ name: 'Test User' });
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasStableContactKey
+// ---------------------------------------------------------------------------
+
+describe('hasStableContactKey', () => {
+  it('returns false for name-only input (name is not a stable key)', () => {
+    expect(hasStableContactKey({})).toBe(false);
+  });
+
+  it('returns true when slug is present', () => {
+    expect(hasStableContactKey({ slug: 'my-slug' })).toBe(true);
+  });
+
+  it('returns true when farcaster_handle is present', () => {
+    expect(hasStableContactKey({ farcaster_handle: 'zaalfc' })).toBe(true);
+  });
+
+  it('returns true when x_handle is present', () => {
+    expect(hasStableContactKey({ x_handle: 'zaalx' })).toBe(true);
+  });
+
+  it('returns true when github_handle is present', () => {
+    expect(hasStableContactKey({ github_handle: 'bettercallzaal' })).toBe(true);
+  });
+
+  it('returns false when all keys are null', () => {
+    expect(
+      hasStableContactKey({
+        slug: null,
+        farcaster_handle: null,
+        x_handle: null,
+        github_handle: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/music/__tests__/curationWeight.test.ts
+++ b/src/lib/music/__tests__/curationWeight.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { curationWeight } from '../curationWeight';
+
+// curationWeight(respect) = max(1, log2(respect + 1))
+// Members with 0 Respect still have weight 1 (their votes count).
+
+describe('curationWeight', () => {
+  it('returns 1 for 0 respect (floor at 1)', () => {
+    expect(curationWeight(0)).toBe(1);
+  });
+
+  it('returns 1 for 1 respect (log2(2)=1, exactly at the floor)', () => {
+    expect(curationWeight(1)).toBe(1);
+  });
+
+  it('returns 2 for 3 respect (log2(4)=2)', () => {
+    expect(curationWeight(3)).toBe(2);
+  });
+
+  it('returns 3 for 7 respect (log2(8)=3)', () => {
+    expect(curationWeight(7)).toBe(3);
+  });
+
+  it('returns ~8.97 for 500 respect (log2(501))', () => {
+    const result = curationWeight(500);
+    expect(result).toBeGreaterThan(8.9);
+    expect(result).toBeLessThan(9.1);
+  });
+
+  it('result is always >= 1 (floor enforced)', () => {
+    for (const r of [0, 1, 2, 10, 100, 1000]) {
+      expect(curationWeight(r)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('result increases monotonically with respect', () => {
+    const weights = [0, 3, 7, 15, 100, 500].map(curationWeight);
+    for (let i = 1; i < weights.length; i++) {
+      expect(weights[i]).toBeGreaterThanOrEqual(weights[i - 1]);
+    }
+  });
+
+  it('returns a finite number for a large respect score', () => {
+    expect(Number.isFinite(curationWeight(100_000))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Test coverage added

**36 cases across 2 modules — pure functions and constants only, no source changes.**

### `src/lib/crm/__tests__/types.test.ts` (28 cases)

**`CANONICAL_CATEGORIES`** (6): 11 entries, all strings, includes Musician/Developer\/Tech/Other, no duplicates

**`slugify` (CRM)** (9): empty→empty, lowercase, trim, strip leading @, spaces→hyphens, runs of specials→single hyphen, dots→hyphens, strip leading/trailing hyphens, 64-char slice

**`deriveContactSlug`** (7): name fallback, explicit slug wins, farcaster > x > github > name priority order, @ stripped from handle, returns non-empty string

**`hasStableContactKey`** (6): name-only→false, slug/farcaster/x/github each→true, all-null→false

### `src/lib/music/__tests__/curationWeight.test.ts` (8 cases)

weight = max(1, log2(respect + 1))

- 0 respect → 1 (floor), 1 respect → 1 (log2(2)=1 exactly at floor)
- 3 → 2, 7 → 3 (clean power-of-2 spot checks)
- 500 → ~8.97 (log2(501))
- Result always ≥ 1, increases monotonically, finite for large inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)