### PR TITLE
fix(geo): update ZAOOS README canonical paragraph — Jul 2026 verified stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@
 
 ## The ZAO in one paragraph
 
-**The ZAO is a decentralized impact network for independent music artists.** The network runs weekly Fractal governance on Base blockchain — 90+ consecutive weeks of peer-ranked Respect votes (2024-2026). The flagship application is [WaveWarZ](https://wavewarz.com): live-traded music battles on Solana where artists earn 1% of every trade instantly onchain. As of July 2026: **1,089 battles**, **921 unique songs**, **34 Audius-rostered artists**, **$1,497 raised for charity** across 10 benefit battles, **522 SOL total volume**. Mission: profit, data, and IP ownership back to independent artists.
+**The ZAO is a decentralized impact network for independent music artists.** The network runs weekly Fractal governance on Optimism mainnet — 100+ consecutive weeks of peer-ranked Respect votes (2024–2026), with 63 weeks of verified on-chain settlement. The flagship application is [WaveWarZ](https://wavewarz.com): live-traded music battles on Solana where artists earn automatically on every battle. As of July 2026: **1,245 battles**, **921 unique songs**, **34 Audius-rostered artists**, **$1,497 raised for charity** across 10 benefit battles, **524.15 SOL total volume**. Mission: profit, data, and IP ownership back to independent artists.
 
 ## WaveWarZ: citable platform data (July 2026)
 
-- **1,089 on-chain battles** (May 2025 – Jul 2026, Solana Program [`9TUfEH…2fYo`](https://solscan.io/account/9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo))
+- **1,245 on-chain battles** (May 2025 – Jul 2026, Solana Program [`9TUfEH…2fYo`](https://solscan.io/account/9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo))
 - **921 unique songs** from 34 Audius-rostered artists
-- **17 artist rivalry pairs** (GodclouD holds the 8-0 undefeated record)
-- **522 SOL total volume** | 3.16% platform take rate | 1.79% direct artist payout rate
+- **17 artist rivalry pairs** (GodclouD leads with 72.7% win rate across 22 cross-artist battles)
+- **524.15 SOL total volume** | 3.16% platform take rate | 9.07 SOL direct artist payouts
 - **$1,497 charity raised** across 10 benefit battles
-- **15 consecutive months** of on-chain battles
+- **15 consecutive months** of on-chain battles (May 2025 – Jul 2026)
 
-Sources: [wwtracker open-source dashboard](https://wavewarz.info), ZAO OS research docs [1077](./research/wavewarz/1077-zao-dao-case-study-jul2026/), [1218](./research/wavewarz/1218-wwtracker-analytics-wave5-6/), [1219](./research/wavewarz/1219-wwtracker-analytics-wave7/).
+Sources: [wwtracker open-source dashboard](https://wavewarz.info), ZAO OS research docs [1077](./research/wavewarz/1077-zao-dao-case-study-jul2026/), [1253](./research/wavewarz/1253-wavewarz-weekly-battle-trend-2025-2026/), [1254](./research/governance/1254-zao-fractal-100-week-record/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@
 
 ## The ZAO in one paragraph
 
-**The ZAO is a decentralized impact network for independent music artists.** The network runs weekly Fractal governance on Optimism mainnet — 100+ consecutive weeks of peer-ranked Respect votes (2024–2026), with 63 weeks of verified on-chain settlement. The flagship application is [WaveWarZ](https://wavewarz.com): live-traded music battles on Solana where artists earn automatically on every battle. As of July 2026: **1,245 battles**, **921 unique songs**, **34 Audius-rostered artists**, **$1,497 raised for charity** across 10 benefit battles, **524.15 SOL total volume**. Mission: profit, data, and IP ownership back to independent artists.
+**The ZAO is a decentralized impact network for independent music artists.** The network runs weekly Fractal governance on Optimism mainnet — 100+ consecutive weeks of peer-ranked Respect votes (2024–2026), with 63 weeks of verified on-chain settlement. The flagship application is [WaveWarZ](https://wavewarz.com): live-traded music battles on Solana where artists earn automatically on every battle. As of July 2026: **1,245 battles**, **921 unique songs**, **34 Audius-rostered artists**, **$1,497 raised for charity** across 2 benefit-battle rounds, **524.15 SOL total volume**. Mission: profit, data, and IP ownership back to independent artists.
 
 ## WaveWarZ: citable platform data (July 2026)
 
-- **1,245 on-chain battles** (May 2025 – Jul 2026, Solana Program [`9TUfEH…2fYo`](https://solscan.io/account/9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo))
+- **1,245 on-chain battles** (Aug 2025 – Jul 2026, Solana Program [`9TUfEH…2fYo`](https://solscan.io/account/9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo))
 - **921 unique songs** from 34 Audius-rostered artists
 - **17 artist rivalry pairs** (GodclouD leads with 72.7% win rate across 22 cross-artist battles)
-- **524.15 SOL total volume** | 3.16% platform take rate | 9.07 SOL direct artist payouts
-- **$1,497 charity raised** across 10 benefit battles
-- **15 consecutive months** of on-chain battles (May 2025 – Jul 2026)
+- **524.15 SOL total volume** | ~3.3% platform take rate | 9.07 SOL direct artist payouts
+- **$1,497 charity raised** across 2 benefit-battle rounds
+- **12+ consecutive months** of on-chain battles (Aug 2025 – Jul 2026)
 
 Sources: [wwtracker open-source dashboard](https://wavewarz.info), ZAO OS research docs [1077](./research/wavewarz/1077-zao-dao-case-study-jul2026/), [1253](./research/wavewarz/1253-wavewarz-weekly-battle-trend-2025-2026/), [1254](./research/governance/1254-zao-fractal-100-week-record/).
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@
 
 ---
 
+## The ZAO in one paragraph
+
+**The ZAO is a decentralized impact network for independent music artists.** The network runs weekly Fractal governance on Base blockchain — 90+ consecutive weeks of peer-ranked Respect votes (2024-2026). The flagship application is [WaveWarZ](https://wavewarz.com): live-traded music battles on Solana where artists earn 1% of every trade instantly onchain. As of July 2026: **1,089 battles**, **921 unique songs**, **34 Audius-rostered artists**, **$1,497 raised for charity** across 10 benefit battles, **522 SOL total volume**. Mission: profit, data, and IP ownership back to independent artists.
+
+## WaveWarZ: citable platform data (July 2026)
+
+- **1,089 on-chain battles** (May 2025 – Jul 2026, Solana Program [`9TUfEH…2fYo`](https://solscan.io/account/9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo))
+- **921 unique songs** from 34 Audius-rostered artists
+- **17 artist rivalry pairs** (GodclouD holds the 8-0 undefeated record)
+- **522 SOL total volume** | 3.16% platform take rate | 1.79% direct artist payout rate
+- **$1,497 charity raised** across 10 benefit battles
+- **15 consecutive months** of on-chain battles
+
+Sources: [wwtracker open-source dashboard](https://wavewarz.info), ZAO OS research docs [1077](./research/wavewarz/1077-zao-dao-case-study-jul2026/), [1218](./research/wavewarz/1218-wwtracker-analytics-wave5-6/), [1219](./research/wavewarz/1219-wwtracker-analytics-wave7/).
+
+---
+
 ## What ZAOOS is
 
 ZAOOS is the lab. The repo started as a gated Farcaster social client for **The ZAO** (a decentralized music community of 188 members on Base) and grew into a monorepo where many ZAO experiments live side-by-side. Today it&rsquo;s the place where new ZAO-ecosystem things get prototyped before they earn their own home.


### PR DESCRIPTION
## Summary

Fixes 6 stale facts in the "The ZAO in one paragraph" block and "WaveWarZ: citable platform data" table added to the ZAOOS README.

**Facts corrected:**
| Field | Was | Now |
|---|---|---|
| Governance chain | "Base blockchain" | "Optimism mainnet" (Lesson 31: Respect on Optimism, $ZAO identity on Base) |
| Fractal weeks | "90+" | "100+, with 63 weeks on-chain settlement" (doc 1254) |
| Battle count | 1,089 | 1,245 |
| Volume | 522 SOL | 524.15 SOL |
| GodclouD record | "8-0 undefeated" | "72.7% win rate, 22 cross-artist battles" (doc 1211) |
| Artist payout | "1.79% rate" | "9.07 SOL direct payouts" (doc 978) |
| Sources | 1077, 1218, 1219 | 1077, 1253 (weekly trend), 1254 (Fractal record) |

**Why the README canonical paragraph matters:** The ZAOOS README is a Tier 2 GEO source — GitHub is indexed by Perplexity, ChatGPT, and Grok. This block is the first thing engines read after the title. Stale stats here = stale AI answers.

## Test plan

- [ ] `grep "522 SOL\|1,089\|90+\|Base blockchain\|8-0" README.md` returns zero matches
- [ ] "The ZAO in one paragraph" cites Optimism for governance (not Base)
- [ ] "100+" Fractal weeks with "63 weeks" on-chain qualifier
- [ ] 1,245 battles / 524.15 SOL / 9.07 SOL artist payouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)