### PR TITLE
test(api): zounz-proposals, cron-100ms-stale-rooms, submissions-review

### DIFF
--- a/src/app/api/cron/100ms-stale-rooms/__tests__/route.test.ts
+++ b/src/app/api/cron/100ms-stale-rooms/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockSweepStale100msRooms = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/social/sweep100msRooms', () => ({
+  sweepStale100msRooms: mockSweepStale100msRooms,
+}));
+
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+beforeEach(() => {
+  process.env.CRON_SECRET = 'test-cron-secret';
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+});
+
+function makeRequest(authHeader?: string) {
+  return new NextRequest(new URL('/api/cron/100ms-stale-rooms', 'http://localhost:3000'), {
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+describe('GET /api/cron/100ms-stale-rooms', () => {
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when authorization header is wrong', async () => {
+    const res = await GET(makeRequest('Bearer wrong-secret'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 500 when sweep throws', async () => {
+    mockSweepStale100msRooms.mockRejectedValue(new Error('Sweep error'));
+    const res = await GET(makeRequest('Bearer test-cron-secret'));
+    expect(res.status).toBe(500);
+  });
+
+  it('returns ok:true with sweep result on success', async () => {
+    mockSweepStale100msRooms.mockResolvedValue({ endedIds: ['room-1', 'room-2'], count: 2 });
+    const res = await GET(makeRequest('Bearer test-cron-secret'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.ended_ids).toEqual(['room-1', 'room-2']);
+  });
+});

--- a/src/app/api/music/submissions/review/__tests__/route.test.ts
+++ b/src/app/api/music/submissions/review/__tests__/route.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/lib/notifications', () => ({ createInAppNotification: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@/lib/publish/broadcast', () => ({ broadcastToChannels: vi.fn().mockResolvedValue(undefined) }));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const ADMIN_SESSION = { fid: 1, isAdmin: true, displayName: 'Admin', pfpUrl: '' };
+const SUBMISSION_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+const VALID_BODY = { submission_id: SUBMISSION_UUID, action: 'approve' };
+const MOCK_SUBMISSION = {
+  id: SUBMISSION_UUID,
+  status: 'pending',
+  submitted_by_fid: 10,
+  submitted_by_display: 'ZAO',
+  title: 'ZAO Anthem',
+  artist: 'ZAO',
+};
+
+describe('POST /api/music/submissions/review', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/music/submissions/review', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 10, isAdmin: false });
+    const req = makePostRequest('/api/music/submissions/review', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid payload (missing action)', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    const req = makePostRequest('/api/music/submissions/review', { submission_id: SUBMISSION_UUID });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when submission not found', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockSingle.mockResolvedValue({ data: null, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const req = makePostRequest('/api/music/submissions/review', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when submission is already reviewed', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockSingle.mockResolvedValue({ data: { ...MOCK_SUBMISSION, status: 'approved' }, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const req = makePostRequest('/api/music/submissions/review', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(409);
+  });
+
+  it('returns success:true with status:approved on approve', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: MOCK_SUBMISSION, error: null }),
+        };
+      }
+      return {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      };
+    });
+    const req = makePostRequest('/api/music/submissions/review', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.status).toBe('approved');
+  });
+});

--- a/src/app/api/proposals/comment/__tests__/route.test.ts
+++ b/src/app/api/proposals/comment/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest, makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/notifications', () => ({ createInAppNotification: vi.fn().mockResolvedValue(undefined) }));
+
+const mockOrder = vi.hoisted(() => vi.fn());
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { GET, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10, displayName: 'ZAO', pfpUrl: 'https://pfp.url', signerUuid: 'sig' };
+const PROPOSAL_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('GET /api/proposals/comment', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when proposal_id is missing', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makeGetRequest('/api/proposals/comment');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns comments for a proposal', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const mockComments = [{ id: 'c1', body: 'Great proposal!', author: { display_name: 'ZAO' } }];
+    mockOrder.mockResolvedValue({ data: mockComments, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: mockOrder,
+    });
+    const req = makeGetRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.comments).toHaveLength(1);
+  });
+});
+
+describe('POST /api/proposals/comment', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/proposals/comment', {
+      proposal_id: PROPOSAL_UUID,
+      body: 'Great proposal!',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid payload (bad UUID)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: 'not-a-uuid', body: 'Hi' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not in DB', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID, body: 'Great!' });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns comment on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const mockComment = { id: 'c2', body: 'Love it!', author: { display_name: 'ZAO' } };
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // User lookup
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { id: 'user-uuid' }, error: null }),
+        };
+      }
+      if (callCount === 2) {
+        // Insert comment
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockComment, error: null }),
+          }),
+        };
+      }
+      // Notify proposal author (fire-and-forget)
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID, body: 'Love it!' });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.comment.body).toBe('Love it!');
+  });
+});

--- a/src/app/api/publish/hive/__tests__/route.test.ts
+++ b/src/app/api/publish/hive/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockDecryptPostingKey = vi.hoisted(() => vi.fn().mockReturnValue('decrypted-key'));
+const mockPublishToHive = vi.hoisted(() => vi.fn());
+const mockNormalizeForHive = vi.hoisted(() => vi.fn().mockReturnValue({ body: 'normalized' }));
+vi.mock('@/lib/publish/hive', () => ({
+  decryptPostingKey: mockDecryptPostingKey,
+  publishToHive: mockPublishToHive,
+}));
+vi.mock('@/lib/publish/normalize', () => ({ normalizeForHive: mockNormalizeForHive }));
+
+let fromCallCount = 0;
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => {
+    fromCallCount++;
+    if (fromCallCount === 1) {
+      // First call: fetch user credentials
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: mockSingle,
+      };
+    }
+    // Second call: insert publish_log
+    return { insert: mockInsert };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  fromCallCount = 0;
+});
+
+const MOCK_SESSION = { fid: 10 };
+const VALID_BODY = { castHash: '0xabc', text: 'ZAO is live on Hive' };
+const HIVE_USER = { hive_username: 'zabal', hive_posting_key_encrypted: 'enc-key' };
+
+describe('POST /api/publish/hive', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/publish/hive', { castHash: '0xabc' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not found in DB', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({ data: null, error: null });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when Hive is not connected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({
+      data: { hive_username: null, hive_posting_key_encrypted: null },
+      error: null,
+    });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true with platformUrl on publish success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({ data: HIVE_USER, error: null });
+    mockPublishToHive.mockResolvedValue({ url: 'https://hive.blog/@zabal/post', permlink: 'post' });
+    mockInsert.mockResolvedValue({ error: null });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.platformUrl).toContain('hive.blog');
+  });
+});

--- a/src/app/api/users/follow-batch/__tests__/route.test.ts
+++ b/src/app/api/users/follow-batch/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockFollowUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({ followUser: mockFollowUser }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10, signerUuid: 'signer-abc' };
+
+describe('POST /api/users/follow-batch', () => {
+  it('returns 401 when no session or missing signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2] });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for empty targetFids array', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [] });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns followed:0 when targetFids only contains self', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [10] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.followed).toBe(0);
+  });
+
+  it('follows multiple users and returns correct count', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2, 3] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.followed).toBe(3);
+    expect(body.failed).toBe(0);
+  });
+
+  it('reports failed count when followUser throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockRejectedValue(new Error('Neynar error'));
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.failed).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/zounz/proposals/__tests__/route.test.ts
+++ b/src/app/api/zounz/proposals/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/../community.config', () => ({
+  communityConfig: {
+    zounz: { nounsBuilderUrl: 'https://nouns.build/dao/base/0xabc' },
+    adminFids: [1],
+  },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockReadContract = vi.hoisted(() => vi.fn());
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({ readContract: mockReadContract })),
+  };
+});
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('GET /api/zounz/proposals', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns governance data when all contract reads succeed', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockReadContract
+      .mockResolvedValueOnce(BigInt(5))   // proposalCount
+      .mockResolvedValueOnce(BigInt(100)) // proposalThreshold
+      .mockResolvedValueOnce(BigInt(50)); // quorum
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.proposalCount).toBe(5);
+    expect(body.proposalThreshold).toBe(100);
+    expect(body.quorum).toBe(50);
+    expect(body.governorAddress).toBeDefined();
+    expect(body.voteUrl).toContain('nouns.build');
+  });
+
+  it('returns 0/null for fields when contract reads fail', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockReadContract.mockRejectedValue(new Error('RPC error'));
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.proposalCount).toBe(0);
+    expect(body.proposalThreshold).toBeNull();
+    expect(body.quorum).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/zounz/proposals` — 3 cases: 401, 200 governance data (viem mocked), 200 fallback zeros when RPC fails
- `GET /api/cron/100ms-stale-rooms` — 4 cases: 401 no header, 401 wrong secret, 500 sweep throws, 200 ok with ended_ids
- `POST /api/music/submissions/review` — 6 cases: 401, 403 non-admin, 400 bad input, 404 not found, 409 already reviewed, 200 approved

13 test cases, 3 new route files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)