### PR TITLE
docs: sweep 90+ weeks → 100+ in internal strategy docs

### DIFF
--- a/research/business/526-distribution-v3-zao-entity-playbooks/README.md
+++ b/research/business/526-distribution-v3-zao-entity-playbooks/README.md
@@ -173,7 +173,7 @@ Do NOT batch entities. ZAO OS sprint and ZAOstock sprint and Devz sprint run in 
 - **17** ZAOstock artists already signed up (memory `feedback_no_regenerate_codes.md`)
 - **188** ZAO members today, primary ICP source (`project_four_pillars.md`)
 - **$0.003** Spotify per-play, $33 per 10k plays - the streaming pain anchor (whitepaper doc 051)
-- **90+ weeks** fractal meetings running, real revealed-preference WTP evidence (doc 106 + 474)
+- **100+ weeks** fractal meetings running, real revealed-preference WTP evidence (doc 106 + 474)
 - **0.1%** behavior change from standalone education (doc 470 168-study meta) - drives the "distribute-with-them not teach-them" wedge
 - **10** minimum first-believer N before any ZAO surface ships outbound copy (V3 ch4 + ch5)
 - **15** weight on paid-and-failing pain signals vs 0.5 on theorizing (Dog Food Labs pattern)

--- a/research/community/169-ai-education-music-creators-landscape/README.md
+++ b/research/community/169-ai-education-music-creators-landscape/README.md
@@ -104,7 +104,7 @@ If ZAO were to run a music-specific AI education cohort, here's what it could lo
 ### What ZAO Has That Others Don't
 
 1. **A live platform** (ZAO OS) — students build features for a real product with real users
-2. **An existing community** (100+ members, 90+ weeks of fractal governance)
+2. **An existing community** (100+ members, 100+ weeks of fractal governance)
 3. **Claude Code skills library** (48 skills, 168+ research docs)
 4. **On-chain infrastructure** (ZOUNZ DAO, Respect tokens, Arweave storage)
 5. **Music domain expertise** (artist org, curation, cross-platform publishing)


### PR DESCRIPTION
## Summary

Single-line sweep updating stale "90+ weeks" to "100+" in two internal strategy docs, consistent with the verified two-layer count (doc 1201 + doc 1202, PR #1647).

- **Doc 169** (AI education landscape): "100+ members, 90+ weeks of fractal governance" → "100+ weeks"
- **Doc 526** (distribution playbooks): "90+ weeks fractal meetings running" → "100+ weeks"

Historical timeline entries (e.g., doc 696 "Fractal governance scales past 90 weeks" for Early 2025) were intentionally left unchanged as they describe a milestone accurate at that time, not a current stat.

See also PR #1650 for higher-priority external-facing docs (363 ZAOstock pitch, 051 artist brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)