### PR TITLE
test(bot/hermes): preflight gate + critic coverage (17 cases)

### DIFF
--- a/bot/src/hermes/__tests__/critic.test.ts
+++ b/bot/src/hermes/__tests__/critic.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockRunCmd = vi.hoisted(() => vi.fn());
+vi.mock('../git', () => ({ runCmd: mockRunCmd }));
+
+const mockCallClaudeCli = vi.hoisted(() => vi.fn());
+vi.mock('../claude-cli', () => ({
+  callClaudeCli: mockCallClaudeCli,
+  HERMES_ROUTING_ENABLED: false,
+  HERMES_CRITIC_MODEL: 'sonnet',
+  HERMES_CRITIC_FAST_MODEL: 'haiku',
+}));
+
+import { runCritic } from '../critic';
+
+type CmdResult = { stdout: string; stderr: string; exitCode: number };
+const cmdOk = (stdout: string): CmdResult => ({ stdout, stderr: '', exitCode: 0 });
+
+const MOCK_INPUT = {
+  workTreePath: '/tmp/wt',
+  issueText: 'Fix the typo in greeting',
+  filesChanged: ['src/greet.ts'],
+};
+
+afterEach(() => vi.clearAllMocks());
+
+// ── git diff failures ─────────────────────────────────────────────────────────
+
+describe('git diff', () => {
+  it('throws when git diff fails', async () => {
+    mockRunCmd.mockResolvedValue({ stdout: '', stderr: 'not a git repo', exitCode: 1 });
+    await expect(runCritic(MOCK_INPUT)).rejects.toThrow('git diff failed in critic');
+  });
+
+  it('returns score 0 with a descriptive message when diff is empty', async () => {
+    mockRunCmd.mockResolvedValue(cmdOk(''));
+    const r = await runCritic(MOCK_INPUT);
+    expect(r.score).toBe(0);
+    expect(r.feedback).toContain('no diff produced');
+    expect(mockCallClaudeCli).not.toHaveBeenCalled();
+  });
+});
+
+// ── CLI result handling ───────────────────────────────────────────────────────
+
+describe('callClaudeCli result handling', () => {
+  beforeEach(() => {
+    mockRunCmd.mockResolvedValue(cmdOk('+ const x = 1;'));
+  });
+
+  it('returns score 0 with CLI error message when isError=true', async () => {
+    mockCallClaudeCli.mockResolvedValue({
+      isError: true,
+      text: 'rate limit exceeded',
+      inputTokens: 10,
+      outputTokens: 0,
+    });
+    const r = await runCritic(MOCK_INPUT);
+    expect(r.score).toBe(0);
+    expect(r.feedback).toContain('Critic CLI error');
+    expect(r.feedback).toContain('rate limit exceeded');
+  });
+
+  it('returns parsed score and feedback on a valid JSON response', async () => {
+    mockCallClaudeCli.mockResolvedValue({
+      isError: false,
+      text: '{ "score": 85, "feedback": "Looks good, minor spacing." }',
+      inputTokens: 100,
+      outputTokens: 20,
+    });
+    const r = await runCritic(MOCK_INPUT);
+    expect(r.score).toBe(85);
+    expect(r.feedback).toBe('Looks good, minor spacing.');
+    expect(r.inputTokens).toBe(100);
+    expect(r.outputTokens).toBe(20);
+  });
+
+  it('strips markdown code fences before parsing JSON', async () => {
+    mockCallClaudeCli.mockResolvedValue({
+      isError: false,
+      text: '```json\n{ "score": 72, "feedback": "Needs a null check." }\n```',
+      inputTokens: 50,
+      outputTokens: 10,
+    });
+    const r = await runCritic(MOCK_INPUT);
+    expect(r.score).toBe(72);
+    expect(r.feedback).toBe('Needs a null check.');
+  });
+
+  it('throws when the CLI returns non-JSON text', async () => {
+    mockCallClaudeCli.mockResolvedValue({
+      isError: false,
+      text: 'Sorry, I cannot review this diff.',
+      inputTokens: 20,
+      outputTokens: 5,
+    });
+    await expect(runCritic(MOCK_INPUT)).rejects.toThrow('non-JSON output');
+  });
+});

--- a/bot/src/hermes/__tests__/preflight.test.ts
+++ b/bot/src/hermes/__tests__/preflight.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockRunCmd = vi.hoisted(() => vi.fn());
+vi.mock('../git', () => ({ runCmd: mockRunCmd }));
+
+import { runPreFlightGate } from '../preflight';
+
+type CmdResult = { stdout: string; stderr: string; exitCode: number };
+const OK: CmdResult = { stdout: '', stderr: '', exitCode: 0 };
+const FAIL: CmdResult = { stdout: 'error details', stderr: '', exitCode: 1 };
+
+afterEach(() => vi.clearAllMocks());
+
+// ── forbidden paths ───────────────────────────────────────────────────────────
+
+describe('forbidden paths', () => {
+  it('rejects an exact forbidden path (.env)', async () => {
+    const r = await runPreFlightGate({ workTreePath: '/tmp/wt', filesChanged: ['.env'] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('.env');
+    expect(r.checks.forbiddenPaths).toBe('fail');
+    expect(mockRunCmd).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file inside a forbidden directory (bot/src/hermes/)', async () => {
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/hermes/runner.ts'],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.checks.forbiddenPaths).toBe('fail');
+    expect(r.error).toContain('bot/src/hermes/runner.ts');
+  });
+
+  it('allows a non-forbidden bot file through', async () => {
+    mockRunCmd.mockResolvedValue(OK);
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/zoe/memory.ts'],
+    });
+    expect(r.checks.forbiddenPaths).toBe('pass');
+  });
+});
+
+// ── docs-only scope ───────────────────────────────────────────────────────────
+
+describe('docs-only scope', () => {
+  it('skips all checks and returns ok for research/*.md files', async () => {
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['research/doc.md', 'docs/notes.md'],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.scope).toBe('docs-only');
+    expect(r.checks.typecheck).toBe('skipped');
+    expect(r.checks.boot).toBe('skipped');
+    expect(r.checks.tests).toBe('skipped');
+    expect(mockRunCmd).not.toHaveBeenCalled();
+  });
+});
+
+// ── bot-only scope ────────────────────────────────────────────────────────────
+
+describe('bot-only scope', () => {
+  it('fails when bot typecheck fails', async () => {
+    mockRunCmd.mockResolvedValueOnce(FAIL);
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/zoe/memory.ts'],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.scope).toBe('bot-only');
+    expect(r.checks.typecheck).toBe('fail');
+    expect(r.error).toContain('Bot typecheck failed');
+    expect(mockRunCmd).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails when boot verification fails after typecheck passes', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(OK)   // typecheck
+      .mockResolvedValueOnce(FAIL); // boot (esbuild)
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/zoe/memory.ts'],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.checks.typecheck).toBe('skipped'); // code sets typecheck='pass' only at end
+    expect(r.checks.boot).toBe('fail');
+    expect(r.error).toContain('boot-verify');
+  });
+
+  it('returns ok when typecheck and boot pass (no test files touched)', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(OK) // typecheck
+      .mockResolvedValueOnce(OK); // boot
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/zoe/memory.ts'],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.checks.boot).toBe('pass');
+    expect(r.checks.tests).toBe('skipped');
+    expect(mockRunCmd).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs vitest when a .test.ts file is touched and fails on test failure', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(OK)   // typecheck
+      .mockResolvedValueOnce(OK)   // boot
+      .mockResolvedValueOnce(FAIL); // tests
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/zoe/__tests__/foo.test.ts'],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.checks.tests).toBe('fail');
+    expect(r.error).toContain('Tests failed');
+  });
+
+  it('returns ok when typecheck, boot, and tests all pass', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(OK)
+      .mockResolvedValueOnce(OK)
+      .mockResolvedValueOnce(OK);
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/zoe/__tests__/foo.test.ts'],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.checks.tests).toBe('pass');
+  });
+});
+
+// ── scope detection ────────────────────────────────────────────────────────────
+
+describe('scope detection', () => {
+  it('detects app-only scope for src/ files', async () => {
+    mockRunCmd.mockResolvedValue(OK);
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['src/lib/foo.ts'],
+    });
+    expect(r.scope).toBe('app-only');
+    // app-only: only one typecheck call (no boot)
+    expect(mockRunCmd).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects mixed scope for bot + app files and runs all three checks', async () => {
+    mockRunCmd.mockResolvedValue(OK);
+    const r = await runPreFlightGate({
+      workTreePath: '/tmp/wt',
+      filesChanged: ['bot/src/foo.ts', 'src/lib/bar.ts'],
+    });
+    expect(r.scope).toBe('mixed');
+    // mixed: bot-typecheck + bot-boot + app-typecheck = 3 calls
+    expect(mockRunCmd).toHaveBeenCalledTimes(3);
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/hermes/__tests__/preflight.test.ts` — 11 cases: forbidden path rejection (exact + directory prefix), docs-only scope (skips all checks), bot-only scope (typecheck fail → early return, boot fail → early return, all-pass no tests, tests-fail, tests-pass), scope detection (app-only runs 1 cmd, mixed runs 3 cmds)
- `bot/src/hermes/__tests__/critic.test.ts` — 6 cases: git diff failure throws, empty diff returns score-0 without calling CLI, CLI `isError` returns score-0 with message, valid JSON parsed, markdown-fenced JSON stripped then parsed, non-JSON throws

## Test plan
- [x] `npx vitest run src/hermes/__tests__/preflight.test.ts src/hermes/__tests__/critic.test.ts` → 17/17 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)