### PR TITLE
test: API routes nexus/links, social/engagement, music/artists (12 cases)

### DIFF
--- a/src/app/api/music/artists/__tests__/route.test.ts
+++ b/src/app/api/music/artists/__tests__/route.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+// Build a chain that resolves via .then (awaitable) to a result
+function makeChain(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'ilike', 'order', 'limit', 'in']) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain.then = vi.fn((resolve: (v: unknown) => void) => resolve(result));
+  return chain;
+}
+
+describe('GET /api/music/artists', () => {
+  it('returns 400 when artist param is missing', async () => {
+    const req = makeGetRequest('/api/music/artists');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns empty stats when no songs are found', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: [], error: null }));
+    const req = makeGetRequest('/api/music/artists', { artist: 'ZAO Artist' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.trackCount).toBe(0);
+    expect(body.tracks).toEqual([]);
+  });
+
+  it('returns 500 when Supabase throws an error', async () => {
+    const errorChain = makeChain({ data: null, error: new Error('DB failure') });
+    mockFrom.mockReturnValue(errorChain);
+    const req = makeGetRequest('/api/music/artists', { artist: 'ArtistX' });
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/nexus/links/__tests__/route.test.ts
+++ b/src/app/api/nexus/links/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { GET } from '../route';
+
+function makeChain(result: { data: unknown; error: unknown }) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    contains: vi.fn().mockReturnThis(),
+    then: vi.fn((resolve: (v: unknown) => void) => resolve(result)),
+  };
+  return chain;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/nexus/links', () => {
+  it('returns links and count on success', async () => {
+    const mockLinks = [{ id: '1', title: 'ZAO Site', portal_group: 'MUSIC' }];
+    mockFrom.mockReturnValue(makeChain({ data: mockLinks, error: null }));
+    const req = makeGetRequest('/api/nexus/links');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.links).toHaveLength(1);
+    expect(body.count).toBe(1);
+  });
+
+  it('returns 400 for an overlong portal_group param', async () => {
+    const req = makeGetRequest('/api/nexus/links', { portal_group: 'x'.repeat(101) });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when Supabase returns an error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'DB error' } }));
+    const req = makeGetRequest('/api/nexus/links');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns empty links array when data is null (no error)', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const req = makeGetRequest('/api/nexus/links');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.links).toEqual([]);
+    expect(body.count).toBe(0);
+  });
+});

--- a/src/app/api/social/engagement/__tests__/route.test.ts
+++ b/src/app/api/social/engagement/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetEngagementScores = vi.hoisted(() => vi.fn());
+const mockGetPersonalizedScores = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/openrank/client', () => ({
+  getEngagementScores: mockGetEngagementScores,
+  getPersonalizedScores: mockGetPersonalizedScores,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 1 };
+
+describe('GET /api/social/engagement', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/social/engagement', { fids: '123' });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when fids param is missing', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makeGetRequest('/api/social/engagement');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an invalid (non-integer) fid', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makeGetRequest('/api/social/engagement', { fids: '123,bad,456' });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns merged scores keyed by FID string', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetEngagementScores.mockResolvedValue(new Map([[123, 0.85], [456, 0.60]]));
+    mockGetPersonalizedScores.mockResolvedValue(new Map([[123, 0.9], [456, 0.5]]));
+    const req = makeGetRequest('/api/social/engagement', { fids: '123,456' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.scores['123'].global).toBe(0.85);
+    expect(body.scores['123'].personalized).toBe(0.9);
+    expect(body.scores['456'].global).toBe(0.60);
+  });
+
+  it('returns zeros when openrank calls both fail', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetEngagementScores.mockRejectedValue(new Error('OpenRank down'));
+    mockGetPersonalizedScores.mockRejectedValue(new Error('OpenRank down'));
+    const req = makeGetRequest('/api/social/engagement', { fids: '789' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.scores['789'].global).toBe(0);
+    expect(body.scores['789'].personalized).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/nexus/links` — 4 cases: success+count, overlong param→400, Supabase error→500, null data→empty links
- `GET /api/social/engagement` — 5 cases: no session→401, missing fids→400, invalid fid→400, merged scores, both openrank fail→zeros
- `GET /api/music/artists` — 3 cases: missing artist→400, no songs→empty stats, Supabase error→500

All 12 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)