### PR TITLE
docs(1392): ZABAL S2 application form — 2 tracks, screening criteria, Jul 31 setup deadline

### DIFF
--- a/research/identity/1392-zabal-s2-application-form-aug2026/README.md
+++ b/research/identity/1392-zabal-s2-application-form-aug2026/README.md
@@ -1,0 +1,248 @@
+---
+topic: identity/zabal
+type: TEMPLATE
+status: ACTIVE — set up application form by Jul 31; open Aug 1
+created: 2026-07-17
+related-docs: 1355, 1259, 1283
+owner: Zaal (setup) + ZOE (promote Aug 1) + Iman (review applications)
+---
+
+# 1392 — ZABAL Season 2 Application Form (Aug 2026)
+
+> **What it is:** The complete application form structure for ZABAL Games Season 2, plus screening criteria and ZOE automation for managing applications. Set up by Jul 31; applications open Aug 1.
+>
+> **ZABAL S2 format (from doc 1355):** Sep 1 – Nov 30, 2026. 20 participants (10 builders + 10 musicians). Builder track = Web3/music tools. Musician track = WaveWarZ + onchain presence. Finals: Nov 17.
+
+---
+
+## Application Form Structure
+
+**Platform:** Google Form (simplest) or Typeform (better UX). Create one form with a track selector.
+
+**Form title:** "ZABAL Season 2 Application — Sep 1–Nov 30, 2026"
+
+---
+
+### Section 1 — Who You Are
+
+**Q1. Your name (as you want to appear in ZABAL)** [Short text]
+
+**Q2. Your X (Twitter) handle** [Short text, optional]
+- *Help text: If you don't have X, no problem.*
+
+**Q3. Your Farcaster handle** [Short text, optional]
+- *Help text: FID or handle. If you don't have Farcaster, we'll help you set it up.*
+
+**Q4. Your email address** [Email, required]
+
+**Q5. Which track are you applying for?** [Multiple choice — required]
+- Builder Track (you build tools, apps, or infrastructure for music/Web3)
+- Musician Track (you make music and want to level up your onchain presence)
+- Interested in both (we'll place you where you fit best)
+
+---
+
+### Section 2 — Builder Track (show only if Builder Track selected)
+
+**Q6. What are you building?** [Long text, 100-300 words]
+- *Help text: Describe the tool, app, or project you're working on. It doesn't have to be finished — ZABAL is for works in progress.*
+
+**Q7. GitHub profile or project link** [URL, optional]
+- *Help text: Any public code or demo you want us to see.*
+
+**Q8. What problem does your project solve for music artists or the Web3 music ecosystem?** [Long text]
+- *Help text: Explain as simply as possible. No jargon required.*
+
+**Q9. What do you want to ship during ZABAL S2 (Sep–Nov)?** [Long text]
+- *Help text: Be specific. "A working API endpoint" beats "a whole app." We celebrate incremental progress.*
+
+**Q10. Have you participated in ZABAL before?** [Multiple choice]
+- Yes — ZABAL S1
+- No, first time
+- I've attended ZAO events but not ZABAL
+
+---
+
+### Section 3 — Musician Track (show only if Musician Track selected)
+
+**Q6M. Where do people hear your music?** [Long text]
+- *Help text: Links to your Audius, Spotify, SoundCloud, YouTube, or wherever. At least one link required.*
+
+**Q7M. Have you ever done a WaveWarZ battle?** [Multiple choice]
+- Yes — [specify how many: first time / 1-5 times / 6+ times]
+- No — not yet
+- I've heard of it but haven't tried
+
+**Q8M. What's your onchain presence like?** [Multiple choice]
+- I have a wallet but don't use it for music
+- I've minted music NFTs
+- I have an Audius account
+- I've done WaveWarZ battles
+- Multiple of the above
+- I don't have any onchain presence yet (we'll help you start)
+
+**Q9M. What do you want to accomplish during ZABAL S2 (Sep–Nov)?** [Long text]
+- *Help text: Examples: "Get my first 5 WaveWarZ battles in", "mint my first track on Audius", "build a fanbase on Farcaster". Be honest about where you are.*
+
+**Q10M. What kind of music do you make?** [Short text + optional link to a track]
+
+---
+
+### Section 4 — Everyone
+
+**Q11. Why ZABAL? Why now?** [Long text, 50-200 words]
+- *Help text: What specifically made you apply? What's the problem you're trying to solve (even if it's just "I don't know how to get started with Web3 music")?*
+
+**Q12. How many hours/week can you commit to ZABAL?** [Multiple choice]
+- 1-2 hours
+- 3-5 hours
+- 6-10 hours
+- More than 10 hours
+
+**Q13. How did you hear about ZABAL S2?** [Multiple choice]
+- @wavewarz on X/Twitter
+- Farcaster /zao or @bettercallzaal
+- ZAO newsletter
+- From a friend or community member (please name them)
+- ZAOstock or COC Concertz
+- Other
+
+---
+
+## Screening Criteria
+
+**Builder Track (10 spots):**
+
+| Criteria | Weight | What ZAO looks for |
+|----------|--------|-------------------|
+| Clear problem/audience | 30% | Can they articulate who they're building for? |
+| Realistic S2 goal | 25% | Is the scope right for 12 weeks? |
+| Technical evidence | 20% | GitHub, link, portfolio — anything showing they can build |
+| Community signal | 15% | ZAO community, Farcaster presence, prior ZABAL |
+| Commitment level | 10% | 3+ hours/week = serious |
+
+**Musician Track (10 spots):**
+
+| Criteria | Weight | What ZAO looks for |
+|----------|--------|-------------------|
+| Music clearly exists | 30% | At least one shareable link (Audius/Spotify/etc.) |
+| Openness to Web3 | 25% | Not already deep in crypto (great!) or hostile to it (hard to help) |
+| Realistic S2 goal | 20% | "5 WaveWarZ battles" beats "become famous" |
+| Community signal | 15% | WaveWarZ history, prior ZAO events |
+| Why ZABAL, why now | 10% | Honest self-awareness beats marketing |
+
+**Automatic disqualifiers:**
+- No working music link AND no evidence of prior music (musician track)
+- Application is entirely AI-generated with no personal voice
+- Asks for funding upfront (ZABAL does not pay participants)
+- Duplicate applications
+
+---
+
+## Application Timeline
+
+| Date | Milestone | Action |
+|------|-----------|--------|
+| **Jul 31** | Form live and tested | Zaal creates Google Form using this structure |
+| **Aug 1** | Applications open | ZOE announces across channels |
+| **Aug 1–21** | Application window (3 weeks) | ZOE sends reminders Aug 7 + Aug 14 |
+| **Aug 22** | Applications close | |
+| **Aug 23–28** | Zaal + Iman review applications | Score each using criteria above |
+| **Aug 29** | Acceptance emails sent | 10 builders + 10 musicians notified |
+| **Aug 31** | Rejection emails sent | Everyone who applied gets a response |
+| **Sep 1** | ZABAL S2 kickoff | First cowork session |
+
+---
+
+## ZOE Announcement Posts
+
+**Aug 1 — Applications open:**
+
+**X (@wavewarz):**
+> ZABAL Season 2 is open. Applications now live.
+>
+> 2 tracks:
+> 🔧 Builders — ship something for music/Web3 in 12 weeks
+> 🎵 Musicians — build your onchain presence, start battling on @wavewarz
+>
+> 20 spots. Free. Sep 1–Nov 30.
+>
+> Apply: [form link] #ZABAL #WaveWarZ
+
+**Farcaster (/zao):**
+> ZABAL Season 2 applications are open.
+>
+> Builder track: 12 weeks to ship a music/Web3 tool
+> Musician track: 12 weeks to build onchain presence
+>
+> If you've been waiting to get into WaveWarZ or crypto music — this is how. Apply by Aug 21. [link]
+
+**Newsletter teaser (in Aug 1 Issue 1):**
+> ZABAL S2 is accepting applications. 20 spots across two tracks: builders who want to ship music tech tools, and musicians who want to level up their onchain presence. Applications close Aug 21. Apply at [link].
+
+---
+
+## Acceptance Email Template
+
+**Subject:** Welcome to ZABAL Season 2 — you're in
+
+---
+
+Hi [name],
+
+You've been accepted to ZABAL Games Season 2 (Sep 1–Nov 30, 2026).
+
+Track: [Builder / Musician]
+
+**Kickoff:** September 1. We'll send details by Aug 28.
+
+**What to do now:**
+1. Join the ZAO Telegram: [t.me/wavewarzclipshq]
+2. Follow @wavewarz on X + Farcaster /zao
+3. If musician track: set up a WaveWarZ account at wavewarz.info before Sep 1
+4. If builder track: make sure your GitHub is public
+
+Questions? DM Zaal: @bettercallzaal on X or Farcaster.
+
+See you Sep 1.
+
+— Zaal Panthaki
+
+---
+
+## Rejection Email Template
+
+**Subject:** ZABAL Season 2 — update on your application
+
+---
+
+Hi [name],
+
+Thank you for applying to ZABAL Season 2.
+
+We received more applications than spots available. Unfortunately, we can't offer you a spot this time.
+
+[If musician track]: We encourage you to check out WaveWarZ at wavewarz.info — you can start battling any time without being in ZABAL. And ZABAL Season 3 opens in early 2027.
+
+[If builder track]: We'd love to see what you build. Tag @wavewarz when you ship something.
+
+The ZAO community is open: follow /zao on Farcaster, join our newsletter [link], and come to ZAOstock (Oct 3, Ellsworth ME).
+
+We hope to have you in a future ZABAL cohort.
+
+— Zaal Panthaki
+
+---
+
+## ZAOstock Connection
+
+ZABAL S2 starts Sep 1 and runs through ZAOstock Oct 3. All 20 ZABAL S2 participants are:
+- Listed as community participants in ZAOstock event materials
+- Invited to attend ZAOstock at no extra cost (use builder/musician code)
+- Eligible for showcase moment at ZABAL S2 Finals Nov 17
+
+ZAOstock is the recruiting moment for ZABAL S2: Zaal announces S2 from the stage (from doc 1383, doc 1380 planning seeds).
+
+---
+
+*Created: 2026-07-17 | Form live by Jul 31 | Applications open Aug 1 | Deadline Aug 21 | Related: 1355 (S2 launch plan), 1259 (S1 mid-season audit), 1380 (2027 planning seeds — ZABAL S3)*


### PR DESCRIPTION
## Summary

Complete application form structure for ZABAL Season 2 (Sep 1–Nov 30, 2026). Set up by Jul 31; applications open Aug 1. Doc 1355 has the launch plan; this doc is the operational execution.

**Two tracks, separate question sets:**

**Builder Track (10 spots):**
- Q6: What are you building? (100-300 words)
- Q7: GitHub/project link (optional)
- Q8: What problem does it solve for artists?
- Q9: What do you want to ship in S2?
- Q10: Prior ZABAL experience?
- Screening: problem clarity 30%, realistic goal 25%, technical evidence 20%, community signal 15%, commitment 10%

**Musician Track (10 spots):**
- Q6M: Where people hear your music (at least 1 link required)
- Q7M: WaveWarZ battle history
- Q8M: Onchain presence level
- Q9M: S2 goal (specific beats vague)
- Q10M: Genre + track link
- Screening: music evidence 30%, Web3 openness 25%, realistic goal 20%, community signal 15%, why ZABAL 10%

**Shared questions:** why ZABAL + hours/week commitment + referral source

**Application timeline:**
- Jul 31: Form live (Google Form or Typeform, use this structure)
- Aug 1: Open — ZOE announces on X, Farcaster, newsletter
- Aug 21: Close
- Aug 22-28: Zaal + Iman review
- Aug 29: Acceptance emails sent (10+10)
- Aug 31: Rejection emails sent (everyone gets a response)
- Sep 1: Kickoff

**Templates included:** acceptance email, rejection email (with encouragement to WaveWarZ + ZABAL S3), ZOE announcement posts for X + Farcaster + newsletter

**ZAOstock tie-in:** All 20 ZABAL S2 participants invited to ZAOstock; Zaal announces S2 from stage (doc 1380)

Builds on doc 1355 (S2 launch plan), 1259 (S1 audit showing July stall — application process should prevent this), 1283 (August mechanics).

Part of ZAOOS build loop.