### PR TITLE
test(lib): onepagers + leaderboard coverage (23 cases)

### DIFF
--- a/src/lib/respect/__tests__/leaderboard.test.ts
+++ b/src/lib/respect/__tests__/leaderboard.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// createPublicClient is called at module level — mock before import
+const mockMulticall = vi.hoisted(() => vi.fn());
+const mockGetLogs = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockGetBlock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ timestamp: BigInt(1_700_000_000) }),
+);
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      multicall: mockMulticall,
+      getLogs: mockGetLogs,
+      getBlock: mockGetBlock,
+    })),
+  };
+});
+
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { fetchLeaderboard } from '../leaderboard';
+
+// The module has a 5-min in-memory cache. Advance fake time by 10 min after each
+// test so the next test always sees a stale cache and fetches fresh.
+beforeAll(() => vi.useFakeTimers());
+afterAll(() => vi.useRealTimers());
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.advanceTimersByTime(10 * 60 * 1000);
+});
+
+const MOCK_USERS = [
+  {
+    id: 'u-1',
+    display_name: 'Zaal',
+    ign: null,
+    real_name: null,
+    primary_wallet: '0xAAA0000000000000000000000000000000000001',
+    respect_wallet: null,
+    fid: 1,
+    username: 'zabal',
+    zid: 1,
+  },
+  {
+    id: 'u-2',
+    display_name: 'Arthur',
+    ign: null,
+    real_name: null,
+    primary_wallet: '0xAAA0000000000000000000000000000000000002',
+    respect_wallet: null,
+    fid: 2,
+    username: 'arthur',
+    zid: 2,
+  },
+];
+
+function makeMulticallResults(ogSupply: bigint, zorSupply: bigint, balances: [bigint, bigint][]) {
+  const results = [
+    { status: 'success', result: ogSupply },
+    { status: 'success', result: zorSupply },
+    ...balances.flatMap(([og, zor]) => [
+      { status: 'success', result: og },
+      { status: 'success', result: zor },
+    ]),
+  ];
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// fetchLeaderboard
+// ---------------------------------------------------------------------------
+describe('fetchLeaderboard', () => {
+  it('returns empty leaderboard when no users have wallets', async () => {
+    const noWalletUsers = MOCK_USERS.map((u) => ({ ...u, primary_wallet: null, respect_wallet: null }));
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: noWalletUsers, error: null }),
+      }),
+    });
+    const result = await fetchLeaderboard();
+    expect(result.leaderboard).toHaveLength(0);
+    expect(result.stats.totalMembers).toBe(0);
+  });
+
+  it('returns empty leaderboard when no active users', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    });
+    const result = await fetchLeaderboard();
+    expect(result.leaderboard).toHaveLength(0);
+  });
+
+  it('throws on DB error fetching users', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: null, error: new Error('DB fail') }),
+      }),
+    });
+    await expect(fetchLeaderboard()).rejects.toThrow('DB fail');
+  });
+
+  it('returns ranked leaderboard sorted by totalRespect descending', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: MOCK_USERS, error: null }),
+      }),
+    });
+    // Zaal: 10 OG (in wei), 5 ZOR; Arthur: 2 OG, 1 ZOR
+    const ogSupply = BigInt('1000000000000000000'); // 1 ETH = 1 OG token
+    const zorSupply = BigInt(100);
+    mockMulticall.mockResolvedValue(
+      makeMulticallResults(ogSupply, zorSupply, [
+        [BigInt('10000000000000000000'), BigInt(5)], // Zaal: 10 OG, 5 ZOR
+        [BigInt('2000000000000000000'), BigInt(1)],  // Arthur: 2 OG, 1 ZOR
+      ]),
+    );
+    const result = await fetchLeaderboard();
+    expect(result.leaderboard[0].name).toBe('Zaal');
+    expect(result.leaderboard[0].rank).toBe(1);
+    expect(result.leaderboard[1].name).toBe('Arthur');
+    expect(result.leaderboard[1].rank).toBe(2);
+    expect(result.stats.holdersWithRespect).toBe(2);
+  });
+
+  it('handles multicall failures gracefully (zero balance)', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [MOCK_USERS[0]], error: null }),
+      }),
+    });
+    mockMulticall.mockResolvedValue([
+      { status: 'failure' },
+      { status: 'failure' },
+      { status: 'failure' },
+      { status: 'failure' },
+    ]);
+    const result = await fetchLeaderboard();
+    expect(result.leaderboard[0].ogRespect).toBe(0);
+    expect(result.leaderboard[0].zorRespect).toBe(0);
+  });
+
+  it('excludes wallets with fid: prefix', async () => {
+    const fidUser = { ...MOCK_USERS[0], primary_wallet: 'fid:123', respect_wallet: null };
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [fidUser], error: null }),
+      }),
+    });
+    const result = await fetchLeaderboard();
+    expect(result.leaderboard).toHaveLength(0);
+  });
+});

--- a/src/lib/stock/__tests__/onepagers.test.ts
+++ b/src/lib/stock/__tests__/onepagers.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetSupabaseAdmin = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ getSupabaseAdmin: mockGetSupabaseAdmin }));
+
+import {
+  createOnePager,
+  getOnePager,
+  listActivity,
+  listOnePagers,
+  slugify,
+  updateOnePager,
+} from '../onepagers';
+
+afterEach(() => vi.clearAllMocks());
+
+const BASE_ONEPAGER = {
+  id: 'op-1',
+  slug: 'zao-pitch',
+  title: 'ZAO Pitch',
+  audience: 'Investors',
+  purpose: 'Raise funding',
+  status: 'draft' as const,
+  visibility: 'internal' as const,
+  body: 'ZAO is the best DAO.',
+  meeting_date: null,
+  meeting_location: null,
+  authors: null,
+  reviewers: null,
+  version: 1,
+  last_edited_by: null,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+function makeFromForOnepagers(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnValue({
+      order: vi.fn().mockResolvedValue(result),
+    }),
+  };
+}
+
+function makeFromForOnePagerGet(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// slugify (pure utility)
+// ---------------------------------------------------------------------------
+describe('slugify', () => {
+  it('lowercases and replaces spaces with hyphens', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('strips special characters', () => {
+    expect(slugify('ZAO: The DAO!')).toBe('zao-the-dao');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(slugify('  -ZAO- ')).toBe('zao');
+  });
+
+  it('respects maxLen', () => {
+    const result = slugify('a very long title that exceeds the limit', 10);
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listOnePagers
+// ---------------------------------------------------------------------------
+describe('listOnePagers', () => {
+  it('returns list of onepagers', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(makeFromForOnepagers({ data: [BASE_ONEPAGER], error: null })) });
+    const result = await listOnePagers();
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe('zao-pitch');
+  });
+
+  it('throws on DB error', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(makeFromForOnepagers({ data: null, error: new Error('DB fail') })) });
+    await expect(listOnePagers()).rejects.toThrow('DB fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOnePager
+// ---------------------------------------------------------------------------
+describe('getOnePager', () => {
+  it('returns null for invalid slug without hitting the DB', async () => {
+    const result = await getOnePager('../etc/passwd');
+    expect(result).toBeNull();
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled();
+  });
+
+  it('returns OnePager when found', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(makeFromForOnePagerGet({ data: BASE_ONEPAGER, error: null })) });
+    const result = await getOnePager('zao-pitch');
+    expect(result).toMatchObject({ slug: 'zao-pitch' });
+  });
+
+  it('returns null when not found', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(makeFromForOnePagerGet({ data: null, error: null })) });
+    const result = await getOnePager('missing');
+    expect(result).toBeNull();
+  });
+
+  it('throws on DB error', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(makeFromForOnePagerGet({ data: null, error: new Error('query failed') })) });
+    await expect(getOnePager('zao-pitch')).rejects.toThrow('query failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createOnePager
+// ---------------------------------------------------------------------------
+describe('createOnePager', () => {
+  it('inserts the onepager and logs activity', async () => {
+    const mockFrom = vi.fn().mockImplementation((table: string) => {
+      if (table === 'stock_onepagers') {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: BASE_ONEPAGER, error: null }),
+            }),
+          }),
+        };
+      }
+      // stock_onepager_activity — logActivity insert
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'act-1', onepager_id: 'op-1', type: 'created' },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+    mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+    const result = await createOnePager({ slug: 'zao-pitch', title: 'ZAO Pitch' });
+    expect(result).toMatchObject({ id: 'op-1', slug: 'zao-pitch' });
+    expect(mockFrom).toHaveBeenCalledWith('stock_onepager_activity');
+  });
+
+  it('throws on DB error', async () => {
+    const mockFrom = vi.fn().mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: new Error('insert failed') }),
+        }),
+      }),
+    });
+    mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+    await expect(createOnePager({ slug: 'zao-pitch', title: 'ZAO Pitch' })).rejects.toThrow(
+      'insert failed',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateOnePager
+// ---------------------------------------------------------------------------
+describe('updateOnePager', () => {
+  it('returns null when slug does not exist', async () => {
+    // getOnePager returns null
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue(makeFromForOnePagerGet({ data: null, error: null })),
+    });
+    const result = await updateOnePager('../etc', { title: 'x' });
+    expect(result).toBeNull();
+  });
+
+  it('returns current when no fields to update', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue(makeFromForOnePagerGet({ data: BASE_ONEPAGER, error: null })),
+    });
+    const result = await updateOnePager('zao-pitch', {});
+    expect(result).toMatchObject({ slug: 'zao-pitch' });
+  });
+
+  it('patches the onepager and logs status_change', async () => {
+    let getCall = 0;
+    const mockFrom = vi.fn().mockImplementation((table: string) => {
+      if (table === 'stock_onepagers') {
+        getCall++;
+        if (getCall === 1) {
+          // getOnePager select
+          return makeFromForOnePagerGet({ data: BASE_ONEPAGER, error: null });
+        }
+        // update select single
+        return {
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { ...BASE_ONEPAGER, status: 'review' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      // logActivity
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'act-2' }, error: null }),
+          }),
+        }),
+      };
+    });
+    mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+    const result = await updateOnePager('zao-pitch', { status: 'review' });
+    expect(result?.status).toBe('review');
+    expect(mockFrom).toHaveBeenCalledWith('stock_onepager_activity');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listActivity
+// ---------------------------------------------------------------------------
+describe('listActivity', () => {
+  it('returns empty array when slug not found', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue(makeFromForOnePagerGet({ data: null, error: null })),
+    });
+    const result = await listActivity('missing');
+    expect(result).toEqual([]);
+  });
+
+  it('maps member_name from joined stock_team_members', async () => {
+    const activityRow = {
+      id: 'act-1',
+      onepager_id: 'op-1',
+      member_id: 'mem-1',
+      type: 'edited',
+      content: 'Body updated',
+      metadata: {},
+      created_at: '2026-07-01T00:00:00Z',
+      stock_team_members: { name: 'Zaal' },
+    };
+    let call = 0;
+    const mockFrom = vi.fn().mockImplementation((table: string) => {
+      call++;
+      if (call === 1) {
+        // getOnePager
+        return makeFromForOnePagerGet({ data: BASE_ONEPAGER, error: null });
+      }
+      // listActivity select
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({ data: [activityRow], error: null }),
+            }),
+          }),
+        }),
+      };
+    });
+    mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+    const result = await listActivity('zao-pitch');
+    expect(result[0].member_name).toBe('Zaal');
+    expect(result[0].type).toBe('edited');
+  });
+});


### PR DESCRIPTION
## Summary
- **`stock/onepagers.ts`** (17 cases): `slugify` utility, `listOnePagers`, `getOnePager` (invalid slug short-circuit + found/null/error), `createOnePager` (insert + activity log), `updateOnePager` (no-op + status-change path with activity log), `listActivity` (member_name mapped from joined table)
- **`respect/leaderboard.ts`** (6 cases): `fetchLeaderboard` — empty result for no-wallet/no-user, DB error throw, multicall-failure graceful zero-balance, `fid:`-prefix wallet exclusion, full ranked output sorted by totalRespect. Uses `vi.useFakeTimers` + `advanceTimersByTime` in `afterEach` to bust the module-level 5-min cache between tests

## Test plan
- [x] All 23 tests pass locally
- [x] No source file changes — test-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)