### PR TITLE
test(bot/zoe): farcaster read-node + research-doc coverage (18 cases)

### DIFF
--- a/bot/src/zoe/__tests__/research-doc.test.ts
+++ b/bot/src/zoe/__tests__/research-doc.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// exec is promisify(execFile) — mock promisify to return a controllable fn
+const mockExec = vi.hoisted(() => vi.fn());
+vi.mock('node:util', () => ({ promisify: vi.fn().mockReturnValue(mockExec) }));
+
+const mockReaddir = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockAppendFile = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', () => ({
+  promises: {
+    readdir: mockReaddir,
+    mkdir: mockMkdir,
+    writeFile: mockWriteFile,
+    appendFile: mockAppendFile,
+  },
+}));
+
+import { commitResearchDoc } from '../research-doc';
+
+afterEach(() => vi.clearAllMocks());
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function execOk(stdout = ''): { stdout: string; stderr: string } {
+  return { stdout, stderr: '' };
+}
+
+/**
+ * Set up mocks for the full happy path.
+ * nextDocNum: readdir returns no matching files → max=0 → num=1
+ *             gh api for PR titles → stdout '' → no PR numbers → num stays 1+1=2 actually 0+1=1
+ * commitResearchDoc git calls: checkout main, pull, checkout -B branch, add, commit, push, checkout main
+ * commitResearchDoc gh call for PR: returns URL
+ */
+function setupHappyPath(num = 1, prUrl = 'https://github.com/org/repo/pull/501') {
+  // readdir: ENOENT for all topic dirs (no existing docs)
+  mockReaddir.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+  mockMkdir.mockResolvedValue(undefined);
+  mockWriteFile.mockResolvedValue(undefined);
+  mockAppendFile.mockResolvedValue(undefined);
+
+  // exec calls in order:
+  // 1. gh api for open PR titles (nextDocNum)
+  // 2. git checkout main
+  // 3. git pull --quiet
+  // 4. git checkout -B branch
+  // 5. git add ...
+  // 6. git commit ...
+  // 7. git push ...
+  // 8. gh api POST create PR → returns URL
+  // 9. git checkout main
+  mockExec
+    .mockResolvedValueOnce(execOk(''))             // gh api PR titles
+    .mockResolvedValueOnce(execOk(''))             // git checkout main
+    .mockResolvedValueOnce(execOk(''))             // git pull
+    .mockResolvedValueOnce(execOk(''))             // git checkout -B branch
+    .mockResolvedValueOnce(execOk(''))             // git add
+    .mockResolvedValueOnce(execOk(''))             // git commit
+    .mockResolvedValueOnce(execOk(''))             // git push
+    .mockResolvedValueOnce(execOk(`${prUrl}\n`))   // gh api POST PR
+    .mockResolvedValueOnce(execOk(''));            // git checkout main (final)
+}
+
+// ── commitResearchDoc ─────────────────────────────────────────────────────────
+
+describe('commitResearchDoc', () => {
+  it('returns ok:true with num and prUrl on success', async () => {
+    setupHappyPath();
+    const r = await commitResearchDoc({ question: 'What is ZAO?', findings: 'ZAO is a music DAO.' });
+    expect(r.ok).toBe(true);
+    expect(r.num).toBe(1);
+    expect(r.prUrl).toBe('https://github.com/org/repo/pull/501');
+  });
+
+  it('uses the passed topic when it is a valid bucket', async () => {
+    setupHappyPath();
+    const r = await commitResearchDoc({ question: 'Farcaster protocol overview', findings: '...', topic: 'farcaster' });
+    expect(r.ok).toBe(true);
+    // The PR URL should still be returned correctly
+    expect(r.prUrl).toBeDefined();
+  });
+
+  it('falls back to "business" for an unknown topic', async () => {
+    setupHappyPath();
+    const r = await commitResearchDoc({ question: 'Random question', findings: '...', topic: 'not-a-topic' });
+    expect(r.ok).toBe(true);
+    // Check that mkdir was called with a path containing 'business'
+    expect(mockMkdir.mock.calls[0][0]).toContain('business');
+  });
+
+  it('increments doc number above existing files', async () => {
+    // One topic dir has a file starting with 500-
+    mockReaddir
+      .mockResolvedValueOnce(['500-existing-doc']) // first topic dir has an existing file
+      .mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })); // rest ENOENT
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    mockAppendFile.mockResolvedValue(undefined);
+    mockExec
+      .mockResolvedValueOnce(execOk(''))  // gh api PR titles
+      .mockResolvedValue(execOk('https://github.com/org/repo/pull/502\n')); // all git + gh POST calls
+    const r = await commitResearchDoc({ question: 'Next question', findings: '...' });
+    expect(r.ok).toBe(true);
+    expect(r.num).toBe(501);
+  });
+
+  it('parses open PR titles to find the highest doc number', async () => {
+    mockReaddir.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    mockAppendFile.mockResolvedValue(undefined);
+    // gh api returns PR titles with doc numbers
+    mockExec
+      .mockResolvedValueOnce(execOk('doc 750: some research\ndoc 755: more research\n'))
+      .mockResolvedValue(execOk('https://github.com/org/repo/pull/756\n'));
+    const r = await commitResearchDoc({ question: 'Another question', findings: '...' });
+    expect(r.ok).toBe(true);
+    expect(r.num).toBe(756);
+  });
+
+  it('returns ok:false with an error message when git fails', async () => {
+    mockReaddir.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    mockExec
+      .mockResolvedValueOnce(execOk(''))  // gh api PR titles
+      .mockRejectedValue(new Error('git checkout failed: not a repo'));
+    const r = await commitResearchDoc({ question: 'Will this fail?', findings: '...' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('git checkout failed');
+  });
+
+  it('writes a markdown file with the question and findings', async () => {
+    setupHappyPath();
+    await commitResearchDoc({ question: 'What is ZAO?', findings: 'ZAO is a music DAO that...' });
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    const content: string = mockWriteFile.mock.calls[0][1];
+    expect(content).toContain('What is ZAO?');
+    expect(content).toContain('ZAO is a music DAO that');
+    expect(content).toContain('topic: business'); // fallback topic
+  });
+});

--- a/bot/src/zoe/farcaster/__tests__/read-node.test.ts
+++ b/bot/src/zoe/farcaster/__tests__/read-node.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Control fetch globally
+const mockFetch = vi.fn();
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  delete process.env.FARCASTER_READ_API_BASE;
+  delete process.env.FARCASTER_READ_FALLBACK_BASE;
+  delete process.env.NEYNAR_API_KEY;
+  delete process.env.FARCASTER_READ_TIMEOUT_MS;
+});
+
+function stubFetch(json: unknown, ok = true) {
+  const res = { ok, status: ok ? 200 : 500, statusText: ok ? 'OK' : 'Internal Server Error', json: vi.fn().mockResolvedValue(json) };
+  mockFetch.mockResolvedValue(res);
+  vi.stubGlobal('fetch', mockFetch);
+}
+
+import { castsByFid, nodeInfo, readV2 } from '../read-node';
+
+// ── readV2 ────────────────────────────────────────────────────────────────────
+
+describe('readV2', () => {
+  it('calls the primary URL when FARCASTER_READ_API_BASE is set', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    stubFetch({ casts: [] });
+    const r = await readV2('/v2/farcaster/feed?fid=1');
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0][0]).toContain('primary.local:3381');
+  });
+
+  it('falls back to the fallback URL when primary is not set', async () => {
+    // No FARCASTER_READ_API_BASE → skip primary, go straight to fallback
+    process.env.FARCASTER_READ_FALLBACK_BASE = 'https://fallback.example.com';
+    stubFetch({ casts: [] });
+    await readV2('/v2/farcaster/feed?fid=1');
+    expect(mockFetch.mock.calls[0][0]).toContain('fallback.example.com');
+  });
+
+  it('falls back to the default haatz URL when no fallback env var is set', async () => {
+    stubFetch({ casts: [] });
+    await readV2('/v2/some/path');
+    expect(mockFetch.mock.calls[0][0]).toContain('haatz.quilibrium.com');
+  });
+
+  it('falls back when the primary request throws', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    process.env.FARCASTER_READ_FALLBACK_BASE = 'https://fallback.example.com';
+    mockFetch
+      .mockRejectedValueOnce(new Error('connection refused')) // primary fails
+      .mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ casts: ['ok'] }) }); // fallback ok
+    vi.stubGlobal('fetch', mockFetch);
+    const r = await readV2('/v2/path');
+    expect(r).toEqual({ casts: ['ok'] });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back when primary returns non-ok status', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    process.env.FARCASTER_READ_FALLBACK_BASE = 'https://fallback.example.com';
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' }) // primary non-ok
+      .mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ data: 1 }) }); // fallback ok
+    vi.stubGlobal('fetch', mockFetch);
+    const r = await readV2('/v2/path');
+    expect(r).toEqual({ data: 1 });
+  });
+
+  it('attaches Neynar api-key header when base includes "neynar" and key is set', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'https://api.neynar.com';
+    process.env.NEYNAR_API_KEY = 'neynar-test-key';
+    stubFetch({ data: [] });
+    await readV2('/v2/path');
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('neynar-test-key');
+  });
+
+  it('does NOT attach api-key header for non-neynar endpoints', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    process.env.NEYNAR_API_KEY = 'neynar-test-key';
+    stubFetch({ data: [] });
+    await readV2('/v2/path');
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+});
+
+// ── nodeInfo ──────────────────────────────────────────────────────────────────
+
+describe('nodeInfo', () => {
+  it('throws when FARCASTER_READ_API_BASE is not set', async () => {
+    await expect(nodeInfo()).rejects.toThrow('FARCASTER_READ_API_BASE not set');
+  });
+
+  it('returns parsed info from the primary node', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    stubFetch({ maxHeight: 100, blockDelay: 5 });
+    const r = await nodeInfo();
+    expect(r.maxHeight).toBe(100);
+    expect(r.blockDelay).toBe(5);
+  });
+});
+
+// ── castsByFid ────────────────────────────────────────────────────────────────
+
+describe('castsByFid', () => {
+  it('calls readV2 with fid and pageSize in the URL', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    stubFetch({ casts: [] });
+    await castsByFid(1325, 5);
+    expect(mockFetch.mock.calls[0][0]).toContain('fid=1325');
+    expect(mockFetch.mock.calls[0][0]).toContain('pageSize=5');
+  });
+
+  it('uses default pageSize of 10', async () => {
+    process.env.FARCASTER_READ_API_BASE = 'http://primary.local:3381';
+    stubFetch({ casts: [] });
+    await castsByFid(42);
+    expect(mockFetch.mock.calls[0][0]).toContain('pageSize=10');
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/zoe/farcaster/__tests__/read-node.test.ts` — 11 cases: `readV2` (primary URL, fallback when no primary, haatz default, primary throw → failover, primary non-ok → failover, Neynar api-key header attached, NOT attached for non-neynar); `nodeInfo` (throws without env, returns parsed result); `castsByFid` (fid+pageSize in URL, default pageSize=10)
- `bot/src/zoe/__tests__/research-doc.test.ts` — 7 cases: `commitResearchDoc` success (ok+num+prUrl), valid topic passed through, unknown topic falls back to 'business', doc num increments above existing files, parses open PR title numbers for max, git failure returns ok:false+error, markdown file contains question+findings+topic

## Test plan
- [x] `npx vitest run src/zoe/farcaster/__tests__/read-node.test.ts src/zoe/__tests__/research-doc.test.ts` → 18/18 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)