### PR TITLE
feat(zoe): add whisper message kind for private approvals with zero group noise

### DIFF
--- a/bot/src/zoe/__tests__/telegram-routing.test.ts
+++ b/bot/src/zoe/__tests__/telegram-routing.test.ts
@@ -14,7 +14,7 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, 'What should I do?', { kind: 'question' });
 
-      expect(sendMessage).toHaveBeenCalledWith(123, 'What should I do?');
+      expect(sendMessage).toHaveBeenCalledWith(123, 'What should I do?', {});
       expect(sendMessage).toHaveBeenCalledTimes(1);
     });
 
@@ -69,7 +69,7 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, 'Status message', { kind: 'status' });
 
-      expect(sendMessage).toHaveBeenCalledWith(123, 'Status message');
+      expect(sendMessage).toHaveBeenCalledWith(123, 'Status message', {});
     });
 
     it('questions always go to DM even if group is configured', async () => {
@@ -82,7 +82,50 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, 'What do you think?', { kind: 'question' });
 
-      expect(sendMessage).toHaveBeenCalledWith(123, 'What do you think?');
+      expect(sendMessage).toHaveBeenCalledWith(123, 'What do you think?', {});
+    });
+
+    it('routes whispers to DM (private approval without group noise)', async () => {
+      const sendMessage = vi.fn().mockResolvedValue({});
+      const deps: TelegramRoutingDeps = {
+        sendMessage,
+        zaalId: 123,
+        groupId: 456,
+      };
+
+      await sendToZaal(deps, 'Approve PR #123?', { kind: 'whisper' });
+
+      expect(sendMessage).toHaveBeenCalledWith(123, 'Approve PR #123?', {});
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('whispers go to DM even when group is configured with thread', async () => {
+      const sendMessage = vi.fn().mockResolvedValue({});
+      const deps: TelegramRoutingDeps = {
+        sendMessage,
+        zaalId: 123,
+        groupId: 456,
+        groupThreadId: 789,
+      };
+
+      await sendToZaal(deps, 'Private approval', { kind: 'whisper' });
+
+      expect(sendMessage).toHaveBeenCalledWith(123, 'Private approval', {});
+      expect(sendMessage).not.toHaveBeenCalledWith(456, expect.anything(), expect.anything());
+    });
+
+    it('whispers pass inline keyboard markup to DM', async () => {
+      const sendMessage = vi.fn().mockResolvedValue({});
+      const deps: TelegramRoutingDeps = {
+        sendMessage,
+        zaalId: 123,
+        groupId: 456,
+      };
+      const replyMarkup = { inline_keyboard: [[{ text: 'Yes', callback_data: 'y' }]] };
+
+      await sendToZaal(deps, 'Approve?', { kind: 'whisper', replyMarkup });
+
+      expect(sendMessage).toHaveBeenCalledWith(123, 'Approve?', { reply_markup: replyMarkup });
     });
   });
 

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -17,9 +17,15 @@
  *
  * Fallback: if group chat id is unset, all messages fall back to Zaal's DM
  * so nothing breaks pre-config.
+ *
+ * Message kinds:
+ * - 'question': DM Zaal — needs his answer/decision.
+ * - 'whisper':  DM Zaal — private notification, no answer required (approval
+ *   prompts, private alerts). Group stays silent; only Zaal sees it.
+ * - 'status':   ZAALBOTS group — informational, visible to all group members.
  */
 
-export type MessageKind = 'question' | 'status';
+export type MessageKind = 'question' | 'status' | 'whisper';
 
 export interface SendToZaalOptions {
   kind?: MessageKind; // defaults to 'status'
@@ -38,11 +44,13 @@ export interface TelegramRoutingDeps {
 }
 
 /**
- * Route a message to either Zaal's DM (questions) or the ZAALBOTS group (status).
+ * Route a message to either Zaal's DM (questions/whispers) or the ZAALBOTS group (status).
  * Centralizes ALL message routing so the decision is in one place.
  *
  * kind='question': DM Zaal directly (personal chat). These need his answer/decision.
- * kind='status': ZAALBOTS group (+ thread if configured). Informational.
+ * kind='whisper':  DM Zaal directly. Private notification with zero group noise.
+ *                  Use for approval prompts that should not be visible in the group.
+ * kind='status':   ZAALBOTS group (+ thread if configured). Informational.
  *
  * Fallback: if groupId is not set, all messages go to Zaal's DM to avoid
  * silent drops before config is complete.
@@ -55,8 +63,8 @@ export async function sendToZaal(
   const kind = opts.kind ?? 'status';
   const markupOpts = opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {};
 
-  // question -> always DM
-  if (kind === 'question') {
+  // question + whisper -> always DM (questions need a reply; whispers stay private)
+  if (kind === 'question' || kind === 'whisper') {
     return deps.sendMessage(deps.zaalId, text, markupOpts);
   }
 
@@ -95,8 +103,9 @@ export function constructRoutingDeps(sendMessageImpl: TelegramRoutingDeps['sendM
   }
 
   const groupIdRaw = process.env.ZAALBOTS_GROUP_CHAT_ID;
-  const groupId = groupIdRaw ? Number(groupIdRaw) : undefined;
-  if (groupIdRaw && Number.isNaN(groupId)) {
+  const groupIdParsed = groupIdRaw ? Number(groupIdRaw) : undefined;
+  const groupId = groupIdParsed !== undefined && Number.isNaN(groupIdParsed) ? undefined : groupIdParsed;
+  if (groupIdRaw && Number.isNaN(groupIdParsed)) {
     console.warn(`Invalid ZAALBOTS_GROUP_CHAT_ID: ${groupIdRaw} (must be a number, will be ignored)`);
   }
 


### PR DESCRIPTION
## Summary
- Adds `'whisper'` to `MessageKind` in `telegram-routing.ts`
- `whisper` routes to Zaal's DM always (like `question`) but is semantically distinct: private notification, no answer required
- Use for approval prompts that should not be visible in the ZAALBOTS group
- Also fixes pre-existing test bugs: assertions expected 2 args when the code always passes 3, and `constructRoutingDeps` now correctly returns `undefined` (not `NaN`) for invalid group IDs
- All 13 `telegram-routing` tests pass

## Before/After
```typescript
// Before: only 'question' | 'status'
export type MessageKind = 'question' | 'status';

// After: add 'whisper' for private notifications
export type MessageKind = 'question' | 'status' | 'whisper';
// whisper → DM Zaal, no group noise, no reply required
```

## Test plan
- [x] All 13 telegram-routing tests pass locally
- [x] 3 new whisper-specific test cases: basic routing, group-with-thread routing, markup passthrough

Board task: 0ed5e5e7

🤖 Generated with [Claude Code](https://claude.com/claude-code)