### PR TITLE
test(api): trending-topics, apo-prompts, spaces-session route coverage

### DIFF
--- a/src/app/api/admin/apo/prompts/__tests__/route.test.ts
+++ b/src/app/api/admin/apo/prompts/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSession: mockGetSession }));
+
+const mockReaddirSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+vi.mock('fs', () => ({
+  readdirSync: mockReaddirSync,
+  readFileSync: mockReadFileSync,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/admin/apo/prompts', () => {
+  it('returns 401 when user is not admin', async () => {
+    mockGetSession.mockResolvedValue({ isAdmin: false });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns list of prompts parsed from disk', async () => {
+    mockGetSession.mockResolvedValue({ isAdmin: true });
+    mockReaddirSync.mockReturnValue(['rag.json', 'music.json']);
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({ name: 'RAG', description: 'rag prompts', testCases: [1, 2] }))
+      .mockReturnValueOnce(JSON.stringify({ name: 'Music', description: 'music prompts', testCases: [] }));
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.prompts).toHaveLength(2);
+    expect(body.prompts[0].name).toBe('RAG');
+    expect(body.prompts[0].testCaseCount).toBe(2);
+    expect(body.prompts[1].name).toBe('Music');
+    expect(body.prompts[1].testCaseCount).toBe(0);
+  });
+
+  it('filters out non-.json files', async () => {
+    mockGetSession.mockResolvedValue({ isAdmin: true });
+    mockReaddirSync.mockReturnValue(['rag.json', 'README.md', 'notes.txt']);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'RAG', description: 'd', testCases: [1] }));
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.prompts).toHaveLength(1);
+  });
+
+  it('returns 500 when filesystem throws', async () => {
+    mockGetSession.mockResolvedValue({ isAdmin: true });
+    mockReaddirSync.mockImplementation(() => { throw new Error('ENOENT: no such file or directory'); });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/social/trending-topics/__tests__/route.test.ts
+++ b/src/app/api/social/trending-topics/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetTrendingTopics = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({ getTrendingTopics: mockGetTrendingTopics }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/social/trending-topics', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/social/trending-topics');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns trending topics with explicit valid limit', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    const mockData = { topics: [{ topic: 'ZAO', rank: 1 }] };
+    mockGetTrendingTopics.mockResolvedValue(mockData);
+    const req = makeGetRequest('/api/social/trending-topics', { limit: '5' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(5);
+    expect(body.topics).toHaveLength(1);
+  });
+
+  it('clamps NaN limit to default 10', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockGetTrendingTopics.mockResolvedValue({ topics: [] });
+    const req = makeGetRequest('/api/social/trending-topics', { limit: 'abc' });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(10);
+  });
+
+  it('clamps limit above 25 to 25', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockGetTrendingTopics.mockResolvedValue({ topics: [] });
+    const req = makeGetRequest('/api/social/trending-topics', { limit: '100' });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(25);
+  });
+
+  it('returns 500 when getTrendingTopics throws', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockGetTrendingTopics.mockRejectedValue(new Error('Neynar down'));
+    const req = makeGetRequest('/api/social/trending-topics');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/spaces/session/__tests__/route.test.ts
+++ b/src/app/api/spaces/session/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockStartSession = vi.hoisted(() => vi.fn());
+const mockEndSessionByFid = vi.hoisted(() => vi.fn());
+const mockUpdateLastActive = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/spaces/sessionsDb', () => ({
+  startSession: mockStartSession,
+  endSessionByFid: mockEndSessionByFid,
+}));
+vi.mock('@/lib/spaces/roomsDb', () => ({ updateLastActive: mockUpdateLastActive }));
+
+import { PATCH, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10 };
+const VALID_ROOM = {
+  roomId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  roomName: 'ZAO Stage',
+  roomType: 'stage' as const,
+};
+
+describe('POST /api/spaces/session', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/spaces/session', VALID_ROOM);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid room payload', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/spaces/session', { roomId: 'not-a-uuid' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns sessionId on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockStartSession.mockResolvedValue('sess-uuid-123');
+    mockUpdateLastActive.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/spaces/session', VALID_ROOM);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.sessionId).toBe('sess-uuid-123');
+  });
+
+  it('returns 500 when startSession rejects', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockStartSession.mockRejectedValue(new Error('DB error'));
+    mockUpdateLastActive.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/spaces/session', VALID_ROOM);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('PATCH /api/spaces/session', () => {
+  const makeRequest = (body: object) =>
+    new NextRequest(new URL('/api/spaces/session', 'http://localhost:3000'), {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
+
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ roomId: VALID_ROOM.roomId }) as Parameters<typeof PATCH>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing roomId', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const res = await PATCH(makeRequest({}) as Parameters<typeof PATCH>[0]);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns ok:true after leaving a room', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockEndSessionByFid.mockResolvedValue(undefined);
+    mockUpdateLastActive.mockResolvedValue(undefined);
+    const res = await PATCH(makeRequest({ roomId: VALID_ROOM.roomId }) as Parameters<typeof PATCH>[0]);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/social/trending-topics` — 5 cases: 401 no-session, returns topics, NaN limit→10, limit>25→25, throws→500
- `GET /api/admin/apo/prompts` — 4 cases: 401 non-admin, disk parse, non-JSON filtered, FS throws→500
- `POST /api/spaces/session` — 4 cases: 401, 400 bad UUID, sessionId success, startSession rejects→500
- `PATCH /api/spaces/session` — 3 cases: 401, 400 missing roomId, ok:true success

16 test cases, 3 new route files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)