### PR TITLE
test: API routes twitch/marker + miniapp/auth-context (9 cases)

### DIFF
--- a/src/app/api/miniapp/auth-context/__tests__/route.test.ts
+++ b/src/app/api/miniapp/auth-context/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetUserByFid = vi.hoisted(() => vi.fn());
+const mockCheckAllowlist = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/farcaster/neynar', () => ({ getUserByFid: mockGetUserByFid }));
+vi.mock('@/lib/gates/allowlist', () => ({ checkAllowlist: mockCheckAllowlist }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_NEYNAR_USER = {
+  fid: 123,
+  username: 'zabal',
+  display_name: 'ZAO AL',
+  pfp_url: 'https://pfp.url/zabal.jpg',
+  verified_addresses: { eth_addresses: [] },
+};
+
+describe('POST /api/miniapp/auth-context', () => {
+  it('returns 400 for invalid (non-positive) fid', async () => {
+    const req = makePostRequest('/api/miniapp/auth-context', { fid: 'bad' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the FID is not found in Neynar', async () => {
+    mockGetUserByFid.mockResolvedValue(null);
+    const req = makePostRequest('/api/miniapp/auth-context', { fid: 999 });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns allowlisted:false when neither FID nor wallet passes the gate', async () => {
+    mockGetUserByFid.mockResolvedValue(MOCK_NEYNAR_USER);
+    mockCheckAllowlist.mockResolvedValue({ allowed: false });
+    const req = makePostRequest('/api/miniapp/auth-context', { fid: 123 });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.allowlisted).toBe(false);
+    expect(body.username).toBe('zabal');
+  });
+
+  it('returns allowlisted:true when FID is in the allowlist', async () => {
+    mockGetUserByFid.mockResolvedValue(MOCK_NEYNAR_USER);
+    mockCheckAllowlist.mockResolvedValue({ allowed: true });
+    const req = makePostRequest('/api/miniapp/auth-context', { fid: 123 });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.allowlisted).toBe(true);
+    expect(body.fid).toBe(123);
+  });
+});

--- a/src/app/api/twitch/marker/__tests__/route.test.ts
+++ b/src/app/api/twitch/marker/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetValidTwitchToken = vi.hoisted(() => vi.fn());
+const mockCreateTwitchMarker = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/twitch/client', () => ({
+  getValidTwitchToken: mockGetValidTwitchToken,
+  createTwitchMarker: mockCreateTwitchMarker,
+}));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10 };
+const MOCK_CREDS = { accessToken: 'tok', userId: 'uid' };
+
+describe('POST /api/twitch/marker', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/twitch/marker', {});
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when Twitch is not connected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(null);
+    const req = makePostRequest('/api/twitch/marker', {});
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when marker creation fails (stream not live)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchMarker.mockResolvedValue(false);
+    const req = makePostRequest('/api/twitch/marker', { description: 'test marker' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true with marker data when creation succeeds', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchMarker.mockResolvedValue(true);
+    const req = makePostRequest('/api/twitch/marker', { description: 'ZAO highlight' });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.marker.description).toBe('ZAO highlight');
+  });
+
+  it('uses default description when none is provided', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchMarker.mockResolvedValue(true);
+    const req = makePostRequest('/api/twitch/marker', {});
+    const res = await POST(req);
+    const body = await res.json();
+    expect(body.marker.description).toBe('ZAO OS marker');
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/twitch/marker` — 5 cases: no session→401, no Twitch creds→401, marker fails (not live)→400, success→marker+description, default description fallback
- `POST /api/miniapp/auth-context` — 4 cases: invalid fid→400, FID not found→404, FID not allowlisted→allowlisted:false, FID allowlisted→allowlisted:true+username

All 9 pass. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)