### PR TITLE
test(bot/zoe): nudges + handoffs-surface coverage (28 cases)

### DIFF
--- a/bot/src/zoe/__tests__/handoffs-surface.test.ts
+++ b/bot/src/zoe/__tests__/handoffs-surface.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: { readFile: mockReadFile, writeFile: mockWriteFile, mkdir: mockMkdir },
+}));
+
+const mockFetch = vi.fn();
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  delete process.env.COWORK_TRACKER_URL;
+  delete process.env.COWORK_TRACKER_KEY;
+});
+
+import { surfaceNewHandoffs } from '../handoffs-surface';
+
+function stubFetch(rows: unknown[], ok = true) {
+  const res = {
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(rows),
+  };
+  mockFetch.mockResolvedValue(res);
+  vi.stubGlobal('fetch', mockFetch);
+}
+
+// ── surfaceNewHandoffs ────────────────────────────────────────────────────────
+
+describe('surfaceNewHandoffs', () => {
+  it('returns 0 when COWORK_TRACKER_URL is not set', async () => {
+    const postToTopic = vi.fn();
+    const result = await surfaceNewHandoffs(postToTopic);
+    expect(result).toBe(0);
+    expect(postToTopic).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when COWORK_TRACKER_KEY is not set', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    const postToTopic = vi.fn();
+    const result = await surfaceNewHandoffs(postToTopic);
+    expect(result).toBe(0);
+    expect(postToTopic).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when fetch returns empty array', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    process.env.COWORK_TRACKER_KEY = 'test-key';
+    // last-seen: ENOENT → default to 1h ago
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    stubFetch([]);
+    const postToTopic = vi.fn();
+    const result = await surfaceNewHandoffs(postToTopic);
+    expect(result).toBe(0);
+    expect(postToTopic).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when fetch returns non-ok status', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    process.env.COWORK_TRACKER_KEY = 'test-key';
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    stubFetch([], false); // ok=false
+    const postToTopic = vi.fn();
+    const result = await surfaceNewHandoffs(postToTopic);
+    expect(result).toBe(0);
+  });
+
+  it('posts each new handoff and returns count', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    process.env.COWORK_TRACKER_KEY = 'test-key';
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const rows = [
+      { title: 'Handoff A', legacy_source: 'handoff:a', created_at: '2026-07-17T10:00:00Z' },
+      { title: 'Handoff B', legacy_source: 'handoff:b', created_at: '2026-07-17T11:00:00Z' },
+    ];
+    stubFetch(rows);
+    const postToTopic = vi.fn().mockResolvedValue(undefined);
+    const result = await surfaceNewHandoffs(postToTopic);
+    expect(result).toBe(2);
+    expect(postToTopic).toHaveBeenCalledTimes(2);
+    expect(postToTopic.mock.calls[0][0]).toContain('Handoff A');
+    expect(postToTopic.mock.calls[1][0]).toContain('Handoff B');
+  });
+
+  it('updates the last-seen timestamp to the max created_at after surfacing', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    process.env.COWORK_TRACKER_KEY = 'test-key';
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const rows = [
+      { title: 'A', legacy_source: 'handoff:a', created_at: '2026-07-17T09:00:00Z' },
+      { title: 'B', legacy_source: 'handoff:b', created_at: '2026-07-17T12:00:00Z' },
+    ];
+    stubFetch(rows);
+    await surfaceNewHandoffs(vi.fn().mockResolvedValue(undefined));
+    // setLastSeen should write the latest timestamp
+    const written = mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1];
+    expect(JSON.parse(written).at).toBe('2026-07-17T12:00:00Z');
+  });
+
+  it('uses the last-seen timestamp from the file for filtering', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    process.env.COWORK_TRACKER_KEY = 'test-key';
+    const since = '2026-07-17T08:00:00Z';
+    mockReadFile.mockResolvedValue(JSON.stringify({ at: since }));
+    stubFetch([]);
+    await surfaceNewHandoffs(vi.fn());
+    // The fetch URL should include the since timestamp
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toContain(encodeURIComponent(since));
+  });
+
+  it('swallows postToTopic errors without stopping other posts', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
+    process.env.COWORK_TRACKER_KEY = 'test-key';
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const rows = [
+      { title: 'A', legacy_source: 'handoff:a', created_at: '2026-07-17T09:00:00Z' },
+      { title: 'B', legacy_source: 'handoff:b', created_at: '2026-07-17T10:00:00Z' },
+    ];
+    stubFetch(rows);
+    const postToTopic = vi.fn()
+      .mockRejectedValueOnce(new Error('TG error')) // first fails
+      .mockResolvedValueOnce(undefined);             // second ok
+    const result = await surfaceNewHandoffs(postToTopic);
+    expect(result).toBe(2); // still returns 2 (rows processed)
+    expect(postToTopic).toHaveBeenCalledTimes(2);
+  });
+});

--- a/bot/src/zoe/__tests__/nudges.test.ts
+++ b/bot/src/zoe/__tests__/nudges.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadTasks = vi.hoisted(() => vi.fn());
+vi.mock('../memory', () => ({
+  ZOE_PATHS: { home: '/tmp/zoe-test' },
+  readTasks: mockReadTasks,
+}));
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+const mockAccess = vi.hoisted(() => vi.fn());
+const mockUnlink = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: {
+    readFile: mockReadFile,
+    writeFile: mockWriteFile,
+    mkdir: mockMkdir,
+    access: mockAccess,
+    unlink: mockUnlink,
+  },
+}));
+
+import {
+  disableNudges,
+  enableNudges,
+  markNudgeSent,
+  nextNudge,
+  NUDGE_COOLDOWN_MS,
+  nudgeCooldownElapsed,
+  nudgesEnabled,
+} from '../nudges';
+
+afterEach(() => vi.clearAllMocks());
+
+const makeTask = (id: string, title: string, priority: 'high' | 'med' | 'low', status: 'pending' | 'done' = 'pending') => ({
+  id, title, priority, status, description: `Do ${title}`, created_at: '2026-01-01',
+});
+
+// ── nextNudge ─────────────────────────────────────────────────────────────────
+
+describe('nextNudge', () => {
+  it('returns null when there are no open tasks', async () => {
+    mockReadTasks.mockResolvedValue([makeTask('1', 'Done task', 'high', 'done')]);
+    expect(await nextNudge()).toBeNull();
+  });
+
+  it('returns null when task list is empty', async () => {
+    mockReadTasks.mockResolvedValue([]);
+    expect(await nextNudge()).toBeNull();
+  });
+
+  it('returns the highest-priority open task', async () => {
+    mockReadTasks.mockResolvedValue([
+      makeTask('1', 'Low task', 'low'),
+      makeTask('2', 'High task', 'high'),
+      makeTask('3', 'Med task', 'med'),
+    ]);
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })); // no pointer
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const nudge = await nextNudge();
+    expect(nudge).toContain('High task');
+    expect(nudge).toContain('[high]');
+  });
+
+  it('starts at index 0 when pointer file does not exist', async () => {
+    mockReadTasks.mockResolvedValue([makeTask('1', 'Task A', 'high'), makeTask('2', 'Task B', 'med')]);
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const nudge = await nextNudge();
+    expect(nudge).toContain('Task A'); // index 0 = first after sort = high
+  });
+
+  it('rotates to the next task using the pointer', async () => {
+    mockReadTasks.mockResolvedValue([makeTask('1', 'Task A', 'high'), makeTask('2', 'Task B', 'med')]);
+    mockReadFile.mockResolvedValue('1'); // pointer says idx=1
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const nudge = await nextNudge();
+    expect(nudge).toContain('Task B'); // sorted high→med; idx 1 = Task B
+  });
+
+  it('includes the open queue count in the message', async () => {
+    mockReadTasks.mockResolvedValue([makeTask('1', 'A', 'high'), makeTask('2', 'B', 'med'), makeTask('3', 'C', 'low')]);
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const nudge = await nextNudge();
+    expect(nudge).toContain('3 open in your queue');
+  });
+
+  it('still sends the nudge even when the pointer write fails', async () => {
+    mockReadTasks.mockResolvedValue([makeTask('1', 'Task A', 'high')]);
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    mockMkdir.mockRejectedValue(new Error('disk full')); // write fails
+    const nudge = await nextNudge();
+    expect(nudge).toContain('Task A');
+  });
+});
+
+// ── nudgesEnabled ─────────────────────────────────────────────────────────────
+
+describe('nudgesEnabled', () => {
+  it('returns true when no flag files exist', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    expect(await nudgesEnabled()).toBe(true);
+  });
+
+  it('returns false when nudges-disabled.flag exists', async () => {
+    mockAccess.mockResolvedValueOnce(undefined); // nudges-disabled.flag found
+    expect(await nudgesEnabled()).toBe(false);
+  });
+
+  it('returns false when the legacy tips-disabled.flag exists', async () => {
+    mockAccess
+      .mockRejectedValueOnce(new Error('ENOENT')) // nudges-disabled absent
+      .mockResolvedValueOnce(undefined);           // tips-disabled found
+    expect(await nudgesEnabled()).toBe(false);
+  });
+});
+
+// ── disableNudges / enableNudges ──────────────────────────────────────────────
+
+describe('disableNudges', () => {
+  it('writes the nudges-disabled.flag file', async () => {
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await disableNudges();
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    expect(mockWriteFile.mock.calls[0][0]).toContain('nudges-disabled.flag');
+  });
+});
+
+describe('enableNudges', () => {
+  it('unlinks both flag files', async () => {
+    mockUnlink.mockResolvedValue(undefined);
+    await enableNudges();
+    expect(mockUnlink).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows ENOENT when flags are already absent', async () => {
+    mockUnlink.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(enableNudges()).resolves.toBeUndefined();
+  });
+});
+
+// ── nudgeCooldownElapsed ──────────────────────────────────────────────────────
+
+describe('nudgeCooldownElapsed', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('returns true when the file does not exist (never sent)', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    expect(await nudgeCooldownElapsed(NOW)).toBe(true);
+  });
+
+  it('returns true when last sent > 4h ago', async () => {
+    const fiveHoursAgo = new Date(NOW - 5 * 60 * 60 * 1000).toISOString();
+    mockReadFile.mockResolvedValue(fiveHoursAgo);
+    expect(await nudgeCooldownElapsed(NOW)).toBe(true);
+  });
+
+  it('returns false when last sent < 4h ago', async () => {
+    const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+    mockReadFile.mockResolvedValue(oneHourAgo);
+    expect(await nudgeCooldownElapsed(NOW)).toBe(false);
+  });
+
+  it('returns false when last sent exactly at cooldown boundary', async () => {
+    const exactlyFourH = new Date(NOW - NUDGE_COOLDOWN_MS).toISOString();
+    mockReadFile.mockResolvedValue(exactlyFourH);
+    expect(await nudgeCooldownElapsed(NOW)).toBe(true); // >= so exactly 4h → true
+  });
+
+  it('returns true when the stored timestamp is invalid (NaN)', async () => {
+    mockReadFile.mockResolvedValue('not-a-date');
+    expect(await nudgeCooldownElapsed(NOW)).toBe(true);
+  });
+});
+
+// ── markNudgeSent ─────────────────────────────────────────────────────────────
+
+describe('markNudgeSent', () => {
+  it('writes the ISO timestamp to the last-sent file', async () => {
+    const NOW = 1_700_000_000_000;
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await markNudgeSent(NOW);
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    expect(mockWriteFile.mock.calls[0][0]).toContain('nudge-last-sent.txt');
+    expect(mockWriteFile.mock.calls[0][1]).toBe(new Date(NOW).toISOString());
+  });
+
+  it('swallows errors without throwing (best-effort)', async () => {
+    mockMkdir.mockRejectedValue(new Error('disk full'));
+    await expect(markNudgeSent(Date.now())).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/zoe/__tests__/nudges.test.ts` — 20 cases: `nextNudge` (null on empty, highest-priority returned, idx=0 on ENOENT, rotates via pointer, queue count in message, pointer write failure still sends); `nudgesEnabled` (true/false for both flag files); `disableNudges`/`enableNudges` (flag file operations); `nudgeCooldownElapsed(now)` (ENOENT→true, >4h→true, <4h→false, exactly 4h→true, invalid NaN→true); `markNudgeSent(now)` (writes ISO, swallows errors)
- `bot/src/zoe/__tests__/handoffs-surface.test.ts` — 8 cases: no URL/key→0, empty fetch→0, non-ok status→0, posts each row with count returned, updates last-seen to max created_at, uses stored since-timestamp in URL query, swallows postToTopic errors without stopping other posts

## Test plan
- [x] `npx vitest run src/zoe/__tests__/nudges.test.ts src/zoe/__tests__/handoffs-surface.test.ts` → 28/28 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)