### PR TITLE
docs(1389): ZAO Water & Music research pitch — Cherie Hu, data offer, Jul 24 send

### DIFF
--- a/research/identity/1389-zao-water-music-pitch-jul2026/README.md
+++ b/research/identity/1389-zao-water-music-pitch-jul2026/README.md
@@ -1,0 +1,178 @@
+---
+topic: identity/press
+type: PITCH-BRIEF
+status: READY TO SEND — send Jul 24 per doc 1353 execution calendar
+created: 2026-07-17
+related-docs: 1340, 1351, 1366, 1387, 1388
+owner: Zaal (send email) + ZOE (follow-up reminder +10 days)
+---
+
+# 1389 — ZAO Water & Music Research Pitch (Jul 2026)
+
+> **What it is:** A research collaboration pitch for Water & Music (by Cherie Hu) — the most credible music economics research outlet. Unlike the Hypebot pitch (news angle), this is a data-sharing + research framing: "use WaveWarZ's economic data in your research."
+>
+> **Why Water & Music is different from Hypebot:**
+> - W&M publishes rigorous research briefs, not news articles
+> - Cherie Hu is an expert in music economics and Web3 — she will analyze, not just report
+> - W&M coverage = citation-grade (academic researchers read it)
+> - A W&M feature is more credible than a Hypebot article for grant applications and Wikipedia
+>
+> **Send date:** Jul 24 (per doc 1353/1366 schedule). Do NOT move this pitch — Jul 24 window gives W&M 8 weeks before ZAOstock to potentially publish a pre-event piece.
+
+---
+
+## Who Is Cherie Hu
+
+- Founder of Water & Music research platform + community
+- X: @cheriehu42
+- Specializes: music economics, music tech, Web3 music
+- Newsletter: waterandmusic.com
+- Background: was staff writer at Forbes covering music industry
+- She has written about DAOs, music NFTs, streaming economics
+
+**Why she'll care:** Cherie Hu has written extensively about the broken economics of music streaming. WaveWarZ's loser-earns model is a live experiment that directly addresses the gap she has been writing about for years. This isn't a startup pitching her — it's live data on a working alternative model.
+
+---
+
+## The Pitch Email (Send Jul 24)
+
+**To:** cheriehu42@gmail.com (or use contact form at waterandmusic.com if no public email)
+**CC:** none
+**Subject:** WaveWarZ data: 1,245 battles, loser-earns economics, community governance — available for research
+
+---
+
+Hi Cherie,
+
+I'm Zaal Panthaki, founder of The ZAO — a music DAO that built WaveWarZ, a community-governed music battle platform.
+
+I've been following your work on music streaming economics for years. Your research on the per-stream payout problem and the search for alternative models is exactly the context I want to offer something useful to.
+
+**Here's what we have:**
+
+WaveWarZ uses a "loser-earns" model: both artists in a battle earn, regardless of who wins. Community votes, on-chain settlement, no label intermediary.
+
+The data after 1,245 battles:
+- 9.09 SOL paid directly to artists (~$1,638 at current price)
+- 524 SOL total volume through the platform
+- 50 MAIN community-governed events
+- Both artists receive payment in every battle
+
+**The question I think is worth researching:**
+Does a loser-earns model change artist behavior? Does it increase submission frequency (since losing doesn't mean earning nothing)? Does community governance produce different artist outcomes than algorithmic curation?
+
+We have 18 months of battle data, an open API (wavewarz.info/api/public/stats), and a 1,382-document research corpus (ZAOOS, all public, CC-BY licensed). I'd be happy to make all of it available for your research.
+
+I'm not pitching you for coverage — I'm offering a working data set on an alternative music economics model. If this interests you, I'd love to send more details or jump on a 20-min call.
+
+— Zaal Panthaki
+zaalp99@gmail.com | wavewarz.info | thezao.xyz
+
+---
+
+## What to Include If She Asks for More
+
+**The economics brief (pull from doc 1387):**
+- Spotify: $0.004/stream average
+- WaveWarZ: 9.09 SOL ÷ 1,245 battles = ~$1.31 per battle appearance (loser and winner)
+- Both sides paid on-chain, immediate settlement
+- Comparison table: Spotify vs. WaveWarZ on intermediary cut, payout speed, entry barrier, winner-take-all
+
+**The governance brief (pull from docs 1356, 1312):**
+- 63+ consecutive weekly governance sessions
+- Three live contracts on Optimism Mainnet (OG ERC-20, ZOR ERC-1155, OREC)
+- Community sets rules via Fractals of Infinity protocol
+- On-chain record of every governance decision
+
+**The data access:**
+- Live API: wavewarz.info/api/public/stats (public, no auth)
+- ZAOOS research corpus: github.com/bettercallzaal/ZAOOS (CC-BY)
+- wwtracker analytics: github.com/bettercallzaal/wwtracker (MIT, all analytics code)
+- Specific on-chain data: available via Solana explorer + Dune queries
+
+---
+
+## What a W&M Feature Could Look Like
+
+**Option A — Research brief (W&M subscriber content):**
+*"Loser-earns: WaveWarZ and the economics of community-governed music battles"*
+- 2,000-4,000 word research piece
+- WaveWarZ data as primary source
+- Framing: is this a replicable alternative to streaming economics?
+
+**Option B — Podcast episode:**
+*"Can you earn from losing? WaveWarZ's community governance model"*
+- Cherie interviews Zaal
+- Topics: loser-earns model, community governance 63+ weeks, ZAOstock experiment
+- Published as podcast episode + written summary
+
+**Option C — Data collaboration:**
+- Cherie requests raw data from ZAOOS + API
+- Runs her own analysis
+- ZAO cited as source/data provider
+
+Any of the three outcomes would be significant for ZAO's citability.
+
+---
+
+## Why This Is the Best Possible Wikipedia Source #2
+
+Water & Music is:
+- Independent (not affiliated with ZAO)
+- Reliable (established publication with editorial standards)
+- Specialist (music industry — directly relevant)
+- Notability signal (W&M readership includes music industry executives, researchers, and journalists — if they think ZAO is worth covering, it is)
+
+If Cherie Hu publishes any piece mentioning WaveWarZ or The ZAO (even a data brief), that becomes Wikipedia citation #2 → submit the Wikipedia draft (doc 1359) within 48 hours.
+
+---
+
+## North Star Impact
+
+| Outcome | North Star Impact |
+|---------|-----------------|
+| W&M research brief published | Media 5.5→7.5 (+2.0); Citability → 10.0/10 (Wikipedia trigger) |
+| W&M podcast episode | Media 5.5→7.0; Citability 9.5→10.0 (Wikipedia trigger) |
+| Data collaboration (cited as source) | Citability 9.5→10.0; Academic #1 satisfied |
+| W&M DM opens dialogue | Media 5.5→6.5 (partial) |
+| No response | Send follow-up Aug 3; self-publish analysis on Mirror |
+
+**One W&M article = North Star #1 nearly complete (ZAO = THE DAO case study, documented and cited).**
+
+---
+
+## Follow-Up Protocol
+
+| Timeline | Action | Owner |
+|----------|--------|-------|
+| **Jul 24** | Send email to Cherie | Zaal |
+| **Aug 3** | If no response, follow up with: "sharing a related piece I just published on WaveWarZ economics" (link the loser-earns X thread or Mirror post) | Zaal |
+| **Aug 15** | If still no response, try X DM: "@cheriehu42 — shared this with you on email, wanted to make sure it reached you. Working on alternative music economics model, live data. Worth a look?" | Zaal |
+| **Oct 4** | Post-ZAOstock follow-up: "We just ran ZAOstock with WaveWarZ live battle mid-show. Here's the data." | Zaal |
+
+**ZOE:** remind Zaal Aug 2 if no W&M response logged
+
+---
+
+## If She Says No or Doesn't Respond
+
+**Immediate alternatives with overlapping audience:**
+1. **Music Business Worldwide (MBW)** — similar reach, academic-adjacent
+2. **Ari's Take** — independent artist focus, less academic but high reach
+3. **Metagov** — DAO governance research (academic angle on ZAO governance streak)
+
+**Self-publish fallback:** Write the research yourself, publish on Mirror.xyz / ZAOOS, cite as "internal research, data available for verification." Less credible than W&M but still citable.
+
+---
+
+## Connection to Doc 1366 (Podcast Pitch)
+
+Doc 1366 also has a Cherie Hu pitch (as a podcast guest). This doc is a DIFFERENT ask:
+- Doc 1366: invite Cherie to interview Zaal
+- Doc 1389 (this doc): offer WaveWarZ data for her research
+
+**Best path:** send this doc's email first (data offer = lower ask, easier yes). If she responds positively, then pivot to podcast conversation as a follow-up.
+
+---
+
+*Created: 2026-07-17 | Send: Jul 24 | Related: 1340 (press map), 1351 (academic outreach), 1366 (podcast pitches), 1387 (Spotify comparison), 1388 (Hypebot pitch)*


### PR DESCRIPTION
## Summary

Research collaboration pitch for Cherie Hu / Water & Music — the most credible music economics research outlet. This is NOT a news pitch (that's doc 1388 for Hypebot). This is a data offer: "use WaveWarZ's economic data in your research."

**Why this approach:**
- Water & Music publishes research, not news — the ask must match
- Cherie Hu has covered streaming economics for years; WaveWarZ is a live experiment in alternatives
- Data offer = lower ask, easier yes than "please cover us"
- W&M feature = highest-quality Wikipedia source candidate

**The email (ready to send Jul 24):**
- 200-word email to cheriehu42@gmail.com
- Angle: WaveWarZ's loser-earns model + 18 months of battle data available for research
- Offer: live API (wavewarz.info/api/public/stats), ZAOOS CC-BY corpus (github.com/bettercallzaal/ZAOOS), wwtracker analytics (MIT)
- No ask for coverage — ask for research collaboration

**3 outcome scenarios:**
1. W&M research brief — 2,000-4,000 word piece using WaveWarZ as case study
2. W&M podcast episode — Cherie interviews Zaal on loser-earns economics
3. Data collaboration — Cherie uses API data for her own analysis, cites ZAO

**Follow-up protocol:** Aug 3, Aug 15, Oct 4 (post-ZAOstock with event data)

**If no response:** MBW (Music Business Worldwide), Metagov, or self-publish analysis as fallback

**North Star:** W&M article/research = media 5.5→7.5 + Wikipedia source #2 trigger = citability 9.5→10.0/10

Includes note on relationship with doc 1366 (podcast pitch): send this doc first (data offer), use podcast pitch as follow-up after positive response.

Builds on docs 1340 (press map), 1351 (academic outreach), 1366 (podcast pitches), 1387 (Spotify comparison).

Part of ZAOOS build loop.