### PR TITLE
feat(zoe): /loops + /loop <name> commands for fleet status from phone

### DIFF
--- a/bot/src/zoe/__tests__/fleet-loops.test.ts
+++ b/bot/src/zoe/__tests__/fleet-loops.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { ageStr, formatLoop, formatLoopsAll, type LoopStatus } from '../fleet-loops';
+
+function loop(overrides: Partial<LoopStatus> = {}): LoopStatus {
+  return {
+    session: 'coc',
+    state: 'working',
+    lastLine: 'esc to interrupt',
+    updatedAt: new Date(Date.now() - 90_000).toISOString(), // 90s ago
+    ...overrides,
+  };
+}
+
+const NOW = 1_700_000_000_000; // fixed reference point for determinism
+
+// ── ageStr ────────────────────────────────────────────────────────────────────
+
+describe('ageStr', () => {
+  it('returns "unknown age" when updatedAt is null', () => {
+    expect(ageStr(null, NOW)).toBe('unknown age');
+  });
+
+  it('returns seconds when age < 90s', () => {
+    const ts = new Date(NOW - 45_000).toISOString();
+    expect(ageStr(ts, NOW)).toBe('45s ago');
+  });
+
+  it('returns minutes when age is 90s to 90m', () => {
+    const ts = new Date(NOW - 5 * 60_000).toISOString();
+    expect(ageStr(ts, NOW)).toBe('5m ago');
+  });
+
+  it('returns hours when age > 90m', () => {
+    const ts = new Date(NOW - 2 * 3_600_000).toISOString();
+    expect(ageStr(ts, NOW)).toBe('2h ago');
+  });
+
+  it('returns "just now" for future timestamps', () => {
+    const ts = new Date(NOW + 5_000).toISOString();
+    expect(ageStr(ts, NOW)).toBe('just now');
+  });
+});
+
+// ── formatLoop ────────────────────────────────────────────────────────────────
+
+describe('formatLoop', () => {
+  it('includes session name', () => {
+    expect(formatLoop(loop({ session: 'ww' }), NOW)).toContain('ww');
+  });
+
+  it('includes state in brackets', () => {
+    expect(formatLoop(loop({ state: 'working' }), NOW)).toContain('[working]');
+  });
+
+  it('includes "idle" state in brackets', () => {
+    expect(formatLoop(loop({ state: 'idle' }), NOW)).toContain('[idle]');
+  });
+
+  it('includes age string', () => {
+    const ts = new Date(NOW - 3 * 60_000).toISOString();
+    expect(formatLoop(loop({ updatedAt: ts }), NOW)).toContain('3m ago');
+  });
+
+  it('includes last line', () => {
+    expect(formatLoop(loop({ lastLine: 'running tests' }), NOW)).toContain('running tests');
+  });
+
+  it('replaces empty lastLine with placeholder', () => {
+    expect(formatLoop(loop({ lastLine: '' }), NOW)).toContain('(no recent output)');
+  });
+
+  it('truncates lastLine to 100 chars', () => {
+    const long = 'x'.repeat(200);
+    const out = formatLoop(loop({ lastLine: long }), NOW);
+    const lastLinePart = out.split('\n')[1].trim();
+    expect(lastLinePart.length).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── formatLoopsAll ────────────────────────────────────────────────────────────
+
+describe('formatLoopsAll', () => {
+  it('returns a no-data message when loops is empty', () => {
+    expect(formatLoopsAll([], NOW)).toContain('No loop status data');
+  });
+
+  it('includes fleet header with working count', () => {
+    const loops = [
+      loop({ session: 'zoe', state: 'working' }),
+      loop({ session: 'coc', state: 'idle' }),
+    ];
+    const out = formatLoopsAll(loops, NOW);
+    expect(out).toContain('Fleet: 1/2 working');
+  });
+
+  it('includes all session names', () => {
+    const loops = [
+      loop({ session: 'zoe' }),
+      loop({ session: 'ww' }),
+      loop({ session: 'coc' }),
+    ];
+    const out = formatLoopsAll(loops, NOW);
+    expect(out).toContain('zoe');
+    expect(out).toContain('ww');
+    expect(out).toContain('coc');
+  });
+
+  it('reports 0 working when all idle', () => {
+    const loops = [loop({ state: 'idle' }), loop({ session: 'ww', state: 'idle' })];
+    expect(formatLoopsAll(loops, NOW)).toContain('Fleet: 0/2 working');
+  });
+});

--- a/bot/src/zoe/fleet-loops.ts
+++ b/bot/src/zoe/fleet-loops.ts
@@ -1,0 +1,90 @@
+/**
+ * fleet-loops.ts - fetch and format loop status for the /loops and /loop commands.
+ *
+ * Reads from the Supabase `fleet_status` table which the loops-keepalive.sh script
+ * refreshes every ~10s. ZOE can call this from the VPS without needing access to
+ * the local tmux sessions.
+ */
+
+const REQUEST_TIMEOUT_MS = 8_000;
+
+const KNOWN_LOOPS = ['zoe', 'ww', 'coc', 'human', 'zol'] as const;
+type LoopName = (typeof KNOWN_LOOPS)[number];
+
+export interface LoopStatus {
+  session: string;
+  state: string;
+  lastLine: string;
+  updatedAt: string | null;
+}
+
+/** Fetch loop statuses from Supabase fleet_status table. Returns [] on error. */
+export async function fetchLoopStatuses(sessions?: string[]): Promise<LoopStatus[]> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return [];
+
+  const targets = sessions ?? [...KNOWN_LOOPS];
+  const inClause = targets.map((s) => `"${s}"`).join(',');
+  const url =
+    `${base.replace(/\/$/, '')}/rest/v1/fleet_status` +
+    `?session=in.(${inClause})&select=session,state,last_line,updated_at&order=session`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const res = await fetch(url, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: controller.signal,
+      cache: 'no-store',
+    }).finally(() => clearTimeout(timer));
+    if (!res.ok) return [];
+    const rows = (await res.json()) as Array<{
+      session: string;
+      state: string;
+      last_line: string | null;
+      updated_at: string | null;
+    }>;
+    return rows.map((r) => ({
+      session: r.session,
+      state: r.state ?? '?',
+      lastLine: (r.last_line ?? '').trim().replace(/\s+/g, ' '),
+      updatedAt: r.updated_at ?? null,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** Age string relative to now. */
+export function ageStr(updatedAt: string | null, now = Date.now()): string {
+  if (!updatedAt) return 'unknown age';
+  const ms = now - new Date(updatedAt).getTime();
+  if (ms < 0) return 'just now';
+  const secs = Math.round(ms / 1000);
+  if (secs < 90) return `${secs}s ago`;
+  const mins = Math.round(ms / 60_000);
+  if (mins < 90) return `${mins}m ago`;
+  const hrs = Math.round(ms / 3_600_000);
+  return `${hrs}h ago`;
+}
+
+/** Format a single loop as a compact status line. */
+export function formatLoop(loop: LoopStatus, now = Date.now()): string {
+  const icon = loop.state === 'working' ? 'working' : loop.state === 'idle' ? 'idle' : loop.state;
+  const age = ageStr(loop.updatedAt, now);
+  const last = loop.lastLine.slice(0, 100) || '(no recent output)';
+  return `${loop.session} [${icon}] (${age})\n  ${last}`;
+}
+
+/** Format all loops as a multi-line Telegram status reply. */
+export function formatLoopsAll(loops: LoopStatus[], now = Date.now()): string {
+  if (loops.length === 0) return 'No loop status data in fleet_status table.';
+  const working = loops.filter((l) => l.state === 'working').length;
+  const header = `Fleet: ${working}/${loops.length} working`;
+  const lines = loops.map((l) => formatLoop(l, now)).join('\n\n');
+  return `${header}\n\n${lines}`;
+}
+
+export { KNOWN_LOOPS };
+export type { LoopName };

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -161,6 +161,7 @@ import {
 } from './focus-guard';
 import { saveCheckpoint, getCheckpoint, offerCheckpoint } from './session-checkpoint';
 import { runAudit, formatAuditForTelegram } from './trust-audit';
+import { fetchLoopStatuses, formatLoopsAll, formatLoop, KNOWN_LOOPS } from './fleet-loops';
 
 const CLAUDE_NOTES_FILE = join(ZOE_PATHS.home, 'claude-code-notes.md');
 const VALID_GROUP_MODES: GroupMode[] = ['silent', 'mention', 'all'];
@@ -701,6 +702,36 @@ bot.command('cockpit', async (ctx) => {
   } catch (e) {
     await ctx.reply(`Cockpit failed: ${e instanceof Error ? e.message : 'unknown error'}`);
   }
+});
+
+// /loops — show all 5 loop states from Supabase fleet_status
+bot.command('loops', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const loops = await fetchLoopStatuses();
+  await replyChunked(ctx, formatLoopsAll(loops));
+});
+
+// /loop <name> — show one loop's state. /loop with no arg = same as /loops
+bot.command('loop', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const arg = (ctx.match ?? '').toString().trim().toLowerCase();
+  if (!arg) {
+    const loops = await fetchLoopStatuses();
+    await replyChunked(ctx, formatLoopsAll(loops));
+    return;
+  }
+  if (!(KNOWN_LOOPS as readonly string[]).includes(arg)) {
+    await ctx.reply(
+      `Unknown loop "${arg}". Valid: ${[...KNOWN_LOOPS].join(', ')}`,
+    );
+    return;
+  }
+  const loops = await fetchLoopStatuses([arg]);
+  if (loops.length === 0) {
+    await ctx.reply(`No status for "${arg}" in fleet_status table.`);
+    return;
+  }
+  await ctx.reply(formatLoop(loops[0]));
 });
 
 bot.command('team', async (ctx) => {


### PR DESCRIPTION
## Summary

- Adds `/loops` Telegram command — shows all 5 loops (zoe|ww|coc|human|zol) with state + age
- Adds `/loop <name>` — single loop detail; no arg falls back to `/loops`
- New module `bot/src/zoe/fleet-loops.ts`: `fetchLoopStatuses`, `ageStr`, `formatLoop`, `formatLoopsAll`, `KNOWN_LOOPS`
- Reads from Supabase `fleet_status` table (refreshed every ~10s by `loops-keepalive.sh`) — no VPS-local tmux access needed
- Uses same `COWORK_TRACKER_URL`/`COWORK_TRACKER_KEY` pattern as cockpit adapters
- 16 pure-function tests, typecheck clean on new files

## Example output

```
Fleet: 3/5 working

coc [working] (45s ago)
  esc to interrupt

zoe [working] (12s ago)
  polling as ZOE_BOT

ww [idle] (8m ago)
  (no recent output)
```

## Test plan

- [ ] `/loops` returns fleet summary from Supabase
- [ ] `/loop coc` returns single loop detail
- [ ] `/loop` (no arg) same as `/loops`
- [ ] Unknown loop name returns helpful error with valid options
- [ ] `fetchLoopStatuses` degrades to `[]` if env vars missing or network error
- [ ] 16 unit tests pass: `npm test --prefix bot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)