### PR TITLE
test(bot): zsfb section detector + callClaudeCli spawn coverage (27 cases)

### DIFF
--- a/bot/src/__tests__/zsfb.test.ts
+++ b/bot/src/__tests__/zsfb.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockSelectChain = vi.hoisted(() => vi.fn(() => ({ single: mockSingle })));
+const mockInsert = vi.hoisted(() => vi.fn(() => ({ select: mockSelectChain })));
+const mockFrom = vi.hoisted(() => vi.fn(() => ({ insert: mockInsert })));
+const mockLogBotActivity = vi.hoisted(() => vi.fn());
+
+vi.mock('../supabase', () => ({ db: vi.fn(() => ({ from: mockFrom })) }));
+vi.mock('../activity', () => ({ logBotActivity: mockLogBotActivity }));
+
+import { addZsFb, detectSection } from '../zsfb';
+import type { TeamMember } from '../auth';
+
+afterEach(() => vi.clearAllMocks());
+
+const MEMBER: TeamMember = {
+  id: 'member-001',
+  name: 'Zaal',
+  scope: 'admin',
+  role: 'admin',
+  telegram_id: 12345,
+  telegram_username: 'bettercallzaal',
+};
+
+// ── detectSection (pure) ──────────────────────────────────────────────────────
+
+describe('detectSection', () => {
+  it('matches hero keywords', () => {
+    expect(detectSection('the hero copy is too long')).toBe('hero');
+    expect(detectSection('first section needs a tagline')).toBe('hero');
+  });
+
+  it('matches lineup keywords', () => {
+    expect(detectSection('the lineup section needs more artists')).toBe('lineup');
+    expect(detectSection('who is the DJ?')).toBe('lineup');
+  });
+
+  it('matches sponsors keywords', () => {
+    expect(detectSection('sponsor section needs more detail')).toBe('sponsors');
+    expect(detectSection('add a broadcast link to the section')).toBe('sponsors');
+  });
+
+  it('matches partners keywords', () => {
+    expect(detectSection('partners section — add Fractured Atlas logo')).toBe('partners');
+  });
+
+  it('matches vibes/photo keywords', () => {
+    expect(detectSection('gallery images look washed out')).toBe('vibes');
+  });
+
+  it('matches about keywords', () => {
+    expect(detectSection('the about section story is too short')).toBe('about');
+  });
+
+  it('matches location/where keywords', () => {
+    expect(detectSection('where is the location on the map?')).toBe('where');
+  });
+
+  it('matches team keywords', () => {
+    expect(detectSection('team roster section looks good')).toBe('team');
+  });
+
+  it('matches rsvp/join keywords', () => {
+    expect(detectSection('rsvp button is hard to find')).toBe('rsvp');
+  });
+
+  it('matches lineage/history keywords', () => {
+    expect(detectSection('add more past events to the lineage')).toBe('lineage');
+  });
+
+  it('matches donate/donation keywords', () => {
+    expect(detectSection('donation page needs a crypto option')).toBe('donate');
+  });
+
+  it('matches sticky/dock keywords', () => {
+    expect(detectSection('sticky header covers the content')).toBe('sticky');
+  });
+
+  it('returns general for unmatched text', () => {
+    expect(detectSection('the font is too small')).toBe('general');
+    expect(detectSection('')).toBe('general');
+  });
+});
+
+// ── addZsFb ───────────────────────────────────────────────────────────────────
+
+describe('addZsFb', () => {
+  it('returns a usage prompt when text is empty', async () => {
+    const reply = await addZsFb(MEMBER, '');
+    expect(reply).toContain('Say something after /zsfb');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns a usage prompt when text is whitespace only', async () => {
+    const reply = await addZsFb(MEMBER, '   ');
+    expect(reply).toContain('Say something after /zsfb');
+  });
+
+  it('inserts to suggestions with the detected section tag and returns success', async () => {
+    mockSingle.mockResolvedValue({ data: { id: 'abc12345-xxxx' }, error: null });
+    mockLogBotActivity.mockResolvedValue(undefined);
+    const reply = await addZsFb(MEMBER, 'hero section headline is too long');
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ suggestion: expect.stringContaining('[zsfb:hero]') }),
+    );
+    expect(reply).toContain('hero');
+    expect(reply).toContain('abc1234'); // first 8 chars of the id
+    expect(mockLogBotActivity).toHaveBeenCalledOnce();
+  });
+
+  it('returns an error message when the DB insert fails', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'DB down' } });
+    const reply = await addZsFb(MEMBER, 'lineup needs work');
+    expect(reply).toBe('Could not save: DB down');
+    expect(mockLogBotActivity).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/hermes/__tests__/claude-cli.test.ts
+++ b/bot/src/hermes/__tests__/claude-cli.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: mockSpawn }));
+
+import { CliAuthError, CliError, callClaudeCli } from '../claude-cli';
+
+afterEach(() => vi.clearAllMocks());
+
+const BASE_OPTS = {
+  model: 'haiku' as const,
+  prompt: 'Test prompt',
+  cwd: '/tmp/test-repo',
+  bare: true,
+};
+
+function makeSpawn(stdout: string, stderr: string, exitCode: number) {
+  return {
+    stdout: {
+      on: vi.fn((ev: string, cb: (b: Buffer) => void) => {
+        if (ev === 'data') process.nextTick(() => cb(Buffer.from(stdout)));
+      }),
+    },
+    stderr: {
+      on: vi.fn((ev: string, cb: (b: Buffer) => void) => {
+        if (ev === 'data' && stderr) process.nextTick(() => cb(Buffer.from(stderr)));
+      }),
+    },
+    on: vi.fn((ev: string, cb: (code: number | null) => void) => {
+      if (ev === 'close') setTimeout(() => cb(exitCode), 10);
+    }),
+    kill: vi.fn(),
+  };
+}
+
+const VALID_JSON_RESULT = JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  result: 'The fix is applied.',
+  usage: { input_tokens: 100, output_tokens: 50 },
+  total_cost_usd: 0.005,
+  duration_ms: 1200,
+  num_turns: 2,
+  session_id: 'sess-abc',
+});
+
+// ── happy paths ───────────────────────────────────────────────────────────────
+
+describe('callClaudeCli — happy paths', () => {
+  it('resolves with parsed ClaudeCliResult for a valid JSON response', async () => {
+    mockSpawn.mockReturnValue(makeSpawn(VALID_JSON_RESULT, '', 0));
+    const result = await callClaudeCli(BASE_OPTS);
+    expect(result.text).toBe('The fix is applied.');
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+    expect(result.model).toBe('haiku');
+    expect(result.sessionId).toBe('sess-abc');
+  });
+
+  it('resolves with plain text for outputFormat=text', async () => {
+    mockSpawn.mockReturnValue(makeSpawn('  Hello from Claude  ', '', 0));
+    const result = await callClaudeCli({ ...BASE_OPTS, outputFormat: 'text' });
+    expect(result.text).toBe('Hello from Claude');
+    expect(result.inputTokens).toBe(0);
+  });
+});
+
+// ── error paths ───────────────────────────────────────────────────────────────
+
+describe('callClaudeCli — error paths', () => {
+  it('rejects with CliError when spawn exits non-zero', async () => {
+    mockSpawn.mockReturnValue(makeSpawn('some error', '', 1));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliError);
+  });
+
+  it('rejects with CliAuthError on auth failure exit', async () => {
+    mockSpawn.mockReturnValue(makeSpawn('API Error: 401 Invalid authentication credentials', '', 1));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliAuthError);
+  });
+
+  it('rejects when stdout is empty on exit 0', async () => {
+    mockSpawn.mockReturnValue(makeSpawn('', '', 0));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliError);
+  });
+
+  it('rejects when JSON payload has is_error=true', async () => {
+    const errJson = JSON.stringify({ type: 'result', subtype: 'error', is_error: true, result: 'Error from model' });
+    mockSpawn.mockReturnValue(makeSpawn(errJson, '', 0));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliError);
+  });
+
+  it('rejects when JSON subtype is not success (truncated run)', async () => {
+    const truncated = JSON.stringify({
+      type: 'result', subtype: 'max_turns', is_error: false,
+      result: 'Partial output', num_turns: 5,
+    });
+    mockSpawn.mockReturnValue(makeSpawn(truncated, '', 0));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toThrow('subtype=max_turns');
+  });
+
+  it('rejects with CliError when stdout is not valid JSON in json mode', async () => {
+    mockSpawn.mockReturnValue(makeSpawn('not-json', '', 0));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliError);
+  });
+
+  it('rejects when the result field is empty in the JSON payload', async () => {
+    const emptyResult = JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: '' });
+    mockSpawn.mockReturnValue(makeSpawn(emptyResult, '', 0));
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliError);
+  });
+
+  it('rejects and calls kill on spawn error event', async () => {
+    const child = makeSpawn('', '', 0);
+    child.on = vi.fn((ev: string, cb: (...args: unknown[]) => void) => {
+      if (ev === 'error') process.nextTick(() => cb(new Error('ENOENT')));
+    });
+    mockSpawn.mockReturnValue(child);
+    await expect(callClaudeCli(BASE_OPTS)).rejects.toBeInstanceOf(CliError);
+  });
+});


### PR DESCRIPTION
## Summary
- `zsfb.test.ts` — 17 cases: `detectSection` all 12 section keyword patterns + general fallback (13 pure tests); `addZsFb` empty/whitespace→usage-prompt, DB success→reply with section tag, DB error→error message; mocks `../supabase` chain + `../activity.logBotActivity`
- `hermes/claude-cli.test.ts` — 10 cases: `callClaudeCli` happy path JSON / happy path text; error paths: non-zero exit / auth exit→CliAuthError / empty stdout / is_error=true / non-success subtype / invalid JSON / spawn error event; uses spawn mock pattern (EventEmitter-like + process.nextTick)

## Test plan
- [x] `npx vitest run` — 27/27 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)