### PR TITLE
chore: sync repo count stats in CLAUDE.md + AGENTS.md (Jul 2026)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,14 +39,14 @@ npx biome check src/lib/agents        # lint specific module
 ## Project Structure
 
 ```
-src/app/api/         # 302 route handlers across 55 domains: /api/[feature]/[action]/route.ts
-src/components/      # 295 components organized by feature
-src/hooks/           # 18 custom hooks (useAuth, useChat, useRadio, etc.)
+src/app/api/         # 313 route handlers across 55 domains: /api/[feature]/[action]/route.ts
+src/components/      # 296 components organized by feature
+src/hooks/           # 20 custom hooks (useAuth, useChat, useRadio, etc.)
 src/lib/             # Utilities across 42 domains (auth, db, farcaster, music, publish, agents)
 src/providers/       # React providers (audio player, contexts)
 src/types/           # TypeScript type definitions
 community.config.ts  # Branding, channels, contract addresses, nav - THE fork point
-research/            # ~820 active research docs (counts verified 2026-06-11, Doc 836)
+research/            # ~1,275 active research docs (counts verified 2026-07-17, Doc 836)
 scripts/             # SQL migrations, wallet generation, webhooks
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The pattern: **Monorepo as Lab.**
 - Sharing model: clone, no deps. Each graduate stands alone.
 - Research stays in ZAOOS forever - it's the institutional memory across every product.
 
-**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (spinning out to its own repo), agent stack (ZOE, the orchestrator), music player components, ~820 active research docs. 302 API routes, 295 components, 18 hooks. (Counts verified 2026-06-11 - see [Doc 836](research/infrastructure/836-zaoos-repo-estate-census/).)
+**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (spinning out to its own repo), agent stack (ZOE, the orchestrator), music player components, ~1,275 active research docs. 313 API routes, 296 components, 20 hooks. (Counts verified 2026-07-17 - see [Doc 836](research/infrastructure/836-zaoos-repo-estate-census/).)
 
 **Stack:** Next.js 16, React 19, Supabase (RLS), Neynar, XMTP, Stream.io, Wagmi/Viem, Tailwind v4, iron-session.
 
@@ -25,15 +25,15 @@ The pattern: **Monorepo as Lab.**
 
 | Directory | What | When to Read |
 |-----------|------|-------------|
-| `src/app/api/` | 302 route handlers across 55 domains | Working on backend |
-| `src/components/` | 295 components by feature | Working on UI |
-| `src/hooks/` | 18 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
+| `src/app/api/` | 313 route handlers across 55 domains | Working on backend |
+| `src/components/` | 296 components by feature | Working on UI |
+| `src/hooks/` | 20 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
 | `src/lib/` | Utils across 42 domains: auth, db, farcaster, music, publish, agents | Working on business logic |
 | `src/lib/agents/` | VAULT/BANKER/DEALER autonomous trading bots | Working on agents |
 | `src/lib/publish/` | Cross-platform posting (Farcaster, X, Bluesky) | Working on distribution |
 | `src/providers/` | Audio player, contexts | Working on player |
 | `community.config.ts` | All branding, channels, admin FIDs, contract addresses, nav | Forking or configuring |
-| `research/` | ~820 active research docs (see research/README.md) | Use grep, not bulk reads |
+| `research/` | ~1,275 active research docs (see research/README.md) | Use grep, not bulk reads |
 | `scripts/` | SQL migrations, wallet generation, webhook setup | DB or infra work |
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Count stats in both CLAUDE.md and AGENTS.md were last verified 2026-06-11 — 6 weeks stale. This PR syncs them to current reality.

| Metric | Old (Jun 11) | New (Jul 17) | Delta |
|--------|-------------|--------------|-------|
| API routes | 302 | 313 | +11 |
| Components | 295 | 296 | +1 |
| Hooks | 18 | 20 | +2 |
| Research docs | ~820 | ~1,275 | +455 |

Closes board task 93c835ec (CLAUDE.md/AGENTS.md count drift sub-item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)