### PR TITLE
fix(bot-tests): curator TDZ + env-capture, cost-governance pct, handoffs timestamp

### DIFF
--- a/bot/src/zoe/__tests__/cost-governance.test.ts
+++ b/bot/src/zoe/__tests__/cost-governance.test.ts
@@ -77,7 +77,7 @@ describe('cost-governance', () => {
 
       const status = getSpendStatus();
       expect(status.percentUsed).toBeGreaterThan(60);
-      expect(status.thresholdLevelPercent).toBe(61);
+      expect(status.thresholdLevelPercent).toBe(60); // threshold level crossed, not the actual pct
       expect(status.isAtThreshold).toBe(true);
     });
 
@@ -128,8 +128,8 @@ describe('cost-governance', () => {
       ]);
 
       const status = getSpendStatus();
-      expect(status.percentUsed).toBe(0); // cap 0 means pct = 0
-      expect(status.capUsd).toBe(10); // falls back to default
+      expect(status.capUsd).toBe(10); // falls back to default when 0 is set
+      expect(status.percentUsed).toBe(10); // $1 of $10 default cap = 10%
     });
 
     it('uses ZOE_DAILY_BUDGET_USD env var', () => {

--- a/bot/src/zoe/__tests__/handoffs-surface.test.ts
+++ b/bot/src/zoe/__tests__/handoffs-surface.test.ts
@@ -90,6 +90,9 @@ describe('surfaceNewHandoffs', () => {
   });
 
   it('updates the last-seen timestamp to the max created_at after surfacing', async () => {
+    // Freeze to 08:00 so the ENOENT fallback (now-1h = 07:00) is before all test rows.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-17T08:00:00.000Z'));
     process.env.COWORK_TRACKER_URL = 'https://tracker.example.com';
     process.env.COWORK_TRACKER_KEY = 'test-key';
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
@@ -101,7 +104,8 @@ describe('surfaceNewHandoffs', () => {
     ];
     stubFetch(rows);
     await surfaceNewHandoffs(vi.fn().mockResolvedValue(undefined));
-    // setLastSeen should write the latest timestamp
+    vi.useRealTimers();
+    // setLastSeen should write the latest timestamp from the rows
     const written = mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1];
     expect(JSON.parse(written).at).toBe('2026-07-17T12:00:00Z');
   });

--- a/bot/src/zoe/curator.ts
+++ b/bot/src/zoe/curator.ts
@@ -48,8 +48,13 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { execSync } from 'node:child_process';
 
-const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
-const TOPIC_THREAD_MAP_PATH = join(ZOE_HOME, 'topic_thread_map.json');
+// Read lazily so tests can override process.env.ZOE_HOME via vi.stubEnv/beforeEach.
+function zoeHome(): string {
+  return process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+}
+function topicThreadMapPath(): string {
+  return join(zoeHome(), 'topic_thread_map.json');
+}
 
 export type TopicKey = 'newsletter' | 'github' | 'artizen' | 'recommendations' | 'general';
 
@@ -63,7 +68,7 @@ export interface TopicThreadMap {
  */
 export async function readTopicThreadMap(): Promise<TopicThreadMap> {
   try {
-    const raw = await fs.readFile(TOPIC_THREAD_MAP_PATH, 'utf8');
+    const raw = await fs.readFile(topicThreadMapPath(), 'utf8');
     return JSON.parse(raw) as TopicThreadMap;
   } catch {
     return {};
@@ -74,8 +79,8 @@ export async function readTopicThreadMap(): Promise<TopicThreadMap> {
  * Write the topic -> thread_id map to disk atomically.
  */
 export async function writeTopicThreadMap(map: TopicThreadMap): Promise<void> {
-  await fs.mkdir(ZOE_HOME, { recursive: true });
-  await fs.writeFile(TOPIC_THREAD_MAP_PATH, JSON.stringify(map, null, 2), 'utf8');
+  await fs.mkdir(zoeHome(), { recursive: true });
+  await fs.writeFile(topicThreadMapPath(), JSON.stringify(map, null, 2), 'utf8');
 }
 
 /**
@@ -216,10 +221,6 @@ export async function generateGithubDigest(): Promise<{ text: string; timestamp:
     for (const pr of topPrs) {
       const repoLabel = pr.repository?.includes('ZAOcowork') ? '[ZAOcowork]' : '';
       digestText += `\n#${pr.number}: ${pr.title}${repoLabel ? ` ${repoLabel}` : ''}`;
-    let digestText = `Today's ships (${dateStr}):
-Merged PRs across ZAO repos:`;
-      digestText += `
-#${pr.number}: ${pr.title}${repoLabel ? ` ${repoLabel}` : ''}`;
     }
 
     // Add a closing note summarizing what shipped (keeps it high-signal, not spammy)
@@ -245,9 +246,6 @@ Merged PRs across ZAO repos:`;
 
     if (categorySummary) {
       digestText += `\n\nToday: ${categorySummary} across the ecosystem.`;
-      digestText += `
-
-Today: ${categorySummary} across the ecosystem.`;
     }
 
     return {


### PR DESCRIPTION
## Summary

Three test failures exposed by PR #1808 (ci-bot-tests), now fixed:

- **curator.ts**: (1) Removed duplicate `let digestText` block inside the `for` loop — the inner `let` created a temporal dead zone causing `digestText +=` on the previous line to throw "Cannot access 'digestText2' before initialization"; (2) Made `ZOE_HOME`/`TOPIC_THREAD_MAP_PATH` lazy (read `process.env.ZOE_HOME` at call time, not module load time) — test `beforeEach` sets this env before each test, but the eager constant captured the real path, causing tests to pollute `~/.zao/zoe/topic_thread_map.json`
- **cost-governance.test.ts**: `thresholdLevelPercent` is `60` (the threshold *level* crossed), not `61` (the actual percentage); `percentUsed` is `10` (cap falls back to $10 default when env is `'0'`, spend=$1 → 10%), not `0`
- **handoffs-surface.test.ts**: Added `vi.useFakeTimers()` frozen to `2026-07-17T08:00:00Z` so the ENOENT fallback (`now-1h = 07:00`) is before the test rows' `created_at` values (`09:00`, `12:00`), allowing `maxAt` to advance to the correct max

## Test plan
- [x] All 3 fixed files pass locally: 50/50 tests (curator 23, cost-governance 19, handoffs-surface 8)
- [x] Unblocks PR #1808 (`chore/ci-bot-tests`) Bot Tests CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)