### PR TITLE
test: agent constants, brand tokens, MCP errors (53 cases)

### DIFF
--- a/src/app/overlay/zabal-games/__tests__/brand.test.ts
+++ b/src/app/overlay/zabal-games/__tests__/brand.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { KEYFRAMES, tokensFor, withAlpha } from '../brand';
+
+// ---------------------------------------------------------------------------
+// withAlpha
+// ---------------------------------------------------------------------------
+
+describe('withAlpha', () => {
+  it('converts #rrggbb to rgba with full opacity', () => {
+    expect(withAlpha('#ff0000', 1)).toBe('rgba(255, 0, 0, 1)');
+  });
+
+  it('converts #ffffff to rgba with half opacity', () => {
+    expect(withAlpha('#ffffff', 0.5)).toBe('rgba(255, 255, 255, 0.5)');
+  });
+
+  it('converts #000000 to rgba with 0 opacity', () => {
+    expect(withAlpha('#000000', 0)).toBe('rgba(0, 0, 0, 0)');
+  });
+
+  it('converts #aabbcc correctly', () => {
+    // aa=170, bb=187, cc=204
+    expect(withAlpha('#aabbcc', 0.8)).toBe('rgba(170, 187, 204, 0.8)');
+  });
+
+  it('passes through input unchanged when not a 6-char hex', () => {
+    expect(withAlpha('#abc', 0.5)).toBe('#abc');
+  });
+
+  it('passes through non-hex strings unchanged', () => {
+    expect(withAlpha('red', 0.5)).toBe('red');
+  });
+
+  it('handles the ZAO gold accent color', () => {
+    expect(withAlpha('#f5a623', 0.45)).toBe('rgba(245, 166, 35, 0.45)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KEYFRAMES
+// ---------------------------------------------------------------------------
+
+describe('KEYFRAMES', () => {
+  it('is a non-empty string', () => {
+    expect(typeof KEYFRAMES).toBe('string');
+    expect(KEYFRAMES.length).toBeGreaterThan(0);
+  });
+
+  it('defines the zg-fade-up animation', () => {
+    expect(KEYFRAMES).toContain('zg-fade-up');
+  });
+
+  it('defines the zg-pulse animation', () => {
+    expect(KEYFRAMES).toContain('zg-pulse');
+  });
+
+  it('includes reduced-motion media query', () => {
+    expect(KEYFRAMES).toContain('prefers-reduced-motion');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tokensFor
+// ---------------------------------------------------------------------------
+
+describe('tokensFor', () => {
+  const darkMediumCfg = { theme: 'dark' as const, size: 'medium' as const, accent: '#f5a623' };
+  const lightSmallCfg = { theme: 'light' as const, size: 'small' as const, accent: '#5865F2' };
+  const largeCfg = { theme: 'dark' as const, size: 'large' as const, accent: '#f5a623' };
+
+  it('returns an object with all required token fields', () => {
+    const t = tokensFor(darkMediumCfg);
+    expect(typeof t.panelBg).toBe('string');
+    expect(typeof t.panelBorder).toBe('string');
+    expect(typeof t.titleColor).toBe('string');
+    expect(typeof t.subtitleColor).toBe('string');
+    expect(typeof t.accent).toBe('string');
+    expect(typeof t.fontStack).toBe('string');
+    expect(typeof t.scale).toBe('number');
+  });
+
+  it('scale is 1 for "medium" size', () => {
+    expect(tokensFor(darkMediumCfg).scale).toBe(1);
+  });
+
+  it('scale is 0.82 for "small" size', () => {
+    expect(tokensFor(lightSmallCfg).scale).toBe(0.82);
+  });
+
+  it('scale is 1.25 for "large" size', () => {
+    expect(tokensFor(largeCfg).scale).toBe(1.25);
+  });
+
+  it('dark theme titleColor is white', () => {
+    expect(tokensFor(darkMediumCfg).titleColor).toBe('#ffffff');
+  });
+
+  it('light theme titleColor is dark navy', () => {
+    expect(tokensFor(lightSmallCfg).titleColor).toBe('#141e27');
+  });
+
+  it('accent passes through from config', () => {
+    expect(tokensFor(darkMediumCfg).accent).toBe('#f5a623');
+    expect(tokensFor(lightSmallCfg).accent).toBe('#5865F2');
+  });
+});

--- a/src/components/admin/agents/__tests__/constants.test.ts
+++ b/src/components/admin/agents/__tests__/constants.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  AGENTS,
+  EVENT_TYPES,
+  deriveStatus,
+  getAgent,
+  getStatusDot,
+} from '../constants';
+
+// ---------------------------------------------------------------------------
+// AGENTS constant
+// ---------------------------------------------------------------------------
+
+describe('AGENTS', () => {
+  it('has exactly 7 agents', () => {
+    expect(AGENTS).toHaveLength(7);
+  });
+
+  it('every agent has name, label, emoji, color, and role', () => {
+    for (const agent of AGENTS) {
+      expect(typeof agent.name).toBe('string');
+      expect(typeof agent.label).toBe('string');
+      expect(typeof agent.emoji).toBe('string');
+      expect(typeof agent.color).toBe('string');
+      expect(typeof agent.role).toBe('string');
+    }
+  });
+
+  it('all agent names are unique', () => {
+    const names = AGENTS.map((a) => a.name);
+    expect(new Set(names).size).toBe(AGENTS.length);
+  });
+
+  it('includes zoe with role "Orchestrator"', () => {
+    const zoe = AGENTS.find((a) => a.name === 'zoe');
+    expect(zoe?.role).toBe('Orchestrator');
+  });
+
+  it('includes caster with role "Social"', () => {
+    const caster = AGENTS.find((a) => a.name === 'caster');
+    expect(caster?.role).toBe('Social');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EVENT_TYPES constant
+// ---------------------------------------------------------------------------
+
+describe('EVENT_TYPES', () => {
+  it('has exactly 6 event types', () => {
+    expect(Object.keys(EVENT_TYPES)).toHaveLength(6);
+  });
+
+  it('every event type has label, color, and icon', () => {
+    for (const et of Object.values(EVENT_TYPES)) {
+      expect(typeof et.label).toBe('string');
+      expect(typeof et.color).toBe('string');
+      expect(typeof et.icon).toBe('string');
+    }
+  });
+
+  it('includes task_started with label "Started"', () => {
+    expect(EVENT_TYPES.task_started.label).toBe('Started');
+  });
+
+  it('includes approval_needed with label "Needs Approval"', () => {
+    expect(EVENT_TYPES.approval_needed.label).toBe('Needs Approval');
+  });
+
+  it('includes heartbeat event type', () => {
+    expect('heartbeat' in EVENT_TYPES).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAgent
+// ---------------------------------------------------------------------------
+
+describe('getAgent', () => {
+  it('returns the zoe agent by name', () => {
+    const agent = getAgent('zoe');
+    expect(agent?.name).toBe('zoe');
+    expect(agent?.role).toBe('Orchestrator');
+  });
+
+  it('returns the builder agent by name', () => {
+    expect(getAgent('builder')?.role).toBe('Code');
+  });
+
+  it('returns undefined for an unknown name', () => {
+    expect(getAgent('unknown')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(getAgent('')).toBeUndefined();
+  });
+
+  it('can retrieve every agent by its name', () => {
+    for (const agent of AGENTS) {
+      expect(getAgent(agent.name)?.name).toBe(agent.name);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStatusDot
+// ---------------------------------------------------------------------------
+
+describe('getStatusDot', () => {
+  it('returns green dot for "active"', () => {
+    expect(getStatusDot('active')).toBe('bg-green-500');
+  });
+
+  it('returns red dot for "error"', () => {
+    expect(getStatusDot('error')).toBe('bg-red-500');
+  });
+
+  it('returns amber dot for "approval_needed"', () => {
+    expect(getStatusDot('approval_needed')).toBe('bg-[#f5a623]');
+  });
+
+  it('returns gray dot for "idle" (default)', () => {
+    expect(getStatusDot('idle')).toBe('bg-gray-500');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveStatus
+// ---------------------------------------------------------------------------
+
+describe('deriveStatus', () => {
+  it('returns "idle" when lastEvent is null', () => {
+    expect(deriveStatus(null)).toBe('idle');
+  });
+
+  it('returns "active" for task_started event', () => {
+    const event = { event_type: 'task_started' } as Parameters<typeof deriveStatus>[0];
+    expect(deriveStatus(event)).toBe('active');
+  });
+
+  it('returns "error" for task_failed event', () => {
+    const event = { event_type: 'task_failed' } as Parameters<typeof deriveStatus>[0];
+    expect(deriveStatus(event)).toBe('error');
+  });
+
+  it('returns "error" for blocked event', () => {
+    const event = { event_type: 'blocked' } as Parameters<typeof deriveStatus>[0];
+    expect(deriveStatus(event)).toBe('error');
+  });
+
+  it('returns "approval_needed" for approval_needed event', () => {
+    const event = { event_type: 'approval_needed' } as Parameters<typeof deriveStatus>[0];
+    expect(deriveStatus(event)).toBe('approval_needed');
+  });
+
+  it('returns "idle" for heartbeat event (default case)', () => {
+    const event = { event_type: 'heartbeat' } as Parameters<typeof deriveStatus>[0];
+    expect(deriveStatus(event)).toBe('idle');
+  });
+
+  it('returns "idle" for task_completed event (default case)', () => {
+    const event = { event_type: 'task_completed' } as Parameters<typeof deriveStatus>[0];
+    expect(deriveStatus(event)).toBe('idle');
+  });
+});

--- a/src/mcp/zao-api/src/lib/__tests__/errors.test.ts
+++ b/src/mcp/zao-api/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { MCPError, handleError } from '../errors';
+
+// ---------------------------------------------------------------------------
+// MCPError class
+// ---------------------------------------------------------------------------
+
+describe('MCPError', () => {
+  it('is an instance of Error', () => {
+    const err = new MCPError('something went wrong', 'TEST_CODE');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('sets name to "MCPError"', () => {
+    expect(new MCPError('msg', 'CODE').name).toBe('MCPError');
+  });
+
+  it('stores message, code, and default status 500', () => {
+    const err = new MCPError('bad request', 'BAD_REQUEST');
+    expect(err.message).toBe('bad request');
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.status).toBe(500);
+  });
+
+  it('accepts a custom status code', () => {
+    const err = new MCPError('not found', 'NOT_FOUND', 404);
+    expect(err.status).toBe(404);
+  });
+
+  it('has a stack trace (is a real Error)', () => {
+    expect(new MCPError('test', 'ERR').stack).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleError
+// ---------------------------------------------------------------------------
+
+describe('handleError', () => {
+  it('returns { error, code } for an MCPError', () => {
+    const err = new MCPError('rate limited', 'RATE_LIMIT', 429);
+    const result = handleError(err);
+    expect(result).toEqual({ error: 'rate limited', code: 'RATE_LIMIT' });
+  });
+
+  it('returns INTERNAL_ERROR code for a generic Error', () => {
+    const result = handleError(new Error('generic failure'));
+    expect(result.code).toBe('INTERNAL_ERROR');
+    expect(result.error).toBe('Internal server error');
+  });
+
+  it('returns INTERNAL_ERROR for a thrown string', () => {
+    const result = handleError('something exploded');
+    expect(result.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('returns INTERNAL_ERROR for null', () => {
+    const result = handleError(null);
+    expect(result.code).toBe('INTERNAL_ERROR');
+  });
+});


### PR DESCRIPTION
## Test coverage added

**53 cases across 3 modules — pure functions and constants, no source changes.**

### `src/components/admin/agents/__tests__/constants.test.ts` (26 cases)

**`AGENTS`** (5): 7 entries, required fields, unique names, zoe→Orchestrator, caster→Social

**`EVENT_TYPES`** (5): 6 entries, required label/color/icon fields, task_started→'Started', approval_needed→'Needs Approval', includes heartbeat

**`getAgent`** (5): zoe→Orchestrator, builder→Code, unknown→undefined, empty→undefined, all 7 agents retrievable

**`getStatusDot`** (4): active→green-500, error→red-500, approval_needed→amber, idle→gray-500

**`deriveStatus`** (7): null→idle, task_started→active, task_failed→error, blocked→error, approval_needed→approval_needed, heartbeat→idle, task_completed→idle

### `src/app/overlay/zabal-games/__tests__/brand.test.ts` (18 cases)

**`withAlpha`** (7): #ff0000/1.0, #ffffff/0.5, #000000/0.0, #aabbcc/0.8, passthrough on 3-char hex, passthrough on non-hex, ZAO gold #f5a623 at 0.45

**`KEYFRAMES`** (4): non-empty string, contains zg-fade-up, zg-pulse, prefers-reduced-motion

**`tokensFor`** (7): all required fields present, scale=1 for medium / 0.82 for small / 1.25 for large, dark→white title / light→#141e27 title, accent passes through

### `src/mcp/zao-api/src/lib/__tests__/errors.test.ts` (9 cases)

**`MCPError`** (5): instanceof Error, name='MCPError', message/code/status, custom status=404, has stack

**`handleError`** (4): MCPError→{error, code}, generic Error→INTERNAL_ERROR, thrown string→INTERNAL_ERROR, null→INTERNAL_ERROR

🤖 Generated with [Claude Code](https://claude.com/claude-code)