### PR TITLE
test(api): juke end-space, respect leaderboard embed, alchemy webhook (17 cases)

### DIFF
--- a/src/app/api/juke/admin/end-space/__tests__/route.test.ts
+++ b/src/app/api/juke/admin/end-space/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockIsValidJukeSpaceId = vi.hoisted(() => vi.fn().mockReturnValue(true));
+vi.mock('@/lib/spaces/juke', () => ({ isValidJukeSpaceId: mockIsValidJukeSpaceId }));
+
+const mockGetJukeSpace = vi.hoisted(() => vi.fn());
+const mockUpdateJukeSpace = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/spaces/jukeSpacesDb', () => ({
+  getJukeSpace: mockGetJukeSpace,
+  updateJukeSpace: mockUpdateJukeSpace,
+}));
+
+const mockEnv = vi.hoisted(() => ({ JUKE_API_KEY: 'test-juke-key' as string | undefined }));
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+
+import { POST } from '../route';
+
+vi.stubGlobal('fetch', mockFetch);
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockEnv.JUKE_API_KEY = 'test-juke-key';
+  mockIsValidJukeSpaceId.mockReturnValue(true);
+});
+
+const SESSION = { fid: 42, isAdmin: false };
+const ADMIN_SESSION = { fid: 1, isAdmin: true };
+const VALID_BODY = { spaceId: 'juke-space-abc' };
+const LIVE_ROOM = { status: 'live', created_by_fid: 42 };
+const ENDED_ROOM = { status: 'ended', created_by_fid: 42 };
+const OTHER_HOST_ROOM = { status: 'live', created_by_fid: 99 };
+
+describe('POST /api/juke/admin/end-space', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when JUKE_API_KEY not configured', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockEnv.JUKE_API_KEY = undefined;
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 when spaceId fails validation', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockIsValidJukeSpaceId.mockReturnValue(false);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', { spaceId: 'bad!' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when space not found in DB', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(null);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user is neither host nor admin', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION); // fid: 42
+    mockGetJukeSpace.mockResolvedValue(OTHER_HOST_ROOM); // created_by_fid: 99
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns ok:true with alreadyEnded:true when space is already ended', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(ENDED_ROOM);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.alreadyEnded).toBe(true);
+  });
+
+  it('returns 502 when fetch to Juke throws a network error', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(LIVE_ROOM);
+    mockFetch.mockRejectedValue(new Error('Network unreachable'));
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 202 with fallback:mark-ended when Juke 404s the endpoint', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(LIVE_ROOM);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: vi.fn().mockResolvedValue('{"error":"Not Found"}'),
+    });
+    mockUpdateJukeSpace.mockResolvedValue(undefined);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(202);
+    expect(body.fallback).toBe('mark-ended');
+  });
+
+  it('returns ok:true when admin ends a room and Juke accepts', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockGetJukeSpace.mockResolvedValue(OTHER_HOST_ROOM); // admin bypasses host check
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue('{"status":"ended"}'),
+    });
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+});

--- a/src/app/api/respect/leaderboard/embed/__tests__/route.test.ts
+++ b/src/app/api/respect/leaderboard/embed/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockFetchLeaderboard = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/respect/leaderboard', () => ({
+  fetchLeaderboard: mockFetchLeaderboard,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_RESULT = {
+  leaderboard: [
+    { rank: 1, name: 'ZAO', ogRespect: 100, zorRespect: 50, totalRespect: 150 },
+    { rank: 2, name: 'Test User', ogRespect: 80, zorRespect: 20, totalRespect: 100 },
+  ],
+  stats: { totalMembers: 42 },
+};
+
+describe('GET /api/respect/leaderboard/embed', () => {
+  it('returns 400 for invalid format query param', async () => {
+    const req = makeGetRequest('/api/respect/leaderboard/embed', { format: 'xml' });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 JSON with leaderboard and stats', async () => {
+    mockFetchLeaderboard.mockResolvedValue(MOCK_RESULT);
+    const req = makeGetRequest('/api/respect/leaderboard/embed');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.leaderboard).toHaveLength(2);
+    expect(body.leaderboard[0].name).toBe('ZAO');
+    expect(body.stats.totalMembers).toBe(42);
+  });
+
+  it('returns 200 HTML with text/html content-type when format=html', async () => {
+    mockFetchLeaderboard.mockResolvedValue(MOCK_RESULT);
+    const req = makeGetRequest('/api/respect/leaderboard/embed', { format: 'html' });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const text = await res.text();
+    expect(text).toContain('ZAO Respect Leaderboard');
+    expect(text).toContain('ZAO');
+  });
+
+  it('returns 500 when fetchLeaderboard throws', async () => {
+    mockFetchLeaderboard.mockRejectedValue(new Error('DB unavailable'));
+    const req = makeGetRequest('/api/respect/leaderboard/embed');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/webhooks/alchemy/__tests__/route.test.ts
+++ b/src/app/api/webhooks/alchemy/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import crypto from 'crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// SIGNING_KEYS is evaluated at module load — must set env before import
+vi.hoisted(() => {
+  process.env.ALCHEMY_WEBHOOK_KEY_ZOR = 'test-alchemy-key';
+});
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockMaybeSingle = vi.hoisted(() => vi.fn().mockResolvedValue({ data: null }));
+const mockIlike = vi.hoisted(() => vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle }));
+const mockSelect = vi.hoisted(() => vi.fn().mockReturnValue({ ilike: mockIlike }));
+const mockUpsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation((table: string) => {
+    if (table === 'respect_transfers') return { upsert: mockUpsert };
+    return { select: mockSelect };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const TEST_KEY = 'test-alchemy-key';
+
+function signBody(body: string): string {
+  return crypto.createHmac('sha256', TEST_KEY).update(body, 'utf8').digest('hex');
+}
+
+function makeAlchemyRequest(body: string, sig?: string) {
+  return new NextRequest(new URL('/api/webhooks/alchemy', 'http://localhost:3000'), {
+    method: 'POST',
+    body,
+    headers: { 'x-alchemy-signature': sig ?? signBody(body) },
+  });
+}
+
+const EMPTY_PAYLOAD = JSON.stringify({ event: { activity: [] } });
+const ZOR_CONTRACT = '0x9885cceef7e8371bf8d6f2413723d25917e7445c';
+const ZOR_ACTIVITY_PAYLOAD = JSON.stringify({
+  createdAt: '2026-01-01T00:00:00Z',
+  event: {
+    activity: [
+      {
+        contractAddress: ZOR_CONTRACT,
+        toAddress: '0xrecipient',
+        fromAddress: '0x0000000000000000000000000000000000000000',
+        log: { transactionHash: '0xtxhash', blockNumber: '0x1' },
+        erc1155Metadata: [{ value: '5' }],
+      },
+    ],
+  },
+});
+
+describe('POST /api/webhooks/alchemy', () => {
+  it('returns 401 when HMAC signature does not match', async () => {
+    const req = makeAlchemyRequest(EMPTY_PAYLOAD, 'wrong-signature-deadbeef');
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns ok:true for valid signature with empty activities', async () => {
+    const req = makeAlchemyRequest(EMPTY_PAYLOAD);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:true and upserts ZOR ERC-1155 mint activity', async () => {
+    const req = makeAlchemyRequest(ZOR_ACTIVITY_PAYLOAD);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ token_type: 'zor_erc1155', tx_hash: '0xtxhash' }),
+      expect.any(Object),
+    );
+  });
+
+  it('returns ok:true with error note when body is malformed JSON', async () => {
+    const invalidBody = 'not-json-at-all';
+    const req = makeAlchemyRequest(invalidBody);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `juke/admin/end-space` — 8 cases: 401, 503 no API key, 400 invalid spaceId, 404 space not found, 403 non-host/non-admin, 200 already-ended, 502 fetch throws, 202 Juke-404 fallback, 200 admin success
- `respect/leaderboard/embed` — 4 cases: 400 invalid format param, 200 JSON response, 200 HTML with `text/html` content-type, 500 on fetchLeaderboard throws
- `webhooks/alchemy` — 4 cases: 401 invalid HMAC, 200 empty activities no-op, 200 ZOR ERC-1155 upsert, 200 ok:true with error for malformed JSON body

## Key patterns
- `vi.hoisted` sets `ALCHEMY_WEBHOOK_KEY_ZOR` before module import (module-level `SIGNING_KEYS` capture)
- Real HMAC computed in test using Node.js `crypto` for alchemy signature validation
- `vi.stubGlobal('fetch', mockFetch)` for Juke external API calls
- `mockFrom.mockImplementation((table) => ...)` to dispatch different chains by table name
- `mockEnv.JUKE_API_KEY = undefined` in specific test to hit 503 path; reset in `afterEach`

## Test plan
- [x] All 17 tests pass locally (`vitest run`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)