### PR TITLE
test: tokenGate error paths + hindsight null fallback (12 cases)

### DIFF
--- a/src/lib/__tests__/hindsight.test.ts
+++ b/src/lib/__tests__/hindsight.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import hindsight, { getHindsightClient } from '../hindsight';
+
+// getHindsightClient lazy-imports @vectorize-io/hindsight-client which is an
+// optional dependency not installed in this repo. The module gracefully returns
+// null so callers can skip Hindsight features when the package is absent.
+
+describe('getHindsightClient', () => {
+  it('is a function', () => {
+    expect(typeof getHindsightClient).toBe('function');
+  });
+
+  it('returns null when the optional package is not installed', async () => {
+    const client = await getHindsightClient();
+    expect(client).toBeNull();
+  });
+
+  it('returns null on repeated calls (no spurious retry)', async () => {
+    const a = await getHindsightClient();
+    const b = await getHindsightClient();
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+  });
+});
+
+describe('hindsight default export', () => {
+  it('has a getClient method', () => {
+    expect(typeof hindsight.getClient).toBe('function');
+  });
+
+  it('getClient is the same function as the named export', () => {
+    expect(hindsight.getClient).toBe(getHindsightClient);
+  });
+});

--- a/src/lib/spaces/__tests__/tokenGate.test.ts
+++ b/src/lib/spaces/__tests__/tokenGate.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { checkTokenGate } from '../tokenGate';
+
+// checkTokenGate delegates live reads to viem. Tests here cover the defensive
+// error paths that throw before any network call, documenting the supported
+// chain set and the ERC-1155 tokenId requirement.
+
+const DEAD_ADDR = '0x000000000000000000000000000000000000dEaD';
+
+describe('checkTokenGate — unsupported chain', () => {
+  it('throws for chain 999 (not supported)', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, { type: 'erc20', contractAddress: DEAD_ADDR, chainId: 999 }),
+    ).rejects.toThrow('Unsupported chain: 999');
+  });
+
+  it('throws for chain 137 (Polygon — not in supported set)', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, { type: 'erc20', contractAddress: DEAD_ADDR, chainId: 137 }),
+    ).rejects.toThrow('Unsupported chain: 137');
+  });
+
+  it('throws for chain 0', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, { type: 'erc20', contractAddress: DEAD_ADDR, chainId: 0 }),
+    ).rejects.toThrow('Unsupported chain: 0');
+  });
+
+  it('error message includes the bad chain id', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, { type: 'erc721', contractAddress: DEAD_ADDR, chainId: 56 }),
+    ).rejects.toThrow('56');
+  });
+});
+
+describe('checkTokenGate — ERC-1155 tokenId guard', () => {
+  it('throws when tokenId is absent for erc1155 gate', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, { type: 'erc1155', contractAddress: DEAD_ADDR, chainId: 8453 }),
+    ).rejects.toThrow('tokenId required for ERC-1155 gate');
+  });
+
+  it('throws when tokenId is an empty string for erc1155 gate', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, {
+        type: 'erc1155',
+        contractAddress: DEAD_ADDR,
+        chainId: 8453,
+        tokenId: '',
+      }),
+    ).rejects.toThrow('tokenId required for ERC-1155 gate');
+  });
+});
+
+describe('checkTokenGate — unknown gate type', () => {
+  it('throws for an unknown gate type', async () => {
+    await expect(
+      checkTokenGate(DEAD_ADDR, {
+        // @ts-expect-error — deliberate runtime test of the default branch
+        type: 'erc777',
+        contractAddress: DEAD_ADDR,
+        chainId: 8453,
+      }),
+    ).rejects.toThrow('Unknown gate type: erc777');
+  });
+});


### PR DESCRIPTION
## What

Pure vitest tests — no source changes. Two modules:

### `src/lib/spaces/__tests__/tokenGate.test.ts` (7 cases)
Tests `checkTokenGate` error paths that resolve before any on-chain call:
- Unsupported chains (999, 137, 0, 56) → `throws 'Unsupported chain: <n>'`
- ERC-1155 gate with absent tokenId → `throws 'tokenId required for ERC-1155 gate'`
- ERC-1155 gate with empty-string tokenId → same throw (falsy check)
- Unknown gate type `'erc777'` → hits `default` branch throw

### `src/lib/__tests__/hindsight.test.ts` (5 cases)
- `getHindsightClient` is a function
- Returns `null` when `@vectorize-io/hindsight-client` is absent (optional dep, not installed here)
- Idempotent: repeated calls still return `null`
- `hindsight` default export has `getClient`
- `hindsight.getClient === getHindsightClient` (same reference)

## Coverage targets

- `src/lib/spaces/tokenGate.ts` — previously untested
- `src/lib/hindsight.ts` — previously untested

All 12 cases pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)