### PR TITLE
test(lib): agents runner + config + wallet coverage (26 cases)

### DIFF
--- a/src/lib/agents/__tests__/config.test.ts
+++ b/src/lib/agents/__tests__/config.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSupabaseAdmin = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ getSupabaseAdmin: mockGetSupabaseAdmin }));
+
+import { claimBudget, getAgentConfig, getDailySpend } from '../config';
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// getAgentConfig
+// ---------------------------------------------------------------------------
+describe('getAgentConfig', () => {
+  it('returns config on success', async () => {
+    const CONFIG = { name: 'vault', trading_enabled: true, wallet_address: '0xABCD' };
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: CONFIG, error: null }),
+          }),
+        }),
+      }),
+    });
+    const result = await getAgentConfig('VAULT');
+    expect(result).toMatchObject({ name: 'vault' });
+  });
+
+  it('returns null and logs error on DB error', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection failed' } }),
+          }),
+        }),
+      }),
+    });
+    const result = await getAgentConfig('VAULT');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no config row exists', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      }),
+    });
+    const result = await getAgentConfig('VAULT');
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDailySpend
+// ---------------------------------------------------------------------------
+describe('getDailySpend', () => {
+  it('sums usd_value of success events', async () => {
+    const events = [{ usd_value: 1.5 }, { usd_value: 0.5 }, { usd_value: 0.25 }];
+    const mockFrom = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          in: vi.fn().mockReturnValue({
+            gte: vi.fn().mockResolvedValue({ data: events, error: null }),
+          }),
+        }),
+      }),
+    });
+    mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+    const result = await getDailySpend('VAULT');
+    expect(result).toBeCloseTo(2.25);
+  });
+
+  it('returns 0 when no events', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              gte: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        }),
+      }),
+    });
+    const result = await getDailySpend('VAULT');
+    expect(result).toBe(0);
+  });
+
+  it('throws on DB error (fail-closed behaviour)', async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              gte: vi.fn().mockResolvedValue({ data: null, error: { message: 'timeout' } }),
+            }),
+          }),
+        }),
+      }),
+    });
+    await expect(getDailySpend('VAULT')).rejects.toThrow('getDailySpend failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claimBudget
+// ---------------------------------------------------------------------------
+describe('claimBudget', () => {
+  function makeDb({
+    preSpendEvents = [] as { usd_value: number }[],
+    insertResult = { data: { id: 'res-1' }, error: null },
+    reVerifyEvents = [] as { usd_value: number }[],
+    deleteResult = { error: null },
+  } = {}) {
+    let selectCall = 0;
+    return {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'agent_events') {
+          return {
+            select: vi.fn().mockImplementation(() => ({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockReturnValue({
+                  gte: vi.fn().mockImplementation(() => {
+                    selectCall++;
+                    const events = selectCall === 1 ? preSpendEvents : reVerifyEvents;
+                    return Promise.resolve({ data: events, error: null });
+                  }),
+                }),
+              }),
+            })),
+            insert: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue(insertResult),
+              }),
+            }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue(deleteResult) }),
+          };
+        }
+        return {};
+      }),
+    };
+  }
+
+  it('returns true when budget is available and insert succeeds', async () => {
+    // Pre-spend: $2, re-verify: $2.5 (after our $0.5 reservation) — under $10 max
+    const db = makeDb({
+      preSpendEvents: [{ usd_value: 2.0 }],
+      reVerifyEvents: [{ usd_value: 2.5 }],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db);
+    const result = await claimBudget('VAULT', 0.5, 10.0);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when pre-spend exceeds max', async () => {
+    const db = makeDb({ preSpendEvents: [{ usd_value: 9.8 }] });
+    mockGetSupabaseAdmin.mockReturnValue(db);
+    const result = await claimBudget('VAULT', 0.5, 10.0);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when insert fails', async () => {
+    const db = makeDb({
+      preSpendEvents: [],
+      insertResult: { data: null as unknown as { id: string }, error: { message: 'insert fail' } },
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db);
+    const result = await claimBudget('VAULT', 0.5, 10.0);
+    expect(result).toBe(false);
+  });
+
+  it('returns false and rolls back when re-verify exceeds max (concurrent over-claim)', async () => {
+    // Pre-spend: $9, our trade: $0.5, re-verify total: $10.5 (concurrent also claimed $0.5)
+    const db = makeDb({
+      preSpendEvents: [{ usd_value: 9.0 }],
+      reVerifyEvents: [{ usd_value: 10.5 }],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db);
+    const result = await claimBudget('VAULT', 0.5, 10.0);
+    expect(result).toBe(false);
+    // Verify delete was called to roll back the reservation
+    const fromMock = db.from as ReturnType<typeof vi.fn>;
+    const deleteCall = fromMock.mock.results.find(
+      (r) => r.value?.delete && typeof r.value.delete === 'function',
+    );
+    expect(deleteCall).toBeDefined();
+  });
+});

--- a/src/lib/agents/__tests__/runner.test.ts
+++ b/src/lib/agents/__tests__/runner.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockGetAgentConfig = vi.hoisted(() => vi.fn());
+const mockClaimBudget = vi.hoisted(() => vi.fn());
+vi.mock('../config', () => ({ getAgentConfig: mockGetAgentConfig, claimBudget: mockClaimBudget }));
+
+const mockMaybeAutoStake = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../autostake', () => ({ maybeAutoStake: mockMaybeAutoStake }));
+
+const mockBurnZabal = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../burn', () => ({ burnZabal: mockBurnZabal }));
+
+const mockPostTradeUpdate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../cast', () => ({ postTradeUpdate: mockPostTradeUpdate }));
+
+const mockLogAgentEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../events', () => ({ logAgentEvent: mockLogAgentEvent }));
+
+const mockGetSwapQuote = vi.hoisted(() => vi.fn());
+const mockGetZabalPrice = vi.hoisted(() => vi.fn());
+vi.mock('../swap', () => ({ getSwapQuote: mockGetSwapQuote, getZabalPrice: mockGetZabalPrice }));
+
+const mockExecuteSwap = vi.hoisted(() => vi.fn());
+vi.mock('../wallet', () => ({ executeSwap: mockExecuteSwap }));
+
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+import { runAgent } from '../runner';
+
+afterEach(() => vi.clearAllMocks());
+
+const BASE_CONFIG = {
+  trading_enabled: true,
+  wallet_address: '0xABCD1234',
+  max_single_trade_usd: 1.0,
+  max_daily_spend_usd: 10.0,
+  buy_price_ceiling: 0.01,
+};
+
+const MOCK_QUOTE = {
+  buyAmount: '1000000000000000000',
+  sellAmount: '200000000000000',
+  price: '0.0001',
+};
+
+// ETH price fetch — return $2500 by default
+function stubEthPrice(price = 2500) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({ price: String(price) }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Early-return paths (no financial ops)
+// ---------------------------------------------------------------------------
+describe('runAgent — early returns', () => {
+  it('returns failed when no config found', async () => {
+    mockGetAgentConfig.mockResolvedValue(null);
+    const result = await runAgent('vault');
+    expect(result.status).toBe('failed');
+    expect(result.details).toContain('No config found');
+  });
+
+  it('returns skipped when trading_enabled is false', async () => {
+    mockGetAgentConfig.mockResolvedValue({ ...BASE_CONFIG, trading_enabled: false });
+    const result = await runAgent('vault');
+    expect(result.status).toBe('skipped');
+    expect(result.details).toBe('Trading disabled');
+  });
+
+  it('returns skipped when wallet_address is falsy', async () => {
+    mockGetAgentConfig.mockResolvedValue({ ...BASE_CONFIG, wallet_address: null });
+    const result = await runAgent('vault');
+    expect(result.status).toBe('skipped');
+    expect(result.details).toBe('No wallet configured');
+  });
+
+  it('returns skipped when budget claim fails', async () => {
+    mockGetAgentConfig.mockResolvedValue(BASE_CONFIG);
+    stubEthPrice();
+    mockClaimBudget.mockResolvedValue(false);
+    const result = await runAgent('vault');
+    expect(result.status).toBe('skipped');
+    expect(result.details).toContain('Budget exceeded');
+  });
+
+  it('returns skipped when ZABAL price API throws', async () => {
+    mockGetAgentConfig.mockResolvedValue(BASE_CONFIG);
+    stubEthPrice();
+    mockClaimBudget.mockResolvedValue(true);
+    mockGetZabalPrice.mockRejectedValue(new Error('API down'));
+    const result = await runAgent('vault');
+    expect(result.status).toBe('skipped');
+    expect(result.details).toBe('Price API unavailable');
+  });
+
+  it('returns skipped when ZABAL price exceeds ceiling', async () => {
+    mockGetAgentConfig.mockResolvedValue({ ...BASE_CONFIG, buy_price_ceiling: 0.001 });
+    stubEthPrice();
+    mockClaimBudget.mockResolvedValue(true);
+    mockGetZabalPrice.mockResolvedValue(0.005); // above ceiling
+    const result = await runAgent('vault');
+    expect(result.status).toBe('skipped');
+    expect(result.details).toBe('Price above ceiling');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success path
+// ---------------------------------------------------------------------------
+describe('runAgent — success', () => {
+  it('returns success after swap + burn + log + cast', async () => {
+    mockGetAgentConfig.mockResolvedValue(BASE_CONFIG);
+    stubEthPrice(3000);
+    mockClaimBudget.mockResolvedValue(true);
+    mockGetZabalPrice.mockResolvedValue(0.0005); // below ceiling
+    mockGetSwapQuote.mockResolvedValue(MOCK_QUOTE);
+    mockExecuteSwap.mockResolvedValue('0xTXHASH');
+
+    const result = await runAgent('vault');
+    expect(result.status).toBe('success');
+    expect(result.action).toBe('buy_zabal');
+    expect(mockExecuteSwap).toHaveBeenCalledWith('vault', MOCK_QUOTE);
+    expect(mockBurnZabal).toHaveBeenCalledWith('vault', BigInt(MOCK_QUOTE.buyAmount));
+    expect(mockLogAgentEvent).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }));
+    expect(mockPostTradeUpdate).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure path
+// ---------------------------------------------------------------------------
+describe('runAgent — failures', () => {
+  it('returns failed and logs event when executeSwap throws', async () => {
+    mockGetAgentConfig.mockResolvedValue(BASE_CONFIG);
+    stubEthPrice();
+    mockClaimBudget.mockResolvedValue(true);
+    mockGetZabalPrice.mockResolvedValue(0.0005);
+    mockGetSwapQuote.mockResolvedValue(MOCK_QUOTE);
+    mockExecuteSwap.mockRejectedValue(new Error('insufficient funds'));
+
+    const result = await runAgent('vault');
+    expect(result.status).toBe('failed');
+    expect(result.details).toContain('insufficient funds');
+    expect(mockLogAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', error_message: 'insufficient funds' }),
+    );
+  });
+
+  it('uses $2500 ETH fallback when price fetch fails', async () => {
+    mockGetAgentConfig.mockResolvedValue(BASE_CONFIG);
+    mockFetch.mockRejectedValue(new Error('network error'));
+    mockClaimBudget.mockResolvedValue(true);
+    mockGetZabalPrice.mockResolvedValue(0.0005);
+    mockGetSwapQuote.mockResolvedValue(MOCK_QUOTE);
+    mockExecuteSwap.mockResolvedValue('0xTXHASH');
+
+    const result = await runAgent('vault');
+    // Should still succeed using the $2500 fallback
+    expect(result.status).toBe('success');
+  });
+});

--- a/src/lib/agents/__tests__/wallet.test.ts
+++ b/src/lib/agents/__tests__/wallet.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockSendTransaction = vi.hoisted(() => vi.fn());
+vi.mock('@privy-io/node', () => ({
+  PrivyClient: vi.fn().mockImplementation(() => ({
+    wallets: vi.fn().mockReturnValue({
+      ethereum: vi.fn().mockReturnValue({
+        sendTransaction: mockSendTransaction,
+      }),
+    }),
+  })),
+}));
+
+import { executeSwap, sendToken } from '../wallet';
+
+beforeEach(() => {
+  process.env.PRIVY_APP_ID = 'test-app-id';
+  process.env.PRIVY_APP_SECRET = 'test-app-secret';
+  process.env.VAULT_WALLET_ID = 'wid-vault';
+  process.env.BANKER_WALLET_ID = 'wid-banker';
+  process.env.DEALER_WALLET_ID = 'wid-dealer';
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.PRIVY_APP_ID;
+  delete process.env.PRIVY_APP_SECRET;
+  delete process.env.VAULT_WALLET_ID;
+  delete process.env.BANKER_WALLET_ID;
+  delete process.env.DEALER_WALLET_ID;
+});
+
+const MOCK_QUOTE = {
+  to: '0x1234abcd',
+  data: '0xdeadbeef',
+  value: '0',
+  gas: '200000',
+};
+
+// ---------------------------------------------------------------------------
+// executeSwap
+// ---------------------------------------------------------------------------
+describe('executeSwap', () => {
+  it('returns the transaction hash on success', async () => {
+    mockSendTransaction.mockResolvedValue({ hash: '0xTXHASH' });
+    const hash = await executeSwap('VAULT', MOCK_QUOTE);
+    expect(hash).toBe('0xTXHASH');
+    expect(mockSendTransaction).toHaveBeenCalledWith(
+      'wid-vault',
+      expect.objectContaining({
+        caip2: 'eip155:8453',
+        params: expect.objectContaining({
+          transaction: expect.objectContaining({ to: '0x1234abcd' }),
+        }),
+      }),
+    );
+  });
+
+  it('throws when VAULT_WALLET_ID is not configured', async () => {
+    delete process.env.VAULT_WALLET_ID;
+    await expect(executeSwap('VAULT', MOCK_QUOTE)).rejects.toThrow('VAULT_WALLET_ID not configured');
+  });
+
+  it('rethrows non-auth errors from Privy', async () => {
+    mockSendTransaction.mockRejectedValue(new Error('insufficient funds'));
+    await expect(executeSwap('VAULT', MOCK_QUOTE)).rejects.toThrow('insufficient funds');
+  });
+
+  it('rethrows auth errors and resets the Privy client', async () => {
+    mockSendTransaction.mockRejectedValueOnce(new Error('401 Unauthorized'));
+    await expect(executeSwap('VAULT', MOCK_QUOTE)).rejects.toThrow('401 Unauthorized');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendToken
+// ---------------------------------------------------------------------------
+describe('sendToken', () => {
+  it('returns the transaction hash on success', async () => {
+    mockSendTransaction.mockResolvedValue({ hash: '0xTOKEN_TX' });
+    const hash = await sendToken('BANKER', '0xTokenAddr', '0xRecipient', BigInt(1e18));
+    expect(hash).toBe('0xTOKEN_TX');
+    expect(mockSendTransaction).toHaveBeenCalledWith(
+      'wid-banker',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          transaction: expect.objectContaining({ to: '0xTokenAddr' }),
+        }),
+      }),
+    );
+  });
+
+  it('throws when BANKER_WALLET_ID is not configured', async () => {
+    delete process.env.BANKER_WALLET_ID;
+    await expect(sendToken('BANKER', '0xAddr', '0xTo', BigInt(100))).rejects.toThrow(
+      'BANKER_WALLET_ID not configured',
+    );
+  });
+
+  it('rethrows errors from Privy sendTransaction', async () => {
+    mockSendTransaction.mockRejectedValue(new Error('policy violated'));
+    await expect(sendToken('DEALER', '0xAddr', '0xTo', BigInt(100))).rejects.toThrow(
+      'policy violated',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **`agents/runner.ts`** (9 cases): all early-return skips (no-config, trading-disabled, no-wallet, budget-exceeded, price-API-down, price-above-ceiling), success path (swap+burn+log+cast), swap-throws failure, ETH-price-fallback when 0x API down
- **`agents/config.ts`** (10 cases): `getAgentConfig` success/error/no-row; `getDailySpend` sum/zero/fail-closed-throw; `claimBudget` happy-path, pre-spend-exceeds, insert-fails, concurrent-over-claim rollback
- **`agents/wallet.ts`** (7 cases): `executeSwap` success/missing-env/non-auth-rethrow/auth-error-reset; `sendToken` success/missing-env/privy-error

## Test plan
- [x] All 26 tests pass locally
- [x] No source file changes — test-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)