### PR TITLE
docs: ZAO grant + funding opportunities tracker (doc 1289)

### DIFF
--- a/research/business/1289-zao-grant-funding-tracker-jul2026/README.md
+++ b/research/business/1289-zao-grant-funding-tracker-jul2026/README.md
@@ -1,0 +1,130 @@
+---
+topic: business/grants
+type: TRACKER
+status: active
+created: 2026-07-17
+audience: Zaal + Iman (internal decision tracker)
+related-docs: 1277, 1278, 1285, 1287, 1288
+---
+
+# 1289 — ZAO + WaveWarZ Grant & Funding Opportunities (July 2026)
+
+> **For Zaal + Iman.** All known funding opportunities in one place. Status, deadlines, amounts, and next actions. Update after each submission.
+
+---
+
+## URGENT — Act This Week
+
+| Opportunity | Deadline | Amount | Status | Next Action |
+|-------------|----------|--------|--------|-------------|
+| **Artizen Project Submission** | Jul 18, 2026 (TODAY) | Variable (crowdfund + matching) | NOT SUBMITTED | doc 1277 has paste-ready copy. ~30 min at artizen.fund |
+| **Heart of Ellsworth Downtown Grant** | Jul 18, 2026 (TODAY) | $1K–$5K (est.) | NOT SUBMITTED | doc 1277 has paste-ready copy. Contact at heartofellsworth.org |
+| **Bank Consortium Sponsor Pitches** | Jul 18, 2026 (TODAY) | $500–$5K each | NOT SUBMITTED | doc 1277 has email templates for 4 banks. Send to: HarborBank, First National Bank, The First, Bangor Savings |
+| **ZAOstock City Permit Call** | Jul 20, 2026 | (non-monetary — permit) | NOT CALLED | doc 1285 has exact phone script. Call City Clerk Suzanne McLean: 207-667-2563 |
+
+---
+
+## HIGH PRIORITY — Act Before August 15
+
+| Opportunity | Deadline | Amount | Status | Next Action |
+|-------------|----------|--------|--------|-------------|
+| **Fractured Atlas Fiscal Sponsorship** | ASAP (unlocks Fisher) | (fiscal sponsor — no direct cash) | APPLICATION IN PROGRESS | Submit at fracturedatlas.org. doc 1266 has paste-ready copy. Blocks Fisher grant. |
+| **Fisher Foundation Grant** | Aug 15, 2026 | ~$10K–$25K (est.) | BLOCKED (needs Fractured Atlas first) | Zaal must find original Fisher email first. Then apply once Fractured Atlas approves. |
+
+---
+
+## ACTIVE — No Immediate Deadline
+
+| Opportunity | Window | Amount | Status | Next Action |
+|-------------|--------|--------|--------|-------------|
+| **Optimism Retro Funding (Atlas)** | Rolling — current round TBD | Variable (OP tokens) | DRAFT IN PROGRESS | doc 1209 has application draft. Requires Zaal to submit on Atlas. DECISION NEEDED. |
+| **Gitcoin Grants** | Next round TBD | Variable (crowdfund) | NOT STARTED | ZAO would qualify as a Public Good (open source analytics + governance). No deadline yet. |
+| **NEA Challenge America** | Annual (typically Jan-Feb) | Up to $10K | NOT STARTED | National Endowment for the Arts. Next deadline est. Feb 2027. Fiscal sponsor required (Fractured Atlas unblocks this). |
+| **Maine Arts Commission** | Annual | $2K–$15K | NOT STARTED | Requires Maine nonprofit or fiscal sponsor. Fractured Atlas unblocks. Check maine.gov/mainearts |
+
+---
+
+## BACKGROUND — Longer Lead Time
+
+| Opportunity | Notes | Amount | Status |
+|-------------|-------|--------|--------|
+| **NEFA (New England Foundation for the Arts)** | Regional arts funder. New England focus. ZAO in Maine qualifies. | $5K–$25K | Explore after Fractured Atlas |
+| **Mozilla Foundation** | Supports open-source/internet health projects. wwtracker open source angle. | $10K–$100K | Long lead — 6-12 months |
+| **Filecoin Foundation** | Supports decentralized web projects. ZAO's Arweave archive angle. | Variable | Explore Q4 2026 |
+| **Ethereum Foundation** | Small grants program. DAO/governance tooling angle. | $5K–$50K | Explore after Retro Funding |
+| **Optimism Foundation (regular grants)** | Separate from Retro Funding. Builders grants. | Variable | Review after Atlas submission |
+| **Web3 Foundation (Polkadot ecosystem)** | Less aligned but open. Low priority. | — | Deprioritize |
+
+---
+
+## Revenue (Non-Grant)
+
+| Source | Status | Monthly Est. | Notes |
+|--------|--------|-------------|-------|
+| WaveWarZ platform fee (3% of trades) | ACTIVE | Variable | 524 SOL total to date. ~$39K lifetime. ZAO gets 3% = ~$1,170 equivalent |
+| ZABAL token utility fees | NOT LIVE | — | Token exists (351 holders on Base) but fee mechanics not deployed |
+| COC Concertz tickets | NOT LIVE | — | Currently free/wallet-gated. Ticket sales possible for ZAOstock |
+| Newsletter paid subscribers | ACTIVE (small) | ~$78/mo | 78 paid supporters × ~$1/mo (Paragraph.com estimate) |
+| ZAOstock ticket sales | PLANNED | — | Festival TBD. Depends on permit + booking |
+| Consulting / client work (BCZ Strategies) | VARIABLE | — | Zaal's external consulting work, separate from ZAO |
+
+---
+
+## What Each Funder Needs to Know
+
+### For music/arts funders (Artizen, HoE, Fisher, NEA, NEFA)
+
+> ZAO is a decentralized artist collective that has run 100+ consecutive weekly governance sessions, built WaveWarZ (a music prediction market with instant artist payouts), and incubated 32 music-tech builders through ZABAL Games. ZAOstock is our first live music event — an outdoor festival in Ellsworth, Maine that will feature WaveWarZ artists performing and battling live for the first time.
+
+Key numbers: 1,245 battles, 921 songs, $1,497 raised for charity, 32 builders in cohort.
+
+### For tech/blockchain funders (Optimism, Ethereum, Gitcoin, Mozilla)
+
+> The ZAO operates the only active Fractal DAO on Optimism — 63 weeks of on-chain Respect settlement, 157 unique holders, 505 transactions. wwtracker is MIT-licensed open source analytics for WaveWarZ with a free public API. ZAOOS is a public research library (1,285+ documents). These are public goods that any DAO or music platform can use.
+
+Key numbers: 63 on-chain weeks, 157 Respect holders, MIT license, free API.
+
+### For all funders (credibility)
+
+> The team: Zaal Panthaki (co-founder, lead builder, 400+ build-in-public newsletter editions) and Iman Fatima (co-founder, ZABAL Games director, 32-person builder cohort). All work is publicly documented on GitHub. doc 1288 has full founder profiles.
+
+---
+
+## Submission Log
+
+| Date | Opportunity | Amount Requested | Outcome |
+|------|-------------|-----------------|---------|
+| (none yet) | — | — | — |
+
+*Update this table after each submission.*
+
+---
+
+## Key Assets for Applications
+
+| Asset | Where to Find |
+|-------|--------------|
+| Press-ready bio (Zaal) | doc 1288 |
+| Short bio (50w) | doc 1288 |
+| ZAO citable claims | doc 1278 |
+| WaveWarZ competitive landscape | doc 1279 |
+| Governance explainer (non-crypto) | doc 1280 |
+| Artizen pitch copy | doc 1277 |
+| Bank email templates | doc 1277 |
+| Fractured Atlas copy | doc 1266 |
+| Optimism Retro Funding draft | doc 1209 |
+| ZAOstock permit call script | doc 1285 |
+
+---
+
+## Cross-References
+
+| Doc | Relevance |
+|-----|-----------|
+| doc 1277 | ZAOstock Artizen + bank pitch pack (paste-ready copy for today's deadlines) |
+| doc 1278 | ZAO Citable Claims fact sheet |
+| doc 1285 | ZAOstock city permit call script |
+| doc 1287 | Open source public good (tech funder framing) |
+| doc 1288 | Founder + team profiles (credibility section) |
+| doc 1209 | Optimism Retro Funding draft application |
+| doc 1266 | Fractured Atlas paste-ready application copy |


### PR DESCRIPTION
## What

Doc 1289 — ZAO + WaveWarZ Grant & Funding Opportunities tracker for July 2026.

## Contents

- **Urgent table** — Artizen (Jul 18), HoE (Jul 18), bank pitches (Jul 18), permit call (Jul 20)
- **High priority** — Fractured Atlas (ASAP) + Fisher grant (Aug 15)
- **Active (no deadline)** — Optimism Retro Funding, Gitcoin
- **Background** — NEFA, Mozilla, Filecoin, Ethereum Foundation, Optimism Foundation
- **Revenue table** — WaveWarZ 3% fee, ZABAL, newsletter, ZAOstock tickets
- **Per-funder talking points** — arts/music funders vs tech/blockchain funders vs general credibility
- **Submission log** — blank table to fill in after each submission
- **Asset map** — links to paste-ready application docs (1266, 1277, 1278, 1285, 1288, 1209)

## Why

All grant threads were scattered across docs 1209, 1266, 1277, 1285. This consolidates them into one decision-ready tracker Zaal + Iman can work from without reading 5 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)