### PR TITLE
test: API routes admin/hidden, search/users, users/follow (13 cases)

### DIFF
--- a/src/app/api/admin/hidden/__tests__/route.test.ts
+++ b/src/app/api/admin/hidden/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockMaybeSingleOrSingle = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => mockMaybeSingleOrSingle()),
+    }),
+  },
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_ADMIN_SESSION = { fid: 1, isAdmin: true };
+const MOCK_USER_SESSION = { fid: 2, isAdmin: false };
+
+describe('GET /api/admin/hidden', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_USER_SESSION);
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 with messages when admin', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_ADMIN_SESSION);
+    const mockMessages = [{ id: 1, content: 'hidden msg', hidden_at: '2026-01-01' }];
+    mockMaybeSingleOrSingle.mockResolvedValue({ data: mockMessages, error: null });
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.messages).toHaveLength(1);
+  });
+
+  it('returns 500 when Supabase returns an error', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_ADMIN_SESSION);
+    mockMaybeSingleOrSingle.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/search/users/__tests__/route.test.ts
+++ b/src/app/api/search/users/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockSearchUsers = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({ searchUsers: mockSearchUsers }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1, username: 'zabal' };
+const MOCK_NEYNAR_USERS = [
+  { fid: 10, username: 'alice', display_name: 'Alice', pfp_url: 'https://example.com/a.jpg' },
+];
+
+describe('GET /api/search/users', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/search/users', { q: 'alice' });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty users when q is absent', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makeGetRequest('/api/search/users');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.users).toEqual([]);
+  });
+
+  it('returns mapped users on successful search', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSearchUsers.mockResolvedValue({ result: { users: MOCK_NEYNAR_USERS } });
+    const req = makeGetRequest('/api/search/users', { q: 'alice' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].username).toBe('alice');
+  });
+
+  it('returns empty users when searchUsers throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSearchUsers.mockRejectedValue(new Error('Neynar search failed'));
+    const req = makeGetRequest('/api/search/users', { q: 'fail' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.users).toEqual([]);
+  });
+});

--- a/src/app/api/users/follow/__tests__/route.test.ts
+++ b/src/app/api/users/follow/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockFollowUser = vi.hoisted(() => vi.fn());
+const mockUnfollowUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({
+  followUser: mockFollowUser,
+  unfollowUser: mockUnfollowUser,
+}));
+
+import { DELETE, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1, signerUuid: 'signer-uuid-abc' };
+
+describe('POST /api/users/follow', () => {
+  it('returns 401 when no signerUuid in session', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    const req = makePostRequest('/api/users/follow', { targetFid: 99 });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid input (non-positive fid)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow', { targetFid: -1 });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true on a valid follow', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/follow', { targetFid: 99 });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockFollowUser).toHaveBeenCalledWith('signer-uuid-abc', [99]);
+  });
+
+  it('returns 500 when followUser throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockRejectedValue(new Error('Neynar error'));
+    const req = makePostRequest('/api/users/follow', { targetFid: 99 });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/users/follow', () => {
+  it('returns success:true on a valid unfollow', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockUnfollowUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/follow', { targetFid: 77 });
+    const res = await DELETE(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockUnfollowUser).toHaveBeenCalledWith('signer-uuid-abc', [77]);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/admin/hidden` — 4 cases: no session→401, non-admin→403, admin+success→200 with messages, Supabase error→500
- `GET /api/search/users` — 4 cases: no session→401, absent q→empty, valid search→mapped users, searchUsers throws→empty
- `POST /api/users/follow` & `DELETE` — 5 cases: no signerUuid→401, invalid fid→400, valid follow→success:true, followUser throws→500, valid unfollow→success:true

All 13 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)