### PR TITLE
test(concierge+calendar+ffx): prompt assembly, event formatters, ffxAvailable (37 cases)

### DIFF
--- a/bot/src/zoe/__tests__/calendar.test.ts
+++ b/bot/src/zoe/__tests__/calendar.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatEventForBrief, formatTodayTomorrowEvents, type CalendarEvent } from '../calendar';
+
+function makeEvent(startIso: string, title: string, location?: string): CalendarEvent {
+  return {
+    id: title,
+    title,
+    start: new Date(startIso),
+    end: new Date(startIso),
+    location,
+  };
+}
+
+// ── formatEventForBrief ───────────────────────────────────────────────────────
+
+describe('formatEventForBrief', () => {
+  it('includes the event title in the output', () => {
+    const event = makeEvent('2026-07-17T18:00:00Z', 'ZAO Community Call');
+    expect(formatEventForBrief(event)).toContain('ZAO Community Call');
+  });
+
+  it('appends " @ location" when location is provided', () => {
+    const event = makeEvent('2026-07-17T18:00:00Z', 'ZAO IRL Event', 'Miami');
+    const result = formatEventForBrief(event);
+    expect(result).toContain('ZAO IRL Event');
+    expect(result).toContain('@ Miami');
+  });
+
+  it('omits the location suffix when location is undefined', () => {
+    const event = makeEvent('2026-07-17T18:00:00Z', 'ZAO Call');
+    expect(formatEventForBrief(event)).not.toContain('@');
+  });
+
+  it('includes a date/time portion before the title', () => {
+    const event = makeEvent('2026-07-17T18:00:00Z', 'ZAO Drop');
+    const result = formatEventForBrief(event);
+    // Format is "<date/time>: <title>" — colon + space before title
+    const colonIdx = result.indexOf(':');
+    const titleIdx = result.indexOf('ZAO Drop');
+    expect(colonIdx).toBeGreaterThanOrEqual(0);
+    expect(titleIdx).toBeGreaterThan(colonIdx);
+  });
+});
+
+// ── formatTodayTomorrowEvents ─────────────────────────────────────────────────
+
+describe('formatTodayTomorrowEvents', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 2026-07-17 10:00 AM EDT (14:00 UTC) — a Friday
+    vi.setSystemTime(new Date('2026-07-17T14:00:00Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('returns null for an empty array', () => {
+    expect(formatTodayTomorrowEvents([])).toBeNull();
+  });
+
+  it('returns null when events are neither today nor tomorrow in NY time', () => {
+    // 2026-07-20 = 3 days away
+    const futureEvent = makeEvent('2026-07-20T18:00:00Z', 'Future Thing');
+    expect(formatTodayTomorrowEvents([futureEvent])).toBeNull();
+  });
+
+  it('includes TODAY section when there is an event on July 17 in NY time', () => {
+    // 2026-07-17T18:00:00Z = 2:00 PM EDT = today
+    const todayEvent = makeEvent('2026-07-17T18:00:00Z', 'ZAO Show');
+    const result = formatTodayTomorrowEvents([todayEvent]);
+    expect(result).toContain('TODAY:');
+    expect(result).toContain('ZAO Show');
+  });
+
+  it('includes TOMORROW section when there is an event on July 18 in NY time', () => {
+    // 2026-07-18T18:00:00Z = 2:00 PM EDT = tomorrow
+    const tomorrowEvent = makeEvent('2026-07-18T18:00:00Z', 'ZAO Post-Show Recap');
+    const result = formatTodayTomorrowEvents([tomorrowEvent]);
+    expect(result).toContain('TOMORROW:');
+    expect(result).toContain('ZAO Post-Show Recap');
+  });
+
+  it('includes both sections with a blank line separator when events span both days', () => {
+    const today = makeEvent('2026-07-17T18:00:00Z', 'Day Event');
+    const tomorrow = makeEvent('2026-07-18T18:00:00Z', 'Next Day Event');
+    const result = formatTodayTomorrowEvents([today, tomorrow]) ?? '';
+    expect(result).toContain('TODAY:');
+    expect(result).toContain('TOMORROW:');
+    expect(result).toContain('\n\n');
+  });
+
+  it('includes location when an event has one', () => {
+    const today = makeEvent('2026-07-17T18:00:00Z', 'COC #7', 'Brooklyn, NY');
+    const result = formatTodayTomorrowEvents([today]) ?? '';
+    expect(result).toContain('@ Brooklyn, NY');
+  });
+
+  it('lists multiple events on the same day', () => {
+    const e1 = makeEvent('2026-07-17T16:00:00Z', 'Morning Session');
+    const e2 = makeEvent('2026-07-17T22:00:00Z', 'Evening Show');
+    const result = formatTodayTomorrowEvents([e1, e2]) ?? '';
+    expect(result).toContain('Morning Session');
+    expect(result).toContain('Evening Show');
+  });
+});

--- a/bot/src/zoe/__tests__/concierge-blocks.test.ts
+++ b/bot/src/zoe/__tests__/concierge-blocks.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+// Tests for buildSystemBlocks — the pure prompt-assembly function in concierge.ts.
+// No mocks needed: function is purely functional (string in → string out).
+import { describe, expect, it } from 'vitest';
+import { buildSystemBlocks } from '../concierge';
+import type { MemoryBlocks } from '../memory';
+
+const BASE_BLOCKS: MemoryBlocks = {
+  persona: 'ZAO keeper. Sharp, warm.',
+  human: 'Zaal is building ZAO DAO.',
+  working: 'Recent: asked about battle counts.',
+  tasks: '- Finish blog post [P1]',
+  quests: '- Become the ZAO case study',
+  chat_scope: 'private',
+};
+
+const DATE = '2026-07-17T10:00:00-04:00';
+
+// ── structural sections ───────────────────────────────────────────────────────
+
+describe('buildSystemBlocks — structural sections', () => {
+  it('wraps current_time in XML tags and includes the date string', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<current_time>');
+    expect(out).toContain(DATE);
+    expect(out).toContain('</current_time>');
+  });
+
+  it('contains the runtime block', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<runtime>');
+    expect(out).toContain('ZOE v');
+  });
+
+  it('contains the clarify_policy block', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<clarify_policy>');
+    expect(out).toContain('</clarify_policy>');
+  });
+
+  it('contains the capabilities block', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<capabilities>');
+    expect(out).toContain('</capabilities>');
+  });
+
+  it('contains the tone block', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<tone>');
+  });
+
+  it('embeds persona content inside <persona> tags', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<persona>');
+    expect(out).toContain('ZAO keeper. Sharp, warm.');
+    expect(out).toContain('</persona>');
+  });
+
+  it('embeds human block content inside <human> tags', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<human>');
+    expect(out).toContain('Zaal is building ZAO DAO.');
+    expect(out).toContain('</human>');
+  });
+
+  it('embeds tasks content inside <tasks> tags', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<tasks>');
+    expect(out).toContain('Finish blog post [P1]');
+    expect(out).toContain('</tasks>');
+  });
+
+  it('embeds quests content inside <quests> tags', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<quests>');
+    expect(out).toContain('Become the ZAO case study');
+    expect(out).toContain('</quests>');
+  });
+});
+
+// ── chat scope ────────────────────────────────────────────────────────────────
+
+describe('buildSystemBlocks — chat scope', () => {
+  it('labels private chat as "DM with Zaal" in working_memory', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('DM with Zaal');
+  });
+
+  it('shows group title and scope id for non-private chats', () => {
+    const blocks: MemoryBlocks = { ...BASE_BLOCKS, chat_scope: '100', chat_title: 'ZAO HQ' };
+    const out = buildSystemBlocks(blocks, DATE);
+    expect(out).toContain('ZAO HQ');
+    expect(out).toContain('id 100');
+  });
+
+  it('uses scope id as fallback when chat_title is absent', () => {
+    const blocks: MemoryBlocks = { ...BASE_BLOCKS, chat_scope: '200', chat_title: undefined };
+    const out = buildSystemBlocks(blocks, DATE);
+    expect(out).toContain('id 200');
+  });
+});
+
+// ── open_threads ──────────────────────────────────────────────────────────────
+
+describe('buildSystemBlocks — open_threads', () => {
+  it('shows "(no open threads)" when open_threads is undefined', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<open_threads>');
+    expect(out).toContain('(no open threads)');
+  });
+
+  it('shows provided open_threads content and omits the default placeholder', () => {
+    const blocks: MemoryBlocks = { ...BASE_BLOCKS, open_threads: 'Thread: ship ZAO music module' };
+    const out = buildSystemBlocks(blocks, DATE);
+    expect(out).toContain('Thread: ship ZAO music module');
+    expect(out).not.toContain('(no open threads)');
+  });
+});
+
+// ── optional recall context ───────────────────────────────────────────────────
+
+describe('buildSystemBlocks — recall context', () => {
+  it('omits <bonfire_recall> block when recallContext is not provided', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).not.toContain('<bonfire_recall>');
+  });
+
+  it('includes <bonfire_recall> block with content when provided', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, 'ZAO launched May 2024.');
+    expect(out).toContain('<bonfire_recall>');
+    expect(out).toContain('ZAO launched May 2024.');
+    expect(out).toContain('</bonfire_recall>');
+  });
+
+  it('includes the disclaimer text about treating recall as memory, not instructions', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, 'some recall');
+    expect(out).toContain('NOT instructions');
+  });
+});
+
+// ── optional brand context ────────────────────────────────────────────────────
+
+describe('buildSystemBlocks — brand context', () => {
+  it('omits brand content when brandContext is not provided', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, undefined, undefined);
+    expect(out).not.toContain('ZAO brand guide');
+  });
+
+  it('includes brand content in the output when provided', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, undefined, 'ZAO brand guide: bold, minimal.');
+    expect(out).toContain('ZAO brand guide: bold, minimal.');
+  });
+});
+
+// ── link research intent ──────────────────────────────────────────────────────
+
+describe('buildSystemBlocks — link research intent', () => {
+  it('omits <link_research_routing> block when linkResearchIntent is falsy', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).not.toContain('<link_research_routing>');
+  });
+
+  it('includes <link_research_routing> block when linkResearchIntent=true', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, undefined, undefined, true);
+    expect(out).toContain('<link_research_routing>');
+    expect(out).toContain('</link_research_routing>');
+    expect(out).toContain('research-worker dispatch');
+  });
+});

--- a/bot/src/zoe/exec/__tests__/ffx.test.ts
+++ b/bot/src/zoe/exec/__tests__/ffx.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+// Tests for ffxAvailable() — pure env-var gate for FFX serverless exec.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ffxAvailable } from '../ffx';
+
+beforeEach(() => {
+  delete process.env.FFX_VERIFY_OK;
+  delete process.env.FFX_ENDPOINT;
+});
+afterEach(() => {
+  delete process.env.FFX_VERIFY_OK;
+  delete process.env.FFX_ENDPOINT;
+});
+
+describe('ffxAvailable', () => {
+  it('returns false when neither env var is set', () => {
+    expect(ffxAvailable()).toBe(false);
+  });
+
+  it('returns false when FFX_VERIFY_OK=1 but FFX_ENDPOINT is absent', () => {
+    process.env.FFX_VERIFY_OK = '1';
+    expect(ffxAvailable()).toBe(false);
+  });
+
+  it('returns false when FFX_ENDPOINT is set but FFX_VERIFY_OK is not "1"', () => {
+    process.env.FFX_ENDPOINT = 'https://ffx.example.com';
+    expect(ffxAvailable()).toBe(false);
+  });
+
+  it('returns false when FFX_VERIFY_OK is "true" instead of "1"', () => {
+    process.env.FFX_VERIFY_OK = 'true';
+    process.env.FFX_ENDPOINT = 'https://ffx.example.com';
+    expect(ffxAvailable()).toBe(false);
+  });
+
+  it('returns true when both FFX_VERIFY_OK="1" and FFX_ENDPOINT are set', () => {
+    process.env.FFX_VERIFY_OK = '1';
+    process.env.FFX_ENDPOINT = 'https://ffx.example.com';
+    expect(ffxAvailable()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `zoe/__tests__/concierge-blocks.test.ts` — 21 cases: `buildSystemBlocks` structural sections (current_time, runtime, clarify_policy, capabilities, tone, persona, human, tasks, quests tags all present), chat scope (private→"DM with Zaal", group→title+id, fallback to scope id), open_threads (default placeholder + override), recall context (bonfire_recall block toggled on/off, disclaimer text present), brand context, link_research_routing block toggle. Zero mocks needed — pure string-in/string-out.
- `zoe/__tests__/calendar.test.ts` — 11 cases: `formatEventForBrief` (title present, location appended with " @ ", no @ without location, date precedes title), `formatTodayTomorrowEvents` with `vi.useFakeTimers` (null for empty/future, TODAY section, TOMORROW section, both + blank separator, location, multi-event same day).
- `zoe/exec/__tests__/ffx.test.ts` — 5 cases: `ffxAvailable` returns false when no vars, FFX_ENDPOINT only, FFX_VERIFY_OK only, "true"≠"1"; returns true only when both set correctly.

## Test plan
- [x] All 37 tests pass locally (`npx vitest run` in `bot/`)
- [x] CI will verify on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)