### PR TITLE
test: autocliper postiz-api + stock artists pure fns (17 cases)

### DIFF
--- a/src/lib/autocliper/__tests__/postiz-api.test.ts
+++ b/src/lib/autocliper/__tests__/postiz-api.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildCaption, postToPostiz, validatePlatforms } from '../postiz-api';
+import type { PostizPostRequest } from '../types';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// validatePlatforms — pure
+// ---------------------------------------------------------------------------
+
+describe('validatePlatforms', () => {
+  it('returns true for all supported platforms', () => {
+    expect(validatePlatforms(['warpcast', 'x', 'bluesky', 'discord'])).toBe(true);
+  });
+
+  it('returns true for a valid subset', () => {
+    expect(validatePlatforms(['x', 'bluesky'])).toBe(true);
+  });
+
+  it('returns false when an unknown platform is included', () => {
+    expect(validatePlatforms(['x', 'tiktok' as never])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCaption — pure
+// ---------------------------------------------------------------------------
+
+describe('buildCaption', () => {
+  it('returns the full caption when within the default 300-char limit', () => {
+    const result = buildCaption('Short Title', 'Short description.');
+    expect(result).toBe('Short Title\n\nShort description.');
+  });
+
+  it('truncates with "..." when caption exceeds maxChars', () => {
+    const longDesc = 'a'.repeat(300);
+    const result = buildCaption('T', longDesc, 50);
+    expect(result).toHaveLength(50);
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  it('returns exactly maxChars characters on boundary', () => {
+    // "T\n\nddddd" — total must == maxChars exactly to NOT truncate
+    const caption = 'T\n\n' + 'x'.repeat(7); // len = 10
+    const result = buildCaption('T', 'x'.repeat(7), 10);
+    expect(result).toHaveLength(10);
+    expect(result.endsWith('...')).toBe(false);
+  });
+
+  it('uses 300 as the default maxChars', () => {
+    const base = 'Title\n\n' + 'x'.repeat(310);
+    const result = buildCaption('Title', 'x'.repeat(310));
+    expect(result).toHaveLength(300);
+    expect(result.endsWith('...')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postToPostiz — no API key → stub response
+// ---------------------------------------------------------------------------
+
+const BASE_REQUEST: PostizPostRequest = {
+  content: 'Check out this clip!',
+  platforms: ['x', 'bluesky'],
+};
+
+describe('postToPostiz (no API key)', () => {
+  it('returns a stub id and scheduled map when POSTIZ_API_KEY is not set', async () => {
+    // In test env POSTIZ_API_KEY is absent → stub path
+    const result = await postToPostiz(BASE_REQUEST);
+    expect(result.id).toMatch(/^stub-\d+$/);
+    expect(result.scheduled).toHaveProperty('x');
+    expect(result.scheduled).toHaveProperty('bluesky');
+  });
+
+  it('includes all requested platforms in the stub scheduled object', async () => {
+    const req: PostizPostRequest = { content: 'hello', platforms: ['discord', 'warpcast'] };
+    const result = await postToPostiz(req);
+    expect(Object.keys(result.scheduled)).toContain('discord');
+    expect(Object.keys(result.scheduled)).toContain('warpcast');
+    expect(result.scheduled['discord']?.status).toBe('scheduled');
+  });
+});

--- a/src/lib/stock/__tests__/artists.test.ts
+++ b/src/lib/stock/__tests__/artists.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { generateClaimToken, slugify, verifyClaimToken } from '../artists';
+
+// ---------------------------------------------------------------------------
+// slugify — pure
+// ---------------------------------------------------------------------------
+
+describe('slugify', () => {
+  it('lowercases and hyphenates words', () => {
+    expect(slugify('ZAO Records')).toBe('zao-records');
+  });
+
+  it('collapses multiple spaces into a single hyphen', () => {
+    expect(slugify('hello  world')).toBe('hello-world');
+  });
+
+  it('strips special characters', () => {
+    expect(slugify("Zaal's Band!")).toBe('zaals-band');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateClaimToken — uses crypto.randomBytes
+// ---------------------------------------------------------------------------
+
+describe('generateClaimToken', () => {
+  it('returns a 16-character hex string', () => {
+    const token = generateClaimToken();
+    expect(token).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('returns a unique value on each call', () => {
+    expect(generateClaimToken()).not.toBe(generateClaimToken());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyClaimToken — early-exit guard (no Supabase call on short tokens)
+// ---------------------------------------------------------------------------
+
+describe('verifyClaimToken (short-token guard)', () => {
+  it('returns null for an empty token without hitting Supabase', async () => {
+    const result = await verifyClaimToken('some-slug', '');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a token shorter than 4 characters', async () => {
+    const result = await verifyClaimToken('some-slug', 'abc');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `autocliper/postiz-api.ts` — 9 cases: `validatePlatforms` (valid subset, all platforms, unknown platform), `buildCaption` (fits/truncates/boundary/default maxChars), `postToPostiz` stub mode (no POSTIZ_API_KEY → stub id + scheduled map)
- `stock/artists.ts` — 8 cases: `slugify` (lowercase+hyphenate, multi-space, special chars, empty), `generateClaimToken` (16-char hex, unique), `verifyClaimToken` early-exit guard (empty/short token → null without Supabase)

All 17 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)