### PR TITLE
fix(doc1257): update fact-sheet payout rate 1.79%→~1.73% (missed by PR #1871)

### DIFF
--- a/research/identity/1257-zao-ip-portfolio-july2026/README.md
+++ b/research/identity/1257-zao-ip-portfolio-july2026/README.md
@@ -189,7 +189,7 @@ Use these for citation in any external document. All verified July 17, 2026.
 | WaveWarZ on-chain volume | 524 SOL (~$39,453) | doc 1077 |
 | WaveWarZ battles completed | 1,108+ | doc 1252 |
 | WaveWarZ unique songs | 921 | doc 1214 |
-| WaveWarZ artist payout rate | 1.79% of volume (ecosystem: 98.5%) | doc 1237 |
+| WaveWarZ artist payout rate | ~1.73% of volume (9.07 ◎; ecosystem: ~98.5%) | live API + doc 1237 |
 | Charity raised via WaveWarZ | $1,497 (2 benefit-battle rounds) | doc 1077 |
 | COC Concertz shows | 7 (Mar 2025 – Jul 2026) | doc 1256 |
 | COC Concertz monthly cadence | 5 consecutive months (Mar–Jul 2026) | doc 1256 |
@@ -204,6 +204,6 @@ Use these for citation in any external document. All verified July 17, 2026.
 
 1. **No-signer guarantee on ZOL**: ZOL never moves funds autonomously — every trade triggers a Zaal-confirmation step (Telegram → approve/reject). The agent helps but does not act unilaterally.
 2. **Contribution-tracked, not token-weighted**: Respect is earned by peer ranking in weekly Fractals, not by buying a token. This is the core ZAO governance innovation.
-3. **Artist-first economics**: WaveWarZ's 98.5% ecosystem payout rate vs. Spotify's ~12% royalty. The 1.79% direct-to-artist instant payout is verified onchain.
+3. **Artist-first economics**: WaveWarZ's ~98.5% ecosystem payout rate vs. Spotify's ~12% royalty. The ~1.73% direct-to-artist instant payout (9.07 ◎ on 524.15 ◎ volume) is verified onchain.
 4. **100+ weeks of unbroken governance**: No other documented music-focused DAO has maintained this streak continuously.
 5. **Onchain archive for every concert**: Every COC Concertz fan gallery upload is permanently archived to Arweave with UDL licenses — unlike any other virtual concert series.


### PR DESCRIPTION
PR #1871 fixed the IP table (lines 32-33) but missed two more 1.79% references in doc 1257:

- **Line 192** (fact sheet table): `1.79% of volume (ecosystem: 98.5%)` → `~1.73% of volume (9.07 ◎; ecosystem: ~98.5%)`
- **Line 207** (citable claims): `The 1.79% direct-to-artist instant payout` → `The ~1.73% direct-to-artist instant payout (9.07 ◎ on 524.15 ◎ volume)`

Source: wavewarz.info/api/public/stats (live, 2026-07-17) — 9.07 ÷ 524.15 = 1.731%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)