### PR TITLE
test(api): github webhook, respect fractal, zounz proposals list (15 cases)

### DIFF
--- a/src/app/api/juke/admin/end-space/__tests__/route.test.ts
+++ b/src/app/api/juke/admin/end-space/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockIsValidJukeSpaceId = vi.hoisted(() => vi.fn().mockReturnValue(true));
+vi.mock('@/lib/spaces/juke', () => ({ isValidJukeSpaceId: mockIsValidJukeSpaceId }));
+
+const mockGetJukeSpace = vi.hoisted(() => vi.fn());
+const mockUpdateJukeSpace = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/spaces/jukeSpacesDb', () => ({
+  getJukeSpace: mockGetJukeSpace,
+  updateJukeSpace: mockUpdateJukeSpace,
+}));
+
+const mockEnv = vi.hoisted(() => ({ JUKE_API_KEY: 'test-juke-key' as string | undefined }));
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+
+import { POST } from '../route';
+
+vi.stubGlobal('fetch', mockFetch);
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockEnv.JUKE_API_KEY = 'test-juke-key';
+  mockIsValidJukeSpaceId.mockReturnValue(true);
+});
+
+const SESSION = { fid: 42, isAdmin: false };
+const ADMIN_SESSION = { fid: 1, isAdmin: true };
+const VALID_BODY = { spaceId: 'juke-space-abc' };
+const LIVE_ROOM = { status: 'live', created_by_fid: 42 };
+const ENDED_ROOM = { status: 'ended', created_by_fid: 42 };
+const OTHER_HOST_ROOM = { status: 'live', created_by_fid: 99 };
+
+describe('POST /api/juke/admin/end-space', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when JUKE_API_KEY not configured', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockEnv.JUKE_API_KEY = undefined;
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 when spaceId fails validation', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockIsValidJukeSpaceId.mockReturnValue(false);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', { spaceId: 'bad!' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when space not found in DB', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(null);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user is neither host nor admin', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION); // fid: 42
+    mockGetJukeSpace.mockResolvedValue(OTHER_HOST_ROOM); // created_by_fid: 99
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns ok:true with alreadyEnded:true when space is already ended', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(ENDED_ROOM);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.alreadyEnded).toBe(true);
+  });
+
+  it('returns 502 when fetch to Juke throws a network error', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(LIVE_ROOM);
+    mockFetch.mockRejectedValue(new Error('Network unreachable'));
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 202 with fallback:mark-ended when Juke 404s the endpoint', async () => {
+    mockGetSessionData.mockResolvedValue(SESSION);
+    mockGetJukeSpace.mockResolvedValue(LIVE_ROOM);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: vi.fn().mockResolvedValue('{"error":"Not Found"}'),
+    });
+    mockUpdateJukeSpace.mockResolvedValue(undefined);
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(202);
+    expect(body.fallback).toBe('mark-ended');
+  });
+
+  it('returns ok:true when admin ends a room and Juke accepts', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockGetJukeSpace.mockResolvedValue(OTHER_HOST_ROOM); // admin bypasses host check
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue('{"status":"ended"}'),
+    });
+    const res = await POST(makePostRequest('/api/juke/admin/end-space', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+});

--- a/src/app/api/music/trending-weighted/__tests__/route.test.ts
+++ b/src/app/api/music/trending-weighted/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { chainMock } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockCurationWeight = vi.hoisted(() => vi.fn().mockReturnValue(1));
+vi.mock('@/lib/music/curationWeight', () => ({ curationWeight: mockCurationWeight }));
+
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_LIKES = [
+  {
+    user_fid: 1,
+    song_id: 'song-1',
+    created_at: '2026-07-01T00:00:00Z',
+    songs: {
+      id: 'song-1',
+      url: 'https://music.example.com/1',
+      title: 'ZAO Track',
+      artist: 'ZAO',
+      artwork_url: null,
+      platform: 'spotify',
+    },
+  },
+];
+const MOCK_MEMBERS = [{ fid: 1, total_respect: 100, name: 'ZAO Member' }];
+
+describe('GET /api/music/trending-weighted', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns tracks:[] when no likes exist in the last 30 days', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockFrom.mockReturnValueOnce(chainMock({ data: [], error: null }).chain);
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.tracks).toHaveLength(0);
+  });
+
+  it('returns 500 when likes query returns an error', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockFrom.mockReturnValueOnce(chainMock({ data: null, error: { message: 'DB fail' } }).chain);
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+
+  it('returns weighted tracks when likes and respect members are present', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockFrom
+      .mockReturnValueOnce(chainMock({ data: MOCK_LIKES, error: null }).chain) // user_song_likes
+      .mockReturnValueOnce(chainMock({ data: MOCK_MEMBERS, error: null }).chain); // respect_members
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.tracks).toHaveLength(1);
+    expect(body.tracks[0].song.title).toBe('ZAO Track');
+    expect(body.tracks[0].likeCount).toBe(1);
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('unexpected failure'));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/respect/fractal/__tests__/route.test.ts
+++ b/src/app/api/respect/fractal/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+vi.mock('@/lib/publish/auto-cast', () => ({
+  autoCastToZao: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation((table: string) => {
+    if (table === 'fractal_sessions') {
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single: mockSingle }),
+        }),
+      };
+    }
+    if (table === 'fractal_scores' || table === 'respect_events') {
+      return { insert: vi.fn().mockResolvedValue({ error: null }) };
+    }
+    if (table === 'respect_members') {
+      // Supports both select/in (lookup) and insert (new member)
+      const chain: Record<string, unknown> = {};
+      const methods = ['select', 'in', 'eq', 'update'];
+      for (const m of methods) chain[m] = vi.fn().mockReturnValue(chain);
+      chain.insert = vi.fn().mockResolvedValue({ error: null });
+      chain.single = vi.fn().mockResolvedValue({ data: null, error: null });
+      chain.then = vi.fn((resolve: (v: unknown) => void) => resolve({ data: [], error: null }));
+      return chain;
+    }
+    return { insert: vi.fn().mockResolvedValue({ error: null }) };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const ADMIN_SESSION = { fid: 1, isAdmin: true };
+const USER_SESSION = { fid: 2, isAdmin: false };
+
+const VALID_BODY = {
+  session_date: '2026-07-15',
+  name: 'COC #7 Fractal',
+  scores: [{ member_name: 'ZAO Member', rank: 1, score: 55 }],
+};
+
+describe('POST /api/respect/fractal', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await POST(makePostRequest('/api/respect/fractal', VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(USER_SESSION);
+    const res = await POST(makePostRequest('/api/respect/fractal', VALID_BODY));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid body (missing session_date)', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    const res = await POST(makePostRequest('/api/respect/fractal', { name: 'Test', scores: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when fractal_sessions insert fails', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'DB fail' } });
+    const res = await POST(makePostRequest('/api/respect/fractal', VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+
+  it('returns success:true with session_id on valid submission', async () => {
+    mockGetSessionData.mockResolvedValue(ADMIN_SESSION);
+    mockSingle.mockResolvedValue({ data: { id: 'session-uuid-1' }, error: null });
+    const res = await POST(makePostRequest('/api/respect/fractal', VALID_BODY));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.session_id).toBe('session-uuid-1');
+    expect(body.scores_recorded).toBe(1);
+  });
+});

--- a/src/app/api/respect/leaderboard/embed/__tests__/route.test.ts
+++ b/src/app/api/respect/leaderboard/embed/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockFetchLeaderboard = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/respect/leaderboard', () => ({
+  fetchLeaderboard: mockFetchLeaderboard,
+}));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_RESULT = {
+  leaderboard: [
+    { rank: 1, name: 'ZAO', ogRespect: 100, zorRespect: 50, totalRespect: 150 },
+    { rank: 2, name: 'Test User', ogRespect: 80, zorRespect: 20, totalRespect: 100 },
+  ],
+  stats: { totalMembers: 42 },
+};
+
+describe('GET /api/respect/leaderboard/embed', () => {
+  it('returns 400 for invalid format query param', async () => {
+    const req = makeGetRequest('/api/respect/leaderboard/embed', { format: 'xml' });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 JSON with leaderboard and stats', async () => {
+    mockFetchLeaderboard.mockResolvedValue(MOCK_RESULT);
+    const req = makeGetRequest('/api/respect/leaderboard/embed');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.leaderboard).toHaveLength(2);
+    expect(body.leaderboard[0].name).toBe('ZAO');
+    expect(body.stats.totalMembers).toBe(42);
+  });
+
+  it('returns 200 HTML with text/html content-type when format=html', async () => {
+    mockFetchLeaderboard.mockResolvedValue(MOCK_RESULT);
+    const req = makeGetRequest('/api/respect/leaderboard/embed', { format: 'html' });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    const text = await res.text();
+    expect(text).toContain('ZAO Respect Leaderboard');
+    expect(text).toContain('ZAO');
+  });
+
+  it('returns 500 when fetchLeaderboard throws', async () => {
+    mockFetchLeaderboard.mockRejectedValue(new Error('DB unavailable'));
+    const req = makeGetRequest('/api/respect/leaderboard/embed');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/scrape/__tests__/route.test.ts
+++ b/src/app/api/scrape/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockScrapeContent = vi.hoisted(() => vi.fn());
+const mockScrapeXUserTimeline = vi.hoisted(() => vi.fn());
+const mockScrapeWaveWarzBattles = vi.hoisted(() => vi.fn());
+const mockScrapeBczFarcasterHistory = vi.hoisted(() => vi.fn());
+const mockScrapeFarcasterHistoryByUsername = vi.hoisted(() => vi.fn());
+const mockScrapeBczSite = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/scrape', () => ({
+  scrapeContent: mockScrapeContent,
+  scrapeXUserTimeline: mockScrapeXUserTimeline,
+  scrapeWaveWarzBattles: mockScrapeWaveWarzBattles,
+  scrapeBczFarcasterHistory: mockScrapeBczFarcasterHistory,
+  scrapeFarcasterHistoryByUsername: mockScrapeFarcasterHistoryByUsername,
+  scrapeBczSite: mockScrapeBczSite,
+}));
+
+const mockCacheScrape = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: false }));
+vi.mock('@/lib/scrape/persist', () => ({ cacheScrape: mockCacheScrape }));
+
+const mockScrapeArtistStats = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/wavewarz/scraper', () => ({ scrapeArtistStats: mockScrapeArtistStats }));
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const AUTHED_SESSION = { fid: 10 };
+
+describe('GET /api/scrape', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/scrape', { url: 'https://x.com/i/status/123' });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when no target query param is provided', async () => {
+    mockGetSessionData.mockResolvedValue(AUTHED_SESSION);
+    const req = makeGetRequest('/api/scrape');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with x source data on url scrape', async () => {
+    mockGetSessionData.mockResolvedValue(AUTHED_SESSION);
+    mockScrapeContent.mockResolvedValue({
+      source: 'x',
+      data: { id: 'tweet-123', text: 'Hello ZAO' },
+    });
+    const req = makeGetRequest('/api/scrape', { url: 'https://x.com/i/status/123' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.source).toBe('x');
+    expect(body.data.id).toBe('tweet-123');
+  });
+
+  it('returns 200 with source:x-timeline on xUser scrape', async () => {
+    mockGetSessionData.mockResolvedValue(AUTHED_SESSION);
+    mockScrapeXUserTimeline.mockResolvedValue({ handle: 'zabal', tweets: [] });
+    const req = makeGetRequest('/api/scrape', { xUser: 'zabal' });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.source).toBe('x-timeline');
+  });
+
+  it('returns 404 when wavewarzArtist stats are unavailable', async () => {
+    mockGetSessionData.mockResolvedValue(AUTHED_SESSION);
+    mockScrapeArtistStats.mockResolvedValue(null);
+    const req = makeGetRequest('/api/scrape', { wavewarzArtist: 'SomeWallet111' });
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 502 when scrape function throws', async () => {
+    mockGetSessionData.mockResolvedValue(AUTHED_SESSION);
+    mockScrapeBczSite.mockRejectedValue(new Error('connection refused'));
+    const req = makeGetRequest('/api/scrape', { bczSite: '1' });
+    const res = await GET(req);
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/app/api/webhooks/alchemy/__tests__/route.test.ts
+++ b/src/app/api/webhooks/alchemy/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import crypto from 'crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// SIGNING_KEYS is evaluated at module load — must set env before import
+vi.hoisted(() => {
+  process.env.ALCHEMY_WEBHOOK_KEY_ZOR = 'test-alchemy-key';
+});
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockMaybeSingle = vi.hoisted(() => vi.fn().mockResolvedValue({ data: null }));
+const mockIlike = vi.hoisted(() => vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle }));
+const mockSelect = vi.hoisted(() => vi.fn().mockReturnValue({ ilike: mockIlike }));
+const mockUpsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation((table: string) => {
+    if (table === 'respect_transfers') return { upsert: mockUpsert };
+    return { select: mockSelect };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const TEST_KEY = 'test-alchemy-key';
+
+function signBody(body: string): string {
+  return crypto.createHmac('sha256', TEST_KEY).update(body, 'utf8').digest('hex');
+}
+
+function makeAlchemyRequest(body: string, sig?: string) {
+  return new NextRequest(new URL('/api/webhooks/alchemy', 'http://localhost:3000'), {
+    method: 'POST',
+    body,
+    headers: { 'x-alchemy-signature': sig ?? signBody(body) },
+  });
+}
+
+const EMPTY_PAYLOAD = JSON.stringify({ event: { activity: [] } });
+const ZOR_CONTRACT = '0x9885cceef7e8371bf8d6f2413723d25917e7445c';
+const ZOR_ACTIVITY_PAYLOAD = JSON.stringify({
+  createdAt: '2026-01-01T00:00:00Z',
+  event: {
+    activity: [
+      {
+        contractAddress: ZOR_CONTRACT,
+        toAddress: '0xrecipient',
+        fromAddress: '0x0000000000000000000000000000000000000000',
+        log: { transactionHash: '0xtxhash', blockNumber: '0x1' },
+        erc1155Metadata: [{ value: '5' }],
+      },
+    ],
+  },
+});
+
+describe('POST /api/webhooks/alchemy', () => {
+  it('returns 401 when HMAC signature does not match', async () => {
+    const req = makeAlchemyRequest(EMPTY_PAYLOAD, 'wrong-signature-deadbeef');
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns ok:true for valid signature with empty activities', async () => {
+    const req = makeAlchemyRequest(EMPTY_PAYLOAD);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:true and upserts ZOR ERC-1155 mint activity', async () => {
+    const req = makeAlchemyRequest(ZOR_ACTIVITY_PAYLOAD);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ token_type: 'zor_erc1155', tx_hash: '0xtxhash' }),
+      expect.any(Object),
+    );
+  });
+
+  it('returns ok:true with error note when body is malformed JSON', async () => {
+    const invalidBody = 'not-json-at-all';
+    const req = makeAlchemyRequest(invalidBody);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.error).toBeDefined();
+  });
+});

--- a/src/app/api/webhooks/github/__tests__/route.test.ts
+++ b/src/app/api/webhooks/github/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/publish/telegram', () => ({
+  publishToTelegram: vi.fn().mockResolvedValue({ success: true }),
+  escapeMarkdownV2: (s: string) => s,
+}));
+
+const mockInsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockFrom = vi.hoisted(() => vi.fn().mockReturnValue({ insert: mockInsert }));
+const mockGetSupabaseAdmin = vi.hoisted(() => vi.fn(() => ({ from: mockFrom })));
+vi.mock('@/lib/db/supabase', () => ({ getSupabaseAdmin: mockGetSupabaseAdmin }));
+
+import { POST } from '../route';
+
+const TEST_SECRET = 'test-github-secret';
+
+beforeEach(() => {
+  process.env.GITHUB_WEBHOOK_SECRET = TEST_SECRET;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.GITHUB_WEBHOOK_SECRET;
+});
+
+function signGithub(body: string): string {
+  return 'sha256=' + crypto.createHmac('sha256', TEST_SECRET).update(body).digest('hex');
+}
+
+function makeGithubRequest(body: object, event: string, sig?: string) {
+  const bodyStr = JSON.stringify(body);
+  return new NextRequest(new URL('/api/webhooks/github', 'http://localhost:3000'), {
+    method: 'POST',
+    body: bodyStr,
+    headers: {
+      'x-github-event': event,
+      'x-hub-signature-256': sig ?? signGithub(bodyStr),
+    },
+  });
+}
+
+describe('POST /api/webhooks/github', () => {
+  it('returns 503 when GITHUB_WEBHOOK_SECRET is not configured', async () => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    const req = makeGithubRequest({ type: 'ping' }, 'ping', 'any-sig');
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when signature does not match', async () => {
+    const req = makeGithubRequest({ type: 'ping' }, 'ping', 'sha256=deadbeef');
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns ok:true pong:true for ping event', async () => {
+    const req = makeGithubRequest({ zen: 'Keep it simple' }, 'ping');
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.pong).toBe(true);
+  });
+
+  it('returns ok:true handled:pull_request.opened for PR opened event', async () => {
+    const payload = {
+      action: 'opened',
+      pull_request: { number: 42, title: 'My PR', html_url: 'https://github.com/pr/42', merged: false, user: { login: 'zabal' }, base: { ref: 'main' } },
+      repository: { full_name: 'bettercallzaal/ZAOOS', name: 'ZAOOS' },
+      sender: { login: 'zabal' },
+    };
+    const req = makeGithubRequest(payload, 'pull_request');
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.handled).toBe('pull_request.opened');
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ action: 'pr_opened' }));
+  });
+
+  it('returns ok:true skipped for push to non-default branch', async () => {
+    const payload = {
+      ref: 'refs/heads/feat/some-feature',
+      commits: [{ id: 'abc', message: 'fix', author: { name: 'zabal' } }],
+      pusher: { name: 'zabal' },
+      repository: { full_name: 'bettercallzaal/ZAOOS', name: 'ZAOOS', default_branch: 'main' },
+    };
+    const req = makeGithubRequest(payload, 'push');
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.skipped).toBe('non-default-branch');
+  });
+
+  it('returns ok:true ignored for unhandled event types', async () => {
+    const req = makeGithubRequest({ action: 'created' }, 'star');
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ignored).toBe('star');
+  });
+});

--- a/src/app/api/webhooks/neynar/__tests__/route.test.ts
+++ b/src/app/api/webhooks/neynar/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import crypto from 'crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// WATCHED_CHANNELS is module-level — community.config mock must be in place before import
+vi.mock('@/../community.config', () => ({
+  communityConfig: { farcaster: { channels: ['zao', 'music'] } },
+}));
+
+const mockEnv = vi.hoisted(() => ({
+  NEYNAR_WEBHOOK_SECRET: 'test-neynar-secret' as string | undefined,
+}));
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+const mockUpsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockInsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockLimit = vi.hoisted(() => vi.fn().mockResolvedValue({ data: [] }));
+const mockEq = vi.hoisted(() => vi.fn().mockReturnValue({ limit: mockLimit }));
+const mockSelect = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ eq: mockEq, onConflict: vi.fn().mockReturnThis() }),
+);
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation((table: string) => {
+    if (table === 'channel_casts') return { upsert: mockUpsert };
+    if (table === 'moderation_log' || table === 'hidden_messages') return { insert: mockInsert };
+    if (table === 'song_submissions') return { select: mockSelect, insert: mockInsert };
+    return { upsert: mockUpsert };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+const mockModerateContent = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ flagged: false, categories: [], scores: {}, action: 'allow' }),
+);
+vi.mock('@/lib/moderation/moderate', () => ({ moderateContent: mockModerateContent }));
+
+const mockIsMusicUrl = vi.hoisted(() => vi.fn().mockReturnValue(null));
+vi.mock('@/lib/music/isMusicUrl', () => ({ isMusicUrl: mockIsMusicUrl }));
+
+import { POST } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockEnv.NEYNAR_WEBHOOK_SECRET = 'test-neynar-secret';
+});
+
+const TEST_SECRET = 'test-neynar-secret';
+
+function signBody(body: string, secret = TEST_SECRET): string {
+  return crypto.createHmac('sha512', secret).update(body).digest('hex');
+}
+
+function makeNeynarRequest(body: object, sig?: string) {
+  const bodyStr = JSON.stringify(body);
+  return new NextRequest(new URL('/api/webhooks/neynar', 'http://localhost:3000'), {
+    method: 'POST',
+    body: bodyStr,
+    headers: { 'X-Neynar-Signature': sig ?? signBody(bodyStr) },
+  });
+}
+
+const CAST_IN_CHANNEL: Record<string, unknown> = {
+  hash: '0xhash1',
+  channel: { id: 'zao' },
+  author: { fid: 42, username: 'zabal', display_name: 'ZAO', pfp_url: 'https://pfp' },
+  text: 'Hello ZAO',
+  timestamp: '2026-07-01T00:00:00Z',
+  embeds: [],
+  reactions: { likes_count: 0, recasts_count: 0, likes: [], recasts: [] },
+  replies: { count: 0 },
+};
+
+describe('POST /api/webhooks/neynar', () => {
+  it('returns 503 when NEYNAR_WEBHOOK_SECRET is not configured', async () => {
+    mockEnv.NEYNAR_WEBHOOK_SECRET = undefined;
+    const req = makeNeynarRequest({ type: 'cast.created', data: CAST_IN_CHANNEL }, 'any-sig');
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when signature does not match', async () => {
+    const req = makeNeynarRequest({ type: 'cast.created', data: CAST_IN_CHANNEL }, 'deadbeef');
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns ok:true for non cast.created event types', async () => {
+    const payload = { type: 'cast.deleted', data: {} };
+    const req = makeNeynarRequest(payload);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+
+  it('returns ok:true for a cast in a non-watched channel', async () => {
+    const payload = {
+      type: 'cast.created',
+      data: { ...CAST_IN_CHANNEL, channel: { id: 'some-other-channel' } },
+    };
+    const req = makeNeynarRequest(payload);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('upserts cast and returns ok:true for a cast in a watched channel', async () => {
+    const payload = { type: 'cast.created', data: CAST_IN_CHANNEL };
+    const req = makeNeynarRequest(payload);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ hash: '0xhash1', channel_id: 'zao' }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/app/api/zounz/proposals/list/__tests__/route.test.ts
+++ b/src/app/api/zounz/proposals/list/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+// createPublicClient is module-level — mock must be in place before import
+const mockGetBlockNumber = vi.hoisted(() => vi.fn().mockResolvedValue(BigInt(1_000_000)));
+const mockGetLogs = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      getBlockNumber: mockGetBlockNumber,
+      getLogs: mockGetLogs,
+    })),
+  };
+});
+
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+import { GET } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SUBGRAPH_PROPOSAL = {
+  proposalId: '0xprop1',
+  proposalNumber: 1,
+  title: 'Fund ZAO',
+  description: 'Fund ZAO development',
+  proposer: { id: '0xproposer' },
+  forVotes: '5',
+  againstVotes: '1',
+  abstainVotes: '0',
+  voteStart: '1000',
+  voteEnd: '2000',
+  status: 'ACTIVE',
+  timeCreated: '900',
+  executableFrom: null,
+  expiresAt: null,
+};
+
+describe('GET /api/zounz/proposals/list', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with proposals when subgraph succeeds', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: { dao: { proposals: [MOCK_SUBGRAPH_PROPOSAL] } },
+      }),
+    });
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.proposals).toHaveLength(1);
+    expect(body.proposals[0].proposalId).toBe('0xprop1');
+  });
+
+  it('returns 200 with empty proposals when both sources fail', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+    // Subgraph fails
+    mockFetch.mockResolvedValue({ ok: false, status: 503 });
+    // getLogs also fails (rejected)
+    mockGetLogs.mockRejectedValue(new Error('RPC unavailable'));
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.proposals).toHaveLength(0);
+    expect(body.error).toBeDefined();
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('session store down'));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- `webhooks/github` — 6 cases: 503 no secret, 401 invalid HMAC-SHA256, 200 ping pong, 200 PR opened (logs activity), 200 push non-default branch skipped, 200 unhandled event ignored
- `respect/fractal` — 5 cases: 401, 403 non-admin, 400 invalid body, 500 fractal_sessions insert error, 200 success with session_id + scores_recorded
- `zounz/proposals/list` — 4 cases: 401, 200 subgraph success, 200 both sources fail gracefully, 500 unexpected error

## Key patterns
- `getSupabaseAdmin()` (non-proxy) pattern: `vi.mock('@/lib/db/supabase', () => ({ getSupabaseAdmin: vi.fn(() => ({ from: mockFrom })) }))`
- Real HMAC-SHA256 (`sha256=<hex>`) for GitHub signature validation
- `mockFrom.mockImplementation((table) => ...)` dispatches different chain shapes by table name
- Fractal's `respect_members` chain supports both `.select().in()` (lookup, thenable) and `.insert()` (new member)
- viem `createPublicClient` module-level mock (same pattern as `zounz/proposals` PR #1706)
- `vi.stubGlobal('fetch', mockFetch)` for subgraph fetch; `mockGetLogs.mockRejectedValue(...)` to test on-chain fallback failure

## Test plan
- [x] All 15 tests pass locally (`vitest run`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)