### PR TITLE
test: API routes fc-identity/check + stream/token (9 cases)

### DIFF
--- a/src/app/api/fc-identity/check/__tests__/route.test.ts
+++ b/src/app/api/fc-identity/check/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockCheckGatingEligibility = vi.hoisted(() => vi.fn());
+const mockGetFcQualityScoreByFid = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/fc-identity', () => ({
+  checkGatingEligibility: mockCheckGatingEligibility,
+  getFcQualityScoreByFid: mockGetFcQualityScoreByFid,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const VALID_ADDRESS = '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12';
+
+describe('GET /api/fc-identity/check', () => {
+  it('returns 400 when neither address nor fid is provided', async () => {
+    const req = makeGetRequest('/api/fc-identity/check');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns address-type result with stringified score', async () => {
+    mockCheckGatingEligibility.mockResolvedValue({
+      eligible: true,
+      fid: 123,
+      score: BigInt(75),
+    });
+    const req = makeGetRequest('/api/fc-identity/check', { address: VALID_ADDRESS });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.type).toBe('address');
+    expect(body.eligible).toBe(true);
+    expect(body.score).toBe('75'); // BigInt serialized to string
+  });
+
+  it('returns fid-type result with eligible based on minScore', async () => {
+    mockGetFcQualityScoreByFid.mockResolvedValue(BigInt(50));
+    const req = makeGetRequest('/api/fc-identity/check', { fid: '456', minScore: '40' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.type).toBe('fid');
+    expect(body.fid).toBe(456);
+    expect(body.score).toBe('50');
+    expect(body.eligible).toBe(true);
+  });
+
+  it('returns 502 when chain read throws', async () => {
+    mockCheckGatingEligibility.mockRejectedValue(new Error('RPC timeout'));
+    const req = makeGetRequest('/api/fc-identity/check', { address: VALID_ADDRESS });
+    const res = await GET(req);
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/app/api/stream/token/__tests__/route.test.ts
+++ b/src/app/api/stream/token/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+vi.mock('@/lib/db/audit-log', () => ({
+  getClientIp: vi.fn().mockReturnValue('127.0.0.1'),
+  logAuditEvent: vi.fn(),
+}));
+
+const mockGenerateUserToken = vi.hoisted(() => vi.fn().mockReturnValue('stream-jwt-token'));
+vi.mock('@stream-io/node-sdk', () => ({
+  StreamClient: vi.fn().mockImplementation(() => ({
+    generateUserToken: mockGenerateUserToken,
+  })),
+}));
+
+import { POST } from '../route';
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_STREAM_API_KEY = 'test-api-key';
+  process.env.STREAM_API_SECRET = 'test-api-secret';
+});
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_STREAM_API_KEY;
+  delete process.env.STREAM_API_SECRET;
+  vi.clearAllMocks();
+});
+
+const MOCK_SESSION = { fid: 42 };
+
+describe('POST /api/stream/token', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/stream/token', { userId: '42' });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 500 when Stream API keys are missing', async () => {
+    delete process.env.NEXT_PUBLIC_STREAM_API_KEY;
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/stream/token', { userId: '42' });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 400 when userId is missing from body', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/stream/token', {});
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when userId does not match session fid', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/stream/token', { userId: '999' });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns a JWT token when userId matches session fid', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/stream/token', { userId: '42' });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.token).toBe('stream-jwt-token');
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/fc-identity/check` — 4 cases: no params→400, address path returns eligible+bigint score as string, fid path eligible vs minScore, chain read throws→502
- `POST /api/stream/token` — 5 cases: no session→401, missing Stream keys→500, missing userId→400, userId mismatch→403, matching userId→token

BigInt serialization (score.toString()) tested in the fc-identity path. Stream.io SDK mocked with generateUserToken stub. All 9 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)