### PR TITLE
test(os+staking): 14 vitest cases for SHELLS constants and getConvictionBatch guard

### DIFF
--- a/src/lib/os/__tests__/shells.test.ts
+++ b/src/lib/os/__tests__/shells.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SHELL, getAllShells, getShell, SHELLS } from '../shells';
+
+describe('SHELLS constant', () => {
+  it('defines exactly four shell variants', () => {
+    expect(Object.keys(SHELLS)).toHaveLength(4);
+  });
+
+  it('includes phone, desktop, dashboard, and feed shells', () => {
+    expect(SHELLS).toHaveProperty('phone');
+    expect(SHELLS).toHaveProperty('desktop');
+    expect(SHELLS).toHaveProperty('dashboard');
+    expect(SHELLS).toHaveProperty('feed');
+  });
+
+  it('each shell has a non-empty id, name, description, and icon', () => {
+    for (const shell of Object.values(SHELLS)) {
+      expect(shell.id).toBeTruthy();
+      expect(shell.name).toBeTruthy();
+      expect(shell.description).toBeTruthy();
+      expect(shell.icon).toBeTruthy();
+    }
+  });
+
+  it('each shell id matches its key in SHELLS', () => {
+    for (const [key, shell] of Object.entries(SHELLS)) {
+      expect(shell.id).toBe(key);
+    }
+  });
+});
+
+describe('DEFAULT_SHELL', () => {
+  it('is "phone"', () => {
+    expect(DEFAULT_SHELL).toBe('phone');
+  });
+
+  it('is a valid key in SHELLS', () => {
+    expect(SHELLS).toHaveProperty(DEFAULT_SHELL);
+  });
+});
+
+describe('getShell', () => {
+  it('returns the correct shell for "phone"', () => {
+    expect(getShell('phone').id).toBe('phone');
+  });
+
+  it('returns the correct shell for "dashboard"', () => {
+    expect(getShell('dashboard').id).toBe('dashboard');
+  });
+
+  it('returns the correct shell for "desktop"', () => {
+    expect(getShell('desktop').name).toBeTruthy();
+  });
+
+  it('returns the correct shell for "feed"', () => {
+    expect(getShell('feed').id).toBe('feed');
+  });
+});
+
+describe('getAllShells', () => {
+  it('returns an array of four shells', () => {
+    const shells = getAllShells();
+    expect(shells).toHaveLength(4);
+  });
+
+  it('all returned shells have non-empty names', () => {
+    for (const shell of getAllShells()) {
+      expect(shell.name.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/staking/__tests__/conviction.test.ts
+++ b/src/lib/staking/__tests__/conviction.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock viem before the module loads — conviction.ts creates a publicClient
+// at module level via createPublicClient.
+const mockReadContract = vi.hoisted(() => vi.fn());
+
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      readContract: mockReadContract,
+    })),
+  };
+});
+
+// conviction.ts checks ZABAL_STAKING_CONTRACT at call time.
+// By default in tests, NEXT_PUBLIC_ZABAL_STAKING_CONTRACT is not set,
+// so ZABAL_STAKING_CONTRACT = '' (falsy) — getConvictionBatch returns []
+// immediately without calling readContract.
+
+import { getConvictionBatch } from '../conviction';
+
+beforeEach(() => {
+  mockReadContract.mockReset();
+});
+
+describe('getConvictionBatch (no contract configured)', () => {
+  it('returns an empty array for an empty address list', async () => {
+    const result = await getConvictionBatch([]);
+    expect(result).toEqual([]);
+    // No readContract calls — short-circuited at contract check or empty array
+    expect(mockReadContract).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when ZABAL_STAKING_CONTRACT is not set', async () => {
+    const result = await getConvictionBatch(['0x0000000000000000000000000000000000000001']);
+    expect(result).toEqual([]);
+    // Short-circuited at !ZABAL_STAKING_CONTRACT check
+    expect(mockReadContract).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `shells.ts`: SHELLS has 4 entries; each has id/name/description/icon; id matches key; DEFAULT_SHELL='phone'; getShell returns correct per id; getAllShells returns 4 (12 cases)
- `conviction.ts`: returns [] for empty address list; returns [] when ZABAL_STAKING_CONTRACT not set (no readContract calls) (2 cases)

## Test plan
- [x] 14 cases pass locally
- [x] Test-only PR targeting test/* branch — auto-merge eligible after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)