### PR TITLE
test(bot/hermes): pr open + pr-watcher coverage (15 cases)

### DIFF
--- a/bot/src/hermes/__tests__/pr-watcher.test.ts
+++ b/bot/src/hermes/__tests__/pr-watcher.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockRunCmd = vi.hoisted(() => vi.fn());
+vi.mock('../git', () => ({ runCmd: mockRunCmd }));
+
+import { watchPullRequest } from '../pr-watcher';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function ghOutput(mergeable: string, checks: Array<{ name: string; conclusion: string; detailsUrl: string }> = []) {
+  return {
+    stdout: JSON.stringify({ mergeable, mergeStateStatus: 'CLEAN', statusCheckRollup: checks }),
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+// pollIntervalMs=100, maxPollMinutes=0.002 → maxIterations = ceil(0.002*60000/100) = ceil(1.2) = 2
+const TWO_ITER = { pollIntervalMs: 100, maxPollMinutes: 0.002 };
+// maxPollMinutes=0.001 → ceil(0.001*60000/100) = ceil(0.6) = 1
+const ONE_ITER = { pollIntervalMs: 100, maxPollMinutes: 0.001 };
+
+// ── basic polling ─────────────────────────────────────────────────────────────
+
+describe('watchPullRequest polling', () => {
+  it('exits early when PR is MERGEABLE with no failing checks after i>=1', async () => {
+    vi.useFakeTimers();
+    // Need MERGEABLE + i >= 1 → requires 2 poll iterations (i=0 skipped, i=1 exits)
+    mockRunCmd.mockResolvedValue(ghOutput('MERGEABLE'));
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...TWO_ITER });
+    await vi.advanceTimersByTimeAsync(200); // two 100ms sleeps
+    await p;
+    expect(mockRunCmd).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs through all iterations when PR stays in UNKNOWN state', async () => {
+    vi.useFakeTimers();
+    mockRunCmd.mockResolvedValue(ghOutput('UNKNOWN'));
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...TWO_ITER });
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
+    // 2 iterations → 2 gh pr view calls
+    expect(mockRunCmd).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the status and continues when gh pr view fails', async () => {
+    vi.useFakeTimers();
+    mockRunCmd.mockResolvedValue({ stdout: '', stderr: 'not found', exitCode: 1 });
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...ONE_ITER });
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+    // Should not throw — returns null, loop continues to end
+  });
+
+  it('returns null and continues when gh output is not valid JSON', async () => {
+    vi.useFakeTimers();
+    mockRunCmd.mockResolvedValue({ stdout: 'not-json', stderr: '', exitCode: 0 });
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...ONE_ITER });
+    await vi.advanceTimersByTimeAsync(100);
+    await p; // should resolve without throwing
+  });
+});
+
+// ── conflict alerts ───────────────────────────────────────────────────────────
+
+describe('conflict detection', () => {
+  it('calls narrator.onCriticDone when merge conflict detected', async () => {
+    vi.useFakeTimers();
+    mockRunCmd.mockResolvedValue(ghOutput('CONFLICTING'));
+    const narrator = { onCriticDone: vi.fn().mockResolvedValue(undefined) };
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...ONE_ITER, narrator: narrator as any });
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+    expect(narrator.onCriticDone).toHaveBeenCalledWith('r1', 0, expect.stringContaining('merge conflicts'));
+  });
+
+  it('deduplicates conflict alerts across multiple poll cycles', async () => {
+    vi.useFakeTimers();
+    mockRunCmd.mockResolvedValue(ghOutput('CONFLICTING'));
+    const narrator = { onCriticDone: vi.fn().mockResolvedValue(undefined) };
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...TWO_ITER, narrator: narrator as any });
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
+    // 2 polls, same conflict → narrator called only once
+    expect(narrator.onCriticDone).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── CI failure alerts ─────────────────────────────────────────────────────────
+
+describe('CI failure detection', () => {
+  it('reports failing checks via narrator', async () => {
+    vi.useFakeTimers();
+    const checks = [{ name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://ci.example.com/1' }];
+    mockRunCmd.mockResolvedValue(ghOutput('MERGEABLE', checks));
+    const narrator = { onCriticDone: vi.fn().mockResolvedValue(undefined) };
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...ONE_ITER, narrator: narrator as any });
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+    expect(narrator.onCriticDone).toHaveBeenCalledWith('r1', 0, expect.stringContaining('lint'));
+  });
+
+  it('deduplicates CI failure alerts across polls', async () => {
+    vi.useFakeTimers();
+    const checks = [{ name: 'tests', conclusion: 'FAILURE', detailsUrl: 'https://ci.example.com/2' }];
+    mockRunCmd.mockResolvedValue(ghOutput('UNKNOWN', checks));
+    const narrator = { onCriticDone: vi.fn().mockResolvedValue(undefined) };
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...TWO_ITER, narrator: narrator as any });
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
+    expect(narrator.onCriticDone).toHaveBeenCalledTimes(1); // deduped across 2 polls
+  });
+
+  it('works without a narrator (no-op)', async () => {
+    vi.useFakeTimers();
+    const checks = [{ name: 'lint', conclusion: 'TIMED_OUT', detailsUrl: '' }];
+    mockRunCmd.mockResolvedValue(ghOutput('MERGEABLE', checks));
+    // No narrator passed — should not throw
+    const p = watchPullRequest({ prNumber: 42, runId: 'r1', branchName: 'fix/foo', ...ONE_ITER });
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+  });
+});

--- a/bot/src/hermes/__tests__/pr.test.ts
+++ b/bot/src/hermes/__tests__/pr.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockRunCmd = vi.hoisted(() => vi.fn());
+vi.mock('../git', () => ({ runCmd: mockRunCmd }));
+
+import { openPullRequest } from '../pr';
+
+afterEach(() => vi.clearAllMocks());
+
+type CmdResult = { stdout: string; stderr: string; exitCode: number };
+const ok = (stdout = ''): CmdResult => ({ stdout, stderr: '', exitCode: 0 });
+const fail = (stderr = 'error'): CmdResult => ({ stdout: '', stderr, exitCode: 1 });
+
+// openPullRequest: push (runCmd #1) then gh pr create (runCmd #2)
+
+describe('openPullRequest', () => {
+  it('returns PR number and URL on success', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(ok())                                                           // git push
+      .mockResolvedValueOnce(ok('https://github.com/org/repo/pull/42\n'));                    // gh pr create
+    const r = await openPullRequest({ workdir: '/tmp/wt', branchName: 'fix/foo', title: 'T', body: 'B' });
+    expect(r.number).toBe(42);
+    expect(r.url).toBe('https://github.com/org/repo/pull/42');
+  });
+
+  it('uses main as the default base branch', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(ok('https://github.com/org/repo/pull/10\n'));
+    await openPullRequest({ workdir: '/tmp/wt', branchName: 'fix/foo', title: 'T', body: 'B' });
+    const ghArgs: string[] = mockRunCmd.mock.calls[1][1];
+    const baseIdx = ghArgs.indexOf('--base');
+    expect(ghArgs[baseIdx + 1]).toBe('main');
+  });
+
+  it('passes a custom base branch through to gh', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(ok('https://github.com/org/repo/pull/11\n'));
+    await openPullRequest({ workdir: '/tmp/wt', branchName: 'fix/foo', title: 'T', body: 'B', base: 'develop' });
+    const ghArgs: string[] = mockRunCmd.mock.calls[1][1];
+    const baseIdx = ghArgs.indexOf('--base');
+    expect(ghArgs[baseIdx + 1]).toBe('develop');
+  });
+
+  it('throws with stderr excerpt when gh pr create exits non-zero', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(fail('a pull request for branch "fix/foo" already exists'));
+    await expect(
+      openPullRequest({ workdir: '/tmp/wt', branchName: 'fix/foo', title: 'T', body: 'B' }),
+    ).rejects.toThrow('gh pr create failed');
+  });
+
+  it('throws when gh output has no parseable PR number', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(ok('Pull request created successfully.\n')); // no /pull/N in URL
+    await expect(
+      openPullRequest({ workdir: '/tmp/wt', branchName: 'fix/foo', title: 'T', body: 'B' }),
+    ).rejects.toThrow('no PR number parsed');
+  });
+
+  it('passes --head <branchName> to gh so auto-detection is bypassed', async () => {
+    mockRunCmd
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(ok('https://github.com/org/repo/pull/77\n'));
+    await openPullRequest({ workdir: '/tmp/wt', branchName: 'my-branch', title: 'T', body: 'B' });
+    const ghArgs: string[] = mockRunCmd.mock.calls[1][1];
+    const headIdx = ghArgs.indexOf('--head');
+    expect(ghArgs[headIdx + 1]).toBe('my-branch');
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/hermes/__tests__/pr.test.ts` — 6 cases: `openPullRequest` success (parses PR number from URL), default base=main, custom base, gh non-zero exit throws, no `/pull/N` in output throws, `--head branchName` arg verified
- `bot/src/hermes/__tests__/pr-watcher.test.ts` — 9 cases: early exit when MERGEABLE after i≥1 (2 poll cycles), full loop on UNKNOWN state, gh failure returns null+continues, invalid JSON returns null+continues, conflict triggers narrator, conflict dedup across polls, CI failure triggers narrator, CI failure dedup, no narrator is a no-op

## Test plan
- [x] `npx vitest run src/hermes/__tests__/pr.test.ts src/hermes/__tests__/pr-watcher.test.ts` → 15/15 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)