### PR TITLE
test(bot/zoe): pending-decisions + groups coverage (43 cases)

### DIFF
--- a/bot/src/zoe/__tests__/groups.test.ts
+++ b/bot/src/zoe/__tests__/groups.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../memory', () => ({
+  ZOE_PATHS: { home: '/tmp/zoe-groups-test' },
+}));
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: { readFile: mockReadFile, writeFile: mockWriteFile, mkdir: mockMkdir },
+}));
+
+import {
+  addAllowlistMember,
+  getGroupConfig,
+  isBotMentioned,
+  readGroups,
+  removeAllowlistMember,
+  setGroupMode,
+  shouldRespond,
+  upsertGroup,
+  writeGroups,
+  type GateContext,
+  type GroupConfig,
+} from '../groups';
+
+afterEach(() => vi.clearAllMocks());
+
+const BASE_CONFIG: GroupConfig = {
+  chat_id: 100,
+  chat_title: 'Test Group',
+  mode: 'mention',
+  member_allowlist: [42],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+// ── readGroups ────────────────────────────────────────────────────────────────
+
+describe('readGroups', () => {
+  it('returns [] when file does not exist (ENOENT)', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    expect(await readGroups()).toEqual([]);
+  });
+
+  it('returns [] when file contains invalid JSON', async () => {
+    mockReadFile.mockResolvedValue('not-json');
+    expect(await readGroups()).toEqual([]);
+  });
+
+  it('parses and returns the stored group list', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    const groups = await readGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].chat_id).toBe(100);
+  });
+});
+
+// ── writeGroups ───────────────────────────────────────────────────────────────
+
+describe('writeGroups', () => {
+  it('creates the directory and writes serialized JSON', async () => {
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await writeGroups([BASE_CONFIG]);
+    expect(mockMkdir).toHaveBeenCalledWith('/tmp/zoe-groups-test', { recursive: true });
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
+    expect(written[0].chat_id).toBe(100);
+  });
+});
+
+// ── getGroupConfig ────────────────────────────────────────────────────────────
+
+describe('getGroupConfig', () => {
+  it('returns null when the group is not found', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    expect(await getGroupConfig(999)).toBeNull();
+  });
+
+  it('returns the matching config by chat_id', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    const cfg = await getGroupConfig(100);
+    expect(cfg?.chat_title).toBe('Test Group');
+  });
+});
+
+// ── upsertGroup ───────────────────────────────────────────────────────────────
+
+describe('upsertGroup', () => {
+  it('creates a new group with defaults when not present', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const cfg = await upsertGroup({ chat_id: 200, chat_title: 'New Group' });
+    expect(cfg.mode).toBe('silent');
+    expect(cfg.member_allowlist).toEqual([]);
+    expect(cfg.chat_title).toBe('New Group');
+  });
+
+  it('updates specified fields on an existing group without touching others', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const cfg = await upsertGroup({ chat_id: 100, mode: 'all' });
+    expect(cfg.mode).toBe('all');
+    expect(cfg.chat_title).toBe('Test Group'); // unchanged
+  });
+
+  it('writes the updated list back to disk', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await upsertGroup({ chat_id: 300 });
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+  });
+});
+
+// ── addAllowlistMember ────────────────────────────────────────────────────────
+
+describe('addAllowlistMember', () => {
+  it('appends the user to the member_allowlist', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const cfg = await addAllowlistMember(100, 99);
+    expect(cfg.member_allowlist).toContain(99);
+  });
+
+  it('does not write when the member is already in the list', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG])); // 42 already present
+    await addAllowlistMember(100, 42);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when the group is not configured', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([]));
+    await expect(addAllowlistMember(999, 1)).rejects.toThrow('not configured');
+  });
+});
+
+// ── removeAllowlistMember ─────────────────────────────────────────────────────
+
+describe('removeAllowlistMember', () => {
+  it('removes the member and writes the updated list', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const cfg = await removeAllowlistMember(100, 42);
+    expect(cfg.member_allowlist).not.toContain(42);
+  });
+
+  it('throws when the group is not configured', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([]));
+    await expect(removeAllowlistMember(999, 1)).rejects.toThrow();
+  });
+});
+
+// ── setGroupMode ──────────────────────────────────────────────────────────────
+
+describe('setGroupMode', () => {
+  it('updates mode and writes', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([BASE_CONFIG]));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const cfg = await setGroupMode(100, 'all');
+    expect(cfg.mode).toBe('all');
+  });
+
+  it('throws when the group is not configured', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([]));
+    await expect(setGroupMode(999, 'all')).rejects.toThrow();
+  });
+});
+
+// ── shouldRespond ─────────────────────────────────────────────────────────────
+
+function makeCtx(overrides?: Partial<GateContext>): GateContext {
+  return {
+    fromId: 42,
+    botUsername: 'zoebot',
+    botId: 7,
+    messageText: 'hey @zoebot',
+    entities: [{ type: 'mention', offset: 4, length: 8 }],
+    ...overrides,
+  };
+}
+
+describe('shouldRespond', () => {
+  it('returns allow=false when config is null (group not configured)', () => {
+    expect(shouldRespond(null, makeCtx())).toEqual({
+      allow: false,
+      reason: expect.stringContaining('not configured'),
+    });
+  });
+
+  it('returns allow=false when mode=silent regardless of sender', () => {
+    const cfg = { ...BASE_CONFIG, mode: 'silent' as const };
+    expect(shouldRespond(cfg, makeCtx()).allow).toBe(false);
+  });
+
+  it('returns allow=false when sender is not in the allowlist', () => {
+    const cfg = { ...BASE_CONFIG, mode: 'all' as const };
+    expect(shouldRespond(cfg, makeCtx({ fromId: 999 })).allow).toBe(false);
+  });
+
+  it('returns allow=true when mode=all and sender is allowlisted', () => {
+    const cfg = { ...BASE_CONFIG, mode: 'all' as const };
+    expect(shouldRespond(cfg, makeCtx({ fromId: 42 })).allow).toBe(true);
+  });
+
+  it('returns allow=true for mode=mention when bot is @-mentioned', () => {
+    const ctx = makeCtx({
+      fromId: 42,
+      messageText: 'hey @zoebot what?',
+      entities: [{ type: 'mention', offset: 4, length: 7 }],
+    });
+    expect(shouldRespond(BASE_CONFIG, ctx).allow).toBe(true);
+  });
+
+  it('returns allow=true for mode=mention when message is a reply to the bot', () => {
+    const ctx = makeCtx({ fromId: 42, messageText: 'yes', entities: [], replyToFromId: 7 });
+    expect(shouldRespond(BASE_CONFIG, ctx).allow).toBe(true);
+  });
+
+  it('returns allow=false for mode=mention with no mention and no bot reply', () => {
+    const ctx = makeCtx({ fromId: 42, messageText: 'random chat', entities: [] });
+    expect(shouldRespond(BASE_CONFIG, ctx).allow).toBe(false);
+  });
+});
+
+// ── isBotMentioned ────────────────────────────────────────────────────────────
+
+describe('isBotMentioned', () => {
+  it('returns false when botUsername is null', () => {
+    expect(isBotMentioned(makeCtx({ botUsername: null }))).toBe(false);
+  });
+
+  it('returns true when a mention entity matches the bot handle', () => {
+    const ctx = makeCtx({
+      messageText: 'hey @zoebot',
+      entities: [{ type: 'mention', offset: 4, length: 8 }],
+    });
+    expect(isBotMentioned(ctx)).toBe(true);
+  });
+
+  it('returns false when the mention entity does not match the bot handle', () => {
+    const ctx = makeCtx({
+      messageText: 'hey @otherbot',
+      entities: [{ type: 'mention', offset: 4, length: 9 }],
+    });
+    expect(isBotMentioned(ctx)).toBe(false);
+  });
+});

--- a/bot/src/zoe/__tests__/pending-decisions.test.ts
+++ b/bot/src/zoe/__tests__/pending-decisions.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractPRDecisions,
+  extractTaskDecisions,
+  formatPendingDecisions,
+  gatherPendingDecisions,
+} from '../pending-decisions';
+
+const PAST_DATE = '2000-01-01'; // always overdue
+const FUTURE_DATE = '2099-12-31'; // never overdue
+
+// ── extractPRDecisions ────────────────────────────────────────────────────────
+
+describe('extractPRDecisions', () => {
+  it('returns [] for an empty PR list', () => {
+    expect(extractPRDecisions([])).toEqual([]);
+  });
+
+  it('filters out PRs with approved or ready-to-merge labels', () => {
+    const prs = [
+      { number: 1, title: 'Feature A', labels: ['approved'] },
+      { number: 2, title: 'Feature B', labels: ['ready-to-merge'] },
+      { number: 3, title: 'Feature C', labels: ['bug'] },
+    ];
+    const result = extractPRDecisions(prs);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain('#3');
+  });
+
+  it('marks urgency=high for [URGENT] and [CRITICAL] title patterns', () => {
+    const prs = [
+      { number: 10, title: '[URGENT] Fix prod bug', labels: [] },
+      { number: 11, title: '[CRITICAL] Payment broken', labels: [] },
+    ];
+    const result = extractPRDecisions(prs);
+    expect(result[0].urgency).toBe('high');
+    expect(result[1].urgency).toBe('high');
+  });
+
+  it('marks urgency=medium and kind=pr-review for plain titles', () => {
+    const prs = [{ number: 20, title: 'Add new feature', labels: [] }];
+    const result = extractPRDecisions(prs);
+    expect(result[0].urgency).toBe('medium');
+    expect(result[0].kind).toBe('pr-review');
+  });
+});
+
+// ── extractTaskDecisions ──────────────────────────────────────────────────────
+
+describe('extractTaskDecisions', () => {
+  it('returns [] for an empty task list', () => {
+    expect(extractTaskDecisions([])).toEqual([]);
+  });
+
+  it('includes blocked tasks as kind=task-blocked urgency=high when not overdue', () => {
+    const tasks = [{ title: 'Stuck task', status: 'blocked', due: FUTURE_DATE, metadata: null }];
+    const result = extractTaskDecisions(tasks);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('task-blocked');
+    expect(result[0].urgency).toBe('high');
+  });
+
+  it('escalates blocked tasks to urgency=critical when overdue', () => {
+    const tasks = [{ title: 'Old stuck task', status: 'blocked', due: PAST_DATE, metadata: null }];
+    const result = extractTaskDecisions(tasks);
+    expect(result[0].urgency).toBe('critical');
+  });
+
+  it('includes in_review tasks as kind=task-review urgency=high', () => {
+    const tasks = [{ title: 'Review task', status: 'in_review', due: null, metadata: null }];
+    const result = extractTaskDecisions(tasks);
+    expect(result[0].kind).toBe('task-review');
+    expect(result[0].urgency).toBe('high');
+  });
+
+  it('includes tasks with next_owner=me as task-review', () => {
+    const tasks = [{ title: 'My task', status: 'pending', due: null, metadata: { next_owner: 'me' } }];
+    const result = extractTaskDecisions(tasks);
+    expect(result[0].kind).toBe('task-review');
+  });
+
+  it('skips tasks with untracked statuses (pending no owner, done, completed)', () => {
+    const tasks = [
+      { title: 'Pending task', status: 'pending', due: null, metadata: null },
+      { title: 'Done task', status: 'done', due: null, metadata: null },
+      { title: 'Completed task', status: 'completed', due: null, metadata: null },
+    ];
+    expect(extractTaskDecisions(tasks)).toEqual([]);
+  });
+});
+
+// ── formatPendingDecisions ────────────────────────────────────────────────────
+
+describe('formatPendingDecisions', () => {
+  it('returns null for an empty list', () => {
+    expect(formatPendingDecisions([])).toBeNull();
+  });
+
+  it('prefixes critical items with [!]', () => {
+    const decisions = [
+      { title: 'Critical thing', kind: 'task-blocked' as const, urgency: 'critical' as const },
+    ];
+    expect(formatPendingDecisions(decisions)).toContain('[!] Critical thing');
+  });
+
+  it('sorts critical before high before medium', () => {
+    const decisions = [
+      { title: 'Medium item', kind: 'pr-review' as const, urgency: 'medium' as const },
+      { title: 'High item', kind: 'task-review' as const, urgency: 'high' as const },
+      { title: 'Critical item', kind: 'task-blocked' as const, urgency: 'critical' as const },
+    ];
+    const result = formatPendingDecisions(decisions)!;
+    const lines = result.split('\n');
+    const critIdx = lines.findIndex((l) => l.includes('Critical item'));
+    const highIdx = lines.findIndex((l) => l.includes('High item'));
+    const medIdx = lines.findIndex((l) => l.includes('Medium item'));
+    expect(critIdx).toBeLessThan(highIdx);
+    expect(highIdx).toBeLessThan(medIdx);
+  });
+
+  it('limits output to the top 5 items', () => {
+    const decisions = Array.from({ length: 8 }, (_, i) => ({
+      title: `Item ${i}`,
+      kind: 'pr-review' as const,
+      urgency: 'medium' as const,
+    }));
+    const result = formatPendingDecisions(decisions)!;
+    expect(result.split('\n')).toHaveLength(5);
+  });
+
+  it('includes dueDate and context in the formatted output', () => {
+    const decisions = [
+      {
+        title: 'My task',
+        kind: 'task-blocked' as const,
+        urgency: 'high' as const,
+        dueDate: '2026-07-20',
+        context: 'awaiting merge',
+      },
+    ];
+    const result = formatPendingDecisions(decisions)!;
+    expect(result).toContain('2026-07-20');
+    expect(result).toContain('awaiting merge');
+  });
+});
+
+// ── gatherPendingDecisions ────────────────────────────────────────────────────
+
+describe('gatherPendingDecisions', () => {
+  it('returns null when there are no PRs or tasks', () => {
+    expect(gatherPendingDecisions({ openPrs: [], teamTasks: [] })).toBeNull();
+  });
+
+  it('combines PR and task decisions into a single output', () => {
+    const result = gatherPendingDecisions({
+      openPrs: [{ number: 1, title: 'Some PR', labels: [] }],
+      teamTasks: [{ title: 'Blocked task', status: 'blocked', due: null, metadata: null }],
+    });
+    expect(result).toContain('PR #1');
+    expect(result).toContain('Blocked task');
+  });
+});


### PR DESCRIPTION
## Summary
- `pending-decisions.test.ts` — 17 cases covering `extractPRDecisions`, `extractTaskDecisions`, `formatPendingDecisions`, `gatherPendingDecisions` (all pure functions, no mocks)
- `groups.test.ts` — 26 cases covering `readGroups`, `writeGroups`, `getGroupConfig`, `upsertGroup`, `addAllowlistMember`, `removeAllowlistMember`, `setGroupMode`, `shouldRespond`, `isBotMentioned`; mocks `node:fs` promises + `../memory`

## Test plan
- [x] `npx vitest run` — 43/43 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)