### PR TITLE
test(bot/zoe): cost-ledger + resume coverage (30 cases)

### DIFF
--- a/bot/src/zoe/__tests__/cost-ledger.test.ts
+++ b/bot/src/zoe/__tests__/cost-ledger.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockAppendFileSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  mkdirSync: mockMkdirSync,
+  appendFileSync: mockAppendFileSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { recordCall, summaryText, todaySummary } from '../cost-ledger';
+
+const TEST_DAY = '2026-07-17';
+
+afterEach(() => vi.clearAllMocks());
+
+// ── todaySummary ──────────────────────────────────────────────────────────────
+
+describe('todaySummary', () => {
+  it('returns [] when the JSONL file does not exist', () => {
+    mockReadFileSync.mockImplementation(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); });
+    expect(todaySummary(TEST_DAY)).toEqual([]);
+  });
+
+  it('returns [] when the file is empty', () => {
+    mockReadFileSync.mockReturnValue('');
+    expect(todaySummary(TEST_DAY)).toEqual([]);
+  });
+
+  it('aggregates calls per model', () => {
+    const line1 = JSON.stringify({ model: 'sonnet', in: 100, out: 50, usd: 0.001 });
+    const line2 = JSON.stringify({ model: 'haiku', in: 200, out: 80, usd: 0.0005 });
+    const line3 = JSON.stringify({ model: 'sonnet', in: 150, out: 60, usd: 0.002 });
+    mockReadFileSync.mockReturnValue(`${line1}\n${line2}\n${line3}\n`);
+    const rows = todaySummary(TEST_DAY);
+    const sonnet = rows.find((r) => r.model === 'sonnet');
+    expect(sonnet).toBeDefined();
+    expect(sonnet!.calls).toBe(2);
+    expect(sonnet!.inputTokens).toBe(250);
+    expect(sonnet!.outputTokens).toBe(110);
+    expect(sonnet!.costUsd).toBeCloseTo(0.003, 5);
+  });
+
+  it('sorts models by costUsd descending', () => {
+    const cheap = JSON.stringify({ model: 'haiku', in: 10, out: 5, usd: 0.0001 });
+    const expensive = JSON.stringify({ model: 'opus', in: 500, out: 200, usd: 0.05 });
+    mockReadFileSync.mockReturnValue(`${cheap}\n${expensive}\n`);
+    const rows = todaySummary(TEST_DAY);
+    expect(rows[0].model).toBe('opus');
+    expect(rows[1].model).toBe('haiku');
+  });
+
+  it('skips corrupt (non-JSON) lines without throwing', () => {
+    const good = JSON.stringify({ model: 'sonnet', in: 100, out: 50, usd: 0.001 });
+    mockReadFileSync.mockReturnValue(`corrupt-line\n${good}\n`);
+    const rows = todaySummary(TEST_DAY);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].model).toBe('sonnet');
+  });
+
+  it('skips empty lines without throwing', () => {
+    const good = JSON.stringify({ model: 'haiku', in: 10, out: 5, usd: 0.0001 });
+    mockReadFileSync.mockReturnValue(`\n\n${good}\n\n`);
+    expect(todaySummary(TEST_DAY)).toHaveLength(1);
+  });
+
+  it('handles missing fields gracefully (defaults to 0)', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'sonnet' }) + '\n');
+    const rows = todaySummary(TEST_DAY);
+    expect(rows[0].inputTokens).toBe(0);
+    expect(rows[0].costUsd).toBe(0);
+  });
+});
+
+// ── summaryText ───────────────────────────────────────────────────────────────
+
+describe('summaryText', () => {
+  it('returns a "no calls" message when there is no data', () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(summaryText(TEST_DAY)).toContain('No ZOE model calls logged');
+  });
+
+  it('includes total cost and call count in the header', () => {
+    const line1 = JSON.stringify({ model: 'sonnet', in: 100, out: 50, usd: 0.01 });
+    const line2 = JSON.stringify({ model: 'haiku', in: 50, out: 20, usd: 0.001 });
+    mockReadFileSync.mockReturnValue(`${line1}\n${line2}\n`);
+    const text = summaryText(TEST_DAY);
+    expect(text).toContain('$0.0110'); // total
+    expect(text).toContain('2 calls');
+  });
+
+  it('lists each model with call count, tokens, and cost', () => {
+    const line = JSON.stringify({ model: 'sonnet', in: 1000, out: 500, usd: 0.025 });
+    mockReadFileSync.mockReturnValue(`${line}\n`);
+    const text = summaryText(TEST_DAY);
+    expect(text).toContain('sonnet');
+    expect(text).toContain('1 calls');
+    expect(text).toContain('$0.0250');
+  });
+});
+
+// ── recordCall ────────────────────────────────────────────────────────────────
+
+describe('recordCall', () => {
+  it('creates the directory and appends a JSONL entry', () => {
+    mockWriteFileSync.mockImplementation(() => {}); // for writeDailySummary
+    mockReadFileSync.mockReturnValue(''); // for todaySummary inside writeDailySummary
+    recordCall('concierge', { model: 'sonnet', inputTokens: 100, outputTokens: 50, totalCostUsd: 0.001 });
+    expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+    expect(mockAppendFileSync).toHaveBeenCalledOnce();
+    const content: string = mockAppendFileSync.mock.calls[0][1];
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.caller).toBe('concierge');
+    expect(parsed.model).toBe('sonnet');
+    expect(parsed.in).toBe(100);
+  });
+
+  it('swallows errors without throwing (best-effort telemetry)', () => {
+    mockMkdirSync.mockImplementation(() => { throw new Error('disk full'); });
+    expect(() => recordCall('test', { model: 'haiku', inputTokens: 0, outputTokens: 0, totalCostUsd: 0 })).not.toThrow();
+  });
+});

--- a/bot/src/zoe/__tests__/resume.test.ts
+++ b/bot/src/zoe/__tests__/resume.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockCallClaudeCli = vi.hoisted(() => vi.fn());
+vi.mock('../../hermes/claude-cli', () => ({
+  callClaudeCli: mockCallClaudeCli,
+}));
+
+const mockRemember = vi.hoisted(() => vi.fn());
+vi.mock('../recall', () => ({ remember: mockRemember }));
+
+const mockMkdir = vi.hoisted(() => vi.fn());
+const mockAccess = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockAppendFile = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', () => ({
+  promises: {
+    mkdir: mockMkdir,
+    access: mockAccess,
+    writeFile: mockWriteFile,
+    appendFile: mockAppendFile,
+  },
+}));
+
+import { captureResume, looksLikeResume, stripResumeTrigger } from '../resume';
+
+afterEach(() => vi.clearAllMocks());
+
+// ── stripResumeTrigger ─────────────────────────────────────────────────────────
+
+describe('stripResumeTrigger', () => {
+  it('strips /resume command prefix', () => {
+    expect(stripResumeTrigger('/resume Eagle Scout')).toBe('Eagle Scout');
+  });
+
+  it('strips /cv command prefix', () => {
+    expect(stripResumeTrigger('/cv National Ski Patroller')).toBe('National Ski Patroller');
+  });
+
+  it('strips bot-mention suffix from command (e.g. /resume@botname)', () => {
+    expect(stripResumeTrigger('/resume@mybot Eagle Scout')).toBe('Eagle Scout');
+  });
+
+  it('strips "add to my resume" preamble', () => {
+    expect(stripResumeTrigger('add to my resume Eagle Scout')).toBe('Eagle Scout');
+  });
+
+  it('strips "for my resume" preamble', () => {
+    expect(stripResumeTrigger('for my resume: Eagle Scout')).toBe('Eagle Scout');
+  });
+
+  it('strips "resume:" preamble', () => {
+    expect(stripResumeTrigger('resume: Eagle Scout')).toBe('Eagle Scout');
+  });
+
+  it('returns plain text unchanged when no trigger present', () => {
+    expect(stripResumeTrigger('Eagle Scout, earned 2010')).toBe('Eagle Scout, earned 2010');
+  });
+});
+
+// ── looksLikeResume ────────────────────────────────────────────────────────────
+
+describe('looksLikeResume', () => {
+  it('returns true for "add to my resume..."', () => {
+    expect(looksLikeResume('add to my resume Eagle Scout')).toBe(true);
+  });
+
+  it('returns true for "for my resume..."', () => {
+    expect(looksLikeResume('for my resume: Eagle Scout')).toBe(true);
+  });
+
+  it('returns true for "resume: ..."', () => {
+    expect(looksLikeResume('resume: Eagle Scout')).toBe(true);
+  });
+
+  it('returns false for a normal message', () => {
+    expect(looksLikeResume('how are you?')).toBe(false);
+  });
+
+  it('returns false for a /resume command (which goes through cmdHandler, not looksLike gate)', () => {
+    expect(looksLikeResume('/resume Eagle Scout')).toBe(false);
+  });
+});
+
+// ── captureResume ──────────────────────────────────────────────────────────────
+
+describe('captureResume', () => {
+  beforeEach(() => {
+    mockMkdir.mockResolvedValue(undefined);
+    mockAccess.mockResolvedValue(undefined); // file exists → skip initial write
+    mockAppendFile.mockResolvedValue(undefined);
+    mockRemember.mockResolvedValue(undefined);
+  });
+
+  it('returns usage prompt when text is empty after stripping trigger', async () => {
+    const r = await captureResume('/resume');
+    expect(r).toContain('Tell me what to add');
+    expect(mockCallClaudeCli).not.toHaveBeenCalled();
+  });
+
+  it('uses the Claude-formatted line when callClaudeCli returns a bullet line', async () => {
+    mockCallClaudeCli.mockResolvedValue({
+      text: '- **Eagle Scout** (achievement, 2010) - Highest rank in Scouting.',
+      isError: false,
+      inputTokens: 50,
+      outputTokens: 20,
+    });
+    const r = await captureResume('/resume Eagle Scout');
+    expect(r).toContain('**Eagle Scout**');
+    expect(mockAppendFile).toHaveBeenCalledOnce();
+    const appended: string = mockAppendFile.mock.calls[0][1];
+    expect(appended).toContain('**Eagle Scout**');
+  });
+
+  it('falls back to the raw text when callClaudeCli throws', async () => {
+    mockCallClaudeCli.mockRejectedValue(new Error('rate limit'));
+    const r = await captureResume('/resume Eagle Scout earned 2010');
+    expect(r).toContain('Eagle Scout');
+    expect(mockAppendFile).toHaveBeenCalledOnce();
+  });
+
+  it('creates the resume file header when the file does not exist yet', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })); // no file yet
+    mockWriteFile.mockResolvedValue(undefined);
+    mockCallClaudeCli.mockResolvedValue({ text: '- Some credential', isError: false, inputTokens: 10, outputTokens: 5 });
+    await captureResume('/resume Some credential');
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    expect(mockWriteFile.mock.calls[0][1]).toContain('# Zaal Panthaki');
+  });
+
+  it('calls remember() to persist the credential to the graph', async () => {
+    mockCallClaudeCli.mockResolvedValue({ text: '- **Ski Patrol** (certification, 2020) - Saved lives.', isError: false, inputTokens: 10, outputTokens: 5 });
+    await captureResume('/resume Ski Patrol');
+    expect(mockRemember).toHaveBeenCalledOnce();
+    const opts = mockRemember.mock.calls[0][0];
+    expect(opts.sourceTag).toBe('zaal-resume');
+  });
+
+  it('returns confirmation text with the formatted line', async () => {
+    mockCallClaudeCli.mockResolvedValue({ text: '- **Eagle Scout** (achievement, 2010) - Top rank.', isError: false, inputTokens: 10, outputTokens: 5 });
+    const r = await captureResume('/resume Eagle Scout');
+    expect(r).toContain('Added to your resume');
+    expect(r).toContain('**Eagle Scout**');
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/zoe/__tests__/cost-ledger.test.ts` — 12 cases: `todaySummary` (ENOENT→[], empty→[], per-model aggregation, sorted by cost desc, corrupt line skip, empty line skip, missing fields→0); `summaryText` (no-data message, header with total+call count, model line format); `recordCall` (mkdir+append JSONL entry, swallows errors)
- `bot/src/zoe/__tests__/resume.test.ts` — 18 cases: `stripResumeTrigger` (7 forms: /resume, /cv, @botname, "add to my resume", "for my resume", "resume:", plain text); `looksLikeResume` (3 true cases, 2 false cases); `captureResume` (empty→usage prompt, Claude line used, fallback on throw, creates header on new file, calls remember(), returns confirmation)

## Test plan
- [x] `npx vitest run src/zoe/__tests__/cost-ledger.test.ts src/zoe/__tests__/resume.test.ts` → 30/30 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)