### PR TITLE
test(lib): jukeSpacesDb CRUD + music library upsert/query (20 cases)

### DIFF
--- a/src/lib/music/__tests__/library.test.ts
+++ b/src/lib/music/__tests__/library.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/music/isMusicUrl', () => ({
+  isMusicUrl: vi.fn().mockReturnValue('spotify'),
+}));
+
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockMaybeSingle = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { querySongs, upsertSong } from '../library';
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// upsertSong
+// ---------------------------------------------------------------------------
+describe('upsertSong', () => {
+  it('returns {isNew:false} and increments play count when URL already exists', async () => {
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: null });
+    mockUpdate.mockReturnValue({ eq: mockUpdateEq });
+
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      switch (call) {
+        case 1:
+          // check existing: select('id').eq().maybeSingle()
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'existing-id' }, error: null }),
+              }),
+            }),
+          };
+        case 2:
+          // incrementPlayCount: select('play_count').eq().single()
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: { play_count: 3 }, error: null }),
+              }),
+            }),
+          };
+        default:
+          // incrementPlayCount: update({...}).eq()
+          return { update: mockUpdate };
+      }
+    });
+
+    const result = await upsertSong({
+      url: 'https://open.spotify.com/track/abc',
+      source: 'submission',
+    });
+    expect(result).toEqual({ id: 'existing-id', isNew: false });
+    expect(mockUpdateEq).toHaveBeenCalled();
+  });
+
+  it('returns {isNew:true} and inserts when URL is new', async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        // check existing: not found
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      // insert: returns new id
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'new-song-id' }, error: null }),
+          }),
+        }),
+      };
+    });
+
+    const result = await upsertSong({
+      url: 'https://open.spotify.com/track/xyz',
+      title: 'New Track',
+      source: 'manual',
+    });
+    expect(result).toEqual({ id: 'new-song-id', isNew: true });
+  });
+
+  it('handles race condition (23505) by re-fetching the existing id', async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        // initial check: not found
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      if (call === 2) {
+        // insert fails with unique violation
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: { code: '23505', message: 'unique' },
+              }),
+            }),
+          }),
+        };
+      }
+      // re-fetch after race
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'raced-id' }, error: null }),
+          }),
+        }),
+      };
+    });
+
+    const result = await upsertSong({
+      url: 'https://open.spotify.com/track/raced',
+      source: 'radio',
+    });
+    expect(result).toEqual({ id: 'raced-id', isNew: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// querySongs
+// ---------------------------------------------------------------------------
+describe('querySongs', () => {
+  it('returns {songs, total} for a basic query', async () => {
+    const SONGS = [{ id: '1', title: 'ZAO Track', platform: 'spotify' }];
+    const chain: Record<string, unknown> = {};
+    const chainable = ['select', 'order', 'textSearch', 'eq'];
+    for (const m of chainable) chain[m] = vi.fn().mockReturnValue(chain);
+    chain.range = vi.fn().mockResolvedValue({ data: SONGS, error: null, count: 1 });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await querySongs({ limit: 10 });
+    expect(result.songs).toEqual(SONGS);
+    expect(result.total).toBe(1);
+  });
+
+  it('throws on DB error', async () => {
+    const chain: Record<string, unknown> = {};
+    const chainable = ['select', 'order', 'textSearch', 'eq'];
+    for (const m of chainable) chain[m] = vi.fn().mockReturnValue(chain);
+    chain.range = vi.fn().mockResolvedValue({ data: null, error: new Error('DB fail'), count: 0 });
+    mockFrom.mockReturnValue(chain);
+
+    await expect(querySongs()).rejects.toThrow();
+  });
+});

--- a/src/lib/spaces/__tests__/jukeSpacesDb.test.ts
+++ b/src/lib/spaces/__tests__/jukeSpacesDb.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockMaybeSingle = vi.hoisted(() => vi.fn());
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockUpsert = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import {
+  addParticipant,
+  bumpParticipantCount,
+  getJukeSpace,
+  insertJukeSpace,
+  recordWebhookEvent,
+  removeParticipant,
+  updateJukeSpace,
+} from '../jukeSpacesDb';
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// insertJukeSpace
+// ---------------------------------------------------------------------------
+describe('insertJukeSpace', () => {
+  it('upserts with status=active when no scheduledAt', async () => {
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+    mockUpsert.mockResolvedValue({ error: null });
+    await insertJukeSpace({ id: 'space-1', title: 'ZAO Live', createdByFid: 42 });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'active' }),
+      expect.any(Object),
+    );
+  });
+
+  it('upserts with status=scheduled when scheduledAt is set', async () => {
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+    mockUpsert.mockResolvedValue({ error: null });
+    await insertJukeSpace({
+      id: 'space-2',
+      title: 'Future Space',
+      createdByFid: 42,
+      scheduledAt: '2026-08-01T20:00:00Z',
+    });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'scheduled', started_at: null }),
+      expect.any(Object),
+    );
+  });
+
+  it('throws on DB error', async () => {
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+    mockUpsert.mockResolvedValue({ error: { message: 'DB fail' } });
+    await expect(insertJukeSpace({ id: 's', title: 't', createdByFid: 1 })).rejects.toThrow(
+      'insertJukeSpace failed',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getJukeSpace
+// ---------------------------------------------------------------------------
+describe('getJukeSpace', () => {
+  it('returns the space row when found', async () => {
+    const ROW = { id: 'space-1', title: 'ZAO Live', status: 'active' };
+    mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
+    mockMaybeSingle.mockResolvedValue({ data: ROW, error: null });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+    const result = await getJukeSpace('space-1');
+    expect(result).toMatchObject({ id: 'space-1' });
+  });
+
+  it('returns null when space not found', async () => {
+    mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+    const result = await getJukeSpace('missing-id');
+    expect(result).toBeNull();
+  });
+
+  it('throws on DB error', async () => {
+    mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'timeout' } });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+    await expect(getJukeSpace('space-1')).rejects.toThrow('getJukeSpace failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateJukeSpace
+// ---------------------------------------------------------------------------
+describe('updateJukeSpace', () => {
+  it('calls update with the patch and throws on error', async () => {
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: { message: 'fail' } });
+    mockFrom.mockReturnValue({ update: vi.fn().mockReturnValue({ eq: mockUpdateEq }) });
+    await expect(updateJukeSpace('space-1', { status: 'ended' })).rejects.toThrow(
+      'updateJukeSpace failed',
+    );
+  });
+
+  it('resolves without error on success', async () => {
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ update: vi.fn().mockReturnValue({ eq: mockUpdateEq }) });
+    await expect(updateJukeSpace('space-1', { status: 'active' })).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bumpParticipantCount
+// ---------------------------------------------------------------------------
+describe('bumpParticipantCount', () => {
+  it('increments participant_count by delta', async () => {
+    let call = 0;
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        // select maybeSingle
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: { participant_count: 3 }, error: null }),
+            }),
+          }),
+        };
+      }
+      // update
+      return { update: vi.fn().mockReturnValue({ eq: mockUpdateEq }) };
+    });
+    await bumpParticipantCount('space-1', 1);
+    expect(mockUpdateEq).toHaveBeenCalledWith('id', 'space-1');
+  });
+
+  it('floors participant_count at 0', async () => {
+    let call = 0;
+    const capturedUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: { participant_count: 0 }, error: null }),
+            }),
+          }),
+        };
+      }
+      return { update: capturedUpdate };
+    });
+    await bumpParticipantCount('space-1', -5);
+    // count should be max(0, 0 + (-5)) = 0
+    expect(capturedUpdate).toHaveBeenCalledWith({ participant_count: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordWebhookEvent
+// ---------------------------------------------------------------------------
+describe('recordWebhookEvent', () => {
+  it('returns true on successful insert', async () => {
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockResolvedValue({ error: null });
+    const result = await recordWebhookEvent({
+      eventType: 'room.started',
+      signatureHash: 'abc123',
+      body: {},
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false on duplicate (23505 unique violation)', async () => {
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockResolvedValue({ error: { code: '23505', message: 'unique violation' } });
+    const result = await recordWebhookEvent({
+      eventType: 'room.started',
+      signatureHash: 'abc123',
+      body: {},
+    });
+    expect(result).toBe(false);
+  });
+
+  it('throws on other DB errors', async () => {
+    mockFrom.mockReturnValue({ insert: mockInsert });
+    mockInsert.mockResolvedValue({ error: { code: '42000', message: 'syntax error' } });
+    await expect(
+      recordWebhookEvent({ eventType: 'room.started', signatureHash: 'abc', body: {} }),
+    ).rejects.toThrow('recordWebhookEvent failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addParticipant / removeParticipant
+// ---------------------------------------------------------------------------
+describe('addParticipant', () => {
+  it('dedupes on fid and appends the entry', async () => {
+    const existing = [{ fid: 1, display_name: 'Old', role: 'host', joined_at: '2026-01-01' }];
+    let call = 0;
+    const capturedUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: { participants: existing }, error: null }),
+            }),
+          }),
+        };
+      }
+      return { update: capturedUpdate };
+    });
+    await addParticipant('space-1', { fid: 1, display_name: 'New', role: 'listener', joined_at: '2026-07-01' });
+    expect(capturedUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ participants: [{ fid: 1, display_name: 'New', role: 'listener', joined_at: '2026-07-01' }] }),
+    );
+  });
+});
+
+describe('removeParticipant', () => {
+  it('filters out the fid from participants', async () => {
+    const existing = [
+      { fid: 1, display_name: 'A', role: 'host', joined_at: '2026-01-01' },
+      { fid: 2, display_name: 'B', role: 'listener', joined_at: '2026-01-02' },
+    ];
+    let call = 0;
+    const capturedUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: { participants: existing }, error: null }),
+            }),
+          }),
+        };
+      }
+      return { update: capturedUpdate };
+    });
+    await removeParticipant('space-1', 1);
+    expect(capturedUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ participants: [{ fid: 2, display_name: 'B', role: 'listener', joined_at: '2026-01-02' }] }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/spaces/jukeSpacesDb` — 15 cases covering all exported functions: `insertJukeSpace` (scheduled/active status detection, error), `getJukeSpace` (found/not-found/error), `updateJukeSpace` (success/error), `bumpParticipantCount` (increment + floor-at-0), `addParticipant` (fid dedup), `removeParticipant` (filter), `recordWebhookEvent` (success → true, 23505 → false, other errors throw)
- `lib/music/library` — 5 cases: `upsertSong` existing URL (isNew:false + play count bump), new URL (isNew:true), race condition 23505 (re-fetch), `querySongs` basic (returns songs+total), DB error (throws)

## Key patterns
- `mockFrom.mockImplementation(() => { call++; switch(call) { ... } })` — sequential call dispatch for multi-step functions (bumpParticipantCount, addParticipant, removeParticipant)
- Each test resets `call` counter in the `let call = 0` closure; `afterEach(vi.clearAllMocks)` resets mock state
- `upsertSong` race condition: call 1 (not found), call 2 (insert 23505), call 3 (re-fetch) — three-stage sequential mock
- `querySongs` chain mock: chainable methods return `chain` itself; `.range()` resolves with data

## Test plan
- [x] All 20 tests pass locally (`vitest run`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)