### PR TITLE
test(bot/zoe): session-checkpoint + message-context coverage (20 cases)

### DIFF
--- a/bot/src/zoe/__tests__/message-context.test.ts
+++ b/bot/src/zoe/__tests__/message-context.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockStat = vi.hoisted(() => vi.fn());
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: { stat: mockStat, readFile: mockReadFile, writeFile: mockWriteFile, mkdir: mockMkdir },
+}));
+
+import {
+  cleanupStaleContexts,
+  clearMessageContext,
+  getMessageContext,
+  recordMessageContext,
+} from '../message-context';
+
+afterEach(() => vi.clearAllMocks());
+
+// ensureContextStore: stat ZOE_HOME then stat CONTEXT_PATH → both exist
+function stubBothExist() {
+  mockStat.mockResolvedValue({ isDirectory: () => true }); // for both stat calls
+}
+
+function stubFileExists(data: Record<string, unknown>) {
+  mockStat.mockResolvedValue({}); // both stat calls succeed
+  mockReadFile.mockResolvedValue(JSON.stringify(data));
+}
+
+// ── recordMessageContext ───────────────────────────────────────────────────────
+
+describe('recordMessageContext', () => {
+  it('writes the context entry to the store keyed by messageId string', async () => {
+    stubFileExists({});
+    mockWriteFile.mockResolvedValue(undefined);
+    await recordMessageContext(101, { qid: 'q-1', questionText: 'What is ZAO?' });
+    const written = JSON.parse(mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1]);
+    expect(written['101']).toBeDefined();
+    expect(written['101'].qid).toBe('q-1');
+    expect(written['101'].questionText).toBe('What is ZAO?');
+  });
+
+  it('preserves existing entries for other message IDs', async () => {
+    stubFileExists({ '200': { qid: 'q-old', ts: '2026-01-01T00:00:00Z' } });
+    mockWriteFile.mockResolvedValue(undefined);
+    await recordMessageContext(201, { taskId: 'task-1' });
+    const written = JSON.parse(mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1]);
+    expect(written['200']).toBeDefined();
+    expect(written['201'].taskId).toBe('task-1');
+  });
+});
+
+// ── getMessageContext ──────────────────────────────────────────────────────────
+
+describe('getMessageContext', () => {
+  it('returns the context for a known messageId', async () => {
+    stubFileExists({ '42': { qid: 'q-42', ts: '2026-07-17T10:00:00Z' } });
+    const ctx = await getMessageContext(42);
+    expect(ctx?.qid).toBe('q-42');
+  });
+
+  it('returns undefined for an unknown messageId', async () => {
+    stubFileExists({ '99': { qid: 'q-99', ts: '2026-07-17T10:00:00Z' } });
+    expect(await getMessageContext(404)).toBeUndefined();
+  });
+
+  it('returns {} (empty object result → undefined) when file does not exist', async () => {
+    // stat throws for the file → writeFile creates it, then readFile returns '{}'
+    mockStat
+      .mockResolvedValueOnce({}) // ZOE_HOME stat ok
+      .mockRejectedValueOnce(new Error('ENOENT')); // file stat fails
+    mockWriteFile.mockResolvedValue(undefined); // create empty file
+    mockReadFile.mockResolvedValue('{}');
+    expect(await getMessageContext(1)).toBeUndefined();
+  });
+});
+
+// ── clearMessageContext ────────────────────────────────────────────────────────
+
+describe('clearMessageContext', () => {
+  it('removes the entry and writes the updated map', async () => {
+    stubFileExists({ '50': { qid: 'q-50', ts: '2026-07-17T10:00:00Z' }, '51': { qid: 'q-51', ts: '2026-07-17T10:00:00Z' } });
+    mockWriteFile.mockResolvedValue(undefined);
+    await clearMessageContext(50);
+    const written = JSON.parse(mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1]);
+    expect(written['50']).toBeUndefined();
+    expect(written['51']).toBeDefined();
+  });
+});
+
+// ── cleanupStaleContexts ──────────────────────────────────────────────────────
+
+describe('cleanupStaleContexts', () => {
+  it('removes entries older than maxAgeMs and returns count', async () => {
+    const staleTs = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25h ago
+    const freshTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();  // 1h ago
+    stubFileExists({ '1': { qid: 'stale', ts: staleTs }, '2': { qid: 'fresh', ts: freshTs } });
+    mockWriteFile.mockResolvedValue(undefined);
+    const removed = await cleanupStaleContexts(24 * 60 * 60 * 1000);
+    expect(removed).toBe(1);
+    const written = JSON.parse(mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1]);
+    expect(written['1']).toBeUndefined();
+    expect(written['2']).toBeDefined();
+  });
+
+  it('returns 0 and does not write when no entries are stale', async () => {
+    const freshTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    stubFileExists({ '1': { qid: 'fresh', ts: freshTs } });
+    mockWriteFile.mockResolvedValue(undefined);
+    const removed = await cleanupStaleContexts(24 * 60 * 60 * 1000);
+    expect(removed).toBe(0);
+    // writeFile called only for ensureContextStore (not for the map update)
+    const lastCall = mockWriteFile.mock.calls.filter(c => !c[0].endsWith('.json') || JSON.parse(c[1] as string)['1']);
+    expect(lastCall.length).toBe(0); // no map rewrite when nothing removed
+  });
+
+  it('keeps entries with invalid timestamps (NaN age comparison is false, not an exception)', async () => {
+    // new Date('not-a-date').getTime() → NaN; NaN > maxAgeMs → false; entry NOT removed
+    stubFileExists({ '1': { qid: 'bad', ts: 'not-a-date' } });
+    mockWriteFile.mockResolvedValue(undefined);
+    const removed = await cleanupStaleContexts(1000);
+    expect(removed).toBe(0);
+  });
+});

--- a/bot/src/zoe/__tests__/session-checkpoint.test.ts
+++ b/bot/src/zoe/__tests__/session-checkpoint.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: { readFile: mockReadFile, writeFile: mockWriteFile, mkdir: mockMkdir },
+}));
+
+import { clearCheckpoint, getCheckpoint, offerCheckpoint, saveCheckpoint } from '../session-checkpoint';
+
+afterEach(() => vi.clearAllMocks());
+
+const THREAD = 'chat-12345';
+const OTHER = 'chat-99999';
+
+// ── getCheckpoint / saveCheckpoint ────────────────────────────────────────────
+
+describe('getCheckpoint', () => {
+  it('returns null when file does not exist (ENOENT)', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    expect(await getCheckpoint(THREAD)).toBeNull();
+  });
+
+  it('returns null when no checkpoint exists for the thread', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ [OTHER]: { checkpoint: 'other thread', savedAt: '2026-01-01T00:00:00Z' } }));
+    expect(await getCheckpoint(THREAD)).toBeNull();
+  });
+
+  it('returns the checkpoint entry for a known thread', async () => {
+    const entry = { checkpoint: 'Working on PR #42', savedAt: '2026-07-17T10:00:00Z' };
+    mockReadFile.mockResolvedValue(JSON.stringify({ [THREAD]: entry }));
+    const result = await getCheckpoint(THREAD);
+    expect(result).toEqual(entry);
+  });
+});
+
+describe('saveCheckpoint', () => {
+  it('writes the checkpoint to the file', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({}));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await saveCheckpoint(THREAD, 'Working on PR #42');
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written[THREAD].checkpoint).toBe('Working on PR #42');
+  });
+
+  it('trims the checkpoint text before saving', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({}));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await saveCheckpoint(THREAD, '  padded  ');
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written[THREAD].checkpoint).toBe('padded');
+  });
+
+  it('preserves existing checkpoints for other threads', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ [OTHER]: { checkpoint: 'other', savedAt: '2026-01-01T00:00:00Z' } }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await saveCheckpoint(THREAD, 'new checkpoint');
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written[OTHER]).toBeDefined();
+    expect(written[THREAD].checkpoint).toBe('new checkpoint');
+  });
+});
+
+// ── clearCheckpoint ───────────────────────────────────────────────────────────
+
+describe('clearCheckpoint', () => {
+  it('removes the thread from the checkpoints file', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ [THREAD]: { checkpoint: 'old', savedAt: '2026-01-01T00:00:00Z' } }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await clearCheckpoint(THREAD);
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written[THREAD]).toBeUndefined();
+  });
+});
+
+// ── offerCheckpoint ───────────────────────────────────────────────────────────
+
+describe('offerCheckpoint', () => {
+  it('returns null when no checkpoint exists', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    expect(await offerCheckpoint(THREAD)).toBeNull();
+  });
+
+  it('returns a message containing the checkpoint text', async () => {
+    const entry = { checkpoint: 'Working on PR #42', savedAt: new Date().toISOString() };
+    mockReadFile.mockResolvedValue(JSON.stringify({ [THREAD]: entry }));
+    const msg = await offerCheckpoint(THREAD);
+    expect(msg).toContain('Working on PR #42');
+    expect(msg).toContain('just now'); // saved right now → hoursAgo = 0
+  });
+
+  it('shows hours ago for an older checkpoint', async () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const entry = { checkpoint: 'Old task', savedAt: twoHoursAgo };
+    mockReadFile.mockResolvedValue(JSON.stringify({ [THREAD]: entry }));
+    const msg = await offerCheckpoint(THREAD);
+    expect(msg).toContain('2 hours ago');
+  });
+
+  it('uses "1 hour ago" for exactly 1 hour', async () => {
+    const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    mockReadFile.mockResolvedValue(JSON.stringify({ [THREAD]: { checkpoint: 'task', savedAt: oneHourAgo } }));
+    const msg = await offerCheckpoint(THREAD);
+    expect(msg).toContain('1 hour ago');
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/zoe/__tests__/session-checkpoint.test.ts` — 11 cases: `getCheckpoint` (ENOENT→null, missing thread→null, known thread); `saveCheckpoint` (writes entry, trims text, preserves other threads); `clearCheckpoint` (removes thread); `offerCheckpoint` (null when none, contains text + "just now", "2 hours ago", "1 hour ago" singular)
- `bot/src/zoe/__tests__/message-context.test.ts` — 9 cases: `recordMessageContext` (keyed by string msgId, preserves existing); `getMessageContext` (returns ctx, undefined for unknown, handles missing file); `clearMessageContext` (removes + writes); `cleanupStaleContexts` (removes 25h-old entry, returns 0 on all-fresh, NaN timestamps kept — `NaN > N` is false, no exception thrown)

## Test plan
- [x] `npx vitest run src/zoe/__tests__/session-checkpoint.test.ts src/zoe/__tests__/message-context.test.ts` → 20/20 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)