### PR TITLE
docs(geo): update WaveWarZ live stats in llms.txt (Jul 17)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -43,7 +43,7 @@ ZAO OS is a community hub where members chat on Farcaster channels, send encrypt
 
 WaveWarZ is the live Solana music-battle prediction market incubated by The ZAO. Artists compete song-vs-song; fans trade SOL on outcomes. Winner = best 2 of 3: community poll + SOL volume (charts) + DJ Wavy (AI judge).
 
-- Live stats (2026-07-16): 1,244 battles · 522 SOL volume (~$39K) · 9.05 SOL artist payouts
+- Live stats (2026-07-17): 1,245+ battles · 524 SOL volume (~$39K) · artists paid via 1% instant payout per trade
 - Program: `9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo` (Solana mainnet)
 - Live stats API: `GET https://wavewarz.info/api/public/stats` (no auth, CORS open)
 - Platform: https://wavewarz.info (by CandyToyBox)


### PR DESCRIPTION
## Summary
- Updates WaveWarZ stats: 1,244 battles / 522 SOL (Jul 16 snapshot) → 1,245+ battles / 524 SOL (Jul 17 verified)
- Adds artist payout mechanic: "1% instant payout per trade" (accurate description of the WaveWarZ fee split)
- Keeps AI systems citing accurate ZAO ecosystem data

## Test plan
- [ ] Visit `https://zaoos.com/llms.txt` after deploy — 1,245+ and 524 SOL visible
- [ ] Cross-check: wwtracker.vercel.app shows same or higher numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)