### PR TITLE
test(schedule): fix hardcoded past date in embedHash acceptance test

### DIFF
--- a/src/app/api/chat/schedule/__tests__/route.test.ts
+++ b/src/app/api/chat/schedule/__tests__/route.test.ts
@@ -295,11 +295,13 @@ describe('POST /api/chat/schedule', () => {
   it('accepts valid embedHash format (0x followed by 40 hex chars)', async () => {
     mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: 'valid-uuid' }));
 
+    const futureDate = new Date();
+    futureDate.setHours(futureDate.getHours() + 1);
     const validHash = '0x1234567890abcdef1234567890abcdef12345678';
     const req = makePostRequest('/api/chat/schedule', {
       text: 'Hello',
       channel: 'zao',
-      scheduledFor: '2026-07-17T10:00:00Z',
+      scheduledFor: futureDate.toISOString(),
       embedHash: validHash,
     });
 


### PR DESCRIPTION
## Summary
- `scheduledFor: '2026-07-17T10:00:00Z'` in the `accepts valid embedHash format` test is now in the past
- Route's future-date guard returns 400; test expects 200 → CI fails on all branches
- Replace with `new Date() + 1h` dynamic pattern (same pattern already used in the time-validation tests below)

## Test plan
- [ ] CI passes on this branch
- [ ] PR #1762 (`feat/zoe-loops-command`) becomes green after this merges to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)