### PR TITLE
test(bot/zoe): focus-guard + trust-audit coverage (29 cases)

### DIFF
--- a/bot/src/zoe/__tests__/focus-guard.test.ts
+++ b/bot/src/zoe/__tests__/focus-guard.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: { readFile: mockReadFile, writeFile: mockWriteFile, mkdir: mockMkdir },
+}));
+
+import {
+  buildFocusDigest,
+  decideQueueOrSend,
+  endFocus,
+  isFocusMode,
+  queuePing,
+  readFocusState,
+  startFocus,
+} from '../focus-guard';
+
+afterEach(() => vi.clearAllMocks());
+
+// ── buildFocusDigest (pure) ───────────────────────────────────────────────────
+
+describe('buildFocusDigest', () => {
+  it('returns a "no queued updates" message when the queue is empty', () => {
+    expect(buildFocusDigest([])).toBe('No queued updates from your focus window.');
+  });
+
+  it('uses singular form for exactly one queued ping', () => {
+    const result = buildFocusDigest(['PR #42 merged']);
+    expect(result).toContain('1 update');
+    expect(result).toContain('PR #42 merged');
+  });
+
+  it('lists all pings with count for multiple entries', () => {
+    const result = buildFocusDigest(['Ping A', 'Ping B', 'Ping C']);
+    expect(result).toContain('3 updates');
+    expect(result).toContain('Ping A');
+    expect(result).toContain('Ping C');
+  });
+});
+
+// ── readFocusState ────────────────────────────────────────────────────────────
+
+describe('readFocusState', () => {
+  it('returns default state when file does not exist (ENOENT)', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    const state = await readFocusState();
+    expect(state.focusMode).toBe(false);
+    expect(state.queuedPings).toEqual([]);
+    expect(state.startedAt).toBeNull();
+  });
+
+  it('returns default state when file contains invalid JSON', async () => {
+    mockReadFile.mockResolvedValue('not-json');
+    const state = await readFocusState();
+    expect(state.focusMode).toBe(false);
+  });
+
+  it('parses a valid focus state from the file', async () => {
+    const stored = { focusMode: true, queuedPings: ['ping1', 'ping2'], startedAt: '2026-07-17T10:00:00Z' };
+    mockReadFile.mockResolvedValue(JSON.stringify(stored));
+    const state = await readFocusState();
+    expect(state.focusMode).toBe(true);
+    expect(state.queuedPings).toEqual(['ping1', 'ping2']);
+    expect(state.startedAt).toBe('2026-07-17T10:00:00Z');
+  });
+
+  it('coerces queuedPings to [] when stored value is not an array', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: false, queuedPings: 'bad', startedAt: null }));
+    const state = await readFocusState();
+    expect(state.queuedPings).toEqual([]);
+  });
+});
+
+// ── startFocus ────────────────────────────────────────────────────────────────
+
+describe('startFocus', () => {
+  it('sets focusMode=true, clears queuedPings, and records startedAt', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: false, queuedPings: ['old ping'], startedAt: null }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await startFocus();
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written.focusMode).toBe(true);
+    expect(written.queuedPings).toEqual([]);
+    expect(written.startedAt).not.toBeNull();
+  });
+});
+
+// ── endFocus ──────────────────────────────────────────────────────────────────
+
+describe('endFocus', () => {
+  it('returns queued pings and resets state', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: true, queuedPings: ['A', 'B'], startedAt: '2026-07-17T10:00:00Z' }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const queued = await endFocus();
+    expect(queued).toEqual(['A', 'B']);
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written.focusMode).toBe(false);
+    expect(written.queuedPings).toEqual([]);
+    expect(written.startedAt).toBeNull();
+  });
+
+  it('returns empty array when not in focus mode', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: false, queuedPings: [], startedAt: null }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    expect(await endFocus()).toEqual([]);
+  });
+});
+
+// ── isFocusMode ───────────────────────────────────────────────────────────────
+
+describe('isFocusMode', () => {
+  it('returns true when focusMode is active', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: true, queuedPings: [], startedAt: '2026-01-01T00:00:00Z' }));
+    expect(await isFocusMode()).toBe(true);
+  });
+
+  it('returns false when focusMode is inactive', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    expect(await isFocusMode()).toBe(false);
+  });
+});
+
+// ── queuePing ──────────────────────────────────────────────────────────────────
+
+describe('queuePing', () => {
+  it('appends the ping when in focus mode', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: true, queuedPings: ['existing'], startedAt: '2026-01-01T00:00:00Z' }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await queuePing('new ping');
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1]);
+    expect(written.queuedPings).toEqual(['existing', 'new ping']);
+  });
+
+  it('does nothing when not in focus mode', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: false, queuedPings: [], startedAt: null }));
+    await queuePing('should be ignored');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+// ── decideQueueOrSend ─────────────────────────────────────────────────────────
+
+describe('decideQueueOrSend', () => {
+  it('returns "send" for urgent items regardless of focus mode', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: true, queuedPings: [], startedAt: '2026-01-01' }));
+    expect(await decideQueueOrSend(true)).toBe('send');
+  });
+
+  it('returns "queue" for non-urgent items when in focus mode', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ focusMode: true, queuedPings: [], startedAt: '2026-01-01' }));
+    expect(await decideQueueOrSend(false)).toBe('queue');
+  });
+
+  it('returns "send" for non-urgent items when not in focus mode', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    expect(await decideQueueOrSend()).toBe('send');
+  });
+});

--- a/bot/src/zoe/__tests__/trust-audit.test.ts
+++ b/bot/src/zoe/__tests__/trust-audit.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', () => ({
+  promises: { readFile: mockReadFile },
+}));
+
+import { formatAuditForTelegram, runAudit } from '../trust-audit';
+
+afterEach(() => vi.clearAllMocks());
+
+const NOW = 1_700_000_000_000; // fixed epoch
+const DAY_MS = 24 * 60 * 60 * 1000;
+const days = (n: number) => new Date(NOW - n * DAY_MS).toISOString();
+
+// tasks.json path → first readFile call; captures.jsonl → second readFile call
+function stubFiles(tasks: unknown[], capLines: string[] = []) {
+  mockReadFile
+    .mockResolvedValueOnce(JSON.stringify(tasks))     // tasks.json
+    .mockResolvedValueOnce(capLines.join('\n'));       // captures.jsonl
+}
+
+// ── formatAuditForTelegram (pure) ─────────────────────────────────────────────
+
+describe('formatAuditForTelegram', () => {
+  it('returns the summary directly when there are no findings', () => {
+    const report = { scannedAt: '2026-07-17T00:00:00Z', findings: [], summary: 'All clear.' };
+    expect(formatAuditForTelegram(report)).toBe('All clear.');
+  });
+
+  it('groups capture and task findings with labels', () => {
+    const report = {
+      scannedAt: '2026-07-17T00:00:00Z',
+      summary: '2 gaps found.',
+      findings: [
+        { type: 'capture' as const, id: 'c1', title: 'Old idea', daysSince: 20, reason: '...' },
+        { type: 'task' as const, id: 't1', title: 'Stuck task', daysSince: 15, status: 'pending', reason: '...' },
+      ],
+    };
+    const msg = formatAuditForTelegram(report);
+    expect(msg).toContain('Captures:');
+    expect(msg).toContain('Old idea');
+    expect(msg).toContain('Tasks:');
+    expect(msg).toContain('Stuck task');
+    expect(msg).toContain('[pending]');
+  });
+});
+
+// ── runAudit ──────────────────────────────────────────────────────────────────
+
+describe('runAudit', () => {
+  it('returns all-clear summary when no tasks/captures exist', async () => {
+    stubFiles([]);
+    const r = await runAudit([], NOW);
+    expect(r.findings).toHaveLength(0);
+    expect(r.summary).toContain('all clear');
+  });
+
+  it('flags a capture older than 14 days with no related done task', async () => {
+    const cap = JSON.stringify({ id: 'c1', text: 'Research ZAO music system', created_at: days(15) });
+    stubFiles([], [cap]);
+    const r = await runAudit([], NOW);
+    expect(r.findings.some((f) => f.type === 'capture' && f.id === 'c1')).toBe(true);
+  });
+
+  it('does NOT flag a capture younger than 14 days', async () => {
+    const cap = JSON.stringify({ id: 'c2', text: 'Fresh idea', created_at: days(5) });
+    stubFiles([], [cap]);
+    const r = await runAudit([], NOW);
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it('does NOT flag a stale capture when a related completed task exists', async () => {
+    const cap = JSON.stringify({ id: 'c3', text: 'add artist profile page', created_at: days(20) });
+    const task = { id: 't1', title: 'artist profile page', status: 'completed', created_at: days(25), priority: 'high', description: '', notes: [] };
+    stubFiles([task], [cap]);
+    const r = await runAudit([], NOW);
+    const capFinding = r.findings.find((f) => f.type === 'capture' && f.id === 'c3');
+    expect(capFinding).toBeUndefined();
+  });
+
+  it('flags a pending task older than 14 days', async () => {
+    const task = { id: 't2', title: 'Old pending task', status: 'pending', created_at: days(20), priority: 'med', description: '', notes: [] };
+    stubFiles([task]);
+    const r = await runAudit([], NOW);
+    const finding = r.findings.find((f) => f.id === 't2');
+    expect(finding).toBeDefined();
+    expect(finding?.reason).toContain('Pending for 20 days');
+  });
+
+  it('does NOT flag a pending task younger than 14 days', async () => {
+    const task = { id: 't3', title: 'Fresh task', status: 'pending', created_at: days(5), priority: 'med', description: '', notes: [] };
+    stubFiles([task]);
+    const r = await runAudit([], NOW);
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it('flags a blocked task older than 14 days', async () => {
+    const task = { id: 't4', title: 'Long-blocked task', status: 'blocked', created_at: days(20), priority: 'high', description: '', notes: ['waiting on API key'] };
+    stubFiles([task]);
+    const r = await runAudit([], NOW);
+    const finding = r.findings.find((f) => f.id === 't4');
+    expect(finding).toBeDefined();
+    expect(finding?.status).toBe('blocked');
+    expect(finding?.reason).toContain('Blocked for 20 days');
+  });
+
+  it('includes the last note in the blocked reason', async () => {
+    const task = { id: 't5', title: 'Blocked task', status: 'blocked', created_at: days(20), priority: 'med', description: '', notes: ['note 1', 'waiting on Zaal decision'] };
+    stubFiles([task]);
+    const r = await runAudit([], NOW);
+    const finding = r.findings.find((f) => f.id === 't5');
+    expect(finding?.reason).toContain('waiting on Zaal decision');
+  });
+
+  it('uses grouped summary for > 3 findings', async () => {
+    const tasks = Array.from({ length: 4 }, (_, i) => ({
+      id: `t${i}`, title: `Old task ${i}`, status: 'pending', created_at: days(20), priority: 'low', description: '', notes: [],
+    }));
+    stubFiles(tasks);
+    const r = await runAudit([], NOW);
+    expect(r.findings).toHaveLength(4);
+    expect(r.summary).toContain('4 potential gaps');
+    expect(r.summary).toContain('stuck tasks');
+  });
+
+  it('records the scannedAt timestamp from the now parameter', async () => {
+    stubFiles([]);
+    const r = await runAudit([], NOW);
+    expect(r.scannedAt).toBe(new Date(NOW).toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
- `bot/src/zoe/__tests__/focus-guard.test.ts` — 17 cases: `buildFocusDigest` (empty/singular/plural); `readFocusState` (ENOENT→default, invalid JSON, valid parse, bad queuedPings coerced to []); `startFocus` (sets mode+clears queue+records timestamp); `endFocus` (returns queued pings, resets state); `isFocusMode` (true/false); `queuePing` (appends in focus, no-op outside); `decideQueueOrSend` (urgent→send, focus+non-urgent→queue, non-focus→send)
- `bot/src/zoe/__tests__/trust-audit.test.ts` — 12 cases: `formatAuditForTelegram` (empty→summary, grouped captures+tasks); `runAudit` (all-clear on empty, flags 15d capture, skips 5d capture, skips stale capture with related done task, flags pending>14d, skips pending<14d, flags blocked>14d with last note, grouped summary for >3 findings, scannedAt from `now` param)

## Test plan
- [x] `npx vitest run src/zoe/__tests__/focus-guard.test.ts src/zoe/__tests__/trust-audit.test.ts` → 29/29 passed
- [x] No source files changed — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)