### PR TITLE
test: empire-builder cache TTL, bluesky labeler, zounz contract constants (21 cases)

### DIFF
--- a/src/lib/bluesky/__tests__/labeler.test.ts
+++ b/src/lib/bluesky/__tests__/labeler.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import type { AtpAgent } from '@atproto/api';
+import { applyMemberLabel, isMemberLabeled } from '../labeler';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// isMemberLabeled — pure function
+// ---------------------------------------------------------------------------
+
+describe('isMemberLabeled', () => {
+  it('returns true when the DID is in the member list', () => {
+    expect(isMemberLabeled('did:plc:alice', ['did:plc:alice', 'did:plc:bob'])).toBe(true);
+  });
+
+  it('returns false when the DID is not in the member list', () => {
+    expect(isMemberLabeled('did:plc:stranger', ['did:plc:alice', 'did:plc:bob'])).toBe(false);
+  });
+
+  it('returns false for an empty member list', () => {
+    expect(isMemberLabeled('did:plc:alice', [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyMemberLabel — mocked AtpAgent
+// ---------------------------------------------------------------------------
+
+function makeAgent(createRecord: ReturnType<typeof vi.fn>): AtpAgent {
+  return {
+    session: { did: 'did:plc:community' },
+    api: { com: { atproto: { repo: { createRecord } } } },
+  } as unknown as AtpAgent;
+}
+
+describe('applyMemberLabel', () => {
+  it('returns true when the API call succeeds', async () => {
+    const createRecord = vi.fn().mockResolvedValue({});
+    const agent = makeAgent(createRecord);
+    const result = await applyMemberLabel(agent, 'did:plc:member1');
+    expect(result).toBe(true);
+    expect(createRecord).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when the API call throws', async () => {
+    const createRecord = vi.fn().mockRejectedValue(new Error('Unauthorized'));
+    const agent = makeAgent(createRecord);
+    const result = await applyMemberLabel(agent, 'did:plc:other');
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/empire-builder/__tests__/cache.test.ts
+++ b/src/lib/empire-builder/__tests__/cache.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({
+  EMPIRE_BUILDER_CACHE_TTL_MS: 5_000,
+}));
+
+import { DEFAULT_TTL_MS, withCache } from '../cache';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('DEFAULT_TTL_MS', () => {
+  it('is exported from config (5000ms in test env)', () => {
+    expect(DEFAULT_TTL_MS).toBe(5_000);
+  });
+});
+
+describe('withCache', () => {
+  it('calls the fetcher on a cache miss', async () => {
+    const fetcher = vi.fn().mockResolvedValue('fresh-value');
+    const result = await withCache('key-miss-a', 1_000, fetcher);
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(result).toBe('fresh-value');
+  });
+
+  it('returns cached value on a cache hit without calling fetcher again', async () => {
+    const fetcher = vi.fn().mockResolvedValue('cached-value');
+    await withCache('key-hit-b', 30_000, fetcher);
+    const result = await withCache('key-hit-b', 30_000, fetcher);
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(result).toBe('cached-value');
+  });
+
+  it('re-fetches after TTL expires', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+
+    await withCache('key-ttl-c', 1_000, fetcher);
+    vi.advanceTimersByTime(1_001); // expire the cache
+    const result = await withCache('key-ttl-c', 1_000, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result).toBe('second');
+  });
+
+  it('different keys are cached independently', async () => {
+    const fetcherX = vi.fn().mockResolvedValue('x');
+    const fetcherY = vi.fn().mockResolvedValue('y');
+    const [rx, ry] = await Promise.all([
+      withCache('key-ind-x', 10_000, fetcherX),
+      withCache('key-ind-y', 10_000, fetcherY),
+    ]);
+    expect(rx).toBe('x');
+    expect(ry).toBe('y');
+    expect(fetcherX).toHaveBeenCalledOnce();
+    expect(fetcherY).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/zounz/__tests__/contracts.test.ts
+++ b/src/lib/zounz/__tests__/contracts.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  ZOUNZ_AUCTION,
+  ZOUNZ_GOVERNOR,
+  ZOUNZ_TOKEN,
+  ZOUNZ_TREASURY,
+  auctionAbi,
+  governorAbi,
+  tokenAbi,
+} from '../contracts';
+
+// ---------------------------------------------------------------------------
+// Address constants — 0x-prefixed 42-char hex strings
+// ---------------------------------------------------------------------------
+
+describe('ZOUNZ contract addresses', () => {
+  const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+  it('ZOUNZ_TOKEN is a valid EVM address', () => {
+    expect(ZOUNZ_TOKEN).toMatch(EVM_ADDRESS);
+  });
+
+  it('ZOUNZ_AUCTION is a valid EVM address', () => {
+    expect(ZOUNZ_AUCTION).toMatch(EVM_ADDRESS);
+  });
+
+  it('ZOUNZ_GOVERNOR is a valid EVM address', () => {
+    expect(ZOUNZ_GOVERNOR).toMatch(EVM_ADDRESS);
+  });
+
+  it('ZOUNZ_TREASURY is a valid EVM address', () => {
+    expect(ZOUNZ_TREASURY).toMatch(EVM_ADDRESS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parsed ABIs — non-empty arrays from viem's parseAbi
+// ---------------------------------------------------------------------------
+
+describe('auctionAbi', () => {
+  it('is a non-empty ABI array', () => {
+    expect(Array.isArray(auctionAbi)).toBe(true);
+    expect(auctionAbi.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('contains the auction() view function', () => {
+    const fn = auctionAbi.find((e) => e.type === 'function' && e.name === 'auction');
+    expect(fn).toBeDefined();
+  });
+
+  it('contains createBid as a payable function', () => {
+    const fn = auctionAbi.find((e) => e.type === 'function' && e.name === 'createBid');
+    expect(fn).toBeDefined();
+    if (fn && fn.type === 'function') expect(fn.stateMutability).toBe('payable');
+  });
+});
+
+describe('governorAbi', () => {
+  it('is a non-empty ABI array', () => {
+    expect(Array.isArray(governorAbi)).toBe(true);
+    expect(governorAbi.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('contains the proposalCount() function', () => {
+    const fn = governorAbi.find((e) => e.type === 'function' && e.name === 'proposalCount');
+    expect(fn).toBeDefined();
+  });
+});
+
+describe('tokenAbi', () => {
+  it('is a non-empty ABI array', () => {
+    expect(Array.isArray(tokenAbi)).toBe(true);
+    expect(tokenAbi.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('contains the ownerOf() function', () => {
+    const fn = tokenAbi.find((e) => e.type === 'function' && e.name === 'ownerOf');
+    expect(fn).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `empire-builder/cache.ts` — 5 cases: cache miss calls fetcher, hit skips fetcher, TTL expiry re-fetches (fake timers), independent keys, DEFAULT_TTL_MS export
- `bluesky/labeler.ts` — 5 cases: `isMemberLabeled` (found/not-found/empty list), `applyMemberLabel` (success→true, throws→false via mocked AtpAgent)
- `zounz/contracts.ts` — 11 cases: all 4 addresses are valid 42-char EVM hex strings; auctionAbi/governorAbi/tokenAbi length + specific named function presence

All 21 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)