### PR TITLE
fix(doc1257): update take rate 3.16%→~3.3% and artist payout rate 1.79%→~1.73%

### DIFF
--- a/research/identity/1257-zao-ip-portfolio-july2026/README.md
+++ b/research/identity/1257-zao-ip-portfolio-july2026/README.md
@@ -29,8 +29,8 @@ The ZAO is a decentralized impact network for independent music artists, founded
 | Unique songs battled | 921 | doc 1214 |
 | Artists with tagged handles | 34 Audius-rostered | doc 1214 |
 | Charity raised | $1,497 across 2 benefit-battle rounds | doc 1077 |
-| Platform take rate | 3.16% | doc 1219 |
-| Artist payouts | 1.79% of volume (9.07 ◎ total) | doc 1211 |
+| Platform take rate | ~3.3% (Jul 2026) | wavewarz.info/api/public/stats |
+| Artist payouts | ~1.73% of volume (9.07 ◎ total) | doc 1211 + live API |
 | Top rival pair | GodclouD 8-0 all-time | doc 1214 |
 | Live cadence | Mon–Fri 8:30 PM EST quick-battle X Space + YouTube | doc 1223 |
 | Launch date | May 2025 | doc 1252 |


### PR DESCRIPTION
Doc 1257 cited doc 1219 (Jun 2026 snapshot rates). Updates to Jul 2026 live API values.

**Changes:**
- Platform take rate: `3.16%` → `~3.3%` (17.44/524.15 = 3.33%)
- Artist payout rate: `1.79% of volume` → `~1.73% of volume` (9.07/524.15 = 1.73%)
- Source updated to `wavewarz.info/api/public/stats` (Jul 2026)

Note: The Jun 2026 rates (doc 1219) were measured on 484.46 SOL buy volume. The Jul 2026 rates are measured on 524.15 SOL. Both measurements are valid for their respective snapshots; this PR uses the current live values.

Source: `wavewarz.info/api/public/stats`, 2026-07-17T17:15Z.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>