### PR TITLE
test(api): track-of-day select, push/send, stream rooms[id] coverage

### DIFF
--- a/src/app/api/music/track-of-day/select/__tests__/route.test.ts
+++ b/src/app/api/music/track-of-day/select/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+vi.mock('@/lib/publish/auto-cast', () => ({ autoCastToZao: vi.fn().mockResolvedValue(undefined) }));
+
+const mockMaybySingle = vi.hoisted(() => vi.fn());
+const mockMaybyTopNomination = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+
+// Chain tracker — 'check' for first call (already-selected), 'top' for second, 'upd' for update
+let callCount = 0;
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => ({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(function (this: unknown) {
+      callCount += 1;
+      if (callCount === 1) return mockMaybySingle();
+      return mockMaybyTopNomination();
+    }),
+    update: mockUpdate,
+  })),
+);
+
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  callCount = 0;
+});
+
+const ADMIN_SESSION = { fid: 1, isAdmin: true };
+
+describe('POST /api/music/track-of-day/select', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 409 when a track is already selected today', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockMaybySingle.mockResolvedValue({ data: { id: 'existing' }, error: null });
+    const res = await POST();
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 404 when no nominations exist today', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockMaybySingle.mockResolvedValue({ data: null, error: null });
+    mockMaybyTopNomination.mockResolvedValue({ data: null, error: null });
+    const res = await POST();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns success with selected track data', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockMaybySingle.mockResolvedValue({ data: null, error: null });
+    const mockNomination = { id: 'nom-1', title: 'ZAO Anthem', artist: 'ZAO' };
+    mockMaybyTopNomination.mockResolvedValue({ data: mockNomination, error: null });
+    const mockSingle = vi.fn().mockResolvedValue({
+      data: { ...mockNomination, selected_date: '2026-07-17' },
+      error: null,
+    });
+    mockUpdate.mockReturnValue({
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const res = await POST();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.selected.title).toBe('ZAO Anthem');
+  });
+});

--- a/src/app/api/notifications/push/send/__tests__/route.test.ts
+++ b/src/app/api/notifications/push/send/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockSendPushNotification = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/push/vapid', () => ({ sendPushNotification: mockSendPushNotification }));
+
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation((table: string) => ({
+    select: mockSelect,
+    delete: mockDelete,
+  })),
+);
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const ADMIN_SESSION = { fid: 1, isAdmin: true };
+const VALID_BODY = { fid: 10, title: 'New Drop', body: 'ZAO has a new track!' };
+
+describe('POST /api/notifications/push/send', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/notifications/push/send', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1, isAdmin: false });
+    const req = makePostRequest('/api/notifications/push/send', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid payload (missing body field)', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    const req = makePostRequest('/api/notifications/push/send', { fid: 10, title: 'Hi' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns sent:0 when user has no subscriptions', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockSelect.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+    });
+    const req = makePostRequest('/api/notifications/push/send', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.sent).toBe(0);
+  });
+
+  it('sends to all subscriptions and returns correct count', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    const subs = [
+      { endpoint: 'https://push.endpoint/1', p256dh: 'key1', auth: 'auth1' },
+      { endpoint: 'https://push.endpoint/2', p256dh: 'key2', auth: 'auth2' },
+    ];
+    mockSelect.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: subs, error: null }),
+    });
+    mockSendPushNotification.mockResolvedValue(true);
+    const req = makePostRequest('/api/notifications/push/send', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.sent).toBe(2);
+    expect(body.total).toBe(2);
+  });
+});

--- a/src/app/api/stream/rooms/[id]/__tests__/route.test.ts
+++ b/src/app/api/stream/rooms/[id]/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest, makePostRequest } from '@/test-utils/api-helpers';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/../community.config', () => ({
+  communityConfig: { adminFids: [1] },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockGetRoomById = vi.hoisted(() => vi.fn());
+const mockEndRoom = vi.hoisted(() => vi.fn());
+const mockUpdateRoom = vi.hoisted(() => vi.fn());
+const mockUpdateRecording = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/spaces/roomsDb', () => ({
+  getRoomById: mockGetRoomById,
+  endRoom: mockEndRoom,
+  updateRoom: mockUpdateRoom,
+  updateRecording: mockUpdateRecording,
+}));
+vi.mock('@/lib/twitch/client', () => ({
+  getValidTwitchToken: vi.fn().mockResolvedValue(null),
+  updateTwitchChannel: vi.fn(),
+}));
+
+import { GET, PATCH } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const ROOM_ID = 'room-uuid-abc';
+const MOCK_ROOM = { id: ROOM_ID, title: 'ZAO Stage', host_fid: 10 };
+const HOST_SESSION = { fid: 10, isAdmin: false };
+const ADMIN_SESSION = { fid: 1, isAdmin: true };
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makePatchRequest(body: object) {
+  return new NextRequest(new URL(`/api/stream/rooms/${ROOM_ID}`, 'http://localhost:3000'), {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/stream/rooms/[id]', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest(`/api/stream/rooms/${ROOM_ID}`);
+    const res = await GET(req, makeParams(ROOM_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when room not found', async () => {
+    mockGetSessionData.mockResolvedValue(HOST_SESSION);
+    mockGetRoomById.mockResolvedValue(null);
+    const req = makeGetRequest(`/api/stream/rooms/${ROOM_ID}`);
+    const res = await GET(req, makeParams(ROOM_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns room data on success', async () => {
+    mockGetSessionData.mockResolvedValue(HOST_SESSION);
+    mockGetRoomById.mockResolvedValue(MOCK_ROOM);
+    const req = makeGetRequest(`/api/stream/rooms/${ROOM_ID}`);
+    const res = await GET(req, makeParams(ROOM_ID));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.room.id).toBe(ROOM_ID);
+  });
+});
+
+describe('PATCH /api/stream/rooms/[id]', () => {
+  it('returns 403 when user is neither host nor admin', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 99, isAdmin: false });
+    mockGetRoomById.mockResolvedValue(MOCK_ROOM);
+    const req = makePatchRequest({ action: 'end' });
+    const res = await PATCH(req, makeParams(ROOM_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns success:true when host ends the room', async () => {
+    mockGetSessionData.mockResolvedValue(HOST_SESSION);
+    mockGetRoomById.mockResolvedValue(MOCK_ROOM);
+    mockEndRoom.mockResolvedValue(undefined);
+    const req = makePatchRequest({ action: 'end' });
+    const res = await PATCH(req, makeParams(ROOM_ID));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns updated room when admin updates title', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockGetRoomById.mockResolvedValue(MOCK_ROOM);
+    const updatedRoom = { ...MOCK_ROOM, title: 'ZAO Stage V2' };
+    mockUpdateRoom.mockResolvedValue(updatedRoom);
+    const req = makePatchRequest({ action: 'update', title: 'ZAO Stage V2' });
+    const res = await PATCH(req, makeParams(ROOM_ID));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.room.title).toBe('ZAO Stage V2');
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/music/track-of-day/select` — 4 cases: 401, 409 already selected, 404 no nominations, 200 success
- `POST /api/notifications/push/send` — 5 cases: 401, 403 non-admin, 400 invalid, sent:0 no subs, sent:2 success
- `GET /api/stream/rooms/[id]` — 3 cases: 401, 404 not found, 200 room data
- `PATCH /api/stream/rooms/[id]` — 3 cases: 403 non-host/admin, 200 end room, 200 update title

15 test cases, 3 new route files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)