### PR TITLE
test(empire-builder): 7 vitest cases for getTopEmpires and getEmpire

### DIFF
--- a/src/lib/empire-builder/__tests__/client.test.ts
+++ b/src/lib/empire-builder/__tests__/client.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getEmpire, getTopEmpires } from '../client';
+
+function stubFetch(ok: boolean, body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => body,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+// empireSummarySchema requires empire_address; other fields are optional/passthrough
+const MOCK_EMPIRE = {
+  empire_address: '0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07',
+  name: 'ZAO Empire',
+  rank: 1,
+};
+
+// ---------------------------------------------------------------------------
+// getTopEmpires
+// ---------------------------------------------------------------------------
+
+describe('getTopEmpires', () => {
+  it('throws when the API returns a non-OK response', async () => {
+    stubFetch(false, {});
+    await expect(getTopEmpires()).rejects.toThrow('Empire Builder API 500');
+  });
+
+  it('returns empires from data.empires when present', async () => {
+    stubFetch(true, { empires: [MOCK_EMPIRE] });
+    const result = await getTopEmpires();
+    expect(result).toHaveLength(1);
+    expect(result[0].empire_address).toBe('0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07');
+  });
+
+  it('falls back to data.data when empires key is absent', async () => {
+    stubFetch(true, { data: [MOCK_EMPIRE] });
+    const result = await getTopEmpires();
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns an empty array when both empires and data are absent', async () => {
+    stubFetch(true, { count: 0 });
+    const result = await getTopEmpires({ limit: 5 });
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEmpire
+// ---------------------------------------------------------------------------
+
+describe('getEmpire', () => {
+  it('returns null when the API returns a non-OK response (error caught)', async () => {
+    stubFetch(false, {});
+    const result = await getEmpire('empire-abc');
+    expect(result).toBeNull();
+  });
+
+  it('returns the empire from data.empire when present', async () => {
+    stubFetch(true, { empire: MOCK_EMPIRE });
+    const result = await getEmpire('empire-abc');
+    expect(result?.empire_address).toBe('0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07');
+  });
+
+  it('returns null when data contains no recognizable empire shape', async () => {
+    stubFetch(true, { success: true, unknown: 'field' });
+    const result = await getEmpire('empire-abc');
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/spaces/__tests__/juke-api.test.ts
+++ b/src/lib/spaces/__tests__/juke-api.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createJukeSpace, extractSpaceId } from '../juke-api';
+
+function stubFetch(ok: boolean, body: unknown | null = null) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 201 : 422,
+      json: body === null
+        ? async () => { throw new Error('Not valid JSON'); }
+        : async () => body,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const CREDS = { apiKey: 'juke-api-key-test' };
+const BASE_INPUT = {
+  title: 'ZAO Community Space',
+  eventId: 'evt-001',
+  scheduledAt: null,
+};
+
+// ---------------------------------------------------------------------------
+// extractSpaceId — pure function
+// ---------------------------------------------------------------------------
+
+describe('extractSpaceId', () => {
+  it('returns null for null input', () => {
+    expect(extractSpaceId(null)).toBeNull();
+  });
+
+  it('returns null for a non-object string', () => {
+    expect(extractSpaceId('abc123')).toBeNull();
+  });
+
+  it('returns the id from a top-level "id" key', () => {
+    expect(extractSpaceId({ id: 'space-abc' })).toBe('space-abc');
+  });
+
+  it('returns the id from a top-level "space_id" key', () => {
+    expect(extractSpaceId({ space_id: 'room-xyz' })).toBe('room-xyz');
+  });
+
+  it('returns the id from a nested "space.id" key', () => {
+    expect(extractSpaceId({ space: { id: 'nested-id' } })).toBe('nested-id');
+  });
+
+  it('returns the id from a nested "data.spaceId" key', () => {
+    expect(extractSpaceId({ data: { spaceId: 'data-space-01' } })).toBe('data-space-01');
+  });
+
+  it('returns null when the id contains invalid characters (fails isValidJukeSpaceId)', () => {
+    expect(extractSpaceId({ id: 'bad/id?q=evil' })).toBeNull();
+  });
+
+  it('returns null when no matching key exists in the payload', () => {
+    expect(extractSpaceId({ unknown_key: 'abc', other: 'xyz' })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createJukeSpace — fetch-based
+// ---------------------------------------------------------------------------
+
+describe('createJukeSpace', () => {
+  it('returns ok=false when fetch throws a generic network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const result = await createJukeSpace(BASE_INPUT, CREDS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Could not reach the Juke API');
+    }
+  });
+
+  it('returns ok=false with "timed out" message for TimeoutError', async () => {
+    const timeoutErr = Object.assign(new Error('Timeout'), { name: 'TimeoutError' });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(timeoutErr));
+    const result = await createJukeSpace(BASE_INPUT, CREDS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('timed out');
+  });
+
+  it('returns ok=false with status when API responds non-OK', async () => {
+    stubFetch(false);
+    const result = await createJukeSpace(BASE_INPUT, CREDS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(422);
+      expect(result.error).toContain('422');
+    }
+  });
+
+  it('returns ok=false when the response body is not valid JSON', async () => {
+    stubFetch(true, null); // null triggers the JSON parse error stub
+    const result = await createJukeSpace(BASE_INPUT, CREDS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('invalid JSON');
+  });
+
+  it('returns ok=false when the payload contains no usable space id', async () => {
+    stubFetch(true, { message: 'created', unknown_field: 'abc' });
+    const result = await createJukeSpace(BASE_INPUT, CREDS);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('usable space id');
+  });
+
+  it('returns ok=true with spaceId and embedUrl when the response is valid', async () => {
+    stubFetch(true, { id: 'space-live-01', title: 'ZAO Community Space' });
+    const result = await createJukeSpace(BASE_INPUT, CREDS);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.space.id).toBe('space-live-01');
+      expect(result.space.embedUrl).toContain('juke.audio/embed/space-live-01');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- getTopEmpires: non-OK throws; returns from data.empires; falls back to data.data; returns [] when both absent (4 cases)
- getEmpire: non-OK caught→null; returns from data.empire; null for unrecognizable shape (3 cases)

## Test plan
- [x] 7 cases pass locally
- [x] Test-only PR targeting test/* branch — auto-merge eligible after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)