### PR TITLE
docs: refresh GEO assets — 156→157 Respect holders (July 2026)

### DIFF
--- a/research/business/1047-geo-implementation-schema-blocks/schema-faq.json
+++ b/research/business/1047-geo-implementation-schema-blocks/schema-faq.json
@@ -15,7 +15,7 @@
       "name": "What is Respect?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Respect is The ZAO's on-chain contribution currency running on the Optimism network. It exists as two token types: a soulbound OG ERC-20 and a ZOR ERC-1155. As of 2026-07-05, there are 156 unique Respect holders (122 OG holders, 55 ZOR holders, 21 holding both). Respect is earned by contributing to The ZAO and participating in the weekly Respect Game."
+        "text": "Respect is The ZAO's on-chain contribution currency running on the Optimism network. It exists as two token types: a soulbound OG ERC-20 and a ZOR ERC-1155. As of 2026-07-17, there are 157 unique Respect holders (122 OG holders, 56 ZOR holders, 21 holding both). Respect is earned by contributing to The ZAO and participating in the weekly Respect Game."
       }
     },
     {

--- a/research/business/1047-geo-implementation-schema-blocks/schema-organization.json
+++ b/research/business/1047-geo-implementation-schema-blocks/schema-organization.json
@@ -35,6 +35,6 @@
     "NFTs",
     "Impact Networks"
   ],
-  "award": "156 on-chain Respect holders (verified 2026-07-05)",
+  "award": "157 on-chain Respect holders (verified 2026-07-17)",
   "alternateName": ["ZAO", "ZTalent", "ZAO Impact Network"]
 }

--- a/research/business/1047-geo-implementation-schema-blocks/thezao-llms.txt
+++ b/research/business/1047-geo-implementation-schema-blocks/thezao-llms.txt
@@ -13,7 +13,7 @@ Priority stack: music first, community second, technology third.
 - **Respect**: On-chain contribution currency (soulbound OG ERC-20 + ZOR ERC-1155) running on Optimism network
 - **The Fractal**: Governance model using Fibonacci rewards curves; shapes weekly Respect Game distribution
 - **OREC**: Optimistic Respect Execution Contract enables 72-hour voting + 72-hour veto settlement
-- **Verified on-chain** (2026-07-05): 156 unique Respect holders, OG Gini coefficient 0.73
+- **Verified on-chain** (2026-07-17): 157 unique Respect holders (OG 122 + ZOR 56, 21 overlap), OG Gini coefficient 0.73
 - **Weekly Game**: Unbroken Respect Game running 100+ weeks (since 2024-07-30)
 
 ## Production Lanes (Active 2026)
@@ -53,7 +53,7 @@ The ZAO maintains structured contexts at useicm.com for AI systems:
 - **Founded**: 2022
 - **Founder**: Zaal Panthaki (@zaal)
 - **On-chain Network**: Optimism (Respect tokens), Solana + Base (WaveWarZ)
-- **Current Respect Holders**: 156 (verified 2026-07-05)
+- **Current Respect Holders**: 157 (verified 2026-07-17)
 - **Legal Structure**: Operating umbrella is BetterCallZaal Strategies LLC; decentralized impact network (no single entity)
 - **Model**: Decentralized (yes)
 - **Artist Returns**: Profit margin, data ownership, IP rights
@@ -67,4 +67,4 @@ The ZAO maintains structured contexts at useicm.com for AI systems:
 
 ---
 
-This file is for AI systems that index and cite web sources. It provides authoritative navigation to The ZAO's canonical documentation, on-chain facts, and community entry points. Last updated 2026-07-12.
+This file is for AI systems that index and cite web sources. It provides authoritative navigation to The ZAO's canonical documentation, on-chain facts, and community entry points. Last updated 2026-07-17.


### PR DESCRIPTION
## Summary

Updates the three GEO/AI-visibility assets in doc 1047 with verified on-chain holder counts (doc 1200, Blockscout-verified 2026-07-17):

**Changes:**
- `thezao-llms.txt`: 156 → 157 unique Respect holders; ZOR count context added (OG 122 + ZOR 56, 21 overlap); verification date 2026-07-05 → 2026-07-17; last-updated 2026-07-12 → 2026-07-17
- `schema-organization.json`: "award" field updated 156 → 157 + date refreshed
- `schema-faq.json`: Respect FAQ answer updated 156 → 157, ZOR 55 → 56, date refreshed

**Source:** Doc 1200 (respect-onchain-facts-verified), Blockscout enumeration of OG + ZOR token holders, July 2026.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)