### PR TITLE
fix(stats): correct stale 522 SOL → 524.15 SOL across 7 docs

### DIFF
--- a/research/community/050-the-zao-complete-guide/README.md
+++ b/research/community/050-the-zao-complete-guide/README.md
@@ -227,7 +227,7 @@ A music competition and discovery platform originally incubated within the ZAO e
 | **What** | Onchain music prediction market on Solana |
 | **Legal** | Delaware C-Corporation |
 | **Smart contract** | `9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo` (Solana Mainnet, Anchor/Rust) |
-| **Volume** | 522 SOL (~$39K USD, July 2026) across 1,245 total battles |
+| **Volume** | 524.15 SOL (~$39K USD, July 2026) across 1,245 total battles |
 | **Website** | [wavewarz.com](https://www.wavewarz.com/) |
 
 **How it works:** Artists battle in 3 consecutive 20-minute rounds. Fans trade using ephemeral bonding curve tokens that exist only during each round. Triple judging combines a human judge, X poll, and SOL trading activity. Artists earn 1% of all trading volume immediately. Losing traders get 50% partial recovery.

--- a/research/community/051-zao-whitepaper-2026/README.md
+++ b/research/community/051-zao-whitepaper-2026/README.md
@@ -96,7 +96,7 @@ The team is supported by a roster of independent artists, a network of mutual co
 | Artists in roster | 22 | [thezao.com](https://www.thezao.com) |
 | Combined Spotify listeners | 378,000+ | Individual artist profiles |
 | Tracks across roster | 500+ | Streaming platforms |
-| WaveWarZ volume | [522 SOL (~$39K)](https://wavewarz.info/) across 1,245 battles | Solana on-chain (2026-07-17) |
+| WaveWarZ volume | [524.15 SOL (~$39K)](https://wavewarz.info/) across 1,245 battles | Solana on-chain (2026-07-17) |
 | Revenue generated | $10,000+ | Festivals + WaveWarZ |
 | IRL festivals produced | 4 | [@zaofestivals](https://www.instagram.com/zaofestivals/) |
 | Metaverse concerts (COC) | 150+ weekly | [stilo.world](https://www.stilo.world/) |

--- a/research/community/1231-zao-history-timeline/README.md
+++ b/research/community/1231-zao-history-timeline/README.md
@@ -68,7 +68,7 @@ tier: STANDARD
 | Jun 3, 2026 | **Fractal Monday Week 100+** (projected). 90+ consecutive weeks of governance. | Two-year mark of consistent decentralized governance — rare in any DAO. |
 | Jun 2026 | Zaal transitions to **Riverside Group** (full-time, software dev support). | Day-job arc closes the Jackson Labs chapter. More time and stability for ZAO ecosystem work. |
 | Jul 8, 2026 | **ZABAL Gamez x POIDH Fireside** with Kenny (POIDH founder), Thy Revolution, Mauro (Zao Poker). | Live validation: POIDH founder endorses the ZAO-native bounty model. First co-production with external protocol founders. |
-| Jul 17, 2026 | **ZAO stats (current):** 188 onchain members, 1,245+ WaveWarZ battles, 522 SOL (~$39K) cumulative volume, 90+ Fractal Monday governance sessions. | As of this doc's writing. |
+| Jul 17, 2026 | **ZAO stats (current):** 188 onchain members, 1,245+ WaveWarZ battles, 524.15 SOL (~$39K) cumulative volume, 100+ Fractal Monday governance sessions. | As of this doc's writing. |
 | Jul 18, 2026 | **COC Concertz #7 — WaveWarZ Takeover** (4PM EST). | Show #7: first show without the wallet gate (pilot for broader attendance). Pilot metrics captured via enhanced `/api/metrics/coc7` endpoint. |
 | Jul 25, 2026 | **ZAOville Pool Party** — Laurel, MD, 11AM-10PM. | First full-day ZAO event outside Maine. Live stream + POIDH engagement bounties. |
 | Oct 3, 2026 | **ZAOstock 2026 (upcoming)** — Ellsworth, ME, Franklin Street Parklet. Budget $5-25K. Fractured Atlas fiscal sponsor via FailOften. | Flagship annual festival. First physical ZAO event in Zaal's home city. Onchain ticketing (Unlock Protocol) + POIDH engagement planned. |
@@ -81,7 +81,7 @@ tier: STANDARD
 |---|---|---|
 | ZAO members (onchain) | 188 | Doc 742, memory |
 | WaveWarZ battles | 1,245+ | Doc 742, wwtracker |
-| WaveWarZ cumulative volume | 522 SOL (~$39K at ~$75/SOL) | Doc 742 |
+| WaveWarZ cumulative volume | 524.15 SOL (~$39K at ~$75/SOL) | Doc 978 |
 | Fractal Monday sessions | 90+ | Doc 1202, projected |
 | Verified onchain Respect settlements | 63 | Doc 1202 |
 | COC Concertz shows | 7 (Show #7 = Jul 18, 2026) | COC repo |

--- a/research/community/363-zao-stock-people-brands-2026/README.md
+++ b/research/community/363-zao-stock-people-brands-2026/README.md
@@ -16,7 +16,7 @@
 |----------|----------------|
 | **Profile gaps** | Tom Fellenz profile COMPLETE. Shawn, DFresh, Craig G need bios from them directly - no public web presence found. |
 | **Brand profiles** | WaveWarZ and COC Concertz have strong public data. FISHBOWLZ, Songjam, ZAOVille are internal/early-stage. |
-| **For pitch page** | USE WaveWarZ stats (1,245 battles, 522 SOL), COC Concertz (5 events), newsletter (400+ editions), fractals (100+ weeks) as credibility proof |
+| **For pitch page** | USE WaveWarZ stats (1,245 battles, 524.15 SOL), COC Concertz (5 events), newsletter (400+ editions), fractals (100+ weeks) as credibility proof |
 | **Missing data** | NEED photos/video from ZAO-CHELLA, Maine Craft Weekend attendance numbers, Fractured Atlas exact wording |
 
 ---
@@ -121,13 +121,13 @@
 | **What** | Live-traded music battle platform on Solana |
 | **Website** | [wavewarz.com](https://www.wavewarz.com), [wavewarz.info](https://wavewarz.info) (analytics) |
 | **Total battles** | 1,245 (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community) |
-| **Total volume** | 522 SOL (~$39K at $75/SOL, 2026-07-17) |
+| **Total volume** | 524.15 SOL (~$39K at $75/SOL, 2026-07-17) |
 | **Total artist payouts** | 9.05 SOL |
 | **Artist economics** | 1% trading volume + 5-7% settlement bonus, instant onchain |
 | **Legal entity** | Delaware C-Corp |
 | **Founders** | Hurric4n3Ike + Candy |
 | **Smart contracts** | Base L2 (Candy's wavewarz-base, 8/8 tests, A+ audit) |
-| **Key stat for sponsors** | 1,245 battles, 522 SOL volume, real artists getting paid |
+| **Key stat for sponsors** | 1,245 battles, 524.15 SOL volume, real artists getting paid |
 
 ### ZAOstock
 
@@ -201,7 +201,7 @@
 | Weekly governance sessions | 100+ consecutive | ZAO Fractals (Mondays 6pm EST) |
 | Newsletter editions | 400+ | Year of the ZABAL on Paragraph |
 | WaveWarZ battles | 1,245 | wavewarz.info/api/public/stats (2026-07-17) |
-| WaveWarZ volume | 522 SOL (~$39K) | wavewarz.info/api/public/stats (2026-07-17) |
+| WaveWarZ volume | 524.15 SOL (~$39K) | wavewarz.info/api/public/stats (2026-07-17) |
 | COC Concertz events | 5 (monthly recurring) | cocconcertz.com |
 | Team members | 14 active + 4 advisors | Dashboard |
 | ZAO members | ~188 gated | ZAO OS |

--- a/research/community/742-zaal-panthaki-profile-dossier/README.md
+++ b/research/community/742-zaal-panthaki-profile-dossier/README.md
@@ -20,7 +20,7 @@ tier: DISPATCH
 | 2 | USE **"The Front Door / Gravity Well"** as Zaal's archetype (LOCKED 2026-05-25 by Zaal) | Zaal corrected the framing during draft review: he is not the rails-closer or partnerships negotiator (those are outcomes). He is the person other founders bring their own ecosystems through. The ZAO is the gravity well; WaveWarZ is what those founders discover once they're inside. Proof points: Tyler/Magnetiq, Jordan/Empire Builder, Arthur/Neynar, Ryan/Bonfires, Nicky/Juke, Vlad/Singularity, Shriyash/Apna Coding — all run their own ecosystems and orbit The ZAO. See [[feedback_zaal_wavewarz_positioning]]. |
 | 3 | USE **BetterCallZaal nickname tie-back** as mythology hook | Direct structural mirror of Ike's "Hurric4n3IKE → WaveZ" tie-back. "Got a problem? BetterCallZaal" is already on the homepage. Lands the same kind of name-foretells-destiny move. |
 | 4 | USE **The ZAO is the purpose, WaveWarZ is the role** framing | Important nuance: Ike's purpose = WaveWarZ. Zaal's purpose = The ZAO (decentralized impact network). WaveWarZ is where his role finally synthesizes every skill he stacked. Honest, and stronger than copy-pasting Ike's "purpose" line. |
-| 5 | USE Solana volume + ZAO scale + Coinflow rail as the proof points | Concrete, specific, verifiable: ~$39K trading volume, 1,245 battles, 522 SOL, 188 ZAO members already trading, Coinflow ISV closed (merchantID "wavestation"). |
+| 5 | USE Solana volume + ZAO scale + Coinflow rail as the proof points | Concrete, specific, verifiable: ~$39K trading volume, 1,245 battles, 524.15 SOL, 188 ZAO members already trading, Coinflow ISV closed (merchantID "wavestation"). |
 
 ## Identity
 
@@ -90,9 +90,9 @@ For the Alliance application Zaal upgrades the title to **"Director of Ecosystem
 
 **WaveWarZ scale to cite in the brag (per public whitepaper + Doc 723d):**
 
-- ~$39K cumulative trading volume (522 SOL at ~$75/SOL, July 2026)
+- ~$39K cumulative trading volume (524.15 SOL at ~$75/SOL, July 2026)
 - 1,245 live battles run
-- 522 SOL cumulative volume
+- 524.15 SOL cumulative volume
 - Daily X Spaces Mon-Fri 11am EST
 - Sunday 8pm EST battles + special events
 - Real-time scoring + automated payout (no team intervention)
@@ -186,7 +186,7 @@ Mirrors Ike's chain (football → EE → Infosys → sales → spaces → indie 
 - **378,000+** combined Spotify monthly listeners
 - **500+** tracks across artist roster
 - **1,245** WaveWarZ live battles
-- **522** SOL cumulative WaveWarZ volume
+- **524.15** SOL cumulative WaveWarZ volume
 - **~$39K** WaveWarZ trading volume (July 2026)
 - **$10,000+** ecosystem revenue (festivals + WaveWarZ)
 - **150+** consecutive weekly COC Concertz concerts

--- a/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
+++ b/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
@@ -35,7 +35,7 @@ tier: STANDARD
 - **zaalcaster** - open-sourced his own Farcaster client, vibe-coded with an AI agent. github.com/bettercallzaal/zaalcaster
 - **ZLANK** - no-code Farcaster snap builder, won FarHack 2026 Snaps track. zlank.online
 - **The ZAO** - 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism. 157 unique Respect holders (doc 1200). thezao.xyz
-- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 522 SOL lifetime volume (~$39K, 1,245 battles, 2026-07-17).
+- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 524.15 SOL lifetime volume (~$39K, 1,245 battles, 2026-07-17).
 - **ZABAL Gamez** - 3-month build-a-thon. zabalgamez.com
 - Build-in-public / vibe-coding lessons; artists owning their tools; onchain music.
 

--- a/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
+++ b/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
@@ -128,7 +128,7 @@ Hub currently links 8 portals. Sub-Agent B identified 25 more projects/people/br
 | SongJam (SANG token + $ZABAL leaderboard) | songjam.space | Live-now widget + top-5 Empire embed | 5 |
 | ZAO Stock (Oct 2026 festival, Ellsworth ME) | zaoos.com/stock | Hero card + countdown | 5 |
 | COC Concertz (150+ weekly VR shows) | cocconcertz.com | "Next show" badge | 4 |
-| WaveWarZ (1,245 battles, 522 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
+| WaveWarZ (1,245 battles, 524.15 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
 | Magnetiq Proof-of-Meet (IRL connection badges) | magnetiq.xyz | Portal card in ecosystem grid | 4 |
 | Ohnahji University ("Web3's first HBCU") | ohnahjiu.com | Portal card | 3 |
 | Hats Protocol (ZAO roles, tree 226 Optimism) | hatsprotocol.xyz | Roles section in About | 3 |


### PR DESCRIPTION
## Summary

Batch correction for the stale WaveWarZ volume figure "522 SOL" — the live API (wavewarz.info/api/public/stats, verified 2026-07-17T17:15Z) shows **524.15 SOL** cumulative volume. Doc 978 (already merged) sets this as the canonical number.

**Docs corrected (7 files, 13 instances):**
- `050-the-zao-complete-guide` — 1 instance
- `051-zao-whitepaper-2026` — 1 instance
- `363-zao-stock-people-brands-2026` — 4 instances
- `742-zaal-panthaki-profile-dossier` — 4 instances (including `**522**` bold marker)
- `1231-zao-history-timeline` — 2 instances (+ "90+" → "100+" Fractal sessions, per doc 978)
- `733-zabal-virality-and-ecosystem-incorporation` — 1 instance
- `987-linkedin-personal-brand-playbook` — 1 instance

**Also:** Doc 1231's source citation updated from `Doc 742` → `Doc 978` (742 cited 522 SOL; 978 is now the canonical numbers framing doc with the corrected figure).

**Note:** Docs 1077, 1211, 1221 were corrected in earlier PRs (already merged).

## Test plan

- [ ] `grep -r "522 SOL" research/` returns zero matches after merge
- [ ] All 7 docs show `524.15 SOL` in volume fields
- [ ] Dollar equivalent `~$39K` unchanged (524.15 × $75.29 ≈ $39,453 — still rounds to $39K)
- [ ] Doc 1231 line 71 shows "100+" not "90+" for Fractal sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)