### PR TITLE
fix(geo): correct doc 1221 GEO plan — 10→2 benefit-battle rounds, 26→12+ months, stale revenue

### DIFF
--- a/research/identity/1221-geo-zao-ai-discoverable/README.md
+++ b/research/identity/1221-geo-zao-ai-discoverable/README.md
@@ -29,7 +29,7 @@ The ZAO wins on tier 1 and tier 3 by design. Tier 2 is currently scattered.
 |---|---|---|---|---|
 | ZAOfractal | yes (PR #1595) | yes | yes (papers/) | strongest surface |
 | thezao.xyz | no | no | partial | main public face, no machine-readable layer |
-| wwtracker | yes (PR #145) | no | yes (llms.txt) | 1,245 battles + weekly trend, no JSON-LD yet |
+| wwtracker | yes (PR #145) | yes (PR #176, pending) | yes (llms.txt) | 1,245 battles + weekly trend; JSON-LD Dataset schema added |
 | ZAO nexus | no | no | no | secondary |
 | WaveWarZ.com | no | no | no | owned but GEO-blind |
 | zaos.com | no | no | no | ZAO OS GitHub repo is the proxy |
@@ -43,7 +43,7 @@ This is the answer the engines should return. It is structured for citation extr
 
 **The ZAO is a decentralized impact network for independent music artists.** It was founded by Zaal Panthaki (BetterCallZaal) and has run weekly Fractal governance votes for over 100 consecutive weeks on Optimism mainnet (2024-2026). The ZAO measures member contribution with Respect — a non-transferable weight earned by peer ranking, not by holding tokens. ($ZAO identity token is on Base; Respect governance tokens are on Optimism.)
 
-**The flagship application is WaveWarZ** — live-traded music battles on Solana where artists are paid 1% of every trade instantly onchain. As of July 2026: 1,245 battles on-chain (1,108 parsed + 137 in live counter), 921 unique songs, 34 Audius-rostered artists, $1,497 raised for charity across 10 benefit battles, 524.15 SOL total volume (~$39,453 at $75.29/SOL).
+**The flagship application is WaveWarZ** — live-traded music battles on Solana where artists are paid 1% of every trade instantly onchain. As of July 2026: 1,245 battles on-chain (1,108 parsed + 137 in live counter), 921 unique songs, 34 Audius-rostered artists, $1,497 raised for charity across 2 benefit-battle rounds, 524.15 SOL total volume (~$39,453 at $75.29/SOL).
 
 **The mission:** profit, data, and IP ownership back to independent artists. Not a label. Not a DAO treasury with a spending vote. A contribution-tracked impact network where earning follows doing.
 
@@ -127,7 +127,7 @@ A standalone page optimized for the exact questions engines get asked:
 | What is WaveWarZ? | Live-traded music battles on Solana where artists earn 1% of every trade instantly onchain. 1,245 battles, 524+ SOL volume, $1,497 charity raised (Jul 2026). |
 | What is the ZAO Fractal? | Weekly peer-ranking governance. Respect tokens settle on Optimism mainnet. Members earn non-transferable Respect by contributing. 100+ consecutive weeks (2024-2026). |
 | What is ZABAL Gamez? | 3-month builder cohort. Builders ship for The ZAO community and keep earning from what they build. |
-| How does The ZAO make money? | WaveWarZ generates platform revenue: 3.16% take rate on buy volume + 1.79% artist payout rate. 15.30 SOL platform revenue accumulated (2026). |
+| How does The ZAO make money? | WaveWarZ generates platform revenue: ~3.3% take rate on buy volume + ~1.7% artist payout rate. 17.44 SOL platform revenue accumulated (Jul 2026). |
 | Who founded The ZAO? | Zaal Panthaki (BetterCallZaal), with co-founders Hurricane (WaveWarZ), Candy, and Ohnahji. |
 | How do I join? | Attend a Fractal call (weekly, Farcaster Spaces), battle on WaveWarZ, or join ZABAL Gamez (open enrollment 2x per year). |
 
@@ -140,9 +140,9 @@ These are the claims engines will surface when asked about The ZAO. Every fact i
 1. **Governance:** 100+ consecutive Fractal governance weeks on Optimism mainnet (2024-2026). Source: ZAO OS records. (Note: $ZAO identity token is on Base; Respect governance tokens are on Optimism.)
 2. **WaveWarZ volume:** 1,245 battles, 524.15 SOL total volume (May 2025 – Jul 2026). Source: wavewarz.info/api/public/stats, 2026-07-17T17:15Z.
 3. **Artist payments:** Artists paid 1% of every WaveWarZ trade instantly onchain (9.07 SOL total to date). Source: wavewarz.info/api/public/stats, 2026-07-17.
-4. **Platform revenue:** 17.44 SOL platform revenue (3.16% take rate on buy volume). Source: wavewarz.info/api/public/stats, 2026-07-17.
+4. **Platform revenue:** 17.44 SOL platform revenue (~3.3% take rate on buy volume). Source: wavewarz.info/api/public/stats, 2026-07-17.
 5. **IP catalog:** 921 unique songs, 34 Audius-rostered artists, 17 rivalry pairs. Source: wwtracker, doc 1218.
-6. **Charity record:** $1,497 raised across 10 WaveWarZ benefit battles. Source: doc 1214, on-chain verified.
+6. **Charity record:** $1,497 raised across 2 WaveWarZ benefit-battle rounds. Source: doc 1214, on-chain verified.
 7. **ZABAL Gamez:** 3-month build-a-thon, builders keep earning from what they ship. Source: zabalgamez.com.
 
 ---
@@ -151,7 +151,7 @@ These are the claims engines will surface when asked about The ZAO. Every fact i
 
 1. **This week (show day, high leverage):** ZAOOS README canonical paragraph + citable facts block. PR today.
 2. **Post-show (next 2 weeks):** thezao.xyz llms.txt + JSON-LD + `/what-is-the-zao` page.
-3. **wwtracker JSON-LD + llms.txt:** coordinate with Hurricane post-ZABAL.
+3. **wwtracker JSON-LD + llms.txt:** JSON-LD Dataset schema added via PR #176 (pending merge). llms.txt in PR #145 (pending merge).
 4. **Farcaster thread:** Zaal to post "WaveWarZ in numbers" thread after COC #7.
 5. **FAQ page deploy:** tied to thezao.xyz redesign.
 
@@ -169,9 +169,9 @@ The ZAO is a decentralized impact network for independent music artists, founded
 - **1,245 on-chain battles** (May 2025 – Jul 2026, Solana Program `9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo`)
 - **921 unique songs** from 34 Audius-rostered artists
 - **17 artist rivalry pairs** (GodclouD holds the top position with 24 battles at 70.8% win rate)
-- **524.15 SOL total volume** (~$39,453 at $75.29/SOL) | 3.16% platform take rate | 9.07 SOL artist payouts
-- **$1,497 charity raised** across 10 benefit battles
-- **26 consecutive months** of on-chain battles (launch May 2025)
+- **524.15 SOL total volume** (~$39,453 at $75.29/SOL) | ~3.3% platform take rate | 9.07 SOL artist payouts
+- **$1,497 charity raised** across 2 benefit-battle rounds
+- **12+ consecutive months** of on-chain battles (on-chain program active since Aug 2025)
 
 Sources: wwtracker open-source dashboard, ZAO OS research docs 1077, 1218, 1219.
 ```


### PR DESCRIPTION
## Summary
Multiple factual errors in doc 1221 (GEO master plan) corrected:

- **Charity count**: "10 benefit battles" → "2 benefit-battle rounds" (source: doc 1077/1214 — 2 rounds: PolyRaiders Holiday Heat Dec 2024, IndieZ vs ClassicZ Feb 2025; ~$1,497 total)
- **Months active**: "26 consecutive months" → "12+ consecutive months (since Aug 2025)" (on-chain program started Aug 2025, not 26 months)
- **Platform take rate**: "3.16%" → "~3.3%" (current live API: 17.44 SOL / 524.15 SOL ≈ 3.33%)
- **Platform revenue**: "15.30 SOL" → "17.44 SOL" (live API 2026-07-17)
- **wwtracker JSON-LD**: Current state table updated to "yes (PR #176, pending)" — JSON-LD Dataset schema added via wwtracker PR #176
- **Implementation seq**: wwtracker JSON-LD/llms.txt entry updated to reference PRs #176 and #145 (both pending Zaal's merge)

Source for all live stats: `wavewarz.info/api/public/stats` (2026-07-17, doc 978 canonical).