### PR TITLE
feat(fleet): zao-board atomic claim — race-safe task-lease (fixes parallel-loop dup)

### DIFF
--- a/scripts/fleet/zao-board.py
+++ b/scripts/fleet/zao-board.py
@@ -116,6 +116,34 @@ def cmd_start(args, url, key) -> int:
     return 0
 
 
+def claim_url(base: str, task_id: str) -> str:
+    """PATCH target for an ATOMIC claim: only matches a row still in 'todo'.
+
+    The &status=eq.todo filter is the whole trick - PostgREST applies the UPDATE
+    only to rows matching the filter, so if a sibling already flipped it to
+    in_progress the update touches 0 rows and returns []. That is a lock-free
+    compare-and-swap on the existing status column (no schema change needed).
+    """
+    return f"{base}/rest/v1/tasks?id=eq.{urllib.parse.quote(task_id)}&status=eq.todo"
+
+
+def cmd_claim(args, url, key) -> int:
+    """Atomically claim a todo task (the race-safe replacement for `start`).
+
+    Exit 0 = you won the claim (task is now yours, in_progress).
+    Exit 2 = a sibling already holds it - pick another task.
+    This is the fix for the parallel-loop duplication that keeps burning fleet
+    work (three P1s built twice in one session, 2026-07-17). Loops MUST claim
+    before starting; on exit 2, move on.
+    """
+    rows = _req("PATCH", claim_url(url, args.id), key, {"status": "in_progress"})
+    if rows:
+        print(f"CLAIMED {args.id}")
+        return 0
+    print(f"ALREADY-CLAIMED {args.id} (a sibling holds it) - pick another task")
+    return 2
+
+
 def cmd_done(args, url, key) -> int:
     cur = _req("GET", f"{url}/rest/v1/tasks?id=eq.{urllib.parse.quote(args.id)}&select=notes", key)
     existing_notes = cur[0].get("notes") if cur else None
@@ -158,6 +186,9 @@ def _selftest() -> int:
     f = dedup_filter("A B", "src")
     checks.append(("dedup filter encodes title + source + open-status",
                    "status=in.(todo,in_progress)" in f and "A%20B" in f and "legacy_source=eq.src" in f))
+    cu = claim_url("https://x.co", "abc-123")
+    checks.append(("claim url is an atomic CAS (id=eq + status=eq.todo)",
+                   "id=eq.abc-123" in cu and "status=eq.todo" in cu and cu.startswith("https://x.co/rest/v1/tasks?")))
     fails = 0
     for label, ok in checks:
         fails += 0 if ok else 1
@@ -174,6 +205,8 @@ def main() -> int:
     a = sub.add_parser("add"); a.add_argument("title")
     a.add_argument("--priority", default="P2"); a.add_argument("--source"); a.add_argument("--project", default="zaodevz")
     a.add_argument("--notes"); a.add_argument("--dedup", action="store_true")
+    cl = sub.add_parser("claim", help="atomically claim a todo task (race-safe; exit 2 if a sibling holds it)")
+    cl.add_argument("id")
     s = sub.add_parser("start"); s.add_argument("id")
     dn = sub.add_parser("done"); dn.add_argument("id"); dn.add_argument("--pr")
     ls = sub.add_parser("list"); ls.add_argument("--source"); ls.add_argument("--status")
@@ -185,7 +218,7 @@ def main() -> int:
         p.print_help(); return 1
 
     url, key = load_creds()
-    return {"add": cmd_add, "start": cmd_start, "done": cmd_done, "list": cmd_list}[args.cmd](args, url, key)
+    return {"add": cmd_add, "claim": cmd_claim, "start": cmd_start, "done": cmd_done, "list": cmd_list}[args.cmd](args, url, key)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Adds `zao-board claim <id>` — an **atomic** task-lease that fixes the **#1 fleet constraint**: parallel-loop duplication.

## Why (surfaced hard today)
Three of Zaal's P1s were built **twice in one session** (2026-07-17) — `/loops` (#1762 vs #1767), the event-workflow (doc 1215 vs 1214), plus repeated doc-# collisions — because `status=in_progress` is set **non-atomically** (`cmd_start` writes it unconditionally). Two loops both "start" the same task and duplicate the work. The board-claim discipline Zaal asked for doesn't hold because the claim isn't race-safe.

## The fix (no schema change)
`claim` does a **compare-and-swap on the existing status column**:
```
PATCH .../tasks?id=eq.<id>&status=eq.todo   body {status: in_progress}
```
The `&status=eq.todo` filter makes the UPDATE a no-op if a sibling already flipped it; PostgREST then returns `[]`.
- **exit 0** = you won → task is yours.
- **exit 2** = a sibling holds it → pick another task.

Loops should `zao-board claim <id>` before starting and move on if it returns exit 2. This is the frontier concurrency-leasing pattern (Temporal/Cloudflare) from this morning's alpha-scan (doc 1216), reduced to a lock-free one-liner on the board we already have.

## Verify
`python3 scripts/fleet/zao-board.py --selftest` → **7/7** (adds a `claim_url` CAS-shape check). `start` kept for back-compat; `claim` is the race-safe replacement.

Follow-up (directive-level): bake `claim`-before-start into every loop directive so the whole fleet uses it. Modified script → awaits your review. Board: `alpha-scan` task-leasing (bumped P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)