### PR TITLE
docs(1209): Optimism Retro Funding draft — 522→524.15 SOL stats correction

### DIFF
--- a/research/governance/1209-optimism-retro-funding-application-draft/README.md
+++ b/research/governance/1209-optimism-retro-funding-application-draft/README.md
@@ -1,0 +1,121 @@
+# 1209 — Optimism Retro Funding Application Draft
+
+**Purpose**: Copy-paste-ready application for the next Optimism Retro Funding (Atlas) round  
+**Owner**: Zaal Panthaki (submit via atlas.optimism.io)  
+**Status**: Draft — ready for Zaal to submit, verify facts, and add any missing context  
+**Research base**: docs 1200, 1201, 1202, 1205, 1206, 1208
+
+---
+
+## Why Apply
+
+Optimism Retro Funding (now "Atlas") rewards public goods that have already delivered measurable value on Optimism. ZAO has run 63 weeks of verified on-chain Respect settlement on Optimism Mainnet — making it one of the longest-running live governance experiments on the network. The OREC contract and Respect tokens are active, with 157 unique holders.
+
+This is not speculative work. It is documented, on-chain, and independently verifiable on Blockscout.
+
+---
+
+## Application Content
+
+### Project Name
+The ZAO — Fractal Governance on Optimism (100+ Weeks)
+
+### One-Line Description
+The longest-running active fractal DAO on Optimism Mainnet: 63 weeks of verified on-chain Respect settlement, 157 unique holders, and a live Optimistic Respect Execution Contract (OREC) powering weekly contribution games.
+
+### Category
+Governance & Collaboration (or: Onchain Builders / Public Goods Infrastructure)
+
+### Project Description (long form)
+
+The ZAO (ZTalent Artist Organization) has run a weekly fractal governance cycle on Optimism Mainnet continuously since July 30, 2024. As of July 2026:
+
+**On-chain governance record:**
+- **102 weeks** of weekly Respect Games (Discord-recorded, publicly logged)
+- **63 weeks** of verified on-chain Respect settlement (OG ERC-20: 33 settlement weeks; ZOR ERC-1155: 31 settlement weeks — Blockscout-verified, independently auditable)
+- **157 unique Respect holders** (122 OG ERC-20 + 56 ZOR ERC-1155, 21 holding both) — verified 2026-07-17
+
+**Contracts deployed on Optimism Mainnet:**
+- **OG Respect** (ERC-20, soulbound): `0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957` — 122 holders
+- **ZOR Respect** (ERC-1155): `0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c` — 56 holders
+- **OREC** (Optimistic Respect Execution Contract): `0xcB05F9254765CA521F7698e61E0A6CA6456Be532` — active governance settlement
+
+**Governance model:**
+The fractal model uses a Fibonacci-weighted contribution curve for weekly Respect distribution. OREC provides 72-hour optimistic execution with veto capability — a lightweight on-chain governance layer that doesn't require multi-sig or centralized admin. Every week, contributors rank their contributions; the Respect Game settles rankings on-chain through OREC; Respect tokens distribute automatically.
+
+**Public goods contribution:**
+1. ZAO is the **only active fractal DAO on Optimism** as of July 2026 (Eden Fractal site is offline; Optimism Fractal paused Jan 2026)
+2. The OREC pattern is open-source and reproducible by any Optimism project
+3. The governance history (63 on-chain weeks) is a live dataset for DAO researchers studying contribution tracking and soulbound token governance
+4. ZAO's fractal model is music-first but domain-agnostic — the same pattern applies to any creator or contributor community
+
+**WaveWarZ companion platform:**
+The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,245 battles, 522 SOL in trading volume (~$39K), 939 real trader withdrawals, 9.05 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
+
+### Impact Metrics
+
+| Metric | Value | Source |
+|---|---|---|
+| Weeks of live governance | 102 | Discord logs + ZAOOS research |
+| On-chain settlement weeks (verified) | 63 (OG:33 + ZOR:31) | Blockscout, Optimism Mainnet |
+| Unique Respect holders | 157 | Blockscout 2026-07-17 |
+| OG Respect contract | `0x34cE89...957` | Optimism Mainnet |
+| ZOR Respect contract | `0x9885CC...45c` | Optimism Mainnet |
+| OREC contract | `0xcB05F9...532` | Optimism Mainnet |
+| Active fractal DAOs on Optimism (July 2026) | 1 (ZAO only) | Research doc 1208 |
+| WaveWarZ battles | 1,245 | wavewarz.info/api/public/stats |
+| WaveWarZ trading volume | 522 SOL (~$39K) | wavewarz.info/api/public/stats |
+
+### Verification Links
+
+- OG Respect holders: `https://optimism.blockscout.com/token/0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957/token-holders`
+- ZOR Respect holders: `https://optimism.blockscout.com/token/0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c/token-holders`
+- OREC contract: `https://optimism.blockscout.com/address/0xcB05F9254765CA521F7698e61E0A6CA6456Be532`
+- WaveWarZ live stats: `https://wavewarz.info/api/public/stats`
+- Project home: `https://thezao.xyz`
+- Research documentation: `https://github.com/bettercallzaal/ZAOOS/tree/main/research/governance`
+
+### Team / Contact
+- **Founder**: Zaal Panthaki (@bettercallzaal on X, @zaal on Farcaster)
+- **Entity**: BetterCallZaal Strategies LLC (operating umbrella)
+- **Primary chain**: Optimism (governance + Respect tokens)
+- **GitHub**: `github.com/bettercallzaal/ZAOOS`
+
+---
+
+## Submission Checklist
+
+Before submitting to atlas.optimism.io, verify:
+
+- [ ] Atlas is accepting applications (check `https://atlas.optimism.io` for active round)
+- [ ] Optimism wallet connected (the OREC deployer address or a ZAO wallet with on-chain history)
+- [ ] Confirm current Respect holder counts on Blockscout (may have grown past 157)
+- [ ] Add any recent governance milestones (new ZIPs, new settlement weeks since 2026-07-17)
+- [ ] Review the funding category selection — "Governance & Collaboration" is most accurate
+- [ ] Add Mirror.xyz links for the ZAO papers if they've been published (see doc 1208 action list)
+
+---
+
+## Notes on Retro Funding Eligibility
+
+**Strong signals in ZAO's favor:**
+1. On-chain activity is Blockscout-verifiable — the core requirement for Retro Funding evidence
+2. 63 weeks of continuous governance is the kind of sustained contribution that Retro Funding was designed to reward (not one-time deployments, but ongoing public goods)
+3. ZAO is the only active fractal DAO on Optimism — which means the OREC pattern and Respect model ARE public goods infrastructure (no one else is maintaining it)
+4. Music-focused DAO is a new category in the Optimism ecosystem — the "culture" angle may align with newer Retro Funding priorities
+
+**Potential challenges:**
+- ZAO is not widely known in the Optimism governance community (see doc 1208 — zero external citations)
+- The music/culture angle may need framing as governance infrastructure, not just cultural activity
+- A Mirror.xyz publication would significantly strengthen the application
+
+---
+
+## Sources
+
+- doc 1200: Respect holder counts (157 unique, Blockscout-verified 2026-07-17)
+- doc 1201: ZAO Fractal governance verified stats (100+ weeks, 63 on-chain)
+- doc 1202: Fractal on-chain settlement history (OG:33 + ZOR:31 weeks)
+- doc 1205: ZAO on-chain contract registry (OREC + Respect addresses)
+- doc 1206: ZAO comparative DAO state July 2026
+- doc 1208: ZAO external citation footprint July 2026

--- a/research/governance/1209-optimism-retro-funding-application-draft/README.md
+++ b/research/governance/1209-optimism-retro-funding-application-draft/README.md
@@ -50,7 +50,7 @@ The fractal model uses a Fibonacci-weighted contribution curve for weekly Respec
 4. ZAO's fractal model is music-first but domain-agnostic — the same pattern applies to any creator or contributor community
 
 **WaveWarZ companion platform:**
-The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,245 battles, 522 SOL in trading volume (~$39K), 939 real trader withdrawals, 9.05 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
+The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,245 battles, 524.15 SOL in trading volume (~$39K), 939 real trader withdrawals, 9.07 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
 
 ### Impact Metrics
 
@@ -64,7 +64,7 @@ The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-bat
 | OREC contract | `0xcB05F9...532` | Optimism Mainnet |
 | Active fractal DAOs on Optimism (July 2026) | 1 (ZAO only) | Research doc 1208 |
 | WaveWarZ battles | 1,245 | wavewarz.info/api/public/stats |
-| WaveWarZ trading volume | 522 SOL (~$39K) | wavewarz.info/api/public/stats |
+| WaveWarZ trading volume | 524.15 SOL (~$39K) | wavewarz.info/api/public/stats |
 
 ### Verification Links
 

--- a/src/app/api/proposals/comment/__tests__/route.test.ts
+++ b/src/app/api/proposals/comment/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest, makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/notifications', () => ({ createInAppNotification: vi.fn().mockResolvedValue(undefined) }));
+
+const mockOrder = vi.hoisted(() => vi.fn());
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { GET, POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10, displayName: 'ZAO', pfpUrl: 'https://pfp.url', signerUuid: 'sig' };
+const PROPOSAL_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+describe('GET /api/proposals/comment', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makeGetRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when proposal_id is missing', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makeGetRequest('/api/proposals/comment');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns comments for a proposal', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const mockComments = [{ id: 'c1', body: 'Great proposal!', author: { display_name: 'ZAO' } }];
+    mockOrder.mockResolvedValue({ data: mockComments, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: mockOrder,
+    });
+    const req = makeGetRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.comments).toHaveLength(1);
+  });
+});
+
+describe('POST /api/proposals/comment', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/proposals/comment', {
+      proposal_id: PROPOSAL_UUID,
+      body: 'Great proposal!',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid payload (bad UUID)', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: 'not-a-uuid', body: 'Hi' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not in DB', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID, body: 'Great!' });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns comment on success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const mockComment = { id: 'c2', body: 'Love it!', author: { display_name: 'ZAO' } };
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // User lookup
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { id: 'user-uuid' }, error: null }),
+        };
+      }
+      if (callCount === 2) {
+        // Insert comment
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockComment, error: null }),
+          }),
+        };
+      }
+      // Notify proposal author (fire-and-forget)
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+    const req = makePostRequest('/api/proposals/comment', { proposal_id: PROPOSAL_UUID, body: 'Love it!' });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.comment.body).toBe('Love it!');
+  });
+});

--- a/src/app/api/publish/hive/__tests__/route.test.ts
+++ b/src/app/api/publish/hive/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+
+const mockDecryptPostingKey = vi.hoisted(() => vi.fn().mockReturnValue('decrypted-key'));
+const mockPublishToHive = vi.hoisted(() => vi.fn());
+const mockNormalizeForHive = vi.hoisted(() => vi.fn().mockReturnValue({ body: 'normalized' }));
+vi.mock('@/lib/publish/hive', () => ({
+  decryptPostingKey: mockDecryptPostingKey,
+  publishToHive: mockPublishToHive,
+}));
+vi.mock('@/lib/publish/normalize', () => ({ normalizeForHive: mockNormalizeForHive }));
+
+let fromCallCount = 0;
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => {
+    fromCallCount++;
+    if (fromCallCount === 1) {
+      // First call: fetch user credentials
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: mockSingle,
+      };
+    }
+    // Second call: insert publish_log
+    return { insert: mockInsert };
+  }),
+);
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
+
+import { POST } from '../route';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  fromCallCount = 0;
+});
+
+const MOCK_SESSION = { fid: 10 };
+const VALID_BODY = { castHash: '0xabc', text: 'ZAO is live on Hive' };
+const HIVE_USER = { hive_username: 'zabal', hive_posting_key_encrypted: 'enc-key' };
+
+describe('POST /api/publish/hive', () => {
+  it('returns 401 when no session', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/publish/hive', { castHash: '0xabc' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not found in DB', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({ data: null, error: null });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when Hive is not connected', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({
+      data: { hive_username: null, hive_posting_key_encrypted: null },
+      error: null,
+    });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns success:true with platformUrl on publish success', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockSingle.mockResolvedValue({ data: HIVE_USER, error: null });
+    mockPublishToHive.mockResolvedValue({ url: 'https://hive.blog/@zabal/post', permlink: 'post' });
+    mockInsert.mockResolvedValue({ error: null });
+    const req = makePostRequest('/api/publish/hive', VALID_BODY);
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.platformUrl).toContain('hive.blog');
+  });
+});

--- a/src/app/api/users/follow-batch/__tests__/route.test.ts
+++ b/src/app/api/users/follow-batch/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockFollowUser = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
+vi.mock('@/lib/farcaster/neynar', () => ({ followUser: mockFollowUser }));
+
+import { POST } from '../route';
+
+afterEach(() => vi.clearAllMocks());
+
+const MOCK_SESSION = { fid: 10, signerUuid: 'signer-abc' };
+
+describe('POST /api/users/follow-batch', () => {
+  it('returns 401 when no session or missing signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2] });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for empty targetFids array', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [] });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns followed:0 when targetFids only contains self', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [10] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.followed).toBe(0);
+  });
+
+  it('follows multiple users and returns correct count', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockResolvedValue(undefined);
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2, 3] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.followed).toBe(3);
+    expect(body.failed).toBe(0);
+  });
+
+  it('reports failed count when followUser throws', async () => {
+    mockGetSessionData.mockResolvedValue(MOCK_SESSION);
+    mockFollowUser.mockRejectedValue(new Error('Neynar error'));
+    const req = makePostRequest('/api/users/follow-batch', { targetFids: [1, 2] });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.failed).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Stats correction for the Optimism Retro Funding application draft — two WaveWarZ figures updated to match the live API (2026-07-17):
- Trading volume: 522 SOL → **524.15 SOL** (2 instances)
- Artist payouts: 9.05 SOL → **9.07 SOL** (1 instance)

**Context:** This is a draft application (DECISION NEEDED gated action — requires Zaal's approval before submission). The stats correction ensures the draft has accurate figures for when/if it's submitted.

Source: wavewarz.info/api/public/stats (2026-07-17T17:15Z). Canonical: doc 978.

## Test plan

- [ ] `grep "522 SOL" research/governance/1209*/README.md` returns zero
- [ ] Volume shows `524.15 SOL (~$39K)` in both narrative and table
- [ ] Artist payouts show `9.07 SOL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)