### PR TITLE
test(discord): 11 unit tests for chunkMessage + fix 2 pre-existing test failures

### DIFF
--- a/bot/src/zoe/__tests__/discord.test.ts
+++ b/bot/src/zoe/__tests__/discord.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+// Tests for chunkMessage — the Discord message chunker in discord.ts.
+// No Discord client or env needed: function is purely functional (string in → string[] out).
+import { vi } from 'vitest';
+
+// discord.js and dotenv must be mocked before the import so the module loads
+// without a real Discord token or fs dependency.
+vi.mock('discord.js', () => ({
+  Client: vi.fn(),
+  GatewayIntentBits: { MessageContent: 1, GuildMessages: 2, DirectMessages: 4 },
+  ChannelType: { DM: 1, GuildText: 0 },
+  EmbedBuilder: vi.fn().mockReturnValue({ setDescription: vi.fn().mockReturnThis(), toJSON: vi.fn().mockReturnValue({}) }),
+}));
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+vi.mock('../concierge', () => ({ runConciergeTurn: vi.fn() }));
+vi.mock('../memory', () => ({ buildMemoryBlocks: vi.fn(), ensureZoeHome: vi.fn() }));
+
+import { test, describe } from 'vitest';
+import assert from 'node:assert/strict';
+import { chunkMessage } from '../discord.ts';
+
+const SHORT = 'hello world';
+const MAX = 1990; // DISCORD_MAX
+
+// ===========================
+// chunkMessage
+// ===========================
+
+describe('chunkMessage — short messages', () => {
+  test('returns single-element array for message at limit', () => {
+    const text = 'x'.repeat(MAX);
+    const chunks = chunkMessage(text);
+    assert.deepEqual(chunks, [text]);
+  });
+
+  test('returns single-element array for message under limit', () => {
+    const chunks = chunkMessage(SHORT);
+    assert.deepEqual(chunks, [SHORT]);
+  });
+
+  test('returns single-element array for empty string', () => {
+    const chunks = chunkMessage('');
+    assert.deepEqual(chunks, ['']);
+  });
+});
+
+describe('chunkMessage — paragraph boundary preference', () => {
+  test('splits on double newline when available near the limit', () => {
+    const part1 = 'a'.repeat(800);
+    const part2 = 'b'.repeat(800);
+    const text = part1 + '\n\n' + part2;
+    const chunks = chunkMessage(text, 1000);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0], part1);
+    assert.equal(chunks[1], part2);
+  });
+
+  test('no trailing whitespace on any chunk', () => {
+    const part1 = 'a'.repeat(800);
+    const part2 = 'b'.repeat(800);
+    const text = part1 + '\n\n' + part2;
+    const chunks = chunkMessage(text, 1000);
+    for (const chunk of chunks) {
+      assert.equal(chunk, chunk.trimEnd(), 'chunk has trailing whitespace');
+    }
+  });
+});
+
+describe('chunkMessage — single newline fallback', () => {
+  test('splits on single newline when no double newline is near limit', () => {
+    const part1 = 'a'.repeat(800);
+    const part2 = 'b'.repeat(800);
+    // no double-newline — only single
+    const text = part1 + '\n' + part2;
+    const chunks = chunkMessage(text, 1000);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0], part1);
+  });
+});
+
+describe('chunkMessage — space fallback', () => {
+  test('splits on space when no newlines are near limit', () => {
+    const words = Array.from({ length: 4 }, (_, i) => 'w' + 'o'.repeat(400) + i);
+    const text = words.join(' ');
+    const chunks = chunkMessage(text, 500);
+    assert.ok(chunks.length > 1, 'expected more than 1 chunk');
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= 500, `chunk too long: ${chunk.length}`);
+    }
+  });
+});
+
+describe('chunkMessage — hard cut fallback', () => {
+  test('hard-cuts when no boundary is found in first half of max', () => {
+    // one long word with no whitespace or newlines — forces hard cut
+    const text = 'x'.repeat(3000);
+    const chunks = chunkMessage(text, 1000);
+    assert.ok(chunks.length >= 3, 'expected at least 3 chunks for 3000-char string with max 1000');
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= 1000, `chunk too long: ${chunk.length}`);
+    }
+  });
+});
+
+describe('chunkMessage — custom max', () => {
+  test('respects custom max parameter', () => {
+    const text = 'hello world goodbye world';
+    const chunks = chunkMessage(text, 12);
+    assert.ok(chunks.length > 1);
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= 12, `chunk too long: ${chunk.length}`);
+    }
+  });
+
+  test('no chunk exceeds the default DISCORD_MAX', () => {
+    const text = ('paragraph content here\n\n').repeat(100);
+    const chunks = chunkMessage(text);
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= MAX, `chunk too long: ${chunk.length}`);
+    }
+  });
+});
+
+describe('chunkMessage — content preservation', () => {
+  test('all content is present across chunks (no data loss)', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `Section ${i}: ${'x'.repeat(300)}`).join('\n\n');
+    const chunks = chunkMessage(text, 1000);
+    const rejoined = chunks.join('');
+    // After chunking, trimEnd + trimStart removes the boundary whitespace
+    assert.ok(rejoined.replace(/\s+/g, ' ').length >= text.replace(/\s+/g, ' ').length * 0.98, 'too much content lost');
+  });
+});

--- a/bot/src/zoe/__tests__/telegram-routing.test.ts
+++ b/bot/src/zoe/__tests__/telegram-routing.test.ts
@@ -14,7 +14,7 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, 'What should I do?', { kind: 'question' });
 
-      expect(sendMessage).toHaveBeenCalledWith(123, 'What should I do?');
+      expect(sendMessage).toHaveBeenCalledWith(123, 'What should I do?', {});
       expect(sendMessage).toHaveBeenCalledTimes(1);
     });
 
@@ -69,7 +69,7 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, 'Status message', { kind: 'status' });
 
-      expect(sendMessage).toHaveBeenCalledWith(123, 'Status message');
+      expect(sendMessage).toHaveBeenCalledWith(123, 'Status message', {});
     });
 
     it('questions always go to DM even if group is configured', async () => {
@@ -82,7 +82,7 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, 'What do you think?', { kind: 'question' });
 
-      expect(sendMessage).toHaveBeenCalledWith(123, 'What do you think?');
+      expect(sendMessage).toHaveBeenCalledWith(123, 'What do you think?', {});
     });
   });
 

--- a/bot/src/zoe/discord.ts
+++ b/bot/src/zoe/discord.ts
@@ -33,7 +33,7 @@ const DISCORD_MAX = 1990;
  * Split a long string into Discord-sized chunks, preferring paragraph then
  * line then word boundaries. Falls back to a hard cut if no boundary is found.
  */
-function chunkMessage(text: string, max = DISCORD_MAX): string[] {
+export function chunkMessage(text: string, max = DISCORD_MAX): string[] {
   if (text.length <= max) return [text];
   const chunks: string[] = [];
   let remaining = text;

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -95,14 +95,16 @@ export function constructRoutingDeps(sendMessageImpl: TelegramRoutingDeps['sendM
   }
 
   const groupIdRaw = process.env.ZAALBOTS_GROUP_CHAT_ID;
-  const groupId = groupIdRaw ? Number(groupIdRaw) : undefined;
-  if (groupIdRaw && Number.isNaN(groupId)) {
+  const groupIdParsed = groupIdRaw ? Number(groupIdRaw) : undefined;
+  const groupId = Number.isNaN(groupIdParsed) ? undefined : groupIdParsed;
+  if (groupIdRaw && Number.isNaN(groupIdParsed)) {
     console.warn(`Invalid ZAALBOTS_GROUP_CHAT_ID: ${groupIdRaw} (must be a number, will be ignored)`);
   }
 
   const threadIdRaw = process.env.ZAALBOTS_STATUS_THREAD_ID;
-  const threadId = threadIdRaw ? Number(threadIdRaw) : undefined;
-  if (threadIdRaw && Number.isNaN(threadId)) {
+  const threadIdParsed = threadIdRaw ? Number(threadIdRaw) : undefined;
+  const threadId = Number.isNaN(threadIdParsed) ? undefined : threadIdParsed;
+  if (threadIdRaw && Number.isNaN(threadIdParsed)) {
     console.warn(`Invalid ZAALBOTS_STATUS_THREAD_ID: ${threadIdRaw} (must be a number, will be ignored)`);
   }
 


### PR DESCRIPTION
## Summary

- Exports `chunkMessage` from `discord.ts` and adds 11 unit tests covering all branching logic
- Fixes 2 pre-existing bugs found while running the full test suite

## Tests added (discord.test.ts, 11 cases)

`chunkMessage` splits long Discord messages at paragraph → line → word → hard-cut boundaries:
- Short / at-limit / empty strings → single-element array
- Paragraph boundary (`\n\n`) preferred when found in the first half
- Single newline fallback when no double-newline is near the limit
- Space fallback for text without newlines
- Hard cut for unbreakable strings (no whitespace)
- Custom `max` parameter respected
- Content preserved across chunks (no data loss)

## Pre-existing bugs fixed

1. **`telegram-routing.ts` NaN leak** — `constructRoutingDeps()` returned `NaN` for `groupId` when `ZAALBOTS_GROUP_CHAT_ID` was set to a non-numeric string. Now returns `undefined` (the documented behavior). Same fix applied to `threadId`.

2. **`telegram-routing.test.ts` stale assertions** — PR #1533 updated `sendToZaal()` to always pass 3 args to `sendMessage()`, but 3 of the existing tests still expected 2-arg calls. Synced assertions to match the current source.

## Test plan

- [x] `npx vitest run src/zoe/__tests__/discord.test.ts` → 11/11 pass
- [x] `npx vitest run src/zoe/__tests__/telegram-routing.test.ts` → 10/10 pass (was 7/10 before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)