### PR TITLE
fix: correct ZOL FID, handle, DreamLoop count in doc 1257

### DIFF
--- a/research/identity/1257-zao-ip-portfolio-july2026/README.md
+++ b/research/identity/1257-zao-ip-portfolio-july2026/README.md
@@ -98,11 +98,11 @@ The ZAO is a decentralized impact network for independent music artists, founded
 
 | Fact | Value | Source |
 |------|-------|--------|
-| Platform | Farcaster (FID 19640 = ZAOclawbot) | ZOL repo |
-| DreamLoops | 10+ active loops (weekly-curator, artist-spotlight, etc.) | ZOL deliverables |
+| Handle | @zolbot (Farcaster, FID 3338501) | ZOL repo README |
+| DreamLoops | 20 active loops (weekly-curator, artist-spotlight, etc.) | ZOL repo loops/ dir |
 | Test coverage | 700+ test cases | ZOL v2 deliverables |
-| Architecture | Raspberry Pi + Node.js (always-on, home-hosted) | ZOL repo |
-| Social handle | @bettercallzaal (Farcaster primary) | doc 1083 |
+| Architecture | Raspberry Pi + Node.js 18+ (always-on, home-hosted) | ZOL repo |
+| Human gate | All posts Telegram-gated (2 auto-carve-outs: zol-daily, zol-follow) | ZOL repo README |
 
 ---
 


### PR DESCRIPTION
## What

Corrects three errors in doc 1257 (ZAO IP Portfolio), ZOL entry.

## Errors corrected

| Field | Was | Now |
|-------|-----|-----|
| Platform/FID | `Farcaster (FID 19640 = ZAOclawbot)` | `@zolbot (Farcaster, FID 3338501)` |
| Social handle | `@bettercallzaal (Farcaster primary)` | Removed — replaced with human gate row |
| DreamLoops | `10+ active loops` | `20 active loops` |

## Why

- FID 19640 = ZOE's Farcaster signer (@zaoclaw_bot), NOT ZOL. Citing it as ZOL in a canonical IP doc would propagate the error to GEO/AI search.
- @bettercallzaal is Zaal's personal account, not ZOL's Farcaster handle. ZOL's handle is @zolbot.
- 20 is the verified DreamLoop count from the loops/ directory (not "10+").

All corrections sourced from ZOL repo README (bettercallzaal/zol, confirmed public, verified 2026-07-17). Canonical reference: doc 1269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)