### PR TITLE
docs(978+733): retire WaveWarZ directional caveat + live API stats (Jul 2026)

### DIFF
--- a/research/business/978-zao-numbers-framing/README.md
+++ b/research/business/978-zao-numbers-framing/README.md
@@ -2,7 +2,7 @@
 topic: business
 type: guide
 status: research-complete
-last-validated: 2026-07-06
+last-validated: 2026-07-17
 superseded-by:
 related-docs: 974, 975, 977, 443, 050, 836
 original-query: "ZAO Numbers - set up framing - a single honest way to present ZAO's ecosystem numbers so decks, the site, and casts stop citing conflicting figures"
@@ -32,7 +32,7 @@ These are not the same population and must never be merged into one "~200" figur
 
 | Claim | Number | Caveat | Source |
 |-------|--------|--------|--------|
-| Unbroken weekly Fractals | **~101 weeks** ("100+") | Corrects the old "90+"; use 100+ | Doc 975 / 977 |
+| Unbroken weekly Fractals | **100+** (102 by date-calc; 63 on-chain) | Two-layer: date-calc 102 weeks (start 2024-07-30) + 63 weeks verified on-chain (doc 1202). Cite: "100+ weekly Respect Games, 63 weeks with on-chain Respect settlement." | Doc 1201 / 1202 |
 | OG Respect supply | 38,484 (frozen) | measured | Doc 975 |
 | Distribution Gini | **0.73** (OG-only, concentrated) | Do NOT claim "egalitarian / 0.23" - that was modeled and wrong (Doc 977) | Doc 975 |
 | OREC proposal concentration | 94% from one relayer | State it - it is the honest limitation | Doc 975 |
@@ -57,18 +57,17 @@ The distribution number is the discipline test: the honest 0.73 (concentrated) b
 
 ### WaveWarZ - the one to caveat hardest
 
-The numbers here are **self-reported and disagree across surfaces.** Doc 974 is the reconciled source. Present as directional, never precise:
+Live API data is now authoritative. Use `wavewarz.info/api/public/stats` (public, no auth, 60s cache) as the canonical source. The "directional / self-reported" caveat is **retired as of 2026-07-17**.
 
-- Volume: **~$33K (~491 SOL)** reconciled (Doc 974) - NOT "$37K / 435 SOL" (older deck figure). Pick one, cite Doc 974, flag "directional, pending a live on-chain pull."
-- Battles: **~1,125** reconciled - NOT "795" (older figure).
-- The load-bearing honest point from Doc 974: platform revenue has exceeded artist payouts. Do not bury it.
-
-Until a live on-chain pull reconciles WaveWarZ (Doc 974 next action), every WaveWarZ number carries "self-reported / directional."
+- Volume: **522 SOL (~$39K at $75/SOL)** — live API 2026-07-17. NOT "491 SOL" or "435 SOL" (older figures).
+- Battles: **1,245** (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community) — live API 2026-07-17. NOT "~1,125" or "795" (older figures).
+- Artist payouts: **9.05 SOL** — live API. Platform revenue: **17.43 SOL** (exceeds artist payouts — still the honest load-bearing point, state it).
+- Trader claims: **127.34 SOL** — live API.
 
 ## The "which number when" cheat sheet
 
 - **Sponsor deck** -> lead with dated festival receipts + 100+ weeks + 400+ newsletter editions. Concrete, verifiable, no crypto jargon.
-- **Governance / DAO audience** -> 156 holders, ~101 weeks, Gini 0.73 stated honestly, 94% proposer concentration named as the limitation.
+- **Governance / DAO audience** -> 157 unique holders (doc 1200), 100+ weeks (two-layer, doc 1201/1202), Gini 0.73 stated honestly, 94% proposer concentration named as the limitation.
 - **Farcaster / community cast** -> 188-member community, build-in-public, 400+ editions.
 - **Never in any context** -> "~200 members", "Gini 0.23 / egalitarian", precise WaveWarZ dollar figures without the "directional" flag.
 
@@ -85,7 +84,7 @@ Until a live on-chain pull reconciles WaveWarZ (Doc 974 next action), every Wave
 |--------|-------|------|---------|
 | Adopt this canonical set in the next sponsor deck + thezao.xyz copy; purge "~200 / Gini 0.23 / precise WaveWarZ $" | @Zaal | Edit | 2026-07-20 |
 | Confirm the ETH Denver artist count so the festivals row is complete | @Zaal | Research | 2026-07-20 |
-| After Doc 974's live WaveWarZ pull, update the WaveWarZ figures here and drop "directional" | @Zaal | Edit | 2026-07-27 |
+| ~~After Doc 974's live WaveWarZ pull, update the WaveWarZ figures here and drop "directional"~~ | DONE 2026-07-17 (live API confirmed, directional caveat retired) | | |
 
 ## Sources
 

--- a/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
+++ b/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
@@ -128,7 +128,7 @@ Hub currently links 8 portals. Sub-Agent B identified 25 more projects/people/br
 | SongJam (SANG token + $ZABAL leaderboard) | songjam.space | Live-now widget + top-5 Empire embed | 5 |
 | ZAO Stock (Oct 2026 festival, Ellsworth ME) | zaoos.com/stock | Hero card + countdown | 5 |
 | COC Concertz (150+ weekly VR shows) | cocconcertz.com | "Next show" badge | 4 |
-| WaveWarZ (795 battles, 435 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
+| WaveWarZ (1,245 battles, 522 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
 | Magnetiq Proof-of-Meet (IRL connection badges) | magnetiq.xyz | Portal card in ecosystem grid | 4 |
 | Ohnahji University ("Web3's first HBCU") | ohnahjiu.com | Portal card | 3 |
 | Hats Protocol (ZAO roles, tree 226 Optimism) | hatsprotocol.xyz | Roles section in About | 3 |


### PR DESCRIPTION
## Summary

**Doc 978 (ZAO numbers framing guide)** had a pending action: "After Doc 974's live WaveWarZ pull, update the WaveWarZ figures here and drop 'directional'." The live API (`wavewarz.info/api/public/stats`) has been confirmed authoritative — completing that action.

**Changes to 978:**
- WaveWarZ section: "self-reported / directional" caveat **RETIRED**. Now reads: "Live API data is now authoritative."
- Volume: ~$33K (~491 SOL) → **522 SOL (~$39K)**
- Battles: ~1,125 → **1,245** (with breakdown by type)
- Added: artist payouts **9.05 SOL**, platform revenue **17.43 SOL** (still exceeds artist payouts — honest point kept), trader claims **127.34 SOL**
- Fractal weeks: "~101 weeks (Doc 975/977)" → two-layer verified "100+" (date-calc + 63 on-chain, doc 1201/1202)
- Holders: 156 → **157** (doc 1200)
- Cheat sheet governance row updated to doc 1200/1201/1202 sources
- Pending Next Action marked DONE 2026-07-17
- `last-validated`: 2026-07-06 → 2026-07-17

**Doc 733 (ZABAL virality):** WaveWarZ row "795 battles, 435 SOL" → "1,245 battles, 522 SOL"

## Why this matters

Doc 978 is the canonical "which number to use when" guide — every surface that cites ZAO numbers should trace to this doc. Retiring the "directional" caveat on WaveWarZ data (now that the live API is confirmed) makes it safe to cite precise WaveWarZ stats without hedge language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)