### PR TITLE
feat(zoe): conversational turns skip task/quest/thread context blocks

### DIFF
--- a/bot/src/zoe/__tests__/concierge-blocks.test.ts
+++ b/bot/src/zoe/__tests__/concierge-blocks.test.ts
@@ -167,3 +167,47 @@ describe('buildSystemBlocks — link research intent', () => {
     expect(out).toContain('research-worker dispatch');
   });
 });
+
+// ── conversational mode ───────────────────────────────────────────────────────
+
+describe('buildSystemBlocks — conversational mode', () => {
+  it('includes tasks/quests/open_threads by default (non-conversational)', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE);
+    expect(out).toContain('<tasks>');
+    expect(out).toContain('<quests>');
+    expect(out).toContain('<open_threads>');
+  });
+
+  it('omits tasks/quests/open_threads when conversational=true', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, undefined, undefined, undefined, true);
+    expect(out).not.toContain('<tasks>');
+    expect(out).not.toContain('<quests>');
+    expect(out).not.toContain('<open_threads>');
+  });
+
+  it('still includes persona/human/working_memory when conversational=true', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, undefined, undefined, undefined, true);
+    expect(out).toContain('<persona>');
+    expect(out).toContain('<human>');
+    expect(out).toContain('<working_memory>');
+    expect(out).toContain('ZAO keeper. Sharp, warm.');
+    expect(out).toContain('Zaal is building ZAO DAO.');
+  });
+
+  it('still includes recall context in conversational mode', () => {
+    const out = buildSystemBlocks(BASE_BLOCKS, DATE, 'recall: ZAO launched May 2024', undefined, undefined, true);
+    expect(out).toContain('<bonfire_recall>');
+    expect(out).toContain('recall: ZAO launched May 2024');
+    expect(out).not.toContain('<tasks>');
+  });
+
+  it('conversational=false behaves the same as omitting it (includes all blocks)', () => {
+    const outDefault = buildSystemBlocks(BASE_BLOCKS, DATE);
+    const outFalse = buildSystemBlocks(BASE_BLOCKS, DATE, undefined, undefined, undefined, false);
+    expect(outFalse).toContain('<tasks>');
+    expect(outFalse).toContain('<quests>');
+    expect(outFalse).toContain('<open_threads>');
+    expect(outFalse).toContain(BASE_BLOCKS.tasks);
+    expect(outDefault).toContain(BASE_BLOCKS.tasks);
+  });
+});

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -24,7 +24,7 @@ const ZOE_VERSION = '0.2.0';
  * Render the 4 memory blocks as a system prompt for Claude Code CLI.
  * The user's message is passed separately as `prompt`.
  */
-export function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallContext?: string, brandContext?: string, linkResearchIntent?: boolean): string {
+export function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallContext?: string, brandContext?: string, linkResearchIntent?: boolean, conversational?: boolean): string {
   const chatLine =
     blocks.chat_scope === 'private'
       ? 'Chat: DM with Zaal'
@@ -97,17 +97,23 @@ export function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, rec
     blocks.working,
     `</working_memory>`,
     ``,
-    `<tasks>`,
-    blocks.tasks,
-    `</tasks>`,
-    ``,
-    `<quests>`,
-    blocks.quests,
-    `</quests>`,
-    ``,
-    `<open_threads>`,
-    blocks.open_threads ?? '(no open threads)',
-    `</open_threads>`,
+    // For conversational turns (short chat, no work keywords) skip the heavy
+    // task/quest/thread context — it's irrelevant overhead and slows the reply.
+    ...(conversational
+      ? []
+      : [
+          `<tasks>`,
+          blocks.tasks,
+          `</tasks>`,
+          ``,
+          `<quests>`,
+          blocks.quests,
+          `</quests>`,
+          ``,
+          `<open_threads>`,
+          blocks.open_threads ?? '(no open threads)',
+          `</open_threads>`,
+        ]),
     ...recallBlock,
     ...brandBlock,
     ...linkResearchBlock,
@@ -160,7 +166,7 @@ async function callModelWithCliRouting(opts: Omit<import('../hermes/claude-cli')
  * 6. Return structured result
  */
 export async function runConciergeTurn(opts: ConciergeOptions): Promise<ConciergeResult> {
-  const systemBlocks = buildSystemBlocks(opts.blocks, opts.context.current_date, opts.recallContext, opts.brandContext, opts.linkResearchIntent);
+  const systemBlocks = buildSystemBlocks(opts.blocks, opts.context.current_date, opts.recallContext, opts.brandContext, opts.linkResearchIntent, opts.conversational);
 
   const senderLabel = opts.senderLabel ?? 'Zaal';
   const userPrompt = `${senderLabel}: ${opts.message}`;

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -1932,6 +1932,8 @@ async function dispatchConcierge(
       recallContext,
       brandContext,
       linkResearchIntent: wantsLinkResearch(text),
+      // Conversational turns skip task/quest/thread context blocks (irrelevant overhead).
+      conversational,
       context: {
         zaal_tg_id: zaalId,
         workspace_dir: repoDir,

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -160,6 +160,8 @@ export interface ConciergeOptions {
   brandContext?: string;
   /** True if the message contains a URL + research intent keywords. Routes toward research-worker dispatch. */
   linkResearchIntent?: boolean;
+  /** True for casual back-and-forth (short, no URLs, no work keywords). Skips task/quest/thread blocks. */
+  conversational?: boolean;
 }
 
 export interface ConciergeResult {


### PR DESCRIPTION
## Summary

- For DM turns classified as conversational (short, no URLs, no work keywords), ZOE no longer injects `<tasks>`, `<quests>`, or `<open_threads>` into the system prompt — irrelevant overhead for casual back-and-forth
- Adds `conversational?: boolean` to `ConciergeOptions` and `buildSystemBlocks()` signature
- `dispatchConcierge()` passes `conversational` alongside the existing quick-model override
- Persona, human profile, working memory (last 8 turns), and Bonfire recall still included on all turns
- +5 tests covering: blocks present by default, omitted when `conversational=true`, core blocks always present, recall still included, `false` same as default

Follows up on PR #1526 (conversational v1: quick-model + no ack-theater). Addresses board task `c39caadb` (Zaal 2026-07-17: ZOE DMs way more conversational, kill remaining ack-theater and overhead for quick back-and-forth).

## Test plan

- [x] 26 concierge-blocks tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)