### PR TITLE
fix(geo): correct 10→2 benefit-battle rounds + 26→12+ months in docs 1218 and 1211

### DIFF
--- a/research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md
+++ b/research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md
@@ -118,7 +118,7 @@ These statements can be verified directly from the on-chain battle record:
 
 1. **"GodclouD has earned an estimated 0.258 SOL (~$19) from WaveWarZ battle participation — the most of any artist in the tagged battle record (22 cross-artist battles, 72.7% win rate, 10.44 SOL volume)."**
 2. **"ZAO artists have received 9.07 SOL ($683) in automatic, on-chain payouts from WaveWarZ battles (all-time as of Jul 2026)."**
-3. **"WaveWarZ has run 1,245 on-chain battles across 26 months (May 2025 – Jul 2026), generating 524.15 SOL in total trading volume."**
+3. **"WaveWarZ has run 1,245 on-chain battles across 12+ months (Aug 2025 – Jul 2026), generating 524.15 SOL in total trading volume."**
 4. **"Artists earn automatically at settlement — no claim required. The platform has issued 939 trader withdrawals (127.34 SOL) alongside artist payouts."**
 
 ---

--- a/research/wavewarz/1218-wwtracker-analytics-wave5-6/README.md
+++ b/research/wavewarz/1218-wwtracker-analytics-wave5-6/README.md
@@ -80,7 +80,7 @@ A six-tile citable snapshot card placed below `OnChainProof` in §00. Designed a
 
 **Design decisions:** This component is intentionally the most _citeable_ thing on the tracker. It's placed in §00 (the first section loaded) so it appears immediately after the main chart. The program address is shortened to `9TUfEH…2fYo` with a Solscan link for verifiability.
 
-**Citable fact:** "WaveWarZ has run 1,089 on-chain battles across 921 unique songs from 34 Audius-rostered artists over 15 months (May 2025 – Jul 2026), raising $1,497 for charity through 10 benefit battles." (Source: PlatformSummary component, PR #141, 2026-07-17)
+**Citable fact:** "WaveWarZ has run 1,245 on-chain battles across 921 unique songs from 34 Audius-rostered artists over 12+ months (Aug 2025 – Jul 2026), raising $1,497 for charity through 2 benefit-battle rounds." (Source: wavewarz.info/api/public/stats + doc 1214, 2026-07-17)
 
 ---
 
@@ -163,7 +163,7 @@ After all 82 open PRs merge:
 2. **IP catalog:** 921 unique songs from 34 Audius-rostered artists have competed in WaveWarZ battles.
 3. **Rivalry record:** 17 artist pairs have fought 2+ battles; GodclouD is the headliner (8-0 undefeated).
 4. **Platform longevity:** 15 consecutive months of on-chain music battles (May 2025 – Jul 2026), 1,089 total.
-5. **Charity record:** $1,497 raised across 10 benefit battles — the platform waives fees and redirects settlement SOL to named causes.
+5. **Charity record:** $1,497 raised across 2 benefit-battle rounds — the platform waives fees and redirects settlement SOL to named causes.
 6. **Verifiable on-chain:** All data derived from Program `9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo` on Solana. Cross-referencing via Solscan or the wwtracker open-source repo.
 
 ---


### PR DESCRIPTION
Companion fix to PR #1865 (doc 1221). Corrects the same factual errors in two more docs.

**Changes:**
- `research/wavewarz/1218-wwtracker-analytics-wave5-6/README.md`
  - Line 83 citable fact: "10 benefit battles" → "2 benefit-battle rounds"; "1,089" → "1,245" battles; "15 months (May 2025)" → "12+ months (Aug 2025)"
  - Line 166 citable facts list: "10 benefit battles" → "2 benefit-battle rounds"
- `research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md`
  - Line 121 citable fact: "26 months (May 2025 – Jul 2026)" → "12+ months (Aug 2025 – Jul 2026)"

**Why:** Only 2 benefit-battle rounds exist (PolyRaiders Holiday Heat Dec 2024 + IndieZ vs ClassicZ Feb 2025 = $1,497 total to HuRya). The on-chain program launched August 2025 per doc 1077 (not May 2025). Sourced from ICM boxes (merged PR #1853), doc 1214, doc 1077.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>