### PR TITLE
test(api): publish-hive, proposals-comment, follow-batch coverage

### DIFF
--- a/src/app/api/proposals/comment/__tests__/route.test.ts
+++ b/src/app/api/proposals/comment/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest, makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/notifications', () => ({ createInAppNotification: vi.fn().mockResolvedValue(undefined) }));
+
+const mockOrder = vi.hoisted(() => vi.fn());
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { GET, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10, displayName: 'ZAO', pfpUrl: 'https://pfp.url', signerUuid: 'sig' };
+const PROPOSAL_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('GET /api/proposals/comment', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when proposal_id is missing', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makeGetRequest('/api/proposals/comment');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns comments for a proposal', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const mockComments = [{ id: 'c1', body: 'Great proposal!', author: { display_name: 'ZAO' } }];
+    mockOrder.mockResolvedValue({ data: mockComments, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: mockOrder,
+    });
+    const req = makeGetRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.comments).toHaveLength(1);
+  });
+});
+
+describe('POST /api/proposals/comment', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/proposals/comment', {
+      proposal_id: PROPOSAL_UUID,
+      body: 'Great proposal!',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid payload (bad UUID)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: 'not-a-uuid', body: 'Hi' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not in DB', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID, body: 'Great!' });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns comment on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const mockComment = { id: 'c2', body: 'Love it!', author: { display_name: 'ZAO' } };
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // User lookup
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { id: 'user-uuid' }, error: null }),
+        };
+      }
+      if (callCount === 2) {
+        // Insert comment
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockComment, error: null }),
+          }),
+        };
+      }
+      // Notify proposal author (fire-and-forget)
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID, body: 'Love it!' });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.comment.body).toBe('Love it!');
+  });
+});

--- a/src/app/api/publish/hive/__tests__/route.test.ts
+++ b/src/app/api/publish/hive/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockDecryptPostingKey = vi.hoisted(() => vi.fn().mockReturnValue('decrypted-key'));
+const mockPublishToHive = vi.hoisted(() => vi.fn());
+const mockNormalizeForHive = vi.hoisted(() => vi.fn().mockReturnValue({ body: 'normalized' }));
+vi.mock('@/lib/publish/hive', () => ({
+  decryptPostingKey: mockDecryptPostingKey,
+  publishToHive: mockPublishToHive,
+}));
+vi.mock('@/lib/publish/normalize', () => ({ normalizeForHive: mockNormalizeForHive }));
+
+let fromCallCount = 0;
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => {
+    fromCallCount++;
+    if (fromCallCount === 1) {
+      // First call: fetch user credentials
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: mockSingle,
+      };
+    }
+    // Second call: insert publish_log
+    return { insert: mockInsert };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  fromCallCount = 0;
+});
+
+const MOCK_SESSION = { fid: 10 };
+const VALID_BODY = { castHash: '0xabc', text: 'ZAO is live on Hive' };
+const HIVE_USER = { hive_username: 'zabal', hive_posting_key_encrypted: 'enc-key' };
+
+describe('POST /api/publish/hive', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/publish/hive', { castHash: '0xabc' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not found in DB', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({ data: null, error: null });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when Hive is not connected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({
+      data: { hive_username: null, hive_posting_key_encrypted: null },
+      error: null,
+    });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true with platformUrl on publish success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({ data: HIVE_USER, error: null });
+    mockPublishToHive.mockResolvedValue({ url: 'https://hive.blog/@zabal/post', permlink: 'post' });
+    mockInsert.mockResolvedValue({ error: null });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.platformUrl).toContain('hive.blog');
+  });
+});

--- a/src/app/api/users/follow-batch/__tests__/route.test.ts
+++ b/src/app/api/users/follow-batch/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockFollowUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({ followUser: mockFollowUser }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10, signerUuid: 'signer-abc' };
+
+describe('POST /api/users/follow-batch', () => {
+  it('returns 401 when no session or missing signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2] });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for empty targetFids array', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [] });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns followed:0 when targetFids only contains self', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [10] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.followed).toBe(0);
+  });
+
+  it('follows multiple users and returns correct count', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2, 3] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.followed).toBe(3);
+    expect(body.failed).toBe(0);
+  });
+
+  it('reports failed count when followUser throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockRejectedValue(new Error('Neynar error'));
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.failed).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /api/publish/hive` — 5 cases: 401, 400 bad input, 404 user not found, 400 hive not connected, 200 success
- `GET /api/proposals/comment` — 3 cases: 401, 400 missing proposal_id, 200 comments list
- `POST /api/proposals/comment` — 4 cases: 401, 400 bad UUID, 404 user not in DB, 200 comment created
- `POST /api/users/follow-batch` — 5 cases: 401, 400 empty array, self-follow removed, 200 followed count, 200 failed count

17 test cases, 3 new route files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)