### PR TITLE
test(agents+models): guard battery, softmax ranker, model router (61 cases)

### DIFF
--- a/bot/src/zoe/agents/__tests__/guards.test.ts
+++ b/bot/src/zoe/agents/__tests__/guards.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCheckText = vi.hoisted(() => vi.fn());
+vi.mock('../../safety/klearu', () => ({ checkText: mockCheckText }));
+
+import { humanizedDelayMs, runGuards } from '../guards';
+import type { GuardState } from '../guards';
+import type { AgentSpec } from '../registry';
+
+afterEach(() => vi.clearAllMocks());
+
+const SAFE_VERDICT = { safe: true, label: 'safe', score: 0.95, reason: 'klearu-json', raw: '{}' };
+const UNSAFE_VERDICT = { safe: false, label: 'unsafe', score: 0.05, reason: 'klearu-json', raw: '{}' };
+
+// 14:00 UTC — within any reasonable daytime schedule
+const NOW_MS = new Date('2026-07-17T14:00:00Z').getTime();
+
+function makeAgent(overrides: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    agent_id: 'test-agent',
+    persona_prompt: 'Test.',
+    topics: ['music', 'zao'],
+    activity_budget: 10,
+    cooldown_seconds: 90,
+    thread_max_depth: 3,
+    priority_weight: 1,
+    schedule: { active_hours_utc: [0, 0] }, // always alive (start === end)
+    persona: { tone: 'warm', domain: 'community', risk: 0.3, social: 0.5, engagement: 0.5 },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<GuardState> = {}): GuardState {
+  return {
+    secondsSinceLastAction: 300,
+    actionsUsed: 0,
+    threadDepth: 0,
+    recentPosts: [],
+    nowMs: NOW_MS,
+    ...overrides,
+  };
+}
+
+const AGENT = makeAgent();
+const OPTS = { jitter: 0.5 };
+
+// ── humanizedDelayMs (pure) ────────────────────────────────────────────────────
+
+describe('humanizedDelayMs', () => {
+  it('returns 15 000 ms at jitter=0', () => {
+    expect(humanizedDelayMs(0)).toBe(15_000);
+  });
+
+  it('returns 90 000 ms at jitter=1', () => {
+    expect(humanizedDelayMs(1)).toBe(90_000);
+  });
+
+  it('interpolates linearly at jitter=0.5', () => {
+    expect(humanizedDelayMs(0.5)).toBe(Math.round((15 + 0.5 * 75) * 1000));
+  });
+});
+
+// ── runGuards (schedule guard) ────────────────────────────────────────────────
+
+describe('runGuards — schedule', () => {
+  beforeEach(() => mockCheckText.mockResolvedValue(SAFE_VERDICT));
+
+  it('blocks when agent is outside its active hours', async () => {
+    // active 10–18 UTC; nowMs is at 14 UTC which is IN range (so not blocked by schedule)
+    const agent = makeAgent({ schedule: { active_hours_utc: [20, 22] } }); // 20–22 UTC
+    const result = await runGuards(agent, 'hello world', makeState(), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('schedule');
+  });
+
+  it('passes when schedule has start===end (always alive)', async () => {
+    const agent = makeAgent({ schedule: { active_hours_utc: [0, 0] } });
+    const result = await runGuards(agent, 'hello', makeState(), OPTS);
+    expect(result.pass).toBe(true);
+  });
+
+  it('handles wrap-around hours correctly (active 22–6 UTC, nowMs 23:00)', async () => {
+    const nowAt23 = new Date('2026-07-17T23:00:00Z').getTime();
+    const agent = makeAgent({ schedule: { active_hours_utc: [22, 6] } });
+    const result = await runGuards(agent, 'hello', makeState({ nowMs: nowAt23 }), OPTS);
+    expect(result.pass).toBe(true);
+  });
+
+  it('blocks when active_days excludes the current day', async () => {
+    // 2026-07-17 is a Friday (day 5). Restrict to Mon–Thu only.
+    const agent = makeAgent({ schedule: { active_hours_utc: [0, 0], active_days: [1, 2, 3, 4] } });
+    const result = await runGuards(agent, 'hello', makeState(), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('schedule');
+  });
+});
+
+// ── runGuards (cooldown) ──────────────────────────────────────────────────────
+
+describe('runGuards — cooldown', () => {
+  beforeEach(() => mockCheckText.mockResolvedValue(SAFE_VERDICT));
+
+  it('blocks when secondsSinceLastAction < cooldown_seconds', async () => {
+    const result = await runGuards(AGENT, 'hello', makeState({ secondsSinceLastAction: 50 }), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('cooldown');
+    expect(result.detail).toContain('50s');
+  });
+
+  it('passes when secondsSinceLastAction >= cooldown_seconds', async () => {
+    const result = await runGuards(AGENT, 'hello', makeState({ secondsSinceLastAction: 91 }), OPTS);
+    expect(result.pass).toBe(true);
+  });
+});
+
+// ── runGuards (budget) ────────────────────────────────────────────────────────
+
+describe('runGuards — budget', () => {
+  beforeEach(() => mockCheckText.mockResolvedValue(SAFE_VERDICT));
+
+  it('blocks when activity_budget is exhausted', async () => {
+    const result = await runGuards(AGENT, 'hello', makeState({ actionsUsed: 10 }), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('budget');
+  });
+
+  it('passes when actionsUsed is below budget', async () => {
+    const result = await runGuards(AGENT, 'hello', makeState({ actionsUsed: 9 }), OPTS);
+    expect(result.pass).toBe(true);
+  });
+});
+
+// ── runGuards (thread depth) ──────────────────────────────────────────────────
+
+describe('runGuards — thread depth', () => {
+  beforeEach(() => mockCheckText.mockResolvedValue(SAFE_VERDICT));
+
+  it('blocks when threadDepth exceeds thread_max_depth', async () => {
+    const result = await runGuards(AGENT, 'hello', makeState({ threadDepth: 4 }), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('thread_depth');
+  });
+
+  it('passes at exactly thread_max_depth', async () => {
+    const result = await runGuards(AGENT, 'hello', makeState({ threadDepth: 3 }), OPTS);
+    expect(result.pass).toBe(true);
+  });
+});
+
+// ── runGuards (dedup) ─────────────────────────────────────────────────────────
+
+describe('runGuards — semantic dedup', () => {
+  beforeEach(() => mockCheckText.mockResolvedValue(SAFE_VERDICT));
+
+  it('blocks when trigger overlaps heavily with a recent post', async () => {
+    const state = makeState({ recentPosts: ['music zao community launch'] });
+    const result = await runGuards(AGENT, 'music zao community launch', state, OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('dedup');
+  });
+
+  it('passes when overlap is below default threshold (0.8)', async () => {
+    const state = makeState({ recentPosts: ['completely different topic about dogs'] });
+    const result = await runGuards(AGENT, 'music zao new drop today', state, OPTS);
+    expect(result.pass).toBe(true);
+  });
+
+  it('respects custom dedupThreshold', async () => {
+    const state = makeState({ recentPosts: ['music zao drop'] });
+    // triggerText shares ~2/3 tokens — below 0.8 default but above 0.5
+    const result = await runGuards(AGENT, 'music zao something else', state, { jitter: 0.5, dedupThreshold: 0.5 });
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('dedup');
+  });
+});
+
+// ── runGuards (conversation closer) ──────────────────────────────────────────
+
+describe('runGuards — conversation closer', () => {
+  beforeEach(() => mockCheckText.mockResolvedValue(SAFE_VERDICT));
+
+  it.each(['thanks', 'thank you', 'ty', 'bye', 'gg', 'gn', 'cya'])(
+    'blocks exact closer "%s"',
+    async (closer) => {
+      const result = await runGuards(AGENT, closer, makeState(), OPTS);
+      expect(result.pass).toBe(false);
+      expect(result.blockedBy).toBe('conversation_closed');
+    },
+  );
+
+  it('blocks a trigger that ends with a conversation closer', async () => {
+    const result = await runGuards(AGENT, 'great session gn', makeState(), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('conversation_closed');
+  });
+
+  it('blocks a trigger that starts with a conversation closer', async () => {
+    const result = await runGuards(AGENT, 'bye everyone have a great day', makeState(), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('conversation_closed');
+  });
+
+  it('does NOT block a trigger that merely contains a closer in the middle', async () => {
+    // "thanks" in the middle of a longer sentence — not a start/end match
+    const result = await runGuards(AGENT, 'many thanks to the whole zao community', makeState(), OPTS);
+    // 'many thanks to the whole...' does not start/end with a closer → passes this guard
+    expect(result.blockedBy).not.toBe('conversation_closed');
+  });
+});
+
+// ── runGuards (klearu safety) ─────────────────────────────────────────────────
+
+describe('runGuards — klearu safety', () => {
+  it('blocks when klearu returns unsafe', async () => {
+    mockCheckText.mockResolvedValue(UNSAFE_VERDICT);
+    const result = await runGuards(AGENT, 'normal text', makeState(), OPTS);
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBe('klearu');
+    expect(result.safety).toMatchObject({ safe: false, label: 'unsafe' });
+  });
+
+  it('passes all guards and returns safety verdict when klearu is safe', async () => {
+    mockCheckText.mockResolvedValue(SAFE_VERDICT);
+    const result = await runGuards(AGENT, 'zao music drop tonight', makeState(), OPTS);
+    expect(result.pass).toBe(true);
+    expect(result.blockedBy).toBeNull();
+    expect(result.detail).toBe('all guards passed');
+    expect(result.safety).toMatchObject({ safe: true });
+  });
+
+  it('includes a non-zero delayMs even on pass', async () => {
+    mockCheckText.mockResolvedValue(SAFE_VERDICT);
+    const result = await runGuards(AGENT, 'hello', makeState(), { jitter: 0.5 });
+    expect(result.delayMs).toBeGreaterThanOrEqual(15_000);
+    expect(result.delayMs).toBeLessThanOrEqual(90_000);
+  });
+});

--- a/bot/src/zoe/agents/__tests__/ranker.test.ts
+++ b/bot/src/zoe/agents/__tests__/ranker.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { rankAgents, sampleAgent } from '../ranker';
+import type { AgentSpec } from '../registry';
+import type { RankInput, RankContext } from '../ranker';
+
+function makeAgent(overrides: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    agent_id: 'test',
+    persona_prompt: 'Test.',
+    topics: ['music'],
+    activity_budget: 10,
+    cooldown_seconds: 90,
+    thread_max_depth: 3,
+    priority_weight: 1,
+    schedule: { active_hours_utc: [0, 0] },
+    persona: { tone: 'warm', domain: 'music', risk: 0.3, social: 0.5, engagement: 0.5 },
+    ...overrides,
+  };
+}
+
+function makeInput(agent: AgentSpec, overrides: Partial<Omit<RankInput, 'agent'>> = {}): RankInput {
+  return {
+    agent,
+    secondsSinceLastAction: Infinity, // fresh / never acted
+    actionsUsed: 0,
+    noise: 0.5,
+    ...overrides,
+  };
+}
+
+const CTX: RankContext = { triggerText: 'zao music drop tonight' };
+
+// ── rankAgents ────────────────────────────────────────────────────────────────
+
+describe('rankAgents', () => {
+  it('returns empty array for empty inputs', () => {
+    expect(rankAgents([], CTX)).toEqual([]);
+  });
+
+  it('single agent gets prob ≈ 1.0', () => {
+    const ranked = rankAgents([makeInput(makeAgent())], CTX);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].prob).toBeCloseTo(1.0);
+  });
+
+  it('includes all factor fields on each entry', () => {
+    const ranked = rankAgents([makeInput(makeAgent())], CTX);
+    const { factors } = ranked[0];
+    expect(factors).toMatchObject({
+      topic: expect.any(Number),
+      semantic: expect.any(Number),
+      recency: expect.any(Number),
+      budget: expect.any(Number),
+      noise: expect.any(Number),
+    });
+  });
+
+  it('returns results sorted by prob descending', () => {
+    const agentA = makeAgent({ agent_id: 'a', topics: ['music'] });
+    const agentB = makeAgent({ agent_id: 'b', topics: ['cooking'] }); // irrelevant topics
+    const ranked = rankAgents([makeInput(agentA), makeInput(agentB)], CTX);
+    expect(ranked[0].prob).toBeGreaterThanOrEqual(ranked[1].prob);
+    expect(ranked[0].agent.agent_id).toBe('a');
+  });
+
+  it('probabilities sum to 1', () => {
+    const inputs = [
+      makeInput(makeAgent({ agent_id: 'a', topics: ['music'] })),
+      makeInput(makeAgent({ agent_id: 'b', topics: ['tech'] })),
+      makeInput(makeAgent({ agent_id: 'c', topics: ['art'] })),
+    ];
+    const ranked = rankAgents(inputs, CTX);
+    const total = ranked.reduce((s, r) => s + r.prob, 0);
+    expect(total).toBeCloseTo(1.0);
+  });
+
+  it('topic-matching agent outranks non-matching agent', () => {
+    const withTopic = makeAgent({ agent_id: 'music-agent', topics: ['music'] });
+    const noTopic = makeAgent({ agent_id: 'other-agent', topics: ['cooking', 'baking'] });
+    const ranked = rankAgents(
+      [makeInput(noTopic, { noise: 0 }), makeInput(withTopic, { noise: 0 })],
+      { triggerText: 'music release' },
+    );
+    expect(ranked[0].agent.agent_id).toBe('music-agent');
+  });
+
+  it('recently-active agent has lower recency score', () => {
+    const fresh = makeAgent({ agent_id: 'fresh', cooldown_seconds: 90 });
+    const cooled = makeAgent({ agent_id: 'cooled', cooldown_seconds: 90 });
+    const ranked = rankAgents(
+      [
+        makeInput(fresh, { secondsSinceLastAction: 5, noise: 0 }),
+        makeInput(cooled, { secondsSinceLastAction: Infinity, noise: 0 }),
+      ],
+      CTX,
+    );
+    expect(ranked[0].agent.agent_id).toBe('cooled');
+    expect(ranked[0].factors.recency).toBeGreaterThan(ranked[1].factors.recency);
+  });
+
+  it('budget-exhausted agent has lower budget score', () => {
+    const full = makeAgent({ agent_id: 'full', activity_budget: 10 });
+    const empty = makeAgent({ agent_id: 'empty', activity_budget: 10 });
+    const ranked = rankAgents(
+      [
+        makeInput(empty, { actionsUsed: 10, noise: 0 }),
+        makeInput(full, { actionsUsed: 0, noise: 0 }),
+      ],
+      CTX,
+    );
+    expect(ranked[0].agent.agent_id).toBe('full');
+    expect(ranked[0].factors.budget).toBeGreaterThan(ranked[1].factors.budget);
+  });
+
+  it('higher priority_weight increases logit proportionally', () => {
+    const hi = makeAgent({ agent_id: 'hi', priority_weight: 3 });
+    const lo = makeAgent({ agent_id: 'lo', priority_weight: 1 });
+    const ranked = rankAgents(
+      [makeInput(lo, { noise: 0 }), makeInput(hi, { noise: 0 })],
+      CTX,
+    );
+    expect(ranked[0].agent.agent_id).toBe('hi');
+    expect(ranked[0].logit).toBeGreaterThan(ranked[1].logit);
+  });
+
+  it('uses injected semanticSim fn instead of token-overlap fallback', () => {
+    const a = makeAgent({ agent_id: 'a', topics: [] });
+    const b = makeAgent({ agent_id: 'b', topics: [] });
+    const ctx: RankContext = {
+      triggerText: 'anything',
+      semanticSim: (agent) => (agent.agent_id === 'a' ? 0.9 : 0.1),
+    };
+    const ranked = rankAgents([makeInput(a, { noise: 0 }), makeInput(b, { noise: 0 })], ctx);
+    expect(ranked[0].agent.agent_id).toBe('a');
+  });
+});
+
+// ── sampleAgent ───────────────────────────────────────────────────────────────
+
+describe('sampleAgent', () => {
+  it('returns null for empty ranked list', () => {
+    expect(sampleAgent([], 0.5)).toBeNull();
+  });
+
+  it('returns the single agent regardless of sample', () => {
+    const ranked = rankAgents([makeInput(makeAgent())], CTX);
+    expect(sampleAgent(ranked, 0)).toBe(ranked[0]);
+    expect(sampleAgent(ranked, 0.99)).toBe(ranked[0]);
+  });
+
+  it('sample near 0 picks the highest-prob agent', () => {
+    const a = makeAgent({ agent_id: 'top', topics: ['music'] });
+    const b = makeAgent({ agent_id: 'bot', topics: ['cooking'] });
+    const ranked = rankAgents([makeInput(a, { noise: 0 }), makeInput(b, { noise: 0 })], CTX);
+    // sample=0.001 should land in the first bucket (highest prob)
+    const picked = sampleAgent(ranked, 0.001);
+    expect(picked?.agent.agent_id).toBe('top');
+  });
+
+  it('sample near 1 falls back to last element', () => {
+    const a = makeAgent({ agent_id: 'a', topics: ['music'] });
+    const b = makeAgent({ agent_id: 'b', topics: ['cooking'] });
+    const ranked = rankAgents([makeInput(a, { noise: 0 }), makeInput(b, { noise: 0 })], CTX);
+    // sample=0.9999 should exceed cumulative prob of top, landing in the tail
+    const picked = sampleAgent(ranked, 0.9999);
+    expect(picked).not.toBeNull();
+  });
+
+  it('is deterministic for the same input', () => {
+    const inputs = [
+      makeInput(makeAgent({ agent_id: 'x', topics: ['music'] }), { noise: 0.3 }),
+      makeInput(makeAgent({ agent_id: 'y', topics: ['art'] }), { noise: 0.7 }),
+    ];
+    const ranked = rankAgents(inputs, CTX);
+    expect(sampleAgent(ranked, 0.4)).toBe(sampleAgent(ranked, 0.4));
+  });
+});

--- a/bot/src/zoe/models/__tests__/router.test.ts
+++ b/bot/src/zoe/models/__tests__/router.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { selectBestModel, shouldUseRouting } from '../router';
+
+function setEnv(vars: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(vars)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+beforeEach(() => {
+  // Start each test with no API keys and routing off
+  setEnv({
+    XAI_API_KEY: undefined,
+    OPENAI_API_KEY: undefined,
+    MODEL_ROUTING_ENABLED: undefined,
+    GROK_MODEL_ID: undefined,
+    GPT_MODEL_ID: undefined,
+    ZOE_DEFAULT_MODEL: undefined,
+  });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+// ── selectBestModel ───────────────────────────────────────────────────────────
+
+describe('selectBestModel', () => {
+  it('defaults to claude when no context flags and no API keys', () => {
+    const result = selectBestModel('tell me about ZAO');
+    expect(result.provider).toBe('claude');
+  });
+
+  it('picks grok for code task when XAI_API_KEY is set', () => {
+    setEnv({ XAI_API_KEY: 'xai-test-key' });
+    const result = selectBestModel('write a react component', { isCodeTask: true });
+    expect(result.provider).toBe('grok');
+    expect(result.rationale).toContain('Grok');
+  });
+
+  it('falls back to claude for code task when XAI_API_KEY is absent', () => {
+    const result = selectBestModel('write a react component', { isCodeTask: true });
+    expect(result.provider).toBe('claude');
+  });
+
+  it('routes strategy tasks to claude', () => {
+    setEnv({ XAI_API_KEY: 'xai-key', OPENAI_API_KEY: 'oai-key' });
+    const result = selectBestModel('design a DAO treasury strategy', { isStrategyTask: true });
+    expect(result.provider).toBe('claude');
+    expect(result.rationale).toContain('Claude');
+  });
+
+  it('routes messages containing "whitepaper" to claude', () => {
+    const result = selectBestModel('draft a whitepaper for ZAO token utility');
+    expect(result.provider).toBe('claude');
+  });
+
+  it('routes messages containing "architecture" to claude', () => {
+    const result = selectBestModel('review the architecture decisions for the ZAO platform');
+    expect(result.provider).toBe('claude');
+  });
+
+  it('routes long messages (> 500 chars) to claude', () => {
+    const longMsg = 'a'.repeat(501);
+    const result = selectBestModel(longMsg);
+    expect(result.provider).toBe('claude');
+  });
+
+  it('picks grok for X-context messages when XAI_API_KEY is set', () => {
+    setEnv({ XAI_API_KEY: 'xai-test-key' });
+    const result = selectBestModel('check this x.com thread');
+    expect(result.provider).toBe('grok');
+    expect(result.rationale).toContain('Grok');
+  });
+
+  it('falls back to claude for X-context when XAI_API_KEY is absent', () => {
+    const result = selectBestModel('check this x.com thread');
+    expect(result.provider).toBe('claude');
+  });
+
+  it('picks grok for X-context flag even without "x.com" in text', () => {
+    setEnv({ XAI_API_KEY: 'xai-key' });
+    const result = selectBestModel('respond to a mention', { isXContext: true });
+    expect(result.provider).toBe('grok');
+  });
+
+  it('uses GROK_MODEL_ID env var for the model name when routing to grok', () => {
+    setEnv({ XAI_API_KEY: 'xai-key', GROK_MODEL_ID: 'grok-4-turbo' });
+    const result = selectBestModel('fix this function', { isCodeTask: true });
+    expect(result.model).toBe('grok-4-turbo');
+  });
+
+  it('uses ZOE_DEFAULT_MODEL env var when falling back to claude', () => {
+    setEnv({ ZOE_DEFAULT_MODEL: 'claude-opus-4-7' });
+    const result = selectBestModel('general question');
+    expect(result.model).toBe('claude-opus-4-7');
+  });
+});
+
+// ── shouldUseRouting ──────────────────────────────────────────────────────────
+
+describe('shouldUseRouting', () => {
+  it('returns false when routing is disabled', () => {
+    setEnv({ XAI_API_KEY: 'xai-key', MODEL_ROUTING_ENABLED: undefined });
+    expect(shouldUseRouting()).toBe(false);
+  });
+
+  it('returns false when routing is enabled but no alternative API keys', () => {
+    setEnv({ MODEL_ROUTING_ENABLED: '1' });
+    expect(shouldUseRouting()).toBe(false);
+  });
+
+  it('returns true when routing is enabled and grok key is present', () => {
+    setEnv({ MODEL_ROUTING_ENABLED: '1', XAI_API_KEY: 'xai-key' });
+    expect(shouldUseRouting()).toBe(true);
+  });
+
+  it('returns true when routing is enabled and openai key is present', () => {
+    setEnv({ MODEL_ROUTING_ENABLED: '1', OPENAI_API_KEY: 'oai-key' });
+    expect(shouldUseRouting()).toBe(true);
+  });
+
+  it('ignores whitespace-only API keys', () => {
+    setEnv({ MODEL_ROUTING_ENABLED: '1', XAI_API_KEY: '   ', OPENAI_API_KEY: '' });
+    expect(shouldUseRouting()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `zoe/agents/__tests__/guards.test.ts` — 29 cases: `humanizedDelayMs` bounds, schedule guard (active hours, wrap-around, active_days), cooldown, budget, thread-depth, semantic dedup with custom threshold, conversation closers (exact/start/end), klearu safe/unsafe gate. Mocks `checkText` from `../safety/klearu`.
- `zoe/agents/__tests__/ranker.test.ts` — 15 cases: `rankAgents` (topic match, recency decay, budget score, priority_weight, injected `semanticSim` fn, probs sum to 1, sorted desc) + `sampleAgent` (null on empty, deterministic, boundary samples). All pure — zero mocks.
- `zoe/models/__tests__/router.test.ts` — 17 cases: `selectBestModel` (code→grok, strategy→claude, X-context→grok/claude fallback, long msg, `whitepaper`/`architecture` keywords, env var overrides) + `shouldUseRouting` (enabled/disabled, no keys, whitespace-only keys).

## Test plan
- [x] All 61 tests pass locally (`npx vitest run` in `bot/`)
- [x] CI will verify on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)