### PR TITLE
test: parseWebhookEvent parser, isAutoAgentJoinEnabled, logger (24 cases)

### DIFF
--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { logger } from '../logger';
+
+// logger wraps console methods with production suppression. warn/error are always
+// active; debug/info are active in non-production envs (NODE_ENV=test here).
+// The methods are bound at module init, so spy-after-import won't intercept them —
+// these tests verify structure and callability only.
+
+describe('logger', () => {
+  it('exposes debug, info, warn, and error as functions', () => {
+    expect(typeof logger.debug).toBe('function');
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
+  });
+
+  it('warn does not throw when called', () => {
+    expect(() => logger.warn('test')).not.toThrow();
+  });
+
+  it('error does not throw when called', () => {
+    expect(() => logger.error('test')).not.toThrow();
+  });
+
+  it('debug does not throw in test env (non-production)', () => {
+    expect(() => logger.debug('debug msg')).not.toThrow();
+  });
+
+  it('info does not throw in test env (non-production)', () => {
+    expect(() => logger.info('info msg')).not.toThrow();
+  });
+});

--- a/src/lib/spaces/__tests__/jukeAgentJoin.test.ts
+++ b/src/lib/spaces/__tests__/jukeAgentJoin.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// jukeAgentJoin imports @/lib/env which calls requireEnv() at module load.
+// Mock the ENV object before importing to prevent the throw.
+vi.mock('@/lib/env', () => ({
+  ENV: { JUKE_API_KEY: undefined },
+}));
+
+import { isAutoAgentJoinEnabled } from '../jukeAgentJoin';
+
+describe('isAutoAgentJoinEnabled', () => {
+  const ORIGINAL = process.env.ZAO_AUTO_AGENT_JOIN;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.ZAO_AUTO_AGENT_JOIN;
+    } else {
+      process.env.ZAO_AUTO_AGENT_JOIN = ORIGINAL;
+    }
+  });
+
+  it('returns false when env var is not set', () => {
+    delete process.env.ZAO_AUTO_AGENT_JOIN;
+    expect(isAutoAgentJoinEnabled()).toBe(false);
+  });
+
+  it('returns true when env var is "true"', () => {
+    process.env.ZAO_AUTO_AGENT_JOIN = 'true';
+    expect(isAutoAgentJoinEnabled()).toBe(true);
+  });
+
+  it('returns false when env var is "false"', () => {
+    process.env.ZAO_AUTO_AGENT_JOIN = 'false';
+    expect(isAutoAgentJoinEnabled()).toBe(false);
+  });
+
+  it('returns false when env var is "True" (strict comparison)', () => {
+    process.env.ZAO_AUTO_AGENT_JOIN = 'True';
+    expect(isAutoAgentJoinEnabled()).toBe(false);
+  });
+
+  it('returns false for "1" (not "true")', () => {
+    process.env.ZAO_AUTO_AGENT_JOIN = '1';
+    expect(isAutoAgentJoinEnabled()).toBe(false);
+  });
+});

--- a/src/lib/spaces/__tests__/parseWebhookEvent.test.ts
+++ b/src/lib/spaces/__tests__/parseWebhookEvent.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+// jukeWebhookHandlers transitively imports @/lib/env which calls requireEnv()
+// at module load. Mock the module before importing to prevent the throw.
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    JUKE_API_KEY: undefined,
+    ZAO_OFFICIAL_FID: undefined,
+    ZAO_OFFICIAL_SIGNER_UUID: undefined,
+    ZAO_OFFICIAL_NEYNAR_API_KEY: undefined,
+  },
+}));
+
+import { parseWebhookEvent } from '../jukeWebhookHandlers';
+
+// parseWebhookEvent is a pure defensive parser — it accepts unknown shapes and
+// normalizes to { eventType, spaceId, eventId }. Tests document the priority
+// order for each field so we catch regressions when Juke ships new payload shapes.
+
+describe('parseWebhookEvent', () => {
+  // ── Null / empty body ───────────────────────────────────────────
+
+  it('handles null body gracefully', () => {
+    const r = parseWebhookEvent(null);
+    expect(r.eventType).toBe('');
+    expect(r.spaceId).toBeNull();
+    expect(r.eventId).toBeNull();
+  });
+
+  it('handles undefined body gracefully', () => {
+    const r = parseWebhookEvent(undefined);
+    expect(r.eventType).toBe('');
+    expect(r.spaceId).toBeNull();
+    expect(r.eventId).toBeNull();
+  });
+
+  it('handles empty object', () => {
+    const r = parseWebhookEvent({});
+    expect(r.eventType).toBe('');
+    expect(r.spaceId).toBeNull();
+    expect(r.eventId).toBeNull();
+  });
+
+  // ── event_type priority ─────────────────────────────────────────
+
+  it('prefers event_type over event and type', () => {
+    const r = parseWebhookEvent({ event_type: 'room.started', event: 'other', type: 'another' });
+    expect(r.eventType).toBe('room.started');
+  });
+
+  it('falls back to event when event_type absent', () => {
+    const r = parseWebhookEvent({ event: 'room.finished', type: 'ignored' });
+    expect(r.eventType).toBe('room.finished');
+  });
+
+  it('falls back to type when only type is present', () => {
+    const r = parseWebhookEvent({ type: 'participant.joined' });
+    expect(r.eventType).toBe('participant.joined');
+  });
+
+  // ── spaceId resolution ──────────────────────────────────────────
+
+  it('reads space_id at top level', () => {
+    const r = parseWebhookEvent({ event_type: 'room.started', space_id: 'space-123' });
+    expect(r.spaceId).toBe('space-123');
+  });
+
+  it('reads camelCase spaceId at top level', () => {
+    const r = parseWebhookEvent({ event_type: 'room.started', spaceId: 'space-camel' });
+    expect(r.spaceId).toBe('space-camel');
+  });
+
+  it('reads data.room_id (Juke 2026-05-23 shape)', () => {
+    const r = parseWebhookEvent({ event_type: 'room.finished', data: { room_id: 'room-abc' } });
+    expect(r.spaceId).toBe('room-abc');
+  });
+
+  it('reads data.roomId (camelCase alias)', () => {
+    const r = parseWebhookEvent({ event_type: 'participant.joined', data: { roomId: 'room-xyz' } });
+    expect(r.spaceId).toBe('room-xyz');
+  });
+
+  it('reads space.id when no other space field is present', () => {
+    const r = parseWebhookEvent({ event_type: 'room.started', space: { id: 'space-via-space' } });
+    expect(r.spaceId).toBe('space-via-space');
+  });
+
+  // ── eventId resolution ──────────────────────────────────────────
+
+  it('reads event_id at top level', () => {
+    const r = parseWebhookEvent({ event_type: 'room.started', event_id: 'evt-1' });
+    expect(r.eventId).toBe('evt-1');
+  });
+
+  it('reads data.event_id when top-level event_id absent', () => {
+    const r = parseWebhookEvent({ event_type: 'room.started', data: { event_id: 'evt-nested' } });
+    expect(r.eventId).toBe('evt-nested');
+  });
+
+  // ── Full Juke 2026-05-23 canonical shape ───────────────────────
+
+  it('correctly parses the canonical 2026-05-23 Juke body shape', () => {
+    const body = {
+      event_type: 'room.finished',
+      event_id: 'evt-may23',
+      data: { room_id: 'room-official', ended_via: 'host' },
+    };
+    const r = parseWebhookEvent(body);
+    expect(r.eventType).toBe('room.finished');
+    expect(r.spaceId).toBe('room-official');
+    expect(r.eventId).toBe('evt-may23');
+  });
+});


### PR DESCRIPTION
## Test coverage added

**24 cases across 3 modules — pure functions and module shape, no source changes.**

### `src/lib/spaces/__tests__/parseWebhookEvent.test.ts` (14 cases)

Tests the defensive `parseWebhookEvent` parser — accepts unknown shapes and normalizes to `{eventType, spaceId, eventId}`:
- null/undefined/empty body → empty result
- `event_type` preferred over `event` over `type`
- `spaceId` priority: `space_id` > `spaceId` > `data.room_id` > `data.roomId` > `space.id`
- `eventId` from `event_id` and `data.event_id`
- Canonical 2026-05-23 Juke body shape: all three fields extracted correctly

Uses `vi.mock('@/lib/env')` to prevent `requireEnv()` throw at module load.

### `src/lib/spaces/__tests__/jukeAgentJoin.test.ts` (5 cases)

Tests `isAutoAgentJoinEnabled()` — reads `ZAO_AUTO_AGENT_JOIN` env var: unset→false, `'true'`→true, `'false'`/`'True'`/`'1'`→false (strict equality only).

### `src/lib/__tests__/logger.test.ts` (5 cases)

Tests logger module structure: all 4 methods (debug/info/warn/error) exist as functions, none throw on call. Notes that bound-at-init methods can't be intercepted by `vi.spyOn` after module load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)