### PR TITLE
test: API routes block, mute, twitch/stream-info, gate-check (19 cases)

### DIFF
--- a/src/app/api/spaces/gate-check/__tests__/route.test.ts
+++ b/src/app/api/spaces/gate-check/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockCheckTokenGate = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/spaces/tokenGate', () => ({ checkTokenGate: mockCheckTokenGate }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1 };
+const VALID_GATE_BODY = {
+  walletAddress: '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12',
+  gateConfig: {
+    type: 'erc721',
+    contractAddress: '0xAbCdEf1234567890AbCdEf1234567890AbCdEf34',
+    chainId: 8453,
+  },
+};
+
+describe('POST /api/spaces/gate-check', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/spaces/gate-check', VALID_GATE_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for an invalid chainId', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/spaces/gate-check', {
+      ...VALID_GATE_BODY,
+      gateConfig: { ...VALID_GATE_BODY.gateConfig, chainId: 999 },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns allowed:true when the wallet passes the gate', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockCheckTokenGate.mockResolvedValue({ allowed: true, balance: '3' });
+    const req = makePostRequest('/api/spaces/gate-check', VALID_GATE_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.allowed).toBe(true);
+    expect(body.balance).toBe('3');
+  });
+
+  it('returns 500 with allowed:false when checkTokenGate throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockCheckTokenGate.mockRejectedValue(new Error('RPC error'));
+    const req = makePostRequest('/api/spaces/gate-check', VALID_GATE_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.allowed).toBe(false);
+  });
+});

--- a/src/app/api/twitch/stream-info/__tests__/route.test.ts
+++ b/src/app/api/twitch/stream-info/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetValidTwitchToken = vi.hoisted(() => vi.fn());
+const mockGetTwitchStreamInfo = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/twitch/client', () => ({
+  getValidTwitchToken: mockGetValidTwitchToken,
+  getTwitchStreamInfo: mockGetTwitchStreamInfo,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 77 };
+const MOCK_CREDS = { accessToken: 'tok', userId: 'user-1' };
+
+describe('GET /api/twitch/stream-info', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns isLive:false, connected:false when Twitch not linked', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(null);
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.isLive).toBe(false);
+    expect(body.connected).toBe(false);
+  });
+
+  it('returns isLive:false, connected:true when stream is offline', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockGetTwitchStreamInfo.mockResolvedValue(null);
+    const res = await GET();
+    const body = await res.json();
+    expect(body.isLive).toBe(false);
+    expect(body.connected).toBe(true);
+  });
+
+  it('returns full stream info when live', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockGetTwitchStreamInfo.mockResolvedValue({
+      viewerCount: 42,
+      title: 'ZAO Stream',
+      gameName: 'Music',
+      startedAt: '2026-07-17T00:00:00Z',
+    });
+    const res = await GET();
+    const body = await res.json();
+    expect(body.isLive).toBe(true);
+    expect(body.connected).toBe(true);
+    expect(body.viewerCount).toBe(42);
+    expect(body.title).toBe('ZAO Stream');
+  });
+
+  it('returns 500 when an unexpected error occurs', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockRejectedValue(new Error('DB unavailable'));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/users/block/__tests__/route.test.ts
+++ b/src/app/api/users/block/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockBlockUser = vi.hoisted(() => vi.fn());
+const mockUnblockUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({
+  blockUser: mockBlockUser,
+  unblockUser: mockUnblockUser,
+}));
+
+import { DELETE, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1, signerUuid: 'signer-abc' };
+
+describe('POST /api/users/block', () => {
+  it('returns 401 when no signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    const req = makePostRequest('/api/users/block', { targetFid: 99 });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid input', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/block', { targetFid: 'not-a-number' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true on valid block', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockBlockUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/block', { targetFid: 99 });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockBlockUser).toHaveBeenCalledWith('signer-abc', 99);
+  });
+
+  it('returns 500 when blockUser throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockBlockUser.mockRejectedValue(new Error('Neynar error'));
+    const req = makePostRequest('/api/users/block', { targetFid: 99 });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/users/block', () => {
+  it('returns success:true on valid unblock', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockUnblockUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/block', { targetFid: 77 });
+    const res = await DELETE(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+});

--- a/src/app/api/users/mute/__tests__/route.test.ts
+++ b/src/app/api/users/mute/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockMuteUser = vi.hoisted(() => vi.fn());
+const mockUnmuteUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({
+  muteUser: mockMuteUser,
+  unmuteUser: mockUnmuteUser,
+}));
+
+import { DELETE, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1, signerUuid: 'signer-xyz' };
+
+describe('POST /api/users/mute', () => {
+  it('returns 401 when no signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    const req = makePostRequest('/api/users/mute', { targetFid: 55 });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for a negative targetFid', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/mute', { targetFid: -5 });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true on valid mute', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockMuteUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/mute', { targetFid: 55 });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockMuteUser).toHaveBeenCalledWith('signer-xyz', 55);
+  });
+
+  it('returns 500 when muteUser throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockMuteUser.mockRejectedValue(new Error('Neynar down'));
+    const req = makePostRequest('/api/users/mute', { targetFid: 55 });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/users/mute', () => {
+  it('returns success:true on valid unmute', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockUnmuteUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/mute', { targetFid: 44 });
+    const res = await DELETE(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `POST/DELETE /api/users/block` — 5 cases: no signerUuid→401, invalid input→400, valid block→success, throws→500, unblock
- `POST/DELETE /api/users/mute` — 5 cases: same pattern as block
- `GET /api/twitch/stream-info` — 5 cases: no session→401, no creds→not connected, offline→connected not live, live→full info, throws→500
- `POST /api/spaces/gate-check` — 4 cases: no session→401, invalid chainId→400, allowed→true+balance, throws→500+allowed:false

All 19 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)