### PR TITLE
test(fc-identity+hats): 9 vitest cases for checkGatingEligibility and clearTreeCache

### DIFF
--- a/src/lib/__tests__/fc-identity.test.ts
+++ b/src/lib/__tests__/fc-identity.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoist the mock so it is available when vi.mock factory runs
+const mockReadContract = vi.hoisted(() => vi.fn());
+
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      readContract: mockReadContract,
+    })),
+  };
+});
+
+import { checkGatingEligibility } from '../fc-identity';
+
+const ADDR = '0x0000000000000000000000000000000000000001' as `0x${string}`;
+
+beforeEach(() => {
+  mockReadContract.mockReset();
+});
+
+// checkGatingEligibility calls getFcQualityScore then resolveEthToFid via Promise.all.
+// Within Promise.all the two readContract calls execute in declaration order:
+//   call 1 → getFcQualityScore   → quality score (bigint)
+//   call 2 → resolveEthToFid     → fid (bigint, cast to number)
+
+describe('checkGatingEligibility', () => {
+  it('returns eligible=false when fid resolves to null (rpc error)', async () => {
+    // Both readContract calls throw → score=null, fid=null
+    mockReadContract
+      .mockRejectedValueOnce(new Error('rpc error'))
+      .mockRejectedValueOnce(new Error('rpc error'));
+
+    const result = await checkGatingEligibility(ADDR);
+    expect(result.eligible).toBe(false);
+    expect(result.fid).toBeNull();
+    expect(result.score).toBeNull();
+    expect(result.reason).toMatch(/No Far ?caster account/i);
+  });
+
+  it('returns eligible=true when score is null but fid is present (no negative signal)', async () => {
+    // getFcQualityScore fails → null; resolveEthToFid succeeds → fid 12345
+    mockReadContract
+      .mockRejectedValueOnce(new Error('score rpc error'))
+      .mockResolvedValueOnce(BigInt(12345));
+
+    const result = await checkGatingEligibility(ADDR);
+    expect(result.eligible).toBe(true);
+    expect(result.score).toBeNull();
+    expect(result.fid).toBe(12345);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('returns eligible=false when score < minScore', async () => {
+    mockReadContract
+      .mockResolvedValueOnce(BigInt(50))   // score = 50
+      .mockResolvedValueOnce(BigInt(12345)); // fid = 12345
+
+    const result = await checkGatingEligibility(ADDR, 100);
+    expect(result.eligible).toBe(false);
+    expect(result.score).toBe(BigInt(50));
+    expect(result.fid).toBe(12345);
+    expect(result.reason).toMatch(/50.*below.*100/i);
+  });
+
+  it('returns eligible=true when score >= minScore', async () => {
+    mockReadContract
+      .mockResolvedValueOnce(BigInt(200))  // score = 200
+      .mockResolvedValueOnce(BigInt(99));  // fid = 99
+
+    const result = await checkGatingEligibility(ADDR, 100);
+    expect(result.eligible).toBe(true);
+    expect(result.score).toBe(BigInt(200));
+    expect(result.fid).toBe(99);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('returns eligible=true when score equals minScore (not strictly below)', async () => {
+    mockReadContract
+      .mockResolvedValueOnce(BigInt(100)) // score = minScore exactly
+      .mockResolvedValueOnce(BigInt(7));  // fid = 7
+
+    const result = await checkGatingEligibility(ADDR, 100);
+    expect(result.eligible).toBe(true);
+  });
+
+  it('default minScore=0: score BigInt(0) is still eligible', async () => {
+    mockReadContract
+      .mockResolvedValueOnce(BigInt(0)) // score = 0, not < 0
+      .mockResolvedValueOnce(BigInt(42));
+
+    const result = await checkGatingEligibility(ADDR); // minScore defaults to 0
+    expect(result.eligible).toBe(true);
+    expect(result.score).toBe(BigInt(0));
+  });
+});

--- a/src/lib/hats/__tests__/tree.test.ts
+++ b/src/lib/hats/__tests__/tree.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+// Tests for clearTreeCache — the only pure (non-on-chain) export in tree.ts.
+// fetchHatTree is not tested here because it requires the Hats SDK + live RPC.
+import { describe, expect, it } from 'vitest';
+import { clearTreeCache } from '../tree';
+
+describe('clearTreeCache', () => {
+  it('does not throw when called with no prior cache', () => {
+    expect(() => clearTreeCache()).not.toThrow();
+  });
+
+  it('returns undefined', () => {
+    expect(clearTreeCache()).toBeUndefined();
+  });
+
+  it('is idempotent — repeated calls do not throw', () => {
+    clearTreeCache();
+    clearTreeCache();
+    expect(() => clearTreeCache()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `checkGatingEligibility` decision tree: 6 cases covering fid=null, score=null+fid, score<min, score>=min, score==min boundary, default minScore=0
- Mocks viem's `createPublicClient` via `vi.hoisted` + `vi.mock('viem')` so no on-chain RPC calls are made
- `clearTreeCache` (hats/tree.ts): 3 cases confirming no-throw, undefined return, idempotency

## Test plan
- [x] 9 cases pass locally: `node .../vitest.mjs run src/lib/__tests__/fc-identity.test.ts src/lib/hats/__tests__/tree.test.ts`
- [x] Test-only PR targeting `test/*` branch — auto-merge eligible after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)