### PR TITLE
test: API routes music/play, twitch/clip, users/xmtp-address (12 cases)

### DIFF
--- a/src/app/api/music/library/play/__tests__/route.test.ts
+++ b/src/app/api/music/library/play/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockIncrementPlayCount = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/music/library', () => ({ incrementPlayCount: mockIncrementPlayCount }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1 };
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('POST /api/music/library/play', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/music/library/play', { songId: VALID_UUID });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for a non-UUID songId', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/music/library/play', { songId: 'not-a-uuid' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true when incrementPlayCount resolves', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockIncrementPlayCount.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/music/library/play', { songId: VALID_UUID });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockIncrementPlayCount).toHaveBeenCalledWith(VALID_UUID);
+  });
+
+  it('returns 500 when incrementPlayCount throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockIncrementPlayCount.mockRejectedValue(new Error('DB error'));
+    const req = makePostRequest('/api/music/library/play', { songId: VALID_UUID });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/twitch/clip/__tests__/route.test.ts
+++ b/src/app/api/twitch/clip/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetValidTwitchToken = vi.hoisted(() => vi.fn());
+const mockCreateTwitchClip = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/twitch/client', () => ({
+  getValidTwitchToken: mockGetValidTwitchToken,
+  createTwitchClip: mockCreateTwitchClip,
+}));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 99 };
+const MOCK_CREDS = { accessToken: 'twitch-token', userId: 'streamer-id' };
+const MOCK_CLIP = { id: 'clip-xyz', editUrl: 'https://clips.twitch.tv/clip-xyz/edit' };
+
+describe('POST /api/twitch/clip', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when Twitch is not connected (no creds)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when clip creation returns null (stream not live)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchClip.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(500);
+  });
+
+  it('returns clipId and editUrl on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchClip.mockResolvedValue(MOCK_CLIP);
+    const res = await POST();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.clipId).toBe('clip-xyz');
+    expect(body.editUrl).toContain('clip-xyz');
+  });
+});

--- a/src/app/api/users/xmtp-address/__tests__/route.test.ts
+++ b/src/app/api/users/xmtp-address/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockEq = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      update: vi.fn().mockReturnValue({ eq: mockEq }),
+    }),
+  },
+}));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 42 };
+const VALID_ADDRESS = '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12';
+
+describe('POST /api/users/xmtp-address', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/users/xmtp-address', { xmtpAddress: VALID_ADDRESS });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for an invalid Ethereum address', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/xmtp-address', { xmtpAddress: 'not-an-address' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when Supabase update fails', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockEq.mockResolvedValue({ error: { message: 'DB error' } });
+    const req = makePostRequest('/api/users/xmtp-address', { xmtpAddress: VALID_ADDRESS });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns ok:true on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockEq.mockResolvedValue({ error: null });
+    const req = makePostRequest('/api/users/xmtp-address', { xmtpAddress: VALID_ADDRESS });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/music/library/play` — 4 cases: no session→401, invalid UUID→400, success→success:true, incrementPlayCount throws→500
- `POST /api/twitch/clip` — 4 cases: no session→401, no Twitch creds→400, clip=null (stream not live)→500, success returns clipId+editUrl
- `POST /api/users/xmtp-address` — 4 cases: no session→401, invalid address→400, Supabase error→500, success→ok:true

All 12 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)