### PR TITLE
docs: ZAO founder + team profile for grants and press (doc 1288)

### DIFF
--- a/research/identity/1288-zao-founder-team-profile-jul2026/README.md
+++ b/research/identity/1288-zao-founder-team-profile-jul2026/README.md
@@ -1,0 +1,139 @@
+---
+topic: identity/founder
+type: FACT-SHEET
+status: verified
+created: 2026-07-17
+audience: grant reviewers, press, Optimism Atlas evaluators, event producers
+related-docs: 1273, 1278, 1282, 1287
+---
+
+# 1288 — The ZAO Founder + Team Profile (July 2026)
+
+> **Purpose:** Press-ready bio, verifiable credentials, and team snapshot for grant applications, media inquiries, and event programs. All claims checkable against public record.
+
+---
+
+## Founder: Zaal Panthaki
+
+**Role:** Co-Founder, The ZAO & WaveWarZ  
+**Location:** Maine, USA (Eastern US timezone)  
+**X:** @bettercallzaal  
+**Farcaster:** @bettercallzaal  
+**Twitch:** twitch.tv/bettercallzaal  
+
+### One-Sentence Bio
+
+Zaal Panthaki is the co-founder of The ZAO — a decentralized artist collective that built WaveWarZ, the first prediction-market music platform with instant onchain artist payouts, and has run Fractal governance on Optimism for 100+ consecutive weeks.
+
+### Short Bio (150 words — for grant applications)
+
+Zaal Panthaki is a builder, musician, and onchain community organizer. As co-founder of The ZAO, he has led the development of WaveWarZ (a music prediction market where fans bet on song battles and artists earn onchain royalties), ZABAL Games (a DAO incubator for 32+ music-tech builders), COC Concertz (a 7-show virtual concert series on Spatial.io), and ZAOstock (a planned outdoor music festival in Ellsworth, Maine). He has hosted The ZAO's Fractal governance sessions for 100+ consecutive weeks and maintains a daily build-in-public newsletter (400+ editions) on Paragraph.com. His work sits at the intersection of decentralized governance, music creator economics, and onchain community building. Based in Maine, he builds live — every commit, PR, and decision is publicly documented.
+
+### Press Bio (50 words — for event programs)
+
+Zaal Panthaki is co-founder of The ZAO — a decentralized artist collective building at the intersection of music and blockchain. He co-built WaveWarZ, runs ZAO Fractal governance weekly on Optimism, and hosts COC Concertz, a monthly virtual concert series with live onchain music battles.
+
+---
+
+## Track Record (Verifiable)
+
+| Achievement | Date | Verifiable At |
+|-------------|------|--------------|
+| WaveWarZ launched | August 2025 | wavewarz.info/api/public/stats |
+| 1,245 WaveWarZ battles | July 2026 | wavewarz.info/api/public/stats |
+| 524 SOL trading volume | July 2026 | wavewarz.info/api/public/stats |
+| $1,497 raised for charity (HuRya) | July 2026 | wavewarz.info/api/public/stats |
+| 921 unique songs battled | July 2026 | wavewarz.info/api/public/stats |
+| 100+ Fractal governance sessions | July 2026 | ZAO Discord, on-chain settlement |
+| 63 weeks on-chain Respect settlement | July 2026 | Blockscout (OG + ZOR contracts) |
+| 157 unique Respect holders | July 2026 | doc 1200 (on-chain verified) |
+| 400+ newsletter editions | July 2026 | paragraph.com/@thezao |
+| ZABAL Games: 32-person builder cohort | June 2026 | ZAOOS research/events/1259 |
+| COC Concertz: 7 shows (Mar 2025 – Jul 2026) | July 2026 | ZAOOS research/events/1256 |
+
+---
+
+## The ZAO Team Snapshot
+
+### Active Builders (Core)
+
+| Name | Role | Verifiable Context |
+|------|------|--------------------|
+| Zaal Panthaki | Co-Founder, Lead Dev | 1,459+ merged PRs to ZAOOS (18 weeks), daily newsletter |
+| Iman Fatima | Co-Founder, ZABAL Director | Leads ZABAL Games build-a-thon (32-person cohort) |
+
+### Community Contributors
+
+The ZAO operates without fixed salaries or traditional employment. Contribution is tracked via:
+- Fractal Respect token (on-chain, Optimism) — 157 unique holders
+- ZABAL token (Base ERC-20) — 351 holders
+- ZAOOS GitHub — public commit history, attribution by contributor
+
+### Agent Fleet (AI Collaborators)
+
+The ZAO deploys 4 active AI agents as "ZAO OS" contributors:
+
+| Agent | Role | Platform |
+|-------|------|---------|
+| ZOE | Community manager, Discord moderator | Discord + Letta |
+| ZOL | ZAO Onchain Listener — tracks on-chain events | Letta |
+| Hermes | Research + document librarian | Letta |
+| ZAO Devz | Code agent, PR generation | Claude Code |
+
+These agents are listed as co-authors on ZAOOS PRs and documented in doc 1272 (ZAO Agent Stack).
+
+---
+
+## Organizational Background
+
+**Founded:** 2023  
+**Structure:** Decentralized Autonomous Organization (DAO) — no traditional legal entity as primary operating vehicle  
+**Governance:** Weekly Fractal sessions on Discord, on-chain settlement via OREC (Optimism mainnet)  
+**Treasury:** Distributed Respect + ZABAL tokens; WaveWarZ platform fee (3%)  
+**Fiscal Sponsor:** Fractured Atlas (pending — application in progress as of July 2026)  
+
+### What "DAO" Means Here (for non-crypto reviewers)
+
+The ZAO is a member-owned collective where decisions are made via weekly democratic sessions rather than a CEO or board. Every member votes on priorities using a peer-ranking system (Fractal Democracy). Votes are recorded on the Optimism blockchain — publicly auditable, tamper-proof, and permanent. The ZAO earns revenue through WaveWarZ platform fees and directs a portion to charitable causes (e.g., $1,497 to HuRya).
+
+---
+
+## Why This Org Matters (North Star Framing)
+
+The ZAO is the only organization that has:
+
+1. **Built and operated a live music prediction market** (WaveWarZ — 1,245 battles, 524 SOL volume, instant artist payouts onchain)
+2. **Run continuous weekly Fractal DAO governance** (100+ sessions, 63 on-chain, only active OREC deployer on Optimism)
+3. **Built an open-source analytics platform** (wwtracker — MIT-licensed, free public API)
+4. **Incubated 32 music-tech builders** (ZABAL Games — June 2026 cohort complete)
+5. **Maintained a 400+ edition build-in-public newsletter** (Paragraph.com/@thezao — daily cadence)
+
+No other organization at the intersection of music and DAO governance has matched all five.
+
+---
+
+## Contact + Links
+
+| Channel | Address/URL |
+|---------|------------|
+| Email | zaalp99@gmail.com |
+| X (Twitter) | @bettercallzaal |
+| Farcaster | @bettercallzaal |
+| Newsletter | paragraph.com/@thezao |
+| WaveWarZ | wavewarz.info |
+| ZAOOS | github.com/bettercallzaal/ZAOOS |
+| wwtracker | github.com/bettercallzaal/wwtracker |
+| Twitch | twitch.tv/bettercallzaal |
+
+---
+
+## Cross-References
+
+| Doc | Relevance |
+|-----|-----------|
+| doc 1273 | ZAO Optimism contribution — governance numbers source |
+| doc 1278 | ZAO Citable Claims — all statistics sourced here |
+| doc 1282 | ZAO vs Artist DAOs — competitive differentiation |
+| doc 1287 | ZAO as Open Source Public Good — technical track record |
+| doc 1200 | Respect on-chain facts — Respect holder count verification |
+| doc 1202 | Fractal on-chain settlement history — 63 weeks verification |


### PR DESCRIPTION
## What

Doc 1288 — The ZAO Founder + Team Profile. Press-ready fact sheet for grant applications, media inquiries, and event programs.

## Contents

- **Founder bio** — 150-word grant version + 50-word event program version for Zaal Panthaki
- **Verifiable track record table** — 11 achievements with public verification URLs (wavewarz.info/api/public/stats, Blockscout, Paragraph.com, ZAOOS)
- **Team snapshot** — Zaal + Iman (human founders) + 4 AI agent fleet (ZOE, ZOL, Hermes, ZAO Devz)
- **Org background** — what "DAO" means for non-crypto grant reviewers, fiscal sponsorship status (Fractured Atlas pending)
- **5 North Star differentiators** — what no other music/DAO org has done simultaneously
- **Contact sheet** — all channels in one table

## Why

Fills a gap in the grant/press corpus: reviewers seeing WaveWarZ or ZAO for the first time need a credible "who built this" answer. Cross-refs docs 1273, 1278, 1282, 1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)