### PR TITLE
feat(bot): /board command — Telegram Mini App web_app button

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -25,3 +25,8 @@ BONFIRE_API_URL=https://tnt-v2.api.bonfires.ai   # optional, this is the default
 # orchestrator is running. Turn ON ONLY when no terminal orchestrator is active.
 ZOE_ORCHESTRATOR_ENABLED=false   # set to 'true' to enable VPS cron tick
 ZOE_ORCHESTRATOR_DAILY=20        # max questions to post per UTC day (prevents runaway)
+
+# ZOE Telegram Mini App board (bot/src/miniapp.ts).
+# When set, /board sends an inline Web App button (opens thezao.xyz/board/mini inside Telegram).
+# Absent => /board replies with a plain text link to the full board instead.
+BOARD_MINI_URL=https://thezao.xyz/board/mini

--- a/bot/src/__tests__/miniapp.test.ts
+++ b/bot/src/__tests__/miniapp.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InlineKeyboard } from 'grammy';
+import type { Context } from 'grammy';
+
+import { cmdBoard } from '../miniapp';
+
+function makeCtx(): { ctx: Context; reply: ReturnType<typeof vi.fn> } {
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const ctx = { reply } as unknown as Context;
+  return { ctx, reply };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.BOARD_MINI_URL;
+});
+
+// ── BOARD_MINI_URL unset ──────────────────────────────────────────────────────
+
+describe('cmdBoard — BOARD_MINI_URL not set', () => {
+  it('replies with a plain text fallback link', async () => {
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    expect(reply).toHaveBeenCalledOnce();
+    const [text] = reply.mock.calls[0];
+    expect(text).toContain('thezao.xyz/board');
+    expect(text).not.toContain('BOARD_MINI_URL'); // instruction string shouldn't leak
+  });
+
+  it('does not include reply_markup in the fallback reply', async () => {
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const args = reply.mock.calls[0];
+    // fallback is a text-only reply — no second options arg with reply_markup
+    expect(args.length).toBe(1);
+  });
+
+  it('treats an empty BOARD_MINI_URL as unset (falls back to plain text)', async () => {
+    process.env.BOARD_MINI_URL = '';
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const args = reply.mock.calls[0];
+    expect(args.length).toBe(1);
+  });
+
+  it('treats a whitespace-only BOARD_MINI_URL as unset', async () => {
+    process.env.BOARD_MINI_URL = '   ';
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const args = reply.mock.calls[0];
+    expect(args.length).toBe(1);
+  });
+});
+
+// ── BOARD_MINI_URL set ────────────────────────────────────────────────────────
+
+describe('cmdBoard — BOARD_MINI_URL set', () => {
+  const TEST_URL = 'https://thezao.xyz/board/mini';
+
+  beforeEach(() => {
+    process.env.BOARD_MINI_URL = TEST_URL;
+  });
+
+  it('replies with an InlineKeyboard containing a webApp button', async () => {
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    expect(reply).toHaveBeenCalledOnce();
+    const [, opts] = reply.mock.calls[0];
+    expect(opts).toBeDefined();
+    expect(opts.reply_markup).toBeInstanceOf(InlineKeyboard);
+  });
+
+  it('webApp button url matches BOARD_MINI_URL', async () => {
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const [, opts] = reply.mock.calls[0];
+    const kb = opts.reply_markup as InlineKeyboard;
+    const rows = kb.inline_keyboard;
+    expect(rows.length).toBeGreaterThan(0);
+    const firstBtn = rows[0]?.[0];
+    expect(firstBtn).toMatchObject({ web_app: { url: TEST_URL } });
+  });
+
+  it('webApp button label is "Open Board"', async () => {
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const [, opts] = reply.mock.calls[0];
+    const kb = opts.reply_markup as InlineKeyboard;
+    const firstBtn = kb.inline_keyboard[0]?.[0];
+    expect(firstBtn?.text).toBe('Open Board');
+  });
+
+  it('reply text mentions the board', async () => {
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const [text] = reply.mock.calls[0];
+    expect(text).toContain('Board');
+  });
+
+  it('trims leading/trailing whitespace from BOARD_MINI_URL', async () => {
+    process.env.BOARD_MINI_URL = `  ${TEST_URL}  `;
+    const { ctx, reply } = makeCtx();
+    await cmdBoard(ctx);
+    const [, opts] = reply.mock.calls[0];
+    const kb = opts.reply_markup as InlineKeyboard;
+    const firstBtn = kb.inline_keyboard[0]?.[0];
+    expect(firstBtn).toMatchObject({ web_app: { url: TEST_URL } });
+  });
+});

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -29,6 +29,7 @@ import {
   cmdCoordinators,
   cmdCharter,
 } from './circles';
+import { cmdBoard } from './miniapp';
 
 const token = process.env.ZAOSTOCK_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
 if (!token) {
@@ -528,6 +529,10 @@ bot.command('coordinators', async (ctx) => {
 bot.command('charter', async (ctx) => {
   const slug = (ctx.match ?? '').trim();
   await cmdCharter(ctx, slug || undefined);
+});
+
+bot.command('board', async (ctx) => {
+  await cmdBoard(ctx);
 });
 
 // ---- Free-text + @mention handler ------------------------------------------

--- a/bot/src/miniapp.ts
+++ b/bot/src/miniapp.ts
@@ -1,0 +1,18 @@
+import { type Context, InlineKeyboard } from 'grammy';
+
+function getBoardUrl(): string | null {
+  const url = process.env.BOARD_MINI_URL;
+  return url && url.trim() ? url.trim() : null;
+}
+
+export async function cmdBoard(ctx: Context): Promise<void> {
+  const url = getBoardUrl();
+  if (!url) {
+    await ctx.reply('ZAO Cowork Board: https://thezao.xyz/board');
+    return;
+  }
+  const kb = new InlineKeyboard().webApp('Open Board', url);
+  await ctx.reply('ZAO Cowork Board — tap to open inside Telegram:', {
+    reply_markup: kb,
+  });
+}


### PR DESCRIPTION
## What

Adds `/board` command to ZOE bot. When `BOARD_MINI_URL` is set, sends an `InlineKeyboard.webApp()` button so the cowork board opens **inside Telegram** (no browser redirect). Falls back to a plain text link when the env var is absent.

## Files changed

- `bot/src/miniapp.ts` — `cmdBoard()` function (new)
- `bot/src/index.ts` — `import { cmdBoard }` + `bot.command('board', …)`
- `bot/.env.example` — documents `BOARD_MINI_URL=https://thezao.xyz/board/mini`
- `bot/src/__tests__/miniapp.test.ts` — 9 unit tests (both paths)

## Design

Per research doc 1317 (PR #1954). The cowork-side PR (Next.js page `/board/mini` + `/api/tg/auth` HMAC endpoint) is tracked separately.

## Deploy

After merge: add `BOARD_MINI_URL=https://thezao.xyz/board/mini` to VPS `.env` and restart `zaostock-bot.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)