### PR TITLE
fix(stats): update 522→524.15 SOL in canonical ledger (1201) + ICM boxes

### DIFF
--- a/research/governance/1201-zao-canonical-facts-ledger/README.md
+++ b/research/governance/1201-zao-canonical-facts-ledger/README.md
@@ -39,10 +39,10 @@ it's a claim that they are **currently un-citable**, which is a fixable liabilit
 | OG Respect on-chain settlement (Optimism) | **33 distinct weeks** (2024-07-30 → 2025-12-20, 438 txs) | Blockscout tx enumeration, verified 2026-07-17 | [1202](../1202-fractal-onchain-settlement-history/) |
 | ZOR Respect on-chain settlement (Optimism) | **31 distinct weeks** (2025-09-25 → 2026-07-06, 67 txs) | Blockscout tx enumeration, verified 2026-07-17 | 1202 |
 | Combined on-chain settlement weeks (OG ∪ ZOR) | **63 distinct weeks** (1 overlap week) | union of OG + ZOR settlement sets | 1202 |
-| WaveWarZ lifetime volume | **522 SOL (~$39K)** | `wavewarz.info/api/public/stats`, live 2026-07-16 | [974](../974-wavewarz-financials-snapshot-2026-07/), [1077](../1077-zao-dao-case-study-jul2026/) |
+| WaveWarZ lifetime volume | **524.15 SOL (~$39K)** | `wavewarz.info/api/public/stats`, live 2026-07-17 | [978](../../business/978-zao-numbers-framing/), [1077](../1077-zao-dao-case-study-jul2026/) |
 | WaveWarZ total battles | **1,245** | same live API | 974, 1077 |
-| WaveWarZ artist payouts | **9.05 SOL** | same | 974 |
-| WaveWarZ platform revenue | **17.42 SOL** | same | 974 |
+| WaveWarZ artist payouts | **9.07 SOL** | same | 978 |
+| WaveWarZ platform revenue | **17.44 SOL** | same | 978 |
 | WaveWarZ trader claims | **127.34 SOL** | same | 974 |
 | PolyRaiders Holiday Heat (benefit battle) | **Dec 12, 2024 · ~$270** | wavewarz.info/events (canonical) + tweet 1999858390567117201 snowflake → 2025-12-13 (anniversary recap, not the event date) | [1077](../1077-zao-dao-case-study-jul2026/) |
 | Love Song Benefit battle | **Feb 13, 2025 · ~$1,221** | wavewarz.info/events | 1077 |
@@ -63,7 +63,7 @@ curl -s "https://api.warpcast.com/v1/channel?channelId=zao" | \
 | **"188 members on Base"** | `CLAUDE.md`, docs 625, 449, 530, 622, 1078, 742 (7+) | The nearest **public** proxy — the `/zao` channel — shows **93 followers / 4 members**, nowhere near 188. So "188" measures something else (most likely the gated Farcaster client's registered users in Supabase, which is not publicly verifiable). Its **definition** ("member" = app-registered? Respect-holder? channel-follower? Discord?) and **as-of date** are unpinned. This is THE most-repeated ZAO headline number and the least traceable. |
 | ~~Fractal weeks: "90+" / "100+"~~ → **RESOLVED (two-layer)** | whitepaper 942, ICM box, dossier 742, doc 622 | Two-layer verified: (1) date-calculation: 716 days ÷ 7 = 102 complete weeks as of 2026-07-16; (2) on-chain settlement: 63 distinct weeks in doc 1202. Cite as: "100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism." |
 | ~~WaveWarZ battles: "735" / "958" / "416"~~ → **RESOLVED** | dossier 742 (735), COC lesson (958), old scraper (416) | **Canonical: 1,245 battles** (live API 2026-07-16). Scraper-era numbers are obsolete. Source: doc 974. |
-| ~~"$60K+ traded"~~ → **PARTIALLY RESOLVED** | dossier 742 | Live volume: 522 SOL (~$39K at $75/SOL, 2026-07-16). The "$60K+" claim was likely from a higher SOL price period (SOL was ~$120–150 in early 2025). Doc 974 reconciles this: the claim is plausible historically but shouldn't be cited at current prices without qualification. |
+| ~~"$60K+ traded"~~ → **RESOLVED** | dossier 742 | Live volume: 524.15 SOL (~$39,453 at $75.29/SOL, 2026-07-17). The "$60K+" claim was from a higher SOL price period (SOL was ~$120–150 in early 2025) — plausible historically but do not cite at current prices. Canonical source: doc 978. |
 | ~~"34 PRs/week"~~ → **resolved** | doc 449 one-pager | **VERIFIED, see [doc 1203](../1203-zaoos-build-velocity/):** "34/week" was the human-era baseline (W12–W15, ~30/week product code). Now 60–175+/week total but **50–73% is agent docs/tests automation**; product (feat/fix) velocity is stable ~30/week. Quote total only with the automation caveat. |
 
 ## Recommendation (single source, same discipline as GEO llms.txt + Respect facts)

--- a/research/identity/icm-boxes/generated/thezao.com.llms.txt
+++ b/research/identity/icm-boxes/generated/thezao.com.llms.txt
@@ -14,8 +14,8 @@ Not a record label or a "music community" - an impact network whose first artist
 - Verified on-chain (2026-07-05): **157 unique Respect holders** (122 OG + 56 ZOR; 21 hold both), OG Gini roughly 0.73.
 
 ## WaveWarZ — live traction (2026-07-16)
-- **1,245 battles** on Solana mainnet, **522 SOL (~$39K) lifetime volume**
-- Artists have earned 9.05 SOL automatically on-chain; traders have claimed 127.34 SOL in winnings
+- **1,245 battles** on Solana mainnet, **524.15 SOL (~$39K) lifetime volume**
+- Artists have earned 9.07 SOL automatically on-chain; traders have claimed 127.34 SOL in winnings
 - Two charity benefit battles raised ~$1,497 for HuRya Empowerment Foundation (8,500+ beneficiaries)
 - Source: wavewarz.info/api/public/stats (public API) + Doc 1077 (ZAO DAO case study)
 

--- a/research/identity/icm-boxes/generated/wavewarz.com.llms.txt
+++ b/research/identity/icm-boxes/generated/wavewarz.com.llms.txt
@@ -13,9 +13,9 @@
 
 ## Live traction (verified 2026-07-16 · wavewarz.info/api/public/stats)
 - **1,245 total battles** (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community)
-- **522 SOL lifetime volume** (~$39K at $75/SOL)
-- **9.05 SOL paid to artists** (automatic, on-chain)
-- **17.43 SOL platform revenue**
+- **524.15 SOL lifetime volume** (~$39K at $75.29/SOL, 2026-07-17)
+- **9.07 SOL paid to artists** (automatic, on-chain)
+- **17.44 SOL platform revenue**
 - **127.34 SOL paid to winning traders**
 
 ## Community and charity impact

--- a/research/identity/icm-boxes/thezao.llm.txt
+++ b/research/identity/icm-boxes/thezao.llm.txt
@@ -14,8 +14,8 @@ Not a record label or a "music community" - an impact network whose first artist
 - Verified on-chain (2026-07-05): **157 unique Respect holders** (122 OG + 56 ZOR; 21 hold both), OG Gini roughly 0.73.
 
 ## WaveWarZ — live traction (2026-07-16)
-- **1,245 battles** on Solana mainnet, **522 SOL (~$39K) lifetime volume**
-- Artists have earned 9.05 SOL automatically on-chain; traders have claimed 127.34 SOL in winnings
+- **1,245 battles** on Solana mainnet, **524.15 SOL (~$39K) lifetime volume**
+- Artists have earned 9.07 SOL automatically on-chain; traders have claimed 127.34 SOL in winnings
 - Two charity benefit battles raised ~$1,497 for HuRya Empowerment Foundation (8,500+ beneficiaries)
 - Source: wavewarz.info/api/public/stats (public API) + Doc 1077 (ZAO DAO case study)
 

--- a/research/identity/icm-boxes/wavewarz.llm.txt
+++ b/research/identity/icm-boxes/wavewarz.llm.txt
@@ -11,9 +11,9 @@ WaveWarZ is live-traded music battles on Solana: artists battle, fans trade posi
 
 ## Live traction (verified 2026-07-16 · wavewarz.info/api/public/stats)
 - **1,245 total battles** (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community)
-- **522 SOL lifetime volume** (~$39K at $75/SOL)
-- **9.05 SOL paid to artists** (automatic, on-chain)
-- **17.43 SOL platform revenue**
+- **524.15 SOL lifetime volume** (~$39K at $75.29/SOL, 2026-07-17)
+- **9.07 SOL paid to artists** (automatic, on-chain)
+- **17.44 SOL platform revenue**
 - **127.34 SOL paid to winning traders**
 
 ## Community and charity impact


### PR DESCRIPTION
## Summary

Corrects the stale WaveWarZ volume figure in the two highest-impact citation sources — the canonical facts ledger and the ICM machine-readable GEO boxes.

**Files changed (5):**
- `research/governance/1201-zao-canonical-facts-ledger/README.md` — lifetime volume 522→524.15 SOL, artist payouts 9.05→9.07 SOL, platform revenue 17.42→17.44 SOL; "$60K+ traded" resolution row promoted to RESOLVED; source updated from doc 974 → doc 978 (which is now the authoritative numbers-framing doc)
- `research/identity/icm-boxes/thezao.llm.txt` — 522→524.15 SOL, 9.05→9.07 SOL
- `research/identity/icm-boxes/wavewarz.llm.txt` — 522→524.15 SOL, 9.05→9.07 SOL, 17.43→17.44 SOL, price updated to $75.29/SOL
- `research/identity/icm-boxes/generated/thezao.com.llms.txt` — same as source
- `research/identity/icm-boxes/generated/wavewarz.com.llms.txt` — same as source

**Why ICM boxes matter:** These are the machine-readable artifacts served to GEO engines (Perplexity, ChatGPT, Grok). When engines query "what is WaveWarZ," they pull from these. Stale volume figures here = stale AI answers.

**Context:** PR #1852 (merged) fixed community/farcaster/cross-platform docs. This PR fixes the canonical source (1201) and the ICM layer. Remaining stale docs (governance/events/wavewarz research index) are on existing PR branches and will self-correct on rebase.

## Test plan

- [ ] Doc 1201 line 42: `524.15 SOL (~$39K)` 
- [ ] Doc 1201 line 44: `9.07 SOL` artist payouts
- [ ] Doc 1201 line 45: `17.44 SOL` platform revenue
- [ ] ICM boxes: all 4 files show `524.15 SOL` and `9.07 SOL`
- [ ] `grep -r "522 SOL" research/governance/1201* research/identity/icm-boxes/` returns zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)