### PR TITLE
test: API routes streaks + spaces/leaderboard (8 cases)

### DIFF
--- a/src/app/api/spaces/leaderboard/__tests__/route.test.ts
+++ b/src/app/api/spaces/leaderboard/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetLeaderboard = vi.hoisted(() => vi.fn());
+const mockGetUsersByFids = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/spaces/sessionsDb', () => ({ getLeaderboard: mockGetLeaderboard }));
+vi.mock('@/lib/farcaster/neynar', () => ({ getUsersByFids: mockGetUsersByFids }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_ENTRY = { fid: 123, totalMinutes: 60, sessionCount: 3 };
+
+describe('GET /api/spaces/leaderboard', () => {
+  it('returns 400 for an invalid period', async () => {
+    const req = makeGetRequest('/api/spaces/leaderboard', { period: 'decade' });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns empty leaderboard when no sessions exist', async () => {
+    mockGetLeaderboard.mockResolvedValue([]);
+    mockGetUsersByFids.mockResolvedValue([]);
+    const req = makeGetRequest('/api/spaces/leaderboard');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.leaderboard).toHaveLength(0);
+    expect(body.totalCommunityMinutes).toBe(0);
+  });
+
+  it('enriches entries with Neynar profile data', async () => {
+    mockGetLeaderboard.mockResolvedValue([MOCK_ENTRY]);
+    mockGetUsersByFids.mockResolvedValue([
+      { fid: 123, username: 'zabal', display_name: 'ZAO AL', pfp_url: 'https://pfp.url' },
+    ]);
+    const req = makeGetRequest('/api/spaces/leaderboard', { period: 'month' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.leaderboard[0].username).toBe('zabal');
+    expect(body.leaderboard[0].totalMinutes).toBe(60);
+    expect(body.period).toBe('month');
+  });
+
+  it('falls back to null profile data when Neynar throws', async () => {
+    mockGetLeaderboard.mockResolvedValue([MOCK_ENTRY]);
+    mockGetUsersByFids.mockRejectedValue(new Error('Neynar down'));
+    const req = makeGetRequest('/api/spaces/leaderboard');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.leaderboard[0].username).toBeNull();
+    expect(body.totalCommunityMinutes).toBe(60);
+  });
+});

--- a/src/app/api/streaks/__tests__/route.test.ts
+++ b/src/app/api/streaks/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockMaybeSingle = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: mockMaybeSingle,
+    }),
+  },
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 11 };
+
+describe('GET /api/streaks', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns zero-defaults when no streak record exists', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.streak.currentStreak).toBe(0);
+    expect(body.streak.isActiveToday).toBe(false);
+  });
+
+  it('returns streak data with computed isActiveToday and isAtRisk', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    // last_activity_date = today
+    const todayStr = new Date().toISOString().split('T')[0];
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        current_streak: 5,
+        longest_streak: 10,
+        last_activity_date: todayStr,
+        total_active_days: 20,
+        streak_freezes_available: 2,
+      },
+      error: null,
+    });
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.streak.currentStreak).toBe(5);
+    expect(body.streak.isActiveToday).toBe(true);
+    expect(body.streak.isAtRisk).toBe(false);
+  });
+
+  it('returns 500 when Supabase returns an error', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/streaks` — 4 cases: no session→401, no record→zero defaults, record with today's date→isActiveToday:true, Supabase error→500
- `GET /api/spaces/leaderboard` — 4 cases: invalid period→400, empty leaderboard, Neynar enrichment, Neynar throws→graceful fallback to null profiles

All 8 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)