### PR TITLE
fix(stats): 9.05→9.07 SOL payouts + snapshot refresh — docs 363 and 1078

### DIFF
--- a/research/community/363-zao-stock-people-brands-2026/README.md
+++ b/research/community/363-zao-stock-people-brands-2026/README.md
@@ -122,7 +122,7 @@
 | **Website** | [wavewarz.com](https://www.wavewarz.com), [wavewarz.info](https://wavewarz.info) (analytics) |
 | **Total battles** | 1,245 (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community) |
 | **Total volume** | 524.15 SOL (~$39K at $75/SOL, 2026-07-17) |
-| **Total artist payouts** | 9.05 SOL |
+| **Total artist payouts** | 9.07 SOL |
 | **Artist economics** | 1% trading volume + 5-7% settlement bonus, instant onchain |
 | **Legal entity** | Delaware C-Corp |
 | **Founders** | Hurric4n3Ike + Candy |

--- a/research/wavewarz/1078-wwtracker-analytics-infrastructure/README.md
+++ b/research/wavewarz/1078-wwtracker-analytics-infrastructure/README.md
@@ -49,13 +49,13 @@ From `GET https://wavewarz.info/api/public/stats`:
 |---|---|
 | Total battles | **1,245** (1,047 quick + 162 main-event + 36 community) |
 | Main events held | **50** |
-| Lifetime volume | **522.23 SOL** (~$38,935 at $74.56/SOL) |
-| Artist payouts (automatic, onchain) | **9.05 SOL** |
-| Platform revenue | **17.43 SOL** |
+| Lifetime volume | **524.15 SOL** (~$39,461 at $75.29/SOL) |
+| Artist payouts (automatic, onchain) | **9.07 SOL** |
+| Platform revenue | **17.44 SOL** |
 | Trader claims paid | **127.34 SOL** (939 withdrawals) |
 | 24h volume | **0.50 SOL** |
 | 7d volume | **12.09 SOL** |
-| SOL price at snapshot | **$74.56** |
+| SOL price at snapshot | **$75.29** |
 
 ---
 


### PR DESCRIPTION
## Summary
- **doc 363** (`research/community/363-zao-stock-people-brands-2026/README.md`): artist payouts table row 9.05→9.07 SOL
- **doc 1078** (`research/wavewarz/1078-wwtracker-analytics-infrastructure/README.md`): full stats table refresh — 522.23→524.15 SOL, 9.05→9.07 SOL payouts, 17.43→17.44 platform rev, $74.56→$75.29/SOL price

Source: live API `wavewarz.info/api/public/stats` (2026-07-17, doc 978 canonical).