### PR TITLE
docs: final 90+→100+ sweep + WaveWarZ stat refresh in whitepaper and guides (050, 051, 649, 742)

### DIFF
--- a/research/community/050-the-zao-complete-guide/README.md
+++ b/research/community/050-the-zao-complete-guide/README.md
@@ -684,7 +684,7 @@ The surviving projects serve different functions — streaming, fan clubs, event
 | Ecosystem participants | 1,000+ (events, livestreams, online community, broader engagement) |
 | Newsletter editions | 400+ |
 | Paid newsletter supporters | 78 |
-| Fractal meetings completed | 90+ |
+| Fractal meetings completed | 100+ |
 | Founding members | 40 |
 | Active community members | 100+ |
 | LTAW3 seasons completed | 3 |

--- a/research/community/051-zao-whitepaper-2026/README.md
+++ b/research/community/051-zao-whitepaper-2026/README.md
@@ -45,7 +45,7 @@ The ZAO began in 2022 as ZTalent Agency. In 2023, the team pivoted to focus full
 
 *(Add founding story here — what sparked the pivot, who was in the room, what the first conversation looked like.)*
 
-The team built a weekly coordination game — small groups of six people sharing contributions and ranking each other — and created a soulbound token called $ZAO Respect to track who was actually showing up. That system has been running consistently for nearly two years, with 90+ meetings completed.
+The team built a weekly coordination game — small groups of six people sharing contributions and ranking each other — and created a soulbound token called $ZAO Respect to track who was actually showing up. That system has been running consistently for nearly two years, with 100+ meetings completed (63 weeks with verified on-chain Respect settlement on Optimism).
 
 *(Add a story about a specific fractal meeting moment that captures the culture — what made someone stay, what surprised a newcomer.)*
 
@@ -89,14 +89,14 @@ The team is supported by a roster of independent artists, a network of mutual co
 | What | How Much | Verify |
 |------|----------|--------|
 | Ecosystem participants | 1,000+ | [thezao.com](https://www.thezao.com/about) |
-| Weekly governance meetings | 90+ | Fractal recordings archive |
+| Weekly governance meetings | 100+ | Fractal recordings archive (doc 1201/1202) |
 | Newsletter editions | [400+](https://paragraph.com/@thezao) | Paragraph archive |
 | Podcast episodes | [19+](https://pods.media/lets-talk-about-web3/) | Pods.media |
 | Paid supporters | 78 before launching the product | Paragraph dashboard |
 | Artists in roster | 22 | [thezao.com](https://www.thezao.com) |
 | Combined Spotify listeners | 378,000+ | Individual artist profiles |
 | Tracks across roster | 500+ | Streaming platforms |
-| WaveWarZ volume | [472.71 SOL (~$37,845 USD)](https://wavewarz.info/) across 735 battles | Solana on-chain (May 2026) |
+| WaveWarZ volume | [522 SOL (~$39K)](https://wavewarz.info/) across 1,245 battles | Solana on-chain (2026-07-17) |
 | Revenue generated | $10,000+ | Festivals + WaveWarZ |
 | IRL festivals produced | 4 | [@zaofestivals](https://www.instagram.com/zaofestivals/) |
 | Metaverse concerts (COC) | 150+ weekly | [stilo.world](https://www.stilo.world/) |
@@ -110,7 +110,7 @@ The team is supported by a roster of independent artists, a network of mutual co
 
 **[ZAO OS](https://github.com/bettercallzaal/ZAOOS)** — A gated Farcaster client where the community lives. Music-first. Inline players for Spotify, SoundCloud, Audius, YouTube, Sound.xyz, and direct audio. Encrypted DMs via XMTP. Push notifications via Farcaster Mini App. Followers/following with sorting and filtering. Open source ([MIT license](https://github.com/bettercallzaal/ZAOOS/blob/main/LICENSE)).
 
-**ZAO Fractal** — Weekly governance circles using the [Respect Game](https://optimystics.io/respectgame). Peer-ranked contributions, Fibonacci-weighted soulbound token distribution. 90+ meetings. [$ZAO Respect token on Base](https://basescan.org/address/0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957).
+**ZAO Fractal** — Weekly governance circles using the [Respect Game](https://optimystics.io/respectgame). Peer-ranked contributions, Fibonacci-weighted soulbound token distribution. 100+ meetings. [$ZAO Respect token on Base](https://basescan.org/address/0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957).
 
 **ZAO Festivals** — Four IRL events bridging onchain culture to physical space:
 - [ZAO-PALOOZA](https://app.manifold.xyz/c/zao-card-jango-uu-ZAO-PALOOZA) (NYC, NFT NYC 2024) — 12 artists, ZAO Cards on Manifold

--- a/research/community/742-zaal-panthaki-profile-dossier/README.md
+++ b/research/community/742-zaal-panthaki-profile-dossier/README.md
@@ -176,7 +176,7 @@ Mirrors Ike's chain (football → EE → Infosys → sales → spaces → indie 
 
 - **188** ZAO members on Base
 - **1,000+** ecosystem participants (broader)
-- **90+** consecutive weekly Respect Games
+- **100+** consecutive weekly Respect Games (63 with on-chain Respect settlement, doc 1202)
 - **540+** research docs in ZAOOS
 - **301** API routes, **279** components, **19** custom hooks
 - **400+** daily newsletter editions

--- a/research/identity/649-zaal-build-profile-ecosystem-survey/README.md
+++ b/research/identity/649-zaal-build-profile-ecosystem-survey/README.md
@@ -46,7 +46,7 @@ ZABAL  (Zaal's personal umbrella brand + token, launched Jan 1 2026 on Base)
   |     +-- ZAOOS  (the monorepo lab - everything prototypes here first)
   |     +-- ZAOstock 2026  (flagship event, Oct 3, Ellsworth ME - graduating to own repo)
   |     +-- ZAONEXUS  (14-brand ecosystem directory)
-  |     +-- ZOUNZ, zao-101, CoC Concertz, ZAO Fractals  (governance, 90+ wks)
+  |     +-- ZOUNZ, zao-101, CoC Concertz, ZAO Fractals  (governance, 100+ wks)
   |
   +-- Incubated projects  (community cofounders, ZAO backs)
         +-- WaveWarZ  (Solana music battles - cofounders Samantha + Hurric4n3ike)

--- a/src/lib/spaces/__tests__/juke.test.ts
+++ b/src/lib/spaces/__tests__/juke.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  isValidJukeSpaceId,
+  jukeAppDeeplinkUrl,
+  jukeEmbedUrl,
+  jukeSpaceOgImageUrl,
+  jukeSpaceUrl,
+  parseJukeSpaceId,
+} from '../juke';
+
+// ---------------------------------------------------------------------------
+// isValidJukeSpaceId
+// ---------------------------------------------------------------------------
+
+describe('isValidJukeSpaceId', () => {
+  it('accepts alphanumeric ids', () => {
+    expect(isValidJukeSpaceId('abc123')).toBe(true);
+  });
+
+  it('accepts ids with underscores and hyphens', () => {
+    expect(isValidJukeSpaceId('my-space_01')).toBe(true);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isValidJukeSpaceId('')).toBe(false);
+  });
+
+  it('rejects ids containing a slash (injection vector)', () => {
+    expect(isValidJukeSpaceId('space/inject')).toBe(false);
+  });
+
+  it('rejects ids containing a query-string character (?)', () => {
+    expect(isValidJukeSpaceId('space?q=evil')).toBe(false);
+  });
+
+  it('rejects ids longer than 128 characters', () => {
+    expect(isValidJukeSpaceId('a'.repeat(129))).toBe(false);
+  });
+
+  it('rejects non-string values (number, null, object)', () => {
+    expect(isValidJukeSpaceId(42)).toBe(false);
+    expect(isValidJukeSpaceId(null)).toBe(false);
+    expect(isValidJukeSpaceId({ id: 'abc' })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jukeEmbedUrl
+// ---------------------------------------------------------------------------
+
+describe('jukeEmbedUrl', () => {
+  it('returns the canonical embed URL for a valid space id', () => {
+    expect(jukeEmbedUrl('my-space')).toBe('https://juke.audio/embed/my-space');
+  });
+
+  it('throws for an invalid space id', () => {
+    expect(() => jukeEmbedUrl('bad/id')).toThrow('Invalid Juke space id');
+  });
+
+  it('appends ?audio=off when audioOff is true', () => {
+    expect(jukeEmbedUrl('space1', { audioOff: true })).toBe(
+      'https://juke.audio/embed/space1?audio=off',
+    );
+  });
+
+  it('appends ?token=... when partnerToken is provided', () => {
+    const url = jukeEmbedUrl('space1', { partnerToken: 'tok-abc' });
+    expect(url).toContain('token=tok-abc');
+  });
+
+  it('appends both audio=off and token when both options are set', () => {
+    const url = jukeEmbedUrl('space1', { audioOff: true, partnerToken: 'tok-xyz' });
+    expect(url).toContain('audio=off');
+    expect(url).toContain('token=tok-xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jukeSpaceUrl
+// ---------------------------------------------------------------------------
+
+describe('jukeSpaceUrl', () => {
+  it('returns the canonical space permalink', () => {
+    expect(jukeSpaceUrl('abc123')).toBe('https://juke.audio/space/abc123');
+  });
+
+  it('throws for an invalid space id', () => {
+    expect(() => jukeSpaceUrl('bad?id')).toThrow('Invalid Juke space id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jukeSpaceOgImageUrl
+// ---------------------------------------------------------------------------
+
+describe('jukeSpaceOgImageUrl', () => {
+  it('returns the OG image URL', () => {
+    expect(jukeSpaceOgImageUrl('abc123')).toBe(
+      'https://juke.audio/space/abc123/opengraph-image',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jukeAppDeeplinkUrl
+// ---------------------------------------------------------------------------
+
+describe('jukeAppDeeplinkUrl', () => {
+  it('returns the native-app deeplink with ?open=app', () => {
+    expect(jukeAppDeeplinkUrl('abc123')).toBe(
+      'https://juke.audio/space/abc123?open=app',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseJukeSpaceId
+// ---------------------------------------------------------------------------
+
+describe('parseJukeSpaceId', () => {
+  it('returns null for an empty string', () => {
+    expect(parseJukeSpaceId('')).toBeNull();
+  });
+
+  it('returns the id when input is a bare valid space id', () => {
+    expect(parseJukeSpaceId('my-space-01')).toBe('my-space-01');
+  });
+
+  it('extracts id from a /embed/{id} URL', () => {
+    expect(parseJukeSpaceId('https://juke.audio/embed/abc123')).toBe('abc123');
+  });
+
+  it('extracts id from a /space/{id} URL', () => {
+    expect(parseJukeSpaceId('https://juke.audio/space/xyz789')).toBe('xyz789');
+  });
+
+  it('handles URLs without a protocol (juke.audio/space/id)', () => {
+    expect(parseJukeSpaceId('juke.audio/space/bare-id')).toBe('bare-id');
+  });
+
+  it('accepts www.juke.audio URLs', () => {
+    expect(parseJukeSpaceId('https://www.juke.audio/space/room1')).toBe('room1');
+  });
+
+  it('returns null for a non-juke URL', () => {
+    expect(parseJukeSpaceId('https://evil.com/space/abc')).toBeNull();
+  });
+
+  it('returns null for a completely invalid string', () => {
+    expect(parseJukeSpaceId('not a url at all!!!')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes missed "90+ weeks" references in 4 docs not caught by the main sweep (PRs #1647-#1667)
- **742** (profile dossier): stat bullet "**90+** consecutive weekly Respect Games" missed by PR #1654 — now "**100+** (63 with on-chain Respect settlement, doc 1202)"
- **050** (complete guide): stats table "Fractal meetings completed | 90+" → "100+"
- **051** (whitepaper): 3 instances updated — body text, stats table row, ZAO Fractal bullet. Also refreshes stale WaveWarZ stats from 472 SOL/735 battles (May 2026) to live API: 522 SOL / 1,245 battles (2026-07-17)
- **649** (build profile): ecosystem tree "governance, 90+ wks" → "100+ wks"

All fractal counts cite doc 1201/1202 (two-layer verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)