### PR TITLE
test: ElevenLabs ConvAI signed URL + 100ms peer-count helpers (16 cases)

### DIFF
--- a/src/lib/agents/voice/__tests__/elevenlabs.test.ts
+++ b/src/lib/agents/voice/__tests__/elevenlabs.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getSignedConversationUrl } from '../elevenlabs';
+
+const AGENT_ID = 'agent-xyz-123';
+
+function stubFetch(ok: boolean, body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 401,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  delete process.env.ELEVENLABS_API_KEY;
+});
+
+describe('getSignedConversationUrl', () => {
+  it('throws when ELEVENLABS_API_KEY is not set', async () => {
+    delete process.env.ELEVENLABS_API_KEY;
+    await expect(getSignedConversationUrl(AGENT_ID)).rejects.toThrow(
+      'ELEVENLABS_API_KEY not configured',
+    );
+  });
+
+  it('returns {signedUrl, agentId} on success', async () => {
+    process.env.ELEVENLABS_API_KEY = 'test-key';
+    stubFetch(true, { signed_url: 'wss://signed.elevenlabs.io/session-123' });
+
+    const result = await getSignedConversationUrl(AGENT_ID);
+    expect(result.signedUrl).toBe('wss://signed.elevenlabs.io/session-123');
+    expect(result.agentId).toBe(AGENT_ID);
+  });
+
+  it('URL includes the agent_id query param (URL-encoded)', async () => {
+    process.env.ELEVENLABS_API_KEY = 'test-key';
+    stubFetch(true, { signed_url: 'wss://ok' });
+
+    await getSignedConversationUrl(AGENT_ID);
+    const [[url]] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(url).toContain(encodeURIComponent(AGENT_ID));
+  });
+
+  it('throws with status code when response is non-OK', async () => {
+    process.env.ELEVENLABS_API_KEY = 'test-key';
+    stubFetch(false, { detail: 'Invalid API key' });
+
+    await expect(getSignedConversationUrl(AGENT_ID)).rejects.toThrow(
+      'ElevenLabs signed-url request failed: 401',
+    );
+  });
+
+  it('throws when signed_url is missing from the response body', async () => {
+    process.env.ELEVENLABS_API_KEY = 'test-key';
+    stubFetch(true, { other_field: 'unexpected' }); // signed_url absent
+
+    await expect(getSignedConversationUrl(AGENT_ID)).rejects.toThrow(
+      'ElevenLabs response missing signed_url',
+    );
+  });
+});

--- a/src/lib/social/__tests__/hms100ms.test.ts
+++ b/src/lib/social/__tests__/hms100ms.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { get100msPeerCount, mintManagementToken } from '../hms100ms';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  delete process.env.NEXT_PUBLIC_100MS_ACCESS_KEY;
+  delete process.env.HMS_APP_SECRET;
+});
+
+// ---------------------------------------------------------------------------
+// mintManagementToken
+// ---------------------------------------------------------------------------
+
+describe('mintManagementToken', () => {
+  it('returns null when NEXT_PUBLIC_100MS_ACCESS_KEY is absent', () => {
+    delete process.env.NEXT_PUBLIC_100MS_ACCESS_KEY;
+    process.env.HMS_APP_SECRET = 'secret';
+    expect(mintManagementToken()).toBeNull();
+  });
+
+  it('returns null when HMS_APP_SECRET is absent', () => {
+    process.env.NEXT_PUBLIC_100MS_ACCESS_KEY = 'key';
+    delete process.env.HMS_APP_SECRET;
+    expect(mintManagementToken()).toBeNull();
+  });
+
+  it('returns null when both credentials are absent', () => {
+    delete process.env.NEXT_PUBLIC_100MS_ACCESS_KEY;
+    delete process.env.HMS_APP_SECRET;
+    expect(mintManagementToken()).toBeNull();
+  });
+
+  it('returns a JWT string when both credentials are present', () => {
+    process.env.NEXT_PUBLIC_100MS_ACCESS_KEY = 'test-access-key';
+    process.env.HMS_APP_SECRET = 'a-test-secret-of-at-least-32-chars--';
+    const token = mintManagementToken();
+    // JWT format: three base64url segments separated by dots
+    expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get100msPeerCount
+// ---------------------------------------------------------------------------
+
+describe('get100msPeerCount', () => {
+  it('returns null when no management token can be minted (no credentials)', async () => {
+    delete process.env.NEXT_PUBLIC_100MS_ACCESS_KEY;
+    delete process.env.HMS_APP_SECRET;
+    const result = await get100msPeerCount('room-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when an explicit null token is passed', async () => {
+    const result = await get100msPeerCount('room-1', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns 0 when 100ms returns 404 (no active session = empty room)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404 }),
+    );
+    const result = await get100msPeerCount('room-1', 'mgmt-token');
+    expect(result).toBe(0);
+  });
+
+  it('returns null for other non-OK responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    const result = await get100msPeerCount('room-1', 'mgmt-token');
+    expect(result).toBeNull();
+  });
+
+  it('returns peer count from data.peers object key count', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ peers: { peer1: {}, peer2: {}, peer3: {} } }),
+      }),
+    );
+    const result = await get100msPeerCount('room-1', 'mgmt-token');
+    expect(result).toBe(3);
+  });
+
+  it('returns data.peer_count when peers is not an object', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ peer_count: 7 }),
+      }),
+    );
+    const result = await get100msPeerCount('room-1', 'mgmt-token');
+    expect(result).toBe(7);
+  });
+
+  it('returns null when fetch throws (network error)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network down')));
+    const result = await get100msPeerCount('room-1', 'mgmt-token');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Pure vitest tests for two server-side API helper modules — no source changes.

### `src/lib/agents/voice/__tests__/elevenlabs.test.ts` (5 cases)

- `getSignedConversationUrl` throws when `ELEVENLABS_API_KEY` absent
- Returns `{signedUrl, agentId}` on success
- URL includes URL-encoded `agent_id`
- Throws with HTTP status on non-OK response
- Throws when `signed_url` is missing from the response body

### `src/lib/social/__tests__/hms100ms.test.ts` (11 cases)

`mintManagementToken`:
- `null` when `NEXT_PUBLIC_100MS_ACCESS_KEY` absent
- `null` when `HMS_APP_SECRET` absent
- `null` when both absent
- JWT string (three base64url segments) when both present

`get100msPeerCount`:
- `null` when no credentials (token can't be minted)
- `null` for explicit `null` token argument
- `0` on HTTP 404 (room exists but no active session)
- `null` on other non-OK responses (e.g. 500)
- Peer count from `data.peers` object key count
- `data.peer_count` when peers field is absent
- `null` on fetch network error (catch block)

All 16 cases pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)