### PR TITLE
docs: update 90+→100+ weeks in profile dossier, LinkedIn playbook, governance docs

### DIFF
--- a/research/business/667-brand-kit-completeness-audit/README.md
+++ b/research/business/667-brand-kit-completeness-audit/README.md
@@ -27,7 +27,7 @@ tier: DEEP
 
 | # | Brand | Category | Status | Why Missing? | Source That Surfaced It |
 |---|---|---|---|---|---|
-| 1 | **ZAO Fractals** | governance (new cat) | active | I rolled it into "The ZAO" card initially; it's distinct enough to stand alone (90+ weeks, two contracts, two ledgers, separate bot, separate frontend at zao.frapps.xyz) | `project_fractal_process.md` + `project_fractal_vision.md` + ZAOOS code paths (`src/app/(auth)/fractals/`, `src/app/api/respect/fractal`, `src/app/api/discord/fractal-live`) |
+| 1 | **ZAO Fractals** | governance (new cat) | active | I rolled it into "The ZAO" card initially; it's distinct enough to stand alone (100+ weeks, two contracts, two ledgers, separate bot, separate frontend at zao.frapps.xyz) | `project_fractal_process.md` + `project_fractal_vision.md` + ZAOOS code paths (`src/app/(auth)/fractals/`, `src/app/api/respect/fractal`, `src/app/api/discord/fractal-live`) |
 | 2 | **ZAO Music** | music | building | Doc 475 explicitly named ZAO Music as a DBA under BCZ Strategies — wasn't in initial scan | `project_zao_music_entity.md` + Doc 475 |
 | 3 | **ZAO Music Bot (`zaomusicbot`)** | agents | active | Live JS bot, 117KB, last push 2026-03-12 — wasn't in my 663b/c/e audits | `gh repo view bettercallzaal/zaomusicbot` |
 | 4 | **ZOUNZ** | music | building | Substantial brand — "Farcaster Music Mini App: AI music gen + Audius + Zora NFT on Base + Attention Markets on Solana." 173KB repo. Has its own `/src/components/zounz/` + `/src/app/api/zounz/` in ZAOOS. | `gh repo view bettercallzaal/ZOUNZ` description; ZAOOS code paths |

--- a/research/community/742-zaal-panthaki-profile-dossier/README.md
+++ b/research/community/742-zaal-panthaki-profile-dossier/README.md
@@ -51,7 +51,7 @@ tier: DISPATCH
 | 2023 | Co-founded WaveWarZ with Hurric4n3IKE + Candytoybox (Samantha Denton-Kinney). | WaveWarZ whitepaper; Doc 050 |
 | 2024 | Apr: produced **ZAO-PALOOZA** at NFT NYC (12 artists, 6 weeks lead, broke even). | Doc 050 |
 | 2024 | Dec: produced **ZAO-CHELLA** at Miami Art Basel (10 artists, WaveWarZ LIVE battle, AR art). | Doc 050 |
-| 2024 | Started weekly Respect Game fractal governance. 90+ consecutive weeks as of May 2026. | Doc 050 |
+| 2024 | Started weekly Respect Game fractal governance. 100+ consecutive weeks as of 2026-07-17 (63 with verified on-chain Respect settlement, doc 1202). | Doc 050 |
 | 2024 | Relocated to Ellsworth, Maine. "Where there was zero blockchain exposure" — turned that into bridging local arts scene to onchain rails. | Doc 050; bettercallzaal.com |
 | 2026 | Jan 1: launched **$ZABAL token** on Base via Clanker/Empire Builder. Liquid reward token, no governance power. Contract `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07`. | memory `project_nexus_hub_live` |
 | 2026 | May 7: shipped **Nexus Hub** — 14-brand ecosystem directory at bettercallzaal.com/nexus.html. | memory `project_nexus_hub_live` |
@@ -134,7 +134,7 @@ Mirrors Ike's chain (football → EE → Infosys → sales → spaces → indie 
 3. **Automation Engineer at PCC Structurals** — $1.5M robotics project, 7x throughput; learning to make systems that move physical value
 4. **2022 bear market Web3 pivot** — discovered software could MOVE VALUE not just compute; smart contracts on Base + Solana, zero exploits
 5. **Founded The ZAO (2023)** in the crypto winter — only-the-serious-people-left timing
-6. **90+ weeks of fractal Respect Game governance** — designed + iterated soulbound mechanics + education-through-participation
+6. **100+ weeks of fractal Respect Game governance** — designed + iterated soulbound mechanics + education-through-participation
 7. **Produced ZAO-PALOOZA (NFT NYC) + ZAO-CHELLA (Art Basel)** — six-person team, six-week lead, broke even on PALOOZA, brought music into web3 events
 8. **400+ daily newsletter editions** building in public — Year of the ZAO, ZABAL, ZTalent
 9. **BCZ YapZ podcast (20 episodes)** + co-hosting LTAW3 — long-form public speaking via voice

--- a/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
+++ b/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
@@ -34,8 +34,8 @@ tier: STANDARD
 
 - **zaalcaster** - open-sourced his own Farcaster client, vibe-coded with an AI agent. github.com/bettercallzaal/zaalcaster
 - **ZLANK** - no-code Farcaster snap builder, won FarHack 2026 Snaps track. zlank.online
-- **The ZAO** - 90+ weeks of onchain peer-ranked Respect governance on Base. thezao.xyz (note: on-chain truth is ~101 weeks / 156 holders per doc 975 - use the accurate figure)
-- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 500+ SOL volume.
+- **The ZAO** - 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism. 157 unique Respect holders (doc 1200). thezao.xyz
+- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 522 SOL lifetime volume (~$39K, 1,245 battles, 2026-07-17).
 - **ZABAL Gamez** - 3-month build-a-thon. zabalgamez.com
 - Build-in-public / vibe-coding lessons; artists owning their tools; onchain music.
 

--- a/research/governance/102-fractals-frapps-ordao-page/README.md
+++ b/research/governance/102-fractals-frapps-ordao-page/README.md
@@ -91,7 +91,7 @@ const balance = await client.getRespectOf(walletAddress);
 | Member fractal history + leaderboard | `src/app/api/fractals/member/[wallet]/route.ts` + `src/app/api/respect/member/route.ts` | ✅ Live |
 | On-chain Respect sync (multicall) | `src/lib/respect/leaderboard.ts` | ✅ Live |
 | Respect member aggregate table | `respect_members` (Supabase) | ✅ 40 ZAO members tracked |
-| ZAO Fractal standing call | Discord/Telegram (Monday 6pm EST) | ✅ 90+ weeks running |
+| ZAO Fractal standing call | Discord/Telegram (Monday 6pm EST) | ✅ 100+ weeks running |
 | Hats Protocol integration (treeId 226) | `community.config.ts` line 125 | ✅ Integrated |
 
 ### Missing (Needed for `/fractals` Page)

--- a/research/governance/188-zao-fractal-bot-process/README.md
+++ b/research/governance/188-zao-fractal-bot-process/README.md
@@ -19,7 +19,7 @@ tier: STANDARD
 
 | Decision | Status | Details |
 |----------|--------|---------|
-| **Process is live + tested** | ACTIVE | 90+ weeks running (since Aug 2024), Mondays 6pm EST + anytime with 4+ unplayed members |
+| **Process is live + tested** | ACTIVE | 100+ weeks running (since Aug 2024), Mondays 6pm EST + anytime with 4+ unplayed members |
 | **Bot platform: Discord** | LIVE | Not Telegram or web; Python 3.10+, discord.py 2.0+, hosted on bot-hosting.net |
 | **Bot repo: fractalbotmarch2026** | v2.1 CURRENT | GitHub: bettercallzaal/fractalbotmarch2026; v2.1 (2026-03-28) - onchain auto-submit, Farcaster linking, Snapshot cog. Storage on Supabase since v2.0. |
 | **Fibonacci scoring (2x era)** | DEPLOYED | Ranks 1-6 award 110/68/42/26/16/10 Respect (Fibonacci double from year 1) |
@@ -454,7 +454,7 @@ respect: {
 - **Doc 102:** Fractals page design (frapps, ORDAO, ZAO OS integration)
 - **Doc 103:** Fractal governance ecosystem
 - **Doc 104:** Fractal communities directory
-- **Doc 109:** ZAO fractal history (90+ weeks, Mondays 6pm EST)
+- **Doc 109:** ZAO fractal history (100+ weeks, Mondays 6pm EST)
 - **Doc 114:** Fractal live infrastructure + data flows (companion to this doc)
 - **Doc 285:** (Community governance deep dives)
 - **Doc 444:** (Governance tools audit)


### PR DESCRIPTION
## Summary

Second sweep updating stale "90+ weeks" Fractal claims to the verified "100+" count in higher-visibility and governance-facing docs.

**Files changed:**

- **742 (Zaal profile dossier):** Two updates — timeline entry and capability list. Now reads: "100+ consecutive weeks as of 2026-07-17 (63 with verified on-chain Respect settlement, doc 1202)" + "100+ weeks of fractal Respect Game governance"
- **987 (LinkedIn personal brand playbook):** Applied cite-discipline phrase — "100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism. 157 unique Respect holders (doc 1200)." Removes the inline self-correction note (now superseded). Also: WaveWarZ "500+ SOL volume" → "522 SOL lifetime volume (~$39K, 1,245 battles, 2026-07-17)"
- **188 (fractal bot process):** "90+ weeks running" → "100+" in process status row; two doc-109 reference lines updated
- **102 (fractals frapps ordao page):** "90+ weeks running" → "100+"
- **667 (brand kit completeness audit):** "90+ weeks" in ZAO Fractals brand card → "100+"

## See also
- PR #1650: external pitch page (363) + artist brief (051) — higher-priority external docs
- PR #1652: internal strategy docs (169, 526)
- PR #1647: canonical facts ledger (1201) — source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)