### PR TITLE
test: API routes snapshot/polls, auth/logout, wavewarz/random-stat (8 cases)

### DIFF
--- a/src/app/api/auth/logout/__tests__/route.test.ts
+++ b/src/app/api/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockClearSession = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({
+  clearSession: mockClearSession,
+}));
+
+import { POST } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/auth/logout', () => {
+  it('returns success:true when clearSession resolves', async () => {
+    mockClearSession.mockResolvedValue(undefined);
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 500 when clearSession throws', async () => {
+    mockClearSession.mockRejectedValue(new Error('Session store error'));
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBeDefined();
+  });
+});

--- a/src/app/api/snapshot/polls/__tests__/route.test.ts
+++ b/src/app/api/snapshot/polls/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockFetchActivePolls = vi.hoisted(() => vi.fn());
+const mockFetchRecentPolls = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/snapshot/client', () => ({
+  fetchActivePolls: mockFetchActivePolls,
+  fetchRecentPolls: mockFetchRecentPolls,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const MOCK_POLL = {
+  id: 'QmAbc',
+  title: 'Test Poll',
+  choices: ['Yes', 'No'],
+  start: 1700000000,
+  end: 1700100000,
+  state: 'active' as const,
+  scores: [10, 5],
+  scores_total: 15,
+  votes: 12,
+};
+
+describe('GET /api/snapshot/polls', () => {
+  it('returns active and recent polls when both succeed', async () => {
+    mockFetchActivePolls.mockResolvedValue([MOCK_POLL]);
+    mockFetchRecentPolls.mockResolvedValue([MOCK_POLL, MOCK_POLL]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.active).toHaveLength(1);
+    expect(body.recent).toHaveLength(2);
+  });
+
+  it('returns empty active array when fetchActivePolls rejects', async () => {
+    mockFetchActivePolls.mockRejectedValue(new Error('Snapshot down'));
+    mockFetchRecentPolls.mockResolvedValue([MOCK_POLL]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.active).toEqual([]);
+    expect(body.recent).toHaveLength(1);
+  });
+
+  it('returns both empty when both reject', async () => {
+    mockFetchActivePolls.mockRejectedValue(new Error('err'));
+    mockFetchRecentPolls.mockRejectedValue(new Error('err'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.active).toEqual([]);
+    expect(body.recent).toEqual([]);
+  });
+});

--- a/src/app/api/wavewarz/random-stat/__tests__/route.test.ts
+++ b/src/app/api/wavewarz/random-stat/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetRandomStat = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/wavewarz/random-stats', () => ({
+  getRandomStat: mockGetRandomStat,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const MOCK_SESSION = { fid: 123, username: 'zabal' };
+const MOCK_STAT = {
+  title: 'ZAO Artist -- 10 WaveWarZ Wins',
+  publish_text: 'ZAO Artist has won 10 battles.',
+  stat_type: 'artist_win_record',
+};
+
+describe('GET /api/wavewarz/random-stat', () => {
+  it('returns 401 when there is no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBeDefined();
+  });
+
+  it('returns 404 when there are no stats available', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetRandomStat.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBeDefined();
+  });
+
+  it('returns 200 with the stat when authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetRandomStat.mockResolvedValue(MOCK_STAT);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.title).toBe(MOCK_STAT.title);
+    expect(body.stat_type).toBe('artist_win_record');
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/snapshot/polls` — 3 cases: both polls resolve, active rejects (graceful fallback), both reject (both empty)
- `POST /api/auth/logout` — 2 cases: clearSession resolves→success:true, clearSession throws→500
- `GET /api/wavewarz/random-stat` — 3 cases: no session→401, no stat→404, authenticated+stat→200

All route handlers tested via direct invocation with mocked dependencies. 8 cases pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)