### PR TITLE
feat(zoe/discord): Stage 1b community zao-ask approval flow

### DIFF
--- a/bot/src/zoe/discord.ts
+++ b/bot/src/zoe/discord.ts
@@ -8,6 +8,8 @@
  * Env config:
  * - DISCORD_BOT_TOKEN: bot token from Discord Developer Portal
  * - DISCORD_ZAAL_ID: Zaal's Discord user ID (optional, for owner-only logic)
+ * - DISCORD_COMMUNITY_ASKS_ENABLED: set to "1" to enable Stage 1b approval flow
+ *   (non-owner messages route through Zaal for button-approval before sending)
  *
  * Intents required:
  * - Message Content Intent
@@ -15,19 +17,35 @@
  * - Direct Messages
  */
 
-import { Client, GatewayIntentBits, ChannelType, EmbedBuilder } from 'discord.js';
+import {
+  Client,
+  GatewayIntentBits,
+  ChannelType,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+  MessageFlags,
+  type TextBasedChannel,
+} from 'discord.js';
 import { runConciergeTurn } from './concierge';
-import { buildMemoryBlocks, ensureZoeHome } from './memory';
-import type { ConciergeOptions } from './types';
+import { buildMemoryBlocks } from './memory';
 import { config as loadEnv } from 'dotenv';
 
 loadEnv();
 
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
 const DISCORD_ZAAL_ID = process.env.DISCORD_ZAAL_ID;
+const COMMUNITY_ASKS_ENABLED = process.env.DISCORD_COMMUNITY_ASKS_ENABLED === '1';
 
 // Maximum message length for Discord (2000 chars).
 const DISCORD_MAX = 1990;
+
+/** Pending community messages awaiting Zaal approval. Keyed by approval-token. */
+const pendingCommunityMessages = new Map<
+  string,
+  { reply: string; channel: TextBasedChannel; messageId: string; senderName: string }
+>();
 
 /**
  * Split a long string into Discord-sized chunks, preferring paragraph then
@@ -50,17 +68,44 @@ function chunkMessage(text: string, max = DISCORD_MAX): string[] {
 }
 
 /**
- * Format ZOE's response for Discord: if the reply is short, send as-is;
- * if it includes code blocks or structured content, preserve formatting.
- * If it exceeds Discord's limit, chunk it.
+ * Build the approval row for community-ask messages.
+ * The token ties button clicks back to the pending message.
  */
-function formatDiscordReply(text: string): { content: string; embeds?: EmbedBuilder[] } {
-  // For now, simple chunking. Advanced: could use embeds for structured replies.
-  if (text.length <= DISCORD_MAX) {
-    return { content: text };
+function buildApprovalRow(token: string): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId(`zask_approve_${token}`).setLabel('Approve').setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId(`zask_regen_${token}`).setLabel('Regen').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId(`zask_skip_${token}`).setLabel('Skip').setStyle(ButtonStyle.Danger),
+  );
+}
+
+/**
+ * Send a community-ask draft to Zaal's DM for approval (Stage 1b).
+ * Returns false if Zaal's DM channel cannot be opened.
+ */
+async function sendCommunityAskForApproval(
+  client: Client,
+  token: string,
+  senderName: string,
+  question: string,
+  draft: string,
+): Promise<boolean> {
+  if (!DISCORD_ZAAL_ID) return false;
+  try {
+    const zaalUser = await client.users.fetch(DISCORD_ZAAL_ID);
+    const dm = await zaalUser.createDM();
+    const embed = new EmbedBuilder()
+      .setTitle(`Community question from ${senderName}`)
+      .setDescription(`**Q:** ${question.slice(0, 500)}\n\n**Draft reply:**\n${draft.slice(0, 1500)}`)
+      .setColor(0xf5a623)
+      .setFooter({ text: 'Approve to send, Regen to regenerate, Skip to dismiss' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await dm.send({ embeds: [embed.toJSON() as any], components: [buildApprovalRow(token).toJSON() as any] });
+    return true;
+  } catch (err) {
+    console.error('[zoe/discord] could not DM Zaal for approval:', (err as Error).message);
+    return false;
   }
-  // Chunking will be handled by the caller (send each chunk as a separate message).
-  return { content: text.slice(0, DISCORD_MAX) };
 }
 
 /**
@@ -84,7 +129,10 @@ export async function bootDiscordClient(): Promise<Client | null> {
   });
 
   client.once('ready', () => {
-    console.log(`[zoe/discord] connected as ${client.user?.username ?? 'unknown'}`);
+    console.log(
+      `[zoe/discord] connected as ${client.user?.username ?? 'unknown'}` +
+        (COMMUNITY_ASKS_ENABLED ? ' [community-asks: ON]' : ''),
+    );
   });
 
   /**
@@ -92,17 +140,18 @@ export async function bootDiscordClient(): Promise<Client | null> {
    * - Respond to DMs from anyone (but only Zaal's DMs are "trusted" for certain ops)
    * - Respond to @mentions in channels
    * - NEVER post proactively or to channels without being pinged
+   *
+   * Stage 1b (DISCORD_COMMUNITY_ASKS_ENABLED=1):
+   * - Non-owner messages: draft → DM Zaal for approval → send after approve
+   * - Owner (Zaal) messages: respond directly as before
    */
   client.on('messageCreate', async (message) => {
     try {
-      // Ignore bot messages and system messages.
       if (message.author.bot || message.system) return;
 
-      // Track whether this message triggered us (DM or @mention).
       let triggered = false;
       let isOwnerDM = false;
 
-      // Case 1: DM to ZOE.
       if (message.channel.isDMBased()) {
         triggered = true;
         if (DISCORD_ZAAL_ID && message.author.id === DISCORD_ZAAL_ID) {
@@ -110,21 +159,15 @@ export async function bootDiscordClient(): Promise<Client | null> {
         }
       }
 
-      // Case 2: @mention in a guild channel. Check if ZOE is mentioned.
       if (message.channel.type === ChannelType.GuildText && message.mentions.has(client.user?.id ?? '')) {
         triggered = true;
       }
 
-      // Not triggered: read for context but stay silent (the hard rule).
       if (!triggered) return;
 
-      // Show typing indicator while we think.
       await message.channel.sendTyping();
 
-      // Build memory blocks for the concierge turn.
       const blocks = await buildMemoryBlocks('private');
-
-      // Format the current date for ZOE's timezone.
       const currentDate = new Date().toLocaleString('en-US', {
         timeZone: 'America/New_York',
         weekday: 'short',
@@ -136,13 +179,11 @@ export async function bootDiscordClient(): Promise<Client | null> {
         timeZoneName: 'short',
       });
 
-      // Prepare context for the concierge turn.
-      const senderLabel = isOwnerDM ? 'Zaal' : message.author.username ?? message.author.displayName ?? 'User';
+      const senderLabel = isOwnerDM ? 'Zaal' : (message.author.username ?? message.author.displayName ?? 'User');
       const messageText = message.content
         .replace(new RegExp(`<@${client.user?.id}>`, 'g'), '')
         .trim();
 
-      // Call the existing concierge brain to generate ZOE's response.
       const result = await runConciergeTurn({
         message: messageText,
         blocks,
@@ -154,18 +195,40 @@ export async function bootDiscordClient(): Promise<Client | null> {
         senderLabel,
       });
 
-      // Extract the reply text from the concierge result.
       const replyText = result.reply ?? 'I could not generate a response.';
 
-      // Send the reply (chunked if needed).
-      const chunks = chunkMessage(replyText);
-      for (const chunk of chunks) {
-        await message.reply({
-          content: chunk,
-          allowedMentions: { repliedUser: false },
+      // Stage 1b: non-owner community messages go through approval if enabled.
+      if (COMMUNITY_ASKS_ENABLED && !isOwnerDM) {
+        const token = `${message.id}-${Date.now().toString(36)}`;
+        pendingCommunityMessages.set(token, {
+          reply: replyText,
+          channel: message.channel as TextBasedChannel,
+          messageId: message.id,
+          senderName: senderLabel,
         });
+
+        const sent = await sendCommunityAskForApproval(client, token, senderLabel, messageText, replyText);
+        if (sent) {
+          await message.reply({
+            content: `Got it, ${senderLabel} — ZOE is reviewing your question and will reply shortly.`,
+            allowedMentions: { repliedUser: false },
+          });
+        } else {
+          // Fallback: send directly if Zaal DM fails.
+          const chunks = chunkMessage(replyText);
+          for (const chunk of chunks) {
+            await message.reply({ content: chunk, allowedMentions: { repliedUser: false } });
+          }
+        }
+        console.log(`[zoe/discord] community-ask from ${senderLabel} queued for approval (token=${token})`);
+        return;
       }
 
+      // Default path (owner or community-asks disabled): reply directly.
+      const chunks = chunkMessage(replyText);
+      for (const chunk of chunks) {
+        await message.reply({ content: chunk, allowedMentions: { repliedUser: false } });
+      }
       console.log(`[zoe/discord] replied to ${senderLabel} in ${message.channel.isDMBased() ? 'DM' : 'channel'}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -176,13 +239,71 @@ export async function bootDiscordClient(): Promise<Client | null> {
           allowedMentions: { repliedUser: false },
         });
       } catch {
-        // If the error reply also fails, just log it.
         console.error('[zoe/discord] could not send error reply');
       }
     }
   });
 
-  // Boot the client.
+  /**
+   * Stage 1b: handle button clicks on community-ask approval messages.
+   * Only Zaal can approve/skip/regen. Other users get an ephemeral "not authorized".
+   */
+  client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isButton()) return;
+    if (!interaction.customId.startsWith('zask_')) return;
+
+    if (DISCORD_ZAAL_ID && interaction.user.id !== DISCORD_ZAAL_ID) {
+      await interaction.reply({ content: 'Only Zaal can approve community asks.', flags: MessageFlags.Ephemeral });
+      return;
+    }
+
+    const parts = interaction.customId.split('_');
+    const action = parts[1];
+    const token = parts.slice(2).join('_');
+    const pending = pendingCommunityMessages.get(token);
+
+    if (!pending) {
+      await interaction.reply({
+        content: 'This request has already been handled or expired.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    pendingCommunityMessages.delete(token);
+
+    if (action === 'approve') {
+      try {
+        const chunks = chunkMessage(pending.reply);
+        for (const chunk of chunks) {
+          await pending.channel.send({ content: chunk });
+        }
+        await interaction.reply({
+          content: `Approved and sent to ${pending.senderName}.`,
+          flags: MessageFlags.Ephemeral,
+        });
+        console.log(`[zoe/discord] approved community-ask reply for ${pending.senderName}`);
+      } catch (err) {
+        await interaction.reply({
+          content: `Send failed: ${(err as Error).message.slice(0, 100)}`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+    } else if (action === 'regen') {
+      await interaction.reply({
+        content: `Draft skipped for ${pending.senderName}. Ask ZOE again in Discord to regenerate.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      console.log(`[zoe/discord] regen requested for community-ask from ${pending.senderName}`);
+    } else if (action === 'skip') {
+      await interaction.reply({
+        content: `Skipped — no reply sent to ${pending.senderName}.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      console.log(`[zoe/discord] skipped community-ask reply for ${pending.senderName}`);
+    }
+  });
+
   await client.login(DISCORD_BOT_TOKEN);
   return client;
 }


### PR DESCRIPTION
## Summary

Implements doc 1135 Stage 1b: community zao-ask with Components V2 button-approval pattern.

**Gated on `DISCORD_COMMUNITY_ASKS_ENABLED=1` — PR-only, default off.**

### What changed in `bot/src/zoe/discord.ts`
- Import `ButtonBuilder`, `ButtonStyle`, `ActionRowBuilder`, `MessageFlags` (discord.js v14, already installed)
- `pendingCommunityMessages: Map` — in-memory queue of unapproved community asks
- `buildApprovalRow(token)` — creates [Approve] [Regen] [Skip] button row
- `sendCommunityAskForApproval()` — DMs Zaal with draft embed + buttons
- **`messageCreate`**: when `COMMUNITY_ASKS_ENABLED && !isOwnerDM`:
  1. Generate ZOE draft via concierge
  2. Queue in pending Map with token
  3. DM Zaal with embed + buttons for approval
  4. Send "reviewing..." ack to community member
  5. Fallback: send directly if Zaal DM fails (safety net)
- **`interactionCreate`** handler for `zask_*` buttons:
  - `zask_approve`: sends approved reply to community channel (chunked)
  - `zask_regen`: dismisses, asks Zaal to re-ask ZOE in Discord
  - `zask_skip`: dismisses silently, no reply sent
  - Non-Zaal users get ephemeral "not authorized" message
- Boot log shows `[community-asks: ON]` when flag set

### Activation (sequential — requires Stage 0 + Stage 1a first)
1. Stage 0: `DISCORD_BOT_TOKEN` + `DISCORD_ZAAL_ID` set on VPS
2. Stage 1a: `DISCORD_WEBHOOK_STATUS` set (PR #1806)
3. Stage 1b: `DISCORD_COMMUNITY_ASKS_ENABLED=1` in bot/.env + `pm2 restart zoe`

## Test plan
- [ ] TS compiles cleanly (verified: no errors in discord.ts)
- [ ] CI green
- [ ] After Stage 0: non-owner Discord mention → Zaal gets DM with [Approve][Regen][Skip]
- [ ] Approve sends reply to channel; Skip/Regen dismiss silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)