### PR TITLE
test(bot): llm + ops coverage (15 cases)

### DIFF
--- a/bot/src/__tests__/llm.test.ts
+++ b/bot/src/__tests__/llm.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.hoisted(() => vi.fn());
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.MINIMAX_API_KEY;
+  delete process.env.MINIMAX_API_URL;
+  delete process.env.MINIMAX_MODEL;
+});
+
+import { ask, askMinimax } from '../llm';
+
+function stubFetch(data: unknown, ok = true, status = 200) {
+  mockFetch.mockResolvedValue({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(data),
+    text: vi.fn().mockResolvedValue(JSON.stringify(data)),
+  });
+  vi.stubGlobal('fetch', mockFetch);
+}
+
+function setEnv() {
+  process.env.MINIMAX_API_KEY = 'test-key';
+  process.env.MINIMAX_API_URL = 'https://api.minimax.test/v1/chat';
+}
+
+const OK_RESPONSE = {
+  choices: [{ message: { content: 'ZAO is the future.' } }],
+  usage: { prompt_tokens: 10, completion_tokens: 5 },
+};
+
+// ── askMinimax ────────────────────────────────────────────────────────────────
+
+describe('askMinimax', () => {
+  it('throws when MINIMAX_API_KEY or MINIMAX_API_URL is not configured', async () => {
+    await expect(askMinimax('hello')).rejects.toThrow('not configured');
+  });
+
+  it('posts to the Minimax API and returns a structured LLMReply', async () => {
+    setEnv();
+    stubFetch(OK_RESPONSE);
+    const reply = await askMinimax('What is ZAO?');
+    expect(reply.text).toBe('ZAO is the future.');
+    expect(reply.persona).toBe('minimax');
+    expect(reply.tokens?.input).toBe(10);
+    expect(reply.tokens?.output).toBe(5);
+  });
+
+  it('includes a system message in the request when provided', async () => {
+    setEnv();
+    stubFetch(OK_RESPONSE);
+    await askMinimax('question', 'You are ZOE.');
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.messages[0]).toMatchObject({ role: 'system', content: 'You are ZOE.' });
+  });
+
+  it('uses MINIMAX_MODEL env var when set', async () => {
+    setEnv();
+    process.env.MINIMAX_MODEL = 'MiniMax-Custom';
+    stubFetch(OK_RESPONSE);
+    await askMinimax('hi');
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.model).toBe('MiniMax-Custom');
+  });
+
+  it('throws on non-ok HTTP status', async () => {
+    setEnv();
+    stubFetch({ error: 'bad' }, false, 400);
+    await expect(askMinimax('hello')).rejects.toThrow('Minimax HTTP 400');
+  });
+
+  it('throws when API returns empty content', async () => {
+    setEnv();
+    stubFetch({ choices: [{ message: { content: '' } }] });
+    await expect(askMinimax('hello')).rejects.toThrow('empty response');
+  });
+});
+
+// ── ask ───────────────────────────────────────────────────────────────────────
+
+describe('ask', () => {
+  it('delegates to askMinimax for the minimax persona', async () => {
+    setEnv();
+    stubFetch(OK_RESPONSE);
+    const reply = await ask('hello', undefined, 'minimax');
+    expect(reply.persona).toBe('minimax');
+  });
+
+  it('throws for an unknown persona', async () => {
+    // @ts-expect-error testing unknown persona
+    await expect(ask('hello', undefined, 'unknown')).rejects.toThrow('Unknown persona');
+  });
+});

--- a/bot/src/__tests__/ops.test.ts
+++ b/bot/src/__tests__/ops.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetZaalDmId = vi.hoisted(() => vi.fn());
+vi.mock('../group', () => ({ getZaalDmId: mockGetZaalDmId }));
+
+import { alertDevops, buildHealthReport } from '../ops';
+
+afterEach(() => vi.clearAllMocks());
+
+// ── buildHealthReport ─────────────────────────────────────────────────────────
+
+describe('buildHealthReport', () => {
+  it('returns a string containing uptime, memory, node version, and pid', async () => {
+    const report = await buildHealthReport();
+    expect(report).toContain('ZAOstock Bot');
+    expect(report).toContain('MB RSS');
+    expect(report).toContain('node');
+    expect(report).toContain(`pid ${process.pid}`);
+  });
+
+  it('formats short uptimes as seconds', async () => {
+    const uptimeSpy = vi.spyOn(process, 'uptime').mockReturnValue(45);
+    const report = await buildHealthReport();
+    expect(report).toContain('45s');
+    uptimeSpy.mockRestore();
+  });
+
+  it('formats minute-range uptimes with m suffix', async () => {
+    const uptimeSpy = vi.spyOn(process, 'uptime').mockReturnValue(90); // 1m 30s
+    const report = await buildHealthReport();
+    expect(report).toContain('1m');
+    uptimeSpy.mockRestore();
+  });
+
+  it('formats hour-range uptimes with h and m', async () => {
+    const uptimeSpy = vi.spyOn(process, 'uptime').mockReturnValue(7290); // 2h 1m 30s
+    const report = await buildHealthReport();
+    expect(report).toContain('2h1m');
+    uptimeSpy.mockRestore();
+  });
+});
+
+// ── alertDevops ───────────────────────────────────────────────────────────────
+
+describe('alertDevops', () => {
+  it('does not send when ZAAL_TELEGRAM_ID is not set (getZaalDmId returns null)', async () => {
+    mockGetZaalDmId.mockReturnValue(null);
+    const bot = { api: { sendMessage: vi.fn() } };
+    await alertDevops(bot, 'startup');
+    expect(bot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends a [devops] prefixed message to Zaal DM when configured', async () => {
+    mockGetZaalDmId.mockReturnValue(12345);
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const bot = { api: { sendMessage } };
+    await alertDevops(bot, 'bot started');
+    expect(sendMessage).toHaveBeenCalledWith(12345, '[devops] bot started');
+  });
+
+  it('swallows errors from sendMessage without throwing', async () => {
+    mockGetZaalDmId.mockReturnValue(12345);
+    const bot = { api: { sendMessage: vi.fn().mockRejectedValue(new Error('network')) } };
+    await expect(alertDevops(bot, 'test')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `llm.test.ts` — 8 cases: `askMinimax` no-key-throws / happy path / system message included / custom model / non-ok-throws / empty-response-throws; `ask` persona dispatch + unknown-throws; mocks `fetch` global
- `ops.test.ts` — 7 cases: `buildHealthReport` content check + uptime format (s/m/h); `alertDevops` no-ZAAL_ID skip / sends prefixed DM / swallows errors; mocks `../group.getZaalDmId`

## Test plan
- [x] `npx vitest run` — 15/15 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)