### PR TITLE
test(api): platforms hive, twitch poll, solana-wallet coverage

### DIFF
--- a/src/app/api/platforms/hive/__tests__/route.test.ts
+++ b/src/app/api/platforms/hive/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockGetAccounts = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/publish/hive', () => ({
+  getHiveClient: vi.fn(() => ({ database: { getAccounts: mockGetAccounts } })),
+  encryptPostingKey: vi.fn().mockReturnValue('encrypted-posting-key'),
+}));
+
+const mockEq = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+import { DELETE, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10 };
+const VALID_BODY = { username: 'zabal', postingKey: 'STM5...' };
+
+describe('POST /api/platforms/hive', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/platforms/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing fields', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/platforms/hive', { username: '' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when Hive account not found on-chain', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetAccounts.mockResolvedValue([]);
+    const req = makePostRequest('/api/platforms/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when Supabase update fails', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetAccounts.mockResolvedValue([{ name: 'zabal' }]);
+    mockEq.mockResolvedValue({ error: { message: 'DB fail' } });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ update: mockUpdate });
+    const req = makePostRequest('/api/platforms/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns success:true with username on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetAccounts.mockResolvedValue([{ name: 'zabal' }]);
+    mockEq.mockResolvedValue({ error: null });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ update: mockUpdate });
+    const req = makePostRequest('/api/platforms/hive', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.username).toBe('zabal');
+  });
+});
+
+describe('DELETE /api/platforms/hive', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns success:true when disconnected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockEq.mockResolvedValue({ error: null });
+    mockUpdate.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ update: mockUpdate });
+    const res = await DELETE();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+});

--- a/src/app/api/twitch/poll/__tests__/route.test.ts
+++ b/src/app/api/twitch/poll/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockGetValidTwitchToken = vi.hoisted(() => vi.fn());
+const mockCreateTwitchPoll = vi.hoisted(() => vi.fn());
+const mockEndTwitchPoll = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/twitch/client', () => ({
+  getValidTwitchToken: mockGetValidTwitchToken,
+  createTwitchPoll: mockCreateTwitchPoll,
+  endTwitchPoll: mockEndTwitchPoll,
+}));
+
+import { PATCH, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10 };
+const MOCK_CREDS = { accessToken: 'tok', userId: 'uid' };
+const VALID_POLL_BODY = { title: 'Favorite ZAO track?', choices: ['Anthem', 'Wave'] };
+
+function makePatchRequest(body: object) {
+  return new NextRequest(new URL('/api/twitch/poll', 'http://localhost:3000'), {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/twitch/poll', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/twitch/poll', VALID_POLL_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid payload (too few choices)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/twitch/poll', { title: 'Q?', choices: ['One'] });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when Twitch is not connected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(null);
+    const req = makePostRequest('/api/twitch/poll', VALID_POLL_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when createTwitchPoll returns null (stream not live)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchPoll.mockResolvedValue(null);
+    const req = makePostRequest('/api/twitch/poll', VALID_POLL_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns success:true with pollId on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockCreateTwitchPoll.mockResolvedValue({ id: 'poll-abc123' });
+    const req = makePostRequest('/api/twitch/poll', VALID_POLL_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.pollId).toBe('poll-abc123');
+  });
+});
+
+describe('PATCH /api/twitch/poll', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await PATCH(makePatchRequest({ pollId: 'p1', status: 'TERMINATED' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when Twitch is not connected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(null);
+    const res = await PATCH(makePatchRequest({ pollId: 'p1', status: 'TERMINATED' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true when poll ended', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockGetValidTwitchToken.mockResolvedValue(MOCK_CREDS);
+    mockEndTwitchPoll.mockResolvedValue(true);
+    const res = await PATCH(makePatchRequest({ pollId: 'p1', status: 'ARCHIVED' }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+});

--- a/src/app/api/users/solana-wallet/__tests__/route.test.ts
+++ b/src/app/api/users/solana-wallet/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockVerify = vi.hoisted(() => vi.fn());
+vi.mock('tweetnacl', () => ({
+  default: { sign: { detached: { verify: mockVerify } } },
+}));
+
+vi.mock('bs58', () => ({
+  default: { decode: vi.fn().mockReturnValue(new Uint8Array(32)) },
+}));
+
+const mockMaybeSingle = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() => vi.fn());
+const mockEqChain = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+import { DELETE, GET, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10 };
+// Valid Solana address format (base58, 32-44 chars)
+const VALID_WALLET = 'So11111111111111111111111111111111111111112';
+const VALID_SIG = 'So11111111111111111111111111111111111111112';
+
+describe('GET /api/users/solana-wallet', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns solana_wallet from database', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockMaybeSingle.mockResolvedValue({ data: { solana_wallet: VALID_WALLET }, error: null });
+    mockEqChain.mockReturnValue({ maybeSingle: mockMaybeSingle });
+    mockEq.mockReturnValue({ eq: mockEqChain });
+    mockFrom.mockReturnValue({ select: vi.fn().mockReturnValue({ eq: mockEq }) });
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.solana_wallet).toBe(VALID_WALLET);
+  });
+});
+
+describe('POST /api/users/solana-wallet', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/users/solana-wallet', {
+      wallet: VALID_WALLET,
+      signature: VALID_SIG,
+      message: `Link wallet ${VALID_WALLET}`,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid wallet address', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/solana-wallet', {
+      wallet: 'invalid!address',
+      signature: VALID_SIG,
+      message: 'msg',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when signature is invalid', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockVerify.mockReturnValue(false);
+    const req = makePostRequest('/api/users/solana-wallet', {
+      wallet: VALID_WALLET,
+      signature: VALID_SIG,
+      message: `Link wallet ${VALID_WALLET}`,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns solana_wallet on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockVerify.mockReturnValue(true);
+    mockEqChain.mockReturnValue({ error: null });
+    mockEq.mockReturnValue({ eq: mockEqChain });
+    mockFrom.mockReturnValue({ update: vi.fn().mockReturnValue({ eq: mockEq }) });
+    const req = makePostRequest('/api/users/solana-wallet', {
+      wallet: VALID_WALLET,
+      signature: VALID_SIG,
+      message: `Link wallet ${VALID_WALLET}`,
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.solana_wallet).toBe(VALID_WALLET);
+  });
+});
+
+describe('DELETE /api/users/solana-wallet', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns solana_wallet:null on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockEqChain.mockReturnValue({ error: null });
+    mockEq.mockReturnValue({ eq: mockEqChain });
+    mockFrom.mockReturnValue({ update: vi.fn().mockReturnValue({ eq: mockEq }) });
+    const res = await DELETE();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.solana_wallet).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/platforms/hive` — 5 cases: 401, 400 missing fields, 400 account not found, 500 DB fail, 200 success
- `DELETE /api/platforms/hive` — 2 cases: 401, 200 success
- `POST /api/twitch/poll` — 5 cases: 401, 400 bad choices, 400 not connected, 500 poll null, 200 pollId
- `PATCH /api/twitch/poll` — 3 cases: 401, 400 not connected, 200 success
- `GET /api/users/solana-wallet` — 2 cases: 401, 200 wallet
- `POST /api/users/solana-wallet` — 4 cases: 401, 400 invalid address, 400 bad sig, 200 success
- `DELETE /api/users/solana-wallet` — 2 cases: 401, 200 null

23 test cases, 3 new route files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)