### PR TITLE
test: API routes wallet, spaces/past, notifications/status (12 cases)

### DIFF
--- a/src/app/api/notifications/status/__tests__/route.test.ts
+++ b/src/app/api/notifications/status/__tests__/route.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+// Supabase admin — mock the Proxy so the route can call .from().select()...maybeSingle()
+const mockMaybeSingle = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: mockMaybeSingle,
+    }),
+  },
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/notifications/status', () => {
+  it('returns enabled:false when there is no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.enabled).toBe(false);
+  });
+
+  it('returns enabled:false when the user has no token record', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const res = await GET();
+    const body = await res.json();
+    expect(body.enabled).toBe(false);
+  });
+
+  it('returns enabled:true when the token is enabled', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+    mockMaybeSingle.mockResolvedValue({ data: { enabled: true }, error: null });
+    const res = await GET();
+    const body = await res.json();
+    expect(body.enabled).toBe(true);
+  });
+
+  it('returns enabled:false when the token is disabled', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+    mockMaybeSingle.mockResolvedValue({ data: { enabled: false }, error: null });
+    const res = await GET();
+    const body = await res.json();
+    expect(body.enabled).toBe(false);
+  });
+});

--- a/src/app/api/spaces/past/__tests__/route.test.ts
+++ b/src/app/api/spaces/past/__tests__/route.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetPastRooms = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/spaces/roomsDb', () => ({ getPastRooms: mockGetPastRooms }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1, username: 'zabal' };
+const MOCK_ROOMS = [{ id: 'r1', name: 'ZAO Call', ended_at: '2026-07-01T00:00:00Z' }];
+
+describe('GET /api/spaces/past', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/spaces/past');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns rooms with default 7-day window', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetPastRooms.mockResolvedValue(MOCK_ROOMS);
+    const req = makeGetRequest('/api/spaces/past');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.rooms).toHaveLength(1);
+    expect(mockGetPastRooms).toHaveBeenCalledWith(7);
+  });
+
+  it('passes the days query param to getPastRooms', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetPastRooms.mockResolvedValue([]);
+    const req = makeGetRequest('/api/spaces/past', { days: '30' });
+    await GET(req);
+    expect(mockGetPastRooms).toHaveBeenCalledWith(30);
+  });
+
+  it('uses default 7 days when days param is invalid', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetPastRooms.mockResolvedValue([]);
+    const req = makeGetRequest('/api/spaces/past', { days: 'bad' });
+    await GET(req);
+    expect(mockGetPastRooms).toHaveBeenCalledWith(7);
+  });
+});

--- a/src/app/api/users/wallet/__tests__/route.test.ts
+++ b/src/app/api/users/wallet/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetUserByFid = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({ getUserByFid: mockGetUserByFid }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 456, username: 'zabal' };
+const MOCK_USER = {
+  fid: 456,
+  custody_address: '0xabc',
+  verified_addresses: { eth_addresses: ['0xdef', '0xghi'] },
+};
+
+describe('GET /api/users/wallet', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when user not found in Neynar', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetUserByFid.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns verified addresses and custody address on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetUserByFid.mockResolvedValue(MOCK_USER);
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.verifiedAddresses).toEqual(['0xdef', '0xghi']);
+    expect(body.custodyAddress).toBe('0xabc');
+  });
+
+  it('returns 500 when getUserByFid throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetUserByFid.mockRejectedValue(new Error('Neynar API down'));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/users/wallet` — 4 cases: no session→401, user not found→404, success returns addresses, Neynar throws→500
- `GET /api/spaces/past` — 4 cases: no session→401, default 7-day window, custom days param, invalid days uses default
- `GET /api/notifications/status` — 4 cases: no session→enabled:false, no token record→false, token enabled→true, token disabled→false

All 12 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)