### PR TITLE
test(lib): applyWebhookEvent handlers + notifications (12 cases)

### DIFF
--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockInsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockIn = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockEq = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ neq: vi.fn().mockReturnThis() }),
+);
+const mockSelect = vi.hoisted(() => vi.fn().mockImplementation(function () {
+  return { eq: mockEq };
+}));
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation((table: string) => {
+    if (table === 'notifications') return { insert: mockInsert };
+    if (table === 'notification_tokens') {
+      const chain = {
+        select: mockSelect,
+        update: vi.fn().mockReturnValue({ in: mockIn }),
+      };
+      return chain;
+    }
+    return {};
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+import { createInAppNotification, sendNotification } from '../notifications';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('createInAppNotification', () => {
+  it('returns without inserting when recipientFids is empty', async () => {
+    await createInAppNotification({
+      recipientFids: [],
+      type: 'system',
+      title: 'Test',
+      body: 'Body',
+      href: '/notifications',
+    });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('inserts one row per recipient with correct fields', async () => {
+    await createInAppNotification({
+      recipientFids: [10, 20],
+      type: 'proposal',
+      title: 'New Proposal',
+      body: 'A new proposal was submitted.',
+      href: '/proposals/1',
+      actorFid: 1,
+      actorDisplayName: 'ZAO',
+    });
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ recipient_fid: 10, type: 'proposal', read: false }),
+        expect.objectContaining({ recipient_fid: 20, type: 'proposal', read: false }),
+      ]),
+    );
+  });
+});
+
+describe('sendNotification', () => {
+  it('returns early when no enabled tokens are found', async () => {
+    mockSelect.mockReturnValueOnce({ eq: vi.fn().mockReturnValue({ data: [] }) });
+    await sendNotification('Title', 'Body', 'https://zaoos.com', 'notif-1');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends fetch to notification URL for each token group', async () => {
+    const tokens = [{ fid: 42, token: 'tok-abc', url: 'https://notif.example.com/push', enabled: true }];
+    mockSelect.mockReturnValueOnce({
+      eq: vi.fn().mockReturnValue({ data: tokens }),
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ invalidTokens: [] }),
+    });
+    await sendNotification('ZAO Alert', 'Something happened', 'https://zaoos.com/live', 'notif-2');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://notif.example.com/push',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('disables invalid tokens returned by the push endpoint', async () => {
+    const tokens = [
+      { fid: 10, token: 'bad-token', url: 'https://notif.example.com/push', enabled: true },
+    ];
+    mockSelect.mockReturnValueOnce({
+      eq: vi.fn().mockReturnValue({ data: tokens }),
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ invalidTokens: ['bad-token'] }),
+    });
+    await sendNotification('Title', 'Body', 'https://zaoos.com', 'notif-3');
+    // Should call update({ enabled: false }).in('token', ['bad-token'])
+    expect(mockIn).toHaveBeenCalledWith('token', ['bad-token']);
+  });
+});

--- a/src/lib/spaces/__tests__/applyWebhookEvent.test.ts
+++ b/src/lib/spaces/__tests__/applyWebhookEvent.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// @/lib/env has a module-level requireEnv() guard — stub before import
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    JUKE_API_KEY: undefined,
+    ZAO_OFFICIAL_FID: undefined,
+    ZAO_OFFICIAL_SIGNER_UUID: undefined,
+    ZAO_OFFICIAL_NEYNAR_API_KEY: undefined,
+    ZAO_AUTO_AGENT_JOIN: undefined,
+  },
+}));
+
+const mockUpdateJukeSpace = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockGetJukeSpace = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const mockBumpParticipantCount = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockAddParticipant = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockRemoveParticipant = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@/lib/spaces/jukeSpacesDb', () => ({
+  updateJukeSpace: mockUpdateJukeSpace,
+  getJukeSpace: mockGetJukeSpace,
+  bumpParticipantCount: mockBumpParticipantCount,
+  addParticipant: mockAddParticipant,
+  removeParticipant: mockRemoveParticipant,
+}));
+
+const mockIsAutoAgentJoinEnabled = vi.hoisted(() => vi.fn().mockReturnValue(false));
+const mockJoinAgentInJukeRoom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/spaces/jukeAgentJoin', () => ({
+  isAutoAgentJoinEnabled: mockIsAutoAgentJoinEnabled,
+  joinAgentInJukeRoom: mockJoinAgentInJukeRoom,
+}));
+
+vi.mock('@/lib/publish/auto-cast', () => ({
+  autoCastToZao: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { applyWebhookEvent } from '../jukeWebhookHandlers';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('applyWebhookEvent', () => {
+  it('returns early without any DB calls when spaceId is null', async () => {
+    await applyWebhookEvent('room.started', null, {});
+    expect(mockUpdateJukeSpace).not.toHaveBeenCalled();
+  });
+
+  it('marks space active on room.started', async () => {
+    await applyWebhookEvent('room.started', 'space-abc', { occurred_at: '2026-07-15T10:00:00Z' });
+    expect(mockUpdateJukeSpace).toHaveBeenCalledWith(
+      'space-abc',
+      expect.objectContaining({ status: 'active' }),
+    );
+  });
+
+  it('marks space ended on room.finished (no recap cast when endedVia=null)', async () => {
+    const { autoCastToZao } = await import('@/lib/publish/auto-cast');
+    await applyWebhookEvent('room.finished', 'space-abc', { data: {} });
+    expect(mockUpdateJukeSpace).toHaveBeenCalledWith(
+      'space-abc',
+      expect.objectContaining({ status: 'ended' }),
+    );
+    // endedVia=null means LiveKit timeout — no recap cast
+    expect(autoCastToZao).not.toHaveBeenCalled();
+  });
+
+  it('bumps count and adds participant on participant.joined with valid fid', async () => {
+    await applyWebhookEvent('participant.joined', 'space-abc', {
+      data: { fid: 42, display_name: 'ZAO Member', role: 'listener' },
+      occurred_at: '2026-07-15T10:05:00Z',
+    });
+    expect(mockBumpParticipantCount).toHaveBeenCalledWith('space-abc', 1);
+    expect(mockAddParticipant).toHaveBeenCalledWith(
+      'space-abc',
+      expect.objectContaining({ fid: 42 }),
+    );
+  });
+
+  it('bumps count and removes participant on participant.left', async () => {
+    await applyWebhookEvent('participant.left', 'space-abc', {
+      data: { fid: 42 },
+      occurred_at: '2026-07-15T10:10:00Z',
+    });
+    expect(mockBumpParticipantCount).toHaveBeenCalledWith('space-abc', -1);
+    expect(mockRemoveParticipant).toHaveBeenCalledWith('space-abc', 42);
+  });
+
+  it('updates recording_url on recording.ready', async () => {
+    await applyWebhookEvent('recording.ready', 'space-abc', {
+      recording_url: 'https://recordings.juke.audio/session.mp4',
+    });
+    expect(mockUpdateJukeSpace).toHaveBeenCalledWith(
+      'space-abc',
+      expect.objectContaining({ recording_url: 'https://recordings.juke.audio/session.mp4' }),
+    );
+  });
+
+  it('returns without DB calls for unknown event types', async () => {
+    await applyWebhookEvent('some.unknown.event', 'space-abc', {});
+    expect(mockUpdateJukeSpace).not.toHaveBeenCalled();
+    expect(mockBumpParticipantCount).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/spaces/jukeWebhookHandlers` — 7 cases for `applyWebhookEvent`: null spaceId early-return, room.started marks active, room.finished marks ended (no recap cast when endedVia=null), participant.joined bumps+adds, participant.left bumps+removes, recording.ready updates recording_url, unknown event no-ops
- `lib/notifications` — 5 cases: createInAppNotification with empty recipients (no-op), with multiple recipients (correct rows), sendNotification with no tokens (no fetch), with tokens (fetch called), with invalidTokens (disables them via update+in)

## Key patterns
- `vi.mock('@/lib/env', () => ({ ENV: {...} }))` required to prevent `requireEnv()` throw at module load in jukeWebhookHandlers
- `mockIsAutoAgentJoinEnabled.mockReturnValue(false)` gates auto-agent-join path so tests stay focused on the webhook logic
- `vi.stubGlobal('fetch', mockFetch)` for sendNotification's outbound push calls
- `mockFrom.mockImplementation((table) => ...)` dispatches different chains by table name (notifications vs notification_tokens)

## Test plan
- [x] All 12 tests pass locally (`vitest run`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)