### PR TITLE
test(discord+snapshot): 14 vitest cases for Discord and Snapshot GraphQL clients

### DIFF
--- a/src/lib/discord/__tests__/client.test.ts
+++ b/src/lib/discord/__tests__/client.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Mock @discordjs/rest BEFORE any module is loaded.
+const mockGet = vi.hoisted(() => vi.fn());
+
+vi.mock('@discordjs/rest', () => ({
+  REST: vi.fn().mockImplementation(() => ({
+    setToken: vi.fn().mockReturnThis(),
+    get: mockGet,
+  })),
+}));
+
+// ── No-credentials path ──────────────────────────────────────────────────────
+// Import the module WITHOUT bot token set — module-level constants capture the
+// env at load time, so we get the "unconfigured" behaviour.
+
+import {
+  getActiveThreads,
+  getChannelMessages,
+  getGuildMembers,
+  isDiscordConfigured,
+} from '../client';
+
+afterEach(() => {
+  mockGet.mockReset();
+});
+
+describe('isDiscordConfigured (no credentials)', () => {
+  it('returns false when DISCORD_BOT_TOKEN and DISCORD_GUILD_ID are not set', () => {
+    // Default test environment has no Discord env vars
+    expect(isDiscordConfigured()).toBe(false);
+  });
+});
+
+describe('getChannelMessages (no credentials)', () => {
+  it('returns an empty array when no bot token is configured', async () => {
+    const result = await getChannelMessages('channel-123');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getGuildMembers (no credentials)', () => {
+  it('returns an empty array when no bot token is configured', async () => {
+    const result = await getGuildMembers();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getActiveThreads (no credentials)', () => {
+  it('returns an empty array when no bot token is configured', async () => {
+    const result = await getActiveThreads();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getChannelMessages error handling (via mocked REST)', () => {
+  // Even without real env vars the REST mock is set up; test the error fallback
+  // by patching the mock to simulate a token being present via beforeAll.
+  // Since DISCORD_BOT_TOKEN is a module-level const we cannot flip it per-test
+  // after import. Instead we test the REST throw path through the no-client
+  // short-circuit: if get() throws and the function catches, it returns [].
+  // These cases verify that the mock REST throw is NOT reached when client is
+  // null (no token) — the empty-array short-circuit comes first.
+
+  it('does not call REST.get when client is null', async () => {
+    await getChannelMessages('any-channel');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not call REST.get when getGuildMembers has no client', async () => {
+    await getGuildMembers();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/snapshot/__tests__/client.test.ts
+++ b/src/lib/snapshot/__tests__/client.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Provide communityConfig before the module loads — snapshot/client.ts reads
+// communityConfig.snapshot.graphqlUrl and .space at module load time.
+vi.mock('@/../community.config', () => ({
+  communityConfig: {
+    snapshot: {
+      graphqlUrl: 'https://hub.snapshot.org/graphql',
+      space: 'zao.eth',
+    },
+  },
+}));
+
+import { fetchActivePolls, fetchPollResults, fetchRecentPolls } from '../client';
+
+function stubFetch(ok: boolean, body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => body,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const MOCK_PROPOSAL = {
+  id: 'QmAbc',
+  title: 'Proposal 1',
+  body: 'Description',
+  choices: ['Yes', 'No'],
+  start: 1700000000,
+  end: 1700100000,
+  state: 'active' as const,
+  scores: [10, 5],
+  scores_total: 15,
+  votes: 12,
+  type: 'single-choice',
+};
+
+// ---------------------------------------------------------------------------
+// fetchActivePolls
+// ---------------------------------------------------------------------------
+
+describe('fetchActivePolls', () => {
+  it('returns proposals from a successful response', async () => {
+    stubFetch(true, { data: { proposals: [MOCK_PROPOSAL] } });
+    const result = await fetchActivePolls();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('QmAbc');
+  });
+
+  it('throws when the HTTP response is not OK', async () => {
+    stubFetch(false, {});
+    await expect(fetchActivePolls()).rejects.toThrow('Snapshot GraphQL error: 500');
+  });
+
+  it('throws when the response contains GraphQL errors', async () => {
+    stubFetch(true, { errors: [{ message: 'Space not found' }] });
+    await expect(fetchActivePolls()).rejects.toThrow('Snapshot GraphQL: Space not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRecentPolls
+// ---------------------------------------------------------------------------
+
+describe('fetchRecentPolls', () => {
+  it('returns recent proposals on a valid response', async () => {
+    stubFetch(true, { data: { proposals: [MOCK_PROPOSAL, MOCK_PROPOSAL] } });
+    const result = await fetchRecentPolls(2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('throws on HTTP error', async () => {
+    stubFetch(false, {});
+    await expect(fetchRecentPolls()).rejects.toThrow('Snapshot GraphQL error: 500');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPollResults
+// ---------------------------------------------------------------------------
+
+describe('fetchPollResults', () => {
+  it('returns a proposal when found', async () => {
+    stubFetch(true, { data: { proposal: MOCK_PROPOSAL } });
+    const result = await fetchPollResults('QmAbc');
+    expect(result?.id).toBe('QmAbc');
+  });
+
+  it('returns null when the proposal does not exist', async () => {
+    stubFetch(true, { data: { proposal: null } });
+    const result = await fetchPollResults('not-found');
+    expect(result).toBeNull();
+  });
+
+  it('throws on HTTP error', async () => {
+    stubFetch(false, {});
+    await expect(fetchPollResults('QmAbc')).rejects.toThrow('Snapshot GraphQL error: 500');
+  });
+});


### PR DESCRIPTION
## Summary
- Discord: isDiscordConfigured() returns false with no env vars; getChannelMessages/getGuildMembers/getActiveThreads return [] when no client; REST.get never called in unconfigured state (6 cases)
- Snapshot: fetchActivePolls/fetchRecentPolls return proposals on success, throw on HTTP/GraphQL errors; fetchPollResults returns proposal or null (8 cases)
- Mocks @discordjs/rest via vi.hoisted; mocks community.config for snapshot module-level constants

## Test plan
- [x] 14 cases pass locally
- [x] Test-only PR targeting test/* branch — auto-merge eligible after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)