### PR TITLE
test(lib): env module-load validation + xmtp/client localStorage utils (32 cases)

### DIFF
--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// All required env vars that env.ts calls requireEnv() on at module load
+const REQUIRED_VARS: Record<string, string> = {
+  NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+  NEXT_PUBLIC_NEYNAR_CLIENT_ID: 'test-neynar-client-id',
+  SUPABASE_SERVICE_ROLE_KEY: 'test-supabase-service-role-key',
+  NEYNAR_API_KEY: 'test-neynar-api-key',
+  SESSION_SECRET: 'test-session-secret',
+  APP_FID: '12345',
+  APP_SIGNER_PRIVATE_KEY: 'test-app-signer-private-key',
+};
+
+function setRequired() {
+  for (const [k, v] of Object.entries(REQUIRED_VARS)) process.env[k] = v;
+}
+
+function clearRequired() {
+  for (const k of Object.keys(REQUIRED_VARS)) delete process.env[k];
+}
+
+describe('ENV module', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setRequired();
+  });
+
+  afterEach(() => {
+    clearRequired();
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.CRM_BOT_SECRET;
+    delete process.env.CRM_CAPTURE_TOKEN;
+  });
+
+  it('loads and exposes required var values', async () => {
+    const { ENV } = await import('../env');
+    expect(ENV.NEXT_PUBLIC_SUPABASE_URL).toBe('https://test.supabase.co');
+    expect(ENV.NEYNAR_API_KEY).toBe('test-neynar-api-key');
+    expect(ENV.APP_FID).toBe('12345');
+  });
+
+  it('throws when a required var is missing', async () => {
+    delete process.env.NEYNAR_API_KEY;
+    await expect(import('../env')).rejects.toThrow(
+      'Missing required environment variable: NEYNAR_API_KEY',
+    );
+  });
+
+  it('returns undefined for unset optional vars', async () => {
+    const { ENV } = await import('../env');
+    expect(ENV.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(ENV.DISCORD_WEBHOOK_URL).toBeUndefined();
+    expect(ENV.PRIVY_APP_ID).toBeUndefined();
+    expect(ENV.CRM_BOT_SECRET).toBeUndefined();
+  });
+
+  it('captures an optional var when set', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'test-bot-token';
+    const { ENV } = await import('../env');
+    expect(ENV.TELEGRAM_BOT_TOKEN).toBe('test-bot-token');
+  });
+});
+
+describe('optionalSecretEnv validation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setRequired();
+  });
+
+  afterEach(() => {
+    clearRequired();
+    delete process.env.CRM_BOT_SECRET;
+    delete process.env.CRM_CAPTURE_TOKEN;
+  });
+
+  it('throws when CRM_BOT_SECRET is set but shorter than 32 chars', async () => {
+    process.env.CRM_BOT_SECRET = 'tooshort';
+    await expect(import('../env')).rejects.toThrow('CRM_BOT_SECRET is set but too short');
+  });
+
+  it('allows CRM_BOT_SECRET when exactly 32 chars', async () => {
+    const secret = 'a'.repeat(32);
+    process.env.CRM_BOT_SECRET = secret;
+    const { ENV } = await import('../env');
+    expect(ENV.CRM_BOT_SECRET).toBe(secret);
+  });
+
+  it('allows CRM_BOT_SECRET longer than 32 chars', async () => {
+    const secret = 'a'.repeat(64);
+    process.env.CRM_BOT_SECRET = secret;
+    const { ENV } = await import('../env');
+    expect(ENV.CRM_BOT_SECRET).toBe(secret);
+  });
+
+  it('throws when CRM_CAPTURE_TOKEN is shorter than 16 chars', async () => {
+    process.env.CRM_CAPTURE_TOKEN = 'short';
+    await expect(import('../env')).rejects.toThrow('CRM_CAPTURE_TOKEN is set but too short');
+  });
+
+  it('allows CRM_CAPTURE_TOKEN when at least 16 chars', async () => {
+    const token = 'a'.repeat(16);
+    process.env.CRM_CAPTURE_TOKEN = token;
+    const { ENV } = await import('../env');
+    expect(ENV.CRM_CAPTURE_TOKEN).toBe(token);
+  });
+});

--- a/src/lib/xmtp/__tests__/client.test.ts
+++ b/src/lib/xmtp/__tests__/client.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getConnectedWallets,
+  getMemberProfiles,
+  getOrCreateLocalKey,
+  getPeerProfiles,
+  removeConnectedWallet,
+  saveConnectedWallet,
+  saveMemberProfile,
+  savePeerProfile,
+  type XMTPPeerProfile,
+} from '../client';
+
+afterEach(() => vi.unstubAllGlobals());
+
+// In-memory localStorage substitute that shares state across getItem/setItem calls
+function makeStorage(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+  };
+}
+
+// Stub both `window` (for typeof check) and bare `localStorage` (for ops)
+function withBrowserWindow(initial: Record<string, string> = {}) {
+  const ls = makeStorage(initial);
+  vi.stubGlobal('window', { localStorage: ls });
+  vi.stubGlobal('localStorage', ls);
+  return ls;
+}
+
+// ── server-side (window === undefined) ─────────────────────────────────────
+
+describe('server-side guards (no window)', () => {
+  it('getConnectedWallets returns []', () => {
+    expect(getConnectedWallets()).toEqual([]);
+  });
+
+  it('saveConnectedWallet is a no-op', () => {
+    expect(() => saveConnectedWallet('0xABC')).not.toThrow();
+  });
+
+  it('removeConnectedWallet is a no-op', () => {
+    expect(() => removeConnectedWallet('0xABC')).not.toThrow();
+  });
+
+  it('getPeerProfiles returns {}', () => {
+    expect(getPeerProfiles()).toEqual({});
+  });
+
+  it('getMemberProfiles returns {}', () => {
+    expect(getMemberProfiles()).toEqual({});
+  });
+
+  it('savePeerProfile is a no-op', () => {
+    const p: XMTPPeerProfile = { fid: 1, username: 'a', displayName: 'A', pfpUrl: '' };
+    savePeerProfile('conv', p);
+    expect(getPeerProfiles()).toEqual({});
+  });
+
+  it('saveMemberProfile is a no-op', () => {
+    const p: XMTPPeerProfile = { fid: 1, username: 'a', displayName: 'A', pfpUrl: '' };
+    saveMemberProfile('inbox', p);
+    expect(getMemberProfiles()).toEqual({});
+  });
+
+  it('getOrCreateLocalKey throws', () => {
+    expect(() => getOrCreateLocalKey(1)).toThrow('Cannot access localStorage on server');
+  });
+});
+
+// ── getConnectedWallets ─────────────────────────────────────────────────────
+
+describe('getConnectedWallets', () => {
+  it('returns [] when storage is empty', () => {
+    withBrowserWindow();
+    expect(getConnectedWallets()).toEqual([]);
+  });
+
+  it('returns stored wallets array', () => {
+    withBrowserWindow({ 'zaoos-xmtp-wallets': JSON.stringify(['0xabc', '0xdef']) });
+    expect(getConnectedWallets()).toEqual(['0xabc', '0xdef']);
+  });
+
+  it('returns [] on corrupted JSON', () => {
+    withBrowserWindow({ 'zaoos-xmtp-wallets': '{bad json}' });
+    expect(getConnectedWallets()).toEqual([]);
+  });
+});
+
+// ── saveConnectedWallet ─────────────────────────────────────────────────────
+
+describe('saveConnectedWallet', () => {
+  it('adds a wallet normalized to lowercase', () => {
+    withBrowserWindow();
+    saveConnectedWallet('0xABCDEF');
+    expect(getConnectedWallets()).toEqual(['0xabcdef']);
+  });
+
+  it('does not add duplicates', () => {
+    withBrowserWindow({ 'zaoos-xmtp-wallets': JSON.stringify(['0xabcdef']) });
+    saveConnectedWallet('0xABCDEF');
+    expect(getConnectedWallets()).toHaveLength(1);
+  });
+});
+
+// ── removeConnectedWallet ───────────────────────────────────────────────────
+
+describe('removeConnectedWallet', () => {
+  it('removes a wallet by address', () => {
+    withBrowserWindow({ 'zaoos-xmtp-wallets': JSON.stringify(['0xabc', '0xdef']) });
+    removeConnectedWallet('0xabc');
+    expect(getConnectedWallets()).toEqual(['0xdef']);
+  });
+
+  it('is a no-op when the wallet is not in the list', () => {
+    withBrowserWindow({ 'zaoos-xmtp-wallets': JSON.stringify(['0xabc']) });
+    removeConnectedWallet('0xother');
+    expect(getConnectedWallets()).toHaveLength(1);
+  });
+});
+
+// ── getPeerProfiles / savePeerProfile ───────────────────────────────────────
+
+const PEER: XMTPPeerProfile = {
+  fid: 42,
+  username: 'zaal',
+  displayName: 'Zaal P',
+  pfpUrl: 'https://pfp.example.com',
+};
+
+describe('getPeerProfiles / savePeerProfile', () => {
+  it('returns {} when no profiles stored', () => {
+    withBrowserWindow();
+    expect(getPeerProfiles()).toEqual({});
+  });
+
+  it('saves and retrieves a peer profile', () => {
+    withBrowserWindow();
+    savePeerProfile('conv-1', PEER);
+    expect(getPeerProfiles()).toEqual({ 'conv-1': PEER });
+  });
+
+  it('returns {} on corrupted JSON', () => {
+    withBrowserWindow({ 'zaoos-xmtp-peers': 'bad json' });
+    expect(getPeerProfiles()).toEqual({});
+  });
+});
+
+// ── getMemberProfiles / saveMemberProfile ────────────────────────────────────
+
+const MEMBER: XMTPPeerProfile = { fid: 99, username: 'arthur', displayName: 'Arthur', pfpUrl: '' };
+
+describe('getMemberProfiles / saveMemberProfile', () => {
+  it('returns {} when no members stored', () => {
+    withBrowserWindow();
+    expect(getMemberProfiles()).toEqual({});
+  });
+
+  it('saves and retrieves a member profile', () => {
+    withBrowserWindow();
+    saveMemberProfile('inbox-1', MEMBER);
+    expect(getMemberProfiles()).toEqual({ 'inbox-1': MEMBER });
+  });
+});
+
+// ── getOrCreateLocalKey ──────────────────────────────────────────────────────
+
+describe('getOrCreateLocalKey', () => {
+  it('generates a valid 0x hex key and persists it', () => {
+    withBrowserWindow();
+    vi.stubGlobal('crypto', {
+      getRandomValues: (arr: Uint8Array) => { arr.fill(0xab); return arr; },
+    });
+    const key = getOrCreateLocalKey(999);
+    expect(key).toBe('0x' + 'ab'.repeat(32));
+    // second call should return same key from storage (no new random values)
+    const stored = getOrCreateLocalKey(999);
+    expect(stored).toBe(key);
+  });
+
+  it('returns the existing stored key without regenerating', () => {
+    const existing = '0x' + 'cd'.repeat(32);
+    withBrowserWindow({ 'zaoos-xmtp-local-key-5': existing });
+    const key = getOrCreateLocalKey(5);
+    expect(key).toBe(existing);
+  });
+
+  it('regenerates if the stored key has an invalid format', () => {
+    withBrowserWindow({ 'zaoos-xmtp-local-key-7': 'notvalidhex' });
+    vi.stubGlobal('crypto', {
+      getRandomValues: (arr: Uint8Array) => { arr.fill(0xee); return arr; },
+    });
+    const key = getOrCreateLocalKey(7);
+    expect(key).toBe('0x' + 'ee'.repeat(32));
+  });
+});


### PR DESCRIPTION
## Summary

- **`src/lib/__tests__/env.test.ts`** (9 tests): Validates `env.ts` module-level initialization via `vi.resetModules()` + dynamic import pattern. Covers `requireEnv` throwing on missing vars, `optionalEnv` returning `undefined` when unset, and `optionalSecretEnv` rejecting `CRM_BOT_SECRET` shorter than 32 chars and `CRM_CAPTURE_TOKEN` shorter than 16 chars.
- **`src/lib/xmtp/__tests__/client.test.ts`** (23 tests): Tests all localStorage utility functions in `xmtp/client.ts`. Server-side guards (8 cases — functions return early/throw when `typeof window === 'undefined'`), `getConnectedWallets`/`saveConnectedWallet`/`removeConnectedWallet` (7 cases), `getPeerProfiles`/`savePeerProfile`/`getMemberProfiles`/`saveMemberProfile` (5 cases), `getOrCreateLocalKey` generate + persist + invalid-format-regeneration (3 cases). Uses `vi.stubGlobal` for both `window` and bare `localStorage` (the module checks `typeof window` but accesses `localStorage` directly).

## Test plan

- [x] `env.test.ts` — 9/9 passing locally
- [x] `xmtp/client.test.ts` — 23/23 passing locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)