### PR TITLE
test: overview dashboard data + juke changelog resolver (31 cases)

### DIFF
--- a/src/app/(auth)/overview/__tests__/data.test.ts
+++ b/src/app/(auth)/overview/__tests__/data.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  botFleet,
+  controlPlane,
+  improvements,
+  repoMap,
+  tooling,
+  toolingNote,
+} from '../data';
+
+const VALID_BOT_STATUSES = ['live', 'pending', 'dormant', 'decommissioned', 'external'] as const;
+const VALID_PRIORITIES = ['P0', 'P1', 'P2', 'P3'] as const;
+
+// ---------------------------------------------------------------------------
+// repoMap
+// ---------------------------------------------------------------------------
+
+describe('repoMap', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(repoMap)).toBe(true);
+    expect(repoMap.length).toBeGreaterThan(0);
+  });
+
+  it('every group has a "group" string and non-empty "areas" array', () => {
+    for (const g of repoMap) {
+      expect(typeof g.group).toBe('string');
+      expect(Array.isArray(g.areas)).toBe(true);
+      expect(g.areas.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every area has area, path, and desc fields', () => {
+    for (const g of repoMap) {
+      for (const a of g.areas) {
+        expect(typeof a.area).toBe('string');
+        expect(typeof a.path).toBe('string');
+        expect(typeof a.desc).toBe('string');
+      }
+    }
+  });
+
+  it('includes an "App & API" group', () => {
+    const groups = repoMap.map((g) => g.group);
+    expect(groups.some((g) => g.includes('App'))).toBe(true);
+  });
+
+  it('includes a bot fleet group', () => {
+    const groups = repoMap.map((g) => g.group);
+    expect(groups.some((g) => g.toLowerCase().includes('bot'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// botFleet
+// ---------------------------------------------------------------------------
+
+describe('botFleet', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(botFleet)).toBe(true);
+    expect(botFleet.length).toBeGreaterThan(0);
+  });
+
+  it('every bot has name, handle, source, status, and board', () => {
+    for (const bot of botFleet) {
+      expect(typeof bot.name).toBe('string');
+      expect(typeof bot.handle).toBe('string');
+      expect(typeof bot.source).toBe('string');
+      expect(typeof bot.status).toBe('string');
+      expect(typeof bot.board).toBe('string');
+    }
+  });
+
+  it('every bot status is a valid BotStatus value', () => {
+    for (const bot of botFleet) {
+      expect(VALID_BOT_STATUSES).toContain(bot.status as typeof VALID_BOT_STATUSES[number]);
+    }
+  });
+
+  it('includes ZOE with status "live"', () => {
+    const zoe = botFleet.find((b) => b.name === 'ZOE');
+    expect(zoe?.status).toBe('live');
+  });
+
+  it('includes ZAO Devz', () => {
+    const devz = botFleet.find((b) => b.name === 'ZAO Devz');
+    expect(devz).toBeDefined();
+  });
+
+  it('all bot names are unique', () => {
+    const names = botFleet.map((b) => b.name);
+    expect(new Set(names).size).toBe(botFleet.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// controlPlane
+// ---------------------------------------------------------------------------
+
+describe('controlPlane', () => {
+  it('has a url, summary, and capabilities array', () => {
+    expect(typeof controlPlane.url).toBe('string');
+    expect(typeof controlPlane.summary).toBe('string');
+    expect(Array.isArray(controlPlane.capabilities)).toBe(true);
+  });
+
+  it('capabilities array is non-empty', () => {
+    expect(controlPlane.capabilities.length).toBeGreaterThan(0);
+  });
+
+  it('every capability is a string', () => {
+    for (const cap of controlPlane.capabilities) {
+      expect(typeof cap).toBe('string');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tooling
+// ---------------------------------------------------------------------------
+
+describe('tooling', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(tooling)).toBe(true);
+    expect(tooling.length).toBeGreaterThan(0);
+  });
+
+  it('every group has a "group" string and non-empty "skills" array', () => {
+    for (const g of tooling) {
+      expect(typeof g.group).toBe('string');
+      expect(Array.isArray(g.skills)).toBe(true);
+      expect(g.skills.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every skill has name and desc', () => {
+    for (const g of tooling) {
+      for (const s of g.skills) {
+        expect(typeof s.name).toBe('string');
+        expect(typeof s.desc).toBe('string');
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolingNote
+// ---------------------------------------------------------------------------
+
+describe('toolingNote', () => {
+  it('is a non-empty string', () => {
+    expect(typeof toolingNote).toBe('string');
+    expect(toolingNote.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// improvements
+// ---------------------------------------------------------------------------
+
+describe('improvements', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(improvements)).toBe(true);
+    expect(improvements.length).toBeGreaterThan(0);
+  });
+
+  it('every improvement has priority, title, and detail', () => {
+    for (const item of improvements) {
+      expect(typeof item.priority).toBe('string');
+      expect(typeof item.title).toBe('string');
+      expect(typeof item.detail).toBe('string');
+    }
+  });
+
+  it('all priorities are valid (P0–P3)', () => {
+    for (const item of improvements) {
+      expect(VALID_PRIORITIES).toContain(item.priority as typeof VALID_PRIORITIES[number]);
+    }
+  });
+
+  it('includes at least one P0 item', () => {
+    expect(improvements.some((i) => i.priority === 'P0')).toBe(true);
+  });
+});

--- a/src/lib/spaces/__tests__/jukeChangelog.test.ts
+++ b/src/lib/spaces/__tests__/jukeChangelog.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { buildResolutionIndex } from '../jukeChangelog';
+import type { JukeChangelog, JukeChangelogEntry } from '../jukeChangelog';
+
+function makeEntry(overrides: Partial<JukeChangelogEntry> = {}): JukeChangelogEntry {
+  return {
+    id: 'entry-1',
+    shipped_at: '2026-05-01',
+    category: 'api',
+    title: 'Some feature',
+    summary: 'Details here',
+    ...overrides,
+  };
+}
+
+function makeChangelog(entries: JukeChangelogEntry[]): JukeChangelog {
+  return {
+    version: 1,
+    generated_at: '2026-05-01T00:00:00Z',
+    canonical_spec: 'https://juke.audio/llms.txt',
+    skill_md: 'https://juke.audio/SKILL.md',
+    entries,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildResolutionIndex
+// ---------------------------------------------------------------------------
+
+describe('buildResolutionIndex', () => {
+  it('returns an empty Map for null changelog', () => {
+    const idx = buildResolutionIndex(null);
+    expect(idx).toBeInstanceOf(Map);
+    expect(idx.size).toBe(0);
+  });
+
+  it('returns an empty Map for a changelog with no entries', () => {
+    expect(buildResolutionIndex(makeChangelog([]))).toEqual(new Map());
+  });
+
+  it('indexes an ask by explicit resolves[]', () => {
+    const entry = makeEntry({ id: 'ship-1', resolves: ['ask-1'] });
+    const idx = buildResolutionIndex(makeChangelog([entry]));
+    expect(idx.has('ask-1')).toBe(true);
+    expect(idx.get('ask-1')).toBe(entry);
+  });
+
+  it('indexes the entry by its own id (implicit join)', () => {
+    const entry = makeEntry({ id: 'ask-implicit' });
+    const idx = buildResolutionIndex(makeChangelog([entry]));
+    expect(idx.has('ask-implicit')).toBe(true);
+  });
+
+  it('maps multiple resolves from a single entry', () => {
+    const entry = makeEntry({ id: 'ship-x', resolves: ['ask-a', 'ask-b', 'ask-c'] });
+    const idx = buildResolutionIndex(makeChangelog([entry]));
+    expect(idx.has('ask-a')).toBe(true);
+    expect(idx.has('ask-b')).toBe(true);
+    expect(idx.has('ask-c')).toBe(true);
+  });
+
+  it('keeps the more recent entry when two entries resolve the same ask', () => {
+    const older = makeEntry({ id: 'old', shipped_at: '2026-04-01', resolves: ['ask-1'] });
+    const newer = makeEntry({ id: 'new', shipped_at: '2026-05-01', resolves: ['ask-1'] });
+    const idx = buildResolutionIndex(makeChangelog([older, newer]));
+    expect(idx.get('ask-1')).toBe(newer);
+  });
+
+  it('order does not matter — newer shipped_at always wins', () => {
+    const older = makeEntry({ id: 'old', shipped_at: '2026-03-01', resolves: ['ask-x'] });
+    const newer = makeEntry({ id: 'new', shipped_at: '2026-06-01', resolves: ['ask-x'] });
+    // newer listed first
+    const idx = buildResolutionIndex(makeChangelog([newer, older]));
+    expect(idx.get('ask-x')).toBe(newer);
+  });
+
+  it('an entry with no resolves still gets indexed by its own id', () => {
+    const entry = makeEntry({ id: 'solo-entry', resolves: undefined });
+    const idx = buildResolutionIndex(makeChangelog([entry]));
+    expect(idx.has('solo-entry')).toBe(true);
+  });
+
+  it('explicit resolves[] does not overwrite a newer implicit id match', () => {
+    // entry-a has a newer shipped_at and id matching 'overlap'
+    const implicit = makeEntry({ id: 'overlap', shipped_at: '2026-06-01' });
+    // entry-b resolves 'overlap' but with an older date
+    const explicit = makeEntry({ id: 'entry-b', shipped_at: '2026-03-01', resolves: ['overlap'] });
+    const idx = buildResolutionIndex(makeChangelog([implicit, explicit]));
+    // implicit (newer) should win
+    expect(idx.get('overlap')).toBe(implicit);
+  });
+});


### PR DESCRIPTION
## Test coverage added

**31 cases across 2 modules — pure data constants and a pure resolver function, no source changes.**

### `src/app/(auth)/overview/__tests__/data.test.ts` (22 cases)

**`repoMap`** (5): non-empty array, group+areas structure, every area has path/desc, includes App&API and bot fleet groups

**`botFleet`** (6): non-empty, required fields, valid BotStatus values, ZOE→'live', ZAO Devz exists, unique names

**`controlPlane`** (3): url/summary/capabilities fields, non-empty capabilities, all strings

**`tooling`** (3): non-empty, group+skills structure, every skill has name+desc

**`toolingNote`** (1): non-empty string

**`improvements`** (4): non-empty, required fields, P0-P3 priorities, at least one P0

### `src/lib/spaces/__tests__/jukeChangelog.test.ts` (9 cases)

**`buildResolutionIndex`**: null→empty Map, empty entries→empty Map, explicit `resolves[]` indexing, implicit `id` indexing (no-resolves entry), multi-resolves from one entry, newer `shipped_at` wins on collision, order-independent (newer-first vs older-first), explicit vs implicit collision resolved by date

🤖 Generated with [Claude Code](https://claude.com/claude-code)