### PR TITLE
feat(zoe): /loops + /loop <name> Telegram fleet-status commands (Zaal P1)

### DIFF
--- a/bot/src/zoe/__tests__/loops-status.test.ts
+++ b/bot/src/zoe/__tests__/loops-status.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+
+import {
+  stateEmoji,
+  agoLabel,
+  isStale,
+  formatLoopsStatus,
+  formatLoopDetail,
+  type FleetStatus,
+} from '../loops-status.ts';
+
+const NOW = Date.parse('2026-07-17T10:00:00Z');
+const sample: FleetStatus = {
+  updated: '2026-07-17T09:59:00Z', // 60s ago
+  loops: [
+    { session: 'zoe', state: 'working', last: '  polling as @zaoclaw_bot   ' },
+    { session: 'ww', state: 'idle', last: '' },
+    { session: 'coc', state: 'dead', last: 'crashed' },
+  ],
+};
+
+test('stateEmoji maps known states + falls back', () => {
+  assert.equal(stateEmoji('working'), '🟢');
+  assert.equal(stateEmoji('IDLE'), '🟡');
+  assert.equal(stateEmoji('dead'), '🔴');
+  assert.equal(stateEmoji('whatever'), '⚪');
+});
+
+test('agoLabel: seconds / minutes / hours / invalid', () => {
+  assert.equal(agoLabel('2026-07-17T09:59:00Z', NOW), '60s ago');
+  assert.equal(agoLabel('2026-07-17T09:50:00Z', NOW), '10m ago');
+  assert.equal(agoLabel('2026-07-17T07:00:00Z', NOW), '3h ago');
+  assert.equal(agoLabel('not-a-date', NOW), 'unknown');
+});
+
+test('isStale: fresh vs >10min vs invalid', () => {
+  assert.equal(isStale('2026-07-17T09:59:00Z', NOW), false);
+  assert.equal(isStale('2026-07-17T09:45:00Z', NOW), true); // 15m
+  assert.equal(isStale('bad', NOW), true);
+});
+
+test('formatLoopsStatus: null -> warning', () => {
+  assert.match(formatLoopsStatus(null, NOW), /No fleet status available/);
+});
+
+test('formatLoopsStatus: one line per loop, emoji, trimmed last, footer', () => {
+  const out = formatLoopsStatus(sample, NOW);
+  assert.match(out, /Fleet loops \(updated 60s ago\)/);
+  assert.match(out, /🟢 zoe: working — polling as @zaoclaw_bot/);
+  assert.match(out, /🟡 ww: idle$/m);
+  assert.match(out, /🔴 coc: dead — crashed/);
+  assert.match(out, /Use \/loop <name> for detail\./);
+});
+
+test('formatLoopsStatus: stale fleet flagged', () => {
+  const stale = { ...sample, updated: '2026-07-17T09:40:00Z' }; // 20m
+  assert.match(formatLoopsStatus(stale, NOW), /⚠️ STALE/);
+});
+
+test('formatLoopsStatus: empty loops', () => {
+  assert.match(formatLoopsStatus({ updated: sample.updated, loops: [] }, NOW), /no loops reporting/);
+});
+
+test('formatLoopDetail: known loop shows state + last line', () => {
+  const out = formatLoopDetail(sample, 'zoe', NOW);
+  assert.match(out, /Loop: zoe/);
+  assert.match(out, /State: working/);
+  assert.match(out, /Last line: polling as @zaoclaw_bot/);
+});
+
+test('formatLoopDetail: case-insensitive match', () => {
+  assert.match(formatLoopDetail(sample, 'WW', NOW), /Loop: ww/);
+});
+
+test('formatLoopDetail: unknown name lists loops', () => {
+  const out = formatLoopDetail(sample, 'nope', NOW);
+  assert.match(out, /No loop named "nope"/);
+  assert.match(out, /zoe, ww, coc/);
+});
+
+test('formatLoopDetail: no name -> usage + loop list', () => {
+  assert.match(formatLoopDetail(sample, '', NOW), /Usage: \/loop <name>/);
+});
+
+test('formatLoopDetail: empty last -> placeholder', () => {
+  assert.match(formatLoopDetail(sample, 'ww', NOW), /Last line: \(no recent output line\)/);
+});
+
+test('formatLoopDetail: null data -> warning', () => {
+  assert.match(formatLoopDetail(null, 'zoe', NOW), /No fleet status available/);
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -28,6 +28,7 @@ import { isConversationalTurn, ZOE_QUICK_MODEL } from './types';
 import { checkAndRecordZoeCall } from './call-budget';
 import { runCockpit } from '../cockpit/cockpit';
 import { applyTaskOps, seedInitialTasks } from './tasks';
+import { readFleetStatus, formatLoopsStatus, formatLoopDetail } from './loops-status';
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
 import { runCrmOps, summarizeCrmResults } from './crm';
@@ -688,6 +689,21 @@ bot.command('tasks', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const blocks = await buildMemoryBlocks('private');
   await replyChunked(ctx, `Open tasks:\n\n${blocks.tasks}`);
+});
+
+// Fleet loop status (Zaal P1, 2026-07-17). /loops = all loops; /loop <name> = one.
+// Reads the keepalive supervisor's /tmp/fleet-status.json. Read-only, Zaal-only.
+bot.command('loops', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const data = await readFleetStatus();
+  await replyChunked(ctx, formatLoopsStatus(data, Date.now()));
+});
+
+bot.command('loop', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const name = (ctx.match ?? '').toString().trim();
+  const data = await readFleetStatus();
+  await replyChunked(ctx, formatLoopDetail(data, name, Date.now()));
 });
 
 // On-demand operator cockpit: the same brief the 5am cron sends, triggerable

--- a/bot/src/zoe/loops-status.ts
+++ b/bot/src/zoe/loops-status.ts
@@ -1,0 +1,99 @@
+/**
+ * loops-status.ts — read + format the tmux fleet loop status for ZOE's
+ * `/loops` and `/loop <name>` Telegram commands.
+ *
+ * The keepalive supervisor publishes /tmp/fleet-status.json every few minutes:
+ *   { "updated": "<ISO>", "loops": [ { "session", "state", "last" }, ... ] }
+ * These are pure formatters (nowMs injected) so they unit-test without clocks
+ * or the bot; only readFleetStatus() touches the filesystem. index.ts wires the
+ * thin command handlers (rule 21: keep testable logic out of the entrypoint).
+ */
+import { readFile } from 'node:fs/promises';
+
+export interface FleetLoop {
+  session: string;
+  state: string;
+  last: string;
+}
+
+export interface FleetStatus {
+  updated: string;
+  loops: FleetLoop[];
+}
+
+const DEFAULT_PATH = '/tmp/fleet-status.json';
+const STALE_MS = 10 * 60 * 1000; // keepalive runs */3 min; >10 min = stale
+
+/** Read + validate the fleet status file. Returns null on any error (missing/bad JSON). */
+export async function readFleetStatus(path: string = DEFAULT_PATH): Promise<FleetStatus | null> {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const data = JSON.parse(raw) as FleetStatus;
+    if (!data || typeof data.updated !== 'string' || !Array.isArray(data.loops)) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function stateEmoji(state: string): string {
+  switch ((state || '').toLowerCase()) {
+    case 'working':
+      return '🟢';
+    case 'idle':
+      return '🟡';
+    case 'dead':
+      return '🔴';
+    default:
+      return '⚪';
+  }
+}
+
+export function agoLabel(iso: string, nowMs: number): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return 'unknown';
+  const s = Math.max(0, Math.round((nowMs - t) / 1000));
+  if (s < 90) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 90) return `${m}m ago`;
+  return `${Math.round(m / 60)}h ago`;
+}
+
+export function isStale(iso: string, nowMs: number, maxMs: number = STALE_MS): boolean {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return true;
+  return nowMs - t > maxMs;
+}
+
+/** `/loops` — one-line-per-loop overview. */
+export function formatLoopsStatus(data: FleetStatus | null, nowMs: number): string {
+  if (!data) {
+    return '⚠️ No fleet status available (/tmp/fleet-status.json missing or unreadable). Is the keepalive supervisor running?';
+  }
+  const staleTag = isStale(data.updated, nowMs) ? ' ⚠️ STALE' : '';
+  const header = `🛰️ Fleet loops (updated ${agoLabel(data.updated, nowMs)}${staleTag}):`;
+  if (data.loops.length === 0) return `${header}\n(no loops reporting)`;
+  const lines = data.loops.map((l) => {
+    const last = (l.last || '').trim();
+    const tail = last ? ` — ${last.slice(0, 60)}` : '';
+    return `${stateEmoji(l.state)} ${l.session}: ${l.state}${tail}`;
+  });
+  return [header, ...lines, '', 'Use /loop <name> for detail.'].join('\n');
+}
+
+/** `/loop <name>` — detail for one loop. */
+export function formatLoopDetail(data: FleetStatus | null, name: string, nowMs: number): string {
+  if (!data) return '⚠️ No fleet status available.';
+  const q = (name || '').trim().toLowerCase();
+  const names = data.loops.map((l) => l.session).join(', ');
+  if (!q) return `Usage: /loop <name> (e.g. /loop zoe). Loops: ${names}`;
+  const loop = data.loops.find((l) => l.session.toLowerCase() === q);
+  if (!loop) return `No loop named "${name}". Loops: ${names}`;
+  const last = (loop.last || '').trim() || '(no recent output line)';
+  return [
+    `${stateEmoji(loop.state)} Loop: ${loop.session}`,
+    `State: ${loop.state}`,
+    `Fleet updated: ${agoLabel(data.updated, nowMs)}${isStale(data.updated, nowMs) ? ' ⚠️ STALE' : ''}`,
+    `Last line: ${last}`,
+  ].join('\n');
+}


### PR DESCRIPTION
## What (Zaal P1 #1)
ZOE reports fleet loop status on demand in Telegram:
- **`/loops`** — one line per loop: state emoji (🟢/🟡/🔴/⚪) + trimmed last output line, "updated Ns ago" header, **⚠️ STALE** if the keepalive hasn't published in >10 min.
- **`/loop <name>`** — detail for one loop (state, updated-ago, last line); case-insensitive; unknown name lists the loops.

Reads the keepalive's `/tmp/fleet-status.json`. Read-only, Zaal-gated.

## Design + verify
Logic in a testable non-entrypoint module `loops-status.ts` (pure formatters, `nowMs` injected); `index.ts` wires two thin handlers via existing `replyChunked`. **Boot-verified:** esbuild bundles `index.ts` clean ✅, module imports ✅, **13/13 vitest** ✅. Staged only the 3 source files (no `node_modules`).

## Note
Ships a clean version per Zaal (the command wasn't on main). Supersedes the stalled sibling **#1762** and my earlier closed **#1767** — pick this one; I can close the others if you prefer. Runtime bot code → awaits merge. Board: `zaal-p1-jul17` (claimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)