### PR TITLE
test(bot/zoe): zaostock-approvals-surface + reflect coverage (12 cases)

### DIFF
--- a/bot/src/zoe/__tests__/reflect.test.ts
+++ b/bot/src/zoe/__tests__/reflect.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockCallClaudeCli = vi.hoisted(() => vi.fn());
+const mockRecordCall = vi.hoisted(() => vi.fn());
+const mockListOpenTasks = vi.hoisted(() => vi.fn());
+const mockListLiveThreads = vi.hoisted(() => vi.fn());
+const mockIsOverdue = vi.hoisted(() => vi.fn());
+const mockExecSync = vi.hoisted(() => vi.fn());
+
+vi.mock('../../hermes/claude-cli', () => ({ callClaudeCli: mockCallClaudeCli }));
+vi.mock('../cost-ledger', () => ({ recordCall: mockRecordCall }));
+vi.mock('../tasks', () => ({ listOpenTasks: mockListOpenTasks }));
+vi.mock('../threads', () => ({
+  listLiveThreads: mockListLiveThreads,
+  isOverdue: mockIsOverdue,
+}));
+vi.mock('node:child_process', () => ({ execSync: mockExecSync }));
+
+import { generateEveningReflection } from '../reflect';
+
+afterEach(() => vi.clearAllMocks());
+
+const REPO_DIR = '/tmp/fake-repo';
+const LONG_REFLECTION =
+  'Evening reflection — Thu Jul 17 9pm\n\nThree quick:\n\n1. What shipped today?\n2. What\'s stuck?\n3. Tomorrow\'s first task?';
+
+function setupHappyPath(claudeText = LONG_REFLECTION) {
+  mockExecSync
+    .mockReturnValueOnce('feat: add feature\nfix: bug fix') // git log
+    .mockReturnValueOnce(JSON.stringify([{ number: 42, title: 'Add new thing' }])); // gh pr list
+  mockListOpenTasks.mockResolvedValue([
+    { id: 't1', title: 'Finish reflection tests', priority: 'high' },
+  ]);
+  mockListLiveThreads.mockReturnValue([]);
+  mockCallClaudeCli.mockResolvedValue({ text: claudeText });
+}
+
+describe('generateEveningReflection', () => {
+  it('returns Claude output when text is >= 60 chars', async () => {
+    setupHappyPath();
+    const result = await generateEveningReflection({ repoDir: REPO_DIR });
+    expect(result).toContain('Evening reflection');
+    expect(mockCallClaudeCli).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to hardcoded 3-question prompt when Claude returns short text', async () => {
+    mockExecSync
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('[]');
+    mockListOpenTasks.mockResolvedValue([]);
+    mockListLiveThreads.mockReturnValue([]);
+    mockCallClaudeCli.mockResolvedValue({ text: 'short' }); // < 60 chars
+    const result = await generateEveningReflection({ repoDir: REPO_DIR });
+    expect(result).toContain('1. What shipped today?');
+    expect(result).toContain("2. What's stuck?");
+  });
+
+  it('always calls recordCall with the Claude result', async () => {
+    setupHappyPath();
+    await generateEveningReflection({ repoDir: REPO_DIR });
+    expect(mockRecordCall).toHaveBeenCalledWith('reflect', expect.any(Object));
+  });
+
+  it('handles execSync throws gracefully (empty commits and PRs)', async () => {
+    mockExecSync.mockImplementation(() => { throw new Error('git not found'); });
+    mockListOpenTasks.mockResolvedValue([]);
+    mockListLiveThreads.mockReturnValue([]);
+    mockCallClaudeCli.mockResolvedValue({ text: LONG_REFLECTION });
+    await expect(generateEveningReflection({ repoDir: REPO_DIR })).resolves.toBeDefined();
+    // user prompt should reflect empty state
+    const promptArg = mockCallClaudeCli.mock.calls[0][0].prompt as string;
+    expect(promptArg).toContain('(none)');
+  });
+
+  it('includes anchor thread summary in the user prompt when a live thread exists', async () => {
+    mockExecSync
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('[]');
+    mockListOpenTasks.mockResolvedValue([]);
+    const thread = {
+      id: 'th1',
+      summary: 'Ship the music module',
+      status: 'open',
+      createdAt: new Date().toISOString(),
+      dueAt: null,
+    };
+    mockListLiveThreads.mockReturnValue([thread]);
+    mockIsOverdue.mockReturnValue(false);
+    mockCallClaudeCli.mockResolvedValue({ text: LONG_REFLECTION });
+    await generateEveningReflection({ repoDir: REPO_DIR });
+    const promptArg = mockCallClaudeCli.mock.calls[0][0].prompt as string;
+    expect(promptArg).toContain('Ship the music module');
+    expect(promptArg).toContain('LEAD with ONE contextual question');
+  });
+
+  it('slices listOpenTasks to the top 5 in the prompt', async () => {
+    mockExecSync
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('[]');
+    const tasks = Array.from({ length: 10 }, (_, i) => ({
+      id: `t${i}`,
+      title: `Task ${i}`,
+      priority: 'low',
+    }));
+    mockListOpenTasks.mockResolvedValue(tasks);
+    mockListLiveThreads.mockReturnValue([]);
+    mockCallClaudeCli.mockResolvedValue({ text: LONG_REFLECTION });
+    await generateEveningReflection({ repoDir: REPO_DIR });
+    const promptArg = mockCallClaudeCli.mock.calls[0][0].prompt as string;
+    // Task 5 and beyond should NOT appear in the prompt (sliced to 3 from the top 5)
+    expect(promptArg).not.toContain('Task 5');
+  });
+});

--- a/bot/src/zoe/__tests__/zaostock-approvals-surface.test.ts
+++ b/bot/src/zoe/__tests__/zaostock-approvals-surface.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockWriteFile = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  promises: { readFile: mockReadFile, writeFile: mockWriteFile, mkdir: mockMkdir },
+}));
+vi.mock('node:os', () => ({ homedir: () => '/tmp' }));
+
+import { surfaceZaostockApprovals } from '../zaostock-approvals-surface';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(text: string, ok = true) {
+  mockFetch.mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    text: vi.fn().mockResolvedValue(text),
+  });
+  vi.stubGlobal('fetch', mockFetch);
+}
+
+function stubFetchThrows() {
+  mockFetch.mockRejectedValue(new Error('network error'));
+  vi.stubGlobal('fetch', mockFetch);
+}
+
+function stubSeenLength(length: number) {
+  mockReadFile.mockResolvedValue(JSON.stringify({ length }));
+}
+
+function stubNoSeen() {
+  mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+}
+
+describe('surfaceZaostockApprovals', () => {
+  it('returns 0 when fetch returns non-ok (e.g., 404)', async () => {
+    stubFetch('', false);
+    const postFn = vi.fn();
+    const count = await surfaceZaostockApprovals(postFn);
+    expect(count).toBe(0);
+    expect(postFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when fetch throws', async () => {
+    stubFetchThrows();
+    const postFn = vi.fn();
+    const count = await surfaceZaostockApprovals(postFn);
+    expect(count).toBe(0);
+    expect(postFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when content has not grown since last check', async () => {
+    const content = 'some prior content';
+    stubFetch(content);
+    stubSeenLength(content.length);
+    const postFn = vi.fn();
+    const count = await surfaceZaostockApprovals(postFn);
+    expect(count).toBe(0);
+    expect(postFn).not.toHaveBeenCalled();
+  });
+
+  it('posts new content and updates the seen length', async () => {
+    const seen = 'old approved stuff';
+    const newContent = '\n\nNew approval needed from the research loop.';
+    const full = seen + newContent;
+    stubFetch(full);
+    stubSeenLength(seen.length);
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const postFn = vi.fn().mockResolvedValue(undefined);
+    const count = await surfaceZaostockApprovals(postFn);
+    expect(count).toBe(1);
+    expect(postFn).toHaveBeenCalledOnce();
+    expect(postFn.mock.calls[0][0]).toContain('New approval needed');
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
+    expect(written.length).toBe(full.length);
+  });
+
+  it('splits large content into multiple chunks with numbered labels', async () => {
+    // two paragraphs each 3000 chars, exceeding the 3800-char chunk limit together
+    const para = 'x'.repeat(3000);
+    const newContent = `${para}\n\n${para}`;
+    stubFetch(newContent);
+    stubNoSeen();
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const postFn = vi.fn().mockResolvedValue(undefined);
+    const count = await surfaceZaostockApprovals(postFn);
+    expect(count).toBeGreaterThan(1);
+    expect(postFn.mock.calls[0][0]).toContain('[1/');
+  });
+
+  it('returns 0 and does not post when new content is only whitespace', async () => {
+    const seen = 'old content';
+    stubFetch(seen + '   \n   ');
+    stubSeenLength(seen.length);
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    const postFn = vi.fn();
+    const count = await surfaceZaostockApprovals(postFn);
+    expect(count).toBe(0);
+    expect(postFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `zaostock-approvals-surface.test.ts` — 6 cases: non-ok fetch→0, fetch throws→0, content not grown→0, new content posted + seen length updated, large content chunked with numbered labels, whitespace-only new content→0; mocks `node:fs` promises + `node:os` + `fetch` global
- `reflect.test.ts` — 6 cases: happy path returns Claude text, short text falls back to hardcoded 3-question prompt, `recordCall` always invoked, `execSync` throws handled gracefully, anchor thread summary appears in user prompt, `listOpenTasks` sliced to top 5; mocks `hermes/claude-cli`, `./cost-ledger`, `./tasks`, `./threads`, `node:child_process`

## Test plan
- [x] `npx vitest run` — 12/12 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)