### PR TITLE
feat(zoe/discord): Stage 1a webhook status mirror

### DIFF
--- a/bot/src/zoe/__tests__/discord-webhook.test.ts
+++ b/bot/src/zoe/__tests__/discord-webhook.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock global fetch before importing the module
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+// Must import AFTER stubbing fetch
+const { postStatusToDiscord, postBriefToDiscord } = await import('../discord-webhook');
+
+const OK_RESPONSE = { ok: true, status: 200, statusText: 'OK' } as Response;
+const FAIL_RESPONSE = { ok: false, status: 429, statusText: 'Too Many Requests' } as Response;
+
+describe('postStatusToDiscord', () => {
+  beforeEach(() => {
+    vi.stubEnv('DISCORD_WEBHOOK_STATUS', 'https://discord.com/api/webhooks/test/token');
+    mockFetch.mockResolvedValue(OK_RESPONSE);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    mockFetch.mockReset();
+  });
+
+  it('no-ops and returns false when DISCORD_WEBHOOK_STATUS is unset', async () => {
+    vi.stubEnv('DISCORD_WEBHOOK_STATUS', '');
+    const result = await postStatusToDiscord({ title: 'test', body: 'hello' });
+    expect(result).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to the webhook URL with JSON content-type', async () => {
+    await postStatusToDiscord({ title: 'Status', body: 'All good' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/test/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+
+  it('includes title and body in the embed', async () => {
+    await postStatusToDiscord({ title: 'My Title', body: 'My body text' });
+    const [, opts] = mockFetch.mock.calls[0];
+    const payload = JSON.parse((opts as RequestInit).body as string);
+    expect(payload.embeds).toHaveLength(1);
+    expect(payload.embeds[0].title).toContain('My Title');
+    expect(payload.embeds[0].description).toBe('My body text');
+  });
+
+  it('prepends emoji to title when provided', async () => {
+    await postStatusToDiscord({ title: 'Brief', body: 'content', emoji: '☀️' });
+    const [, opts] = mockFetch.mock.calls[0];
+    const payload = JSON.parse((opts as RequestInit).body as string);
+    expect(payload.embeds[0].title).toBe('☀️ Brief');
+  });
+
+  it('includes fields in the embed when provided', async () => {
+    await postStatusToDiscord({
+      title: 'Report',
+      body: 'text',
+      fields: [{ name: 'PRs merged', value: '5' }],
+    });
+    const [, opts] = mockFetch.mock.calls[0];
+    const payload = JSON.parse((opts as RequestInit).body as string);
+    expect(payload.embeds[0].fields).toEqual([{ name: 'PRs merged', value: '5', inline: true }]);
+  });
+
+  it('returns true on HTTP 200', async () => {
+    const result = await postStatusToDiscord({ title: 'T', body: 'B' });
+    expect(result).toBe(true);
+  });
+
+  it('returns false and logs on non-OK response', async () => {
+    mockFetch.mockResolvedValue(FAIL_RESPONSE);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await postStatusToDiscord({ title: 'T', body: 'B' });
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('429'));
+    consoleSpy.mockRestore();
+  });
+
+  it('returns false and logs on fetch network error', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await postStatusToDiscord({ title: 'T', body: 'B' });
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('post error'),
+      expect.stringContaining('ECONNREFUSED'),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('truncates body longer than 4096 chars', async () => {
+    const longBody = 'x'.repeat(5000);
+    await postStatusToDiscord({ title: 'T', body: longBody });
+    const [, opts] = mockFetch.mock.calls[0];
+    const payload = JSON.parse((opts as RequestInit).body as string);
+    expect(payload.embeds[0].description.length).toBe(4096);
+  });
+});
+
+describe('postBriefToDiscord', () => {
+  beforeEach(() => {
+    vi.stubEnv('DISCORD_WEBHOOK_STATUS', 'https://discord.com/api/webhooks/test/token');
+    mockFetch.mockResolvedValue(OK_RESPONSE);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    mockFetch.mockReset();
+  });
+
+  it('posts with morning brief title and sunrise emoji', async () => {
+    await postBriefToDiscord('Good morning!');
+    const [, opts] = mockFetch.mock.calls[0];
+    const payload = JSON.parse((opts as RequestInit).body as string);
+    expect(payload.embeds[0].title).toBe('☀️ ZOE Morning Brief');
+    expect(payload.embeds[0].description).toBe('Good morning!');
+  });
+
+  it('no-ops when webhook url is unset', async () => {
+    vi.stubEnv('DISCORD_WEBHOOK_STATUS', '');
+    const result = await postBriefToDiscord('anything');
+    expect(result).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/zoe/discord-webhook.ts
+++ b/bot/src/zoe/discord-webhook.ts
@@ -1,0 +1,70 @@
+/**
+ * Discord webhook poster for ZOE status feed parity (doc 1135 Stage 1a).
+ *
+ * Posts ZOE status updates (morning brief, research publish, agent ticks) to a
+ * Discord channel via an incoming webhook. Zero Discord bot required — just an
+ * HTTP POST to a webhook URL.
+ *
+ * Activation: set DISCORD_WEBHOOK_STATUS env var to the webhook URL from
+ * Discord Server Settings → Integrations → Webhooks → Create webhook → Copy URL.
+ * No-ops silently when the env var is unset (PR-only; activates after Zaal's Stage 0).
+ */
+
+const ZAO_GOLD = 0xf5a623;
+
+export interface DiscordStatusMessage {
+  title: string;
+  body: string;
+  emoji?: string;
+  fields?: Array<{ name: string; value: string }>;
+}
+
+/**
+ * Post a status embed to the configured Discord webhook channel.
+ * Returns true on success, false on any error (caller should log, not throw).
+ */
+export async function postStatusToDiscord(msg: DiscordStatusMessage): Promise<boolean> {
+  const WEBHOOK_URL = process.env.DISCORD_WEBHOOK_STATUS;
+  if (!WEBHOOK_URL) return false;
+
+  const label = msg.emoji ? `${msg.emoji} ${msg.title}` : msg.title;
+
+  const embed: Record<string, unknown> = {
+    title: label,
+    description: msg.body.slice(0, 4096),
+    color: ZAO_GOLD,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (msg.fields?.length) {
+    embed.fields = msg.fields.map((f) => ({ name: f.name, value: f.value.slice(0, 1024), inline: true }));
+  }
+
+  try {
+    const res = await fetch(WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds: [embed] }),
+    });
+    if (!res.ok) {
+      console.error(`[zoe/discord-webhook] post failed: ${res.status} ${res.statusText}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error('[zoe/discord-webhook] post error:', (err as Error).message);
+    return false;
+  }
+}
+
+/**
+ * Convenience wrapper: post a morning brief (or any long text) as a Discord embed.
+ * Truncates the body to Discord's 4096-char embed description limit.
+ */
+export async function postBriefToDiscord(briefText: string): Promise<boolean> {
+  return postStatusToDiscord({
+    title: 'ZOE Morning Brief',
+    body: briefText,
+    emoji: '☀️',
+  });
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -52,6 +52,7 @@ import { runPingLifecycleTick } from './ping-lifecycle';
 import { sendToZaal as sendToZaalRouted, constructRoutingDeps, type SendToZaalOptions } from './telegram-routing';
 import { getOpenTeamTasks } from './team-tracker';
 import { buildVetoKeyboard, type VetoTask } from './brief-veto';
+import { postBriefToDiscord } from './discord-webhook';
 
 /** await-reflection waits overnight for Zaal's reply, so a 14h TTL not 30m. */
 const AWAIT_REFLECTION_TTL_MS = 14 * 60 * 60 * 1000;
@@ -142,6 +143,10 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
             await opts.bot.api.sendMessage(opts.zaalTgId, brief, sendOpts);
           }
           console.log('[zoe/scheduler] morning brief sent (cockpit)' + (vetoKeyboard?.inline_keyboard.length ? ' + veto keyboard' : ''));
+          // Mirror to Discord #zao-status if DISCORD_WEBHOOK_STATUS is set (doc 1135 Stage 1a).
+          postBriefToDiscord(brief).catch((err) =>
+            console.warn('[zoe/scheduler] discord webhook failed (non-fatal):', (err as Error).message),
+          );
         } catch (err) {
           await releaseFire('morning-brief');
           console.error('[zoe/scheduler] morning brief failed:', (err as Error).message);


### PR DESCRIPTION
## Summary

Implements doc 1135 Stage 1a: Discord webhook status mirror for zao-status feed parity.

- **New `bot/src/zoe/discord-webhook.ts`**: `postStatusToDiscord()` + `postBriefToDiscord()`
  - Reads `DISCORD_WEBHOOK_STATUS` lazily per call — no-ops when unset (PR-only activation)
  - Posts rich Discord embeds (title, description, optional fields, ZAO gold `0xf5a623`)
  - Truncates to Discord's 4096-char embed limit
  - Non-fatal on any error — returns false, logs to console
- **`bot/src/zoe/scheduler.ts`**: wire `postBriefToDiscord()` after morning brief TG send — best-effort `.catch()` so Discord failure never breaks the brief pipeline
- **11 tests**: no-op when unset, POST structure, embed content, emoji prefix, field inclusion, HTTP error, network error, truncation, brief wrapper

## Activation (Zaal-gated Stage 0 prerequisite)
1. Create Discord webhook: Server Settings → Integrations → Webhooks → #zao-status → Create → Copy URL
2. Set env var on VPS: `echo "DISCORD_WEBHOOK_STATUS=<url>" >> /home/zaal/.env`
3. `pm2 restart zoe`

ZOE will then mirror its morning brief to Discord every day at 5am EST alongside the Telegram send. Nothing posts to Discord until step 2 is done.

## Test plan
- [ ] 11 tests pass (verified locally)
- [ ] CI green
- [ ] After Zaal activates: morning brief appears in #zao-status channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)