### PR TITLE
test(curator): fix test isolation via lazy ZOE_HOME + remove duplicate digestText

### DIFF
--- a/bot/src/zoe/curator.ts
+++ b/bot/src/zoe/curator.ts
@@ -48,8 +48,12 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { execSync } from 'node:child_process';
 
-const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
-const TOPIC_THREAD_MAP_PATH = join(ZOE_HOME, 'topic_thread_map.json');
+function getZoeHome(): string {
+  return process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+}
+function getTopicThreadMapPath(): string {
+  return join(getZoeHome(), 'topic_thread_map.json');
+}
 
 export type TopicKey = 'newsletter' | 'github' | 'artizen' | 'recommendations' | 'general';
 
@@ -63,7 +67,7 @@ export interface TopicThreadMap {
  */
 export async function readTopicThreadMap(): Promise<TopicThreadMap> {
   try {
-    const raw = await fs.readFile(TOPIC_THREAD_MAP_PATH, 'utf8');
+    const raw = await fs.readFile(getTopicThreadMapPath(), 'utf8');
     return JSON.parse(raw) as TopicThreadMap;
   } catch {
     return {};
@@ -74,8 +78,8 @@ export async function readTopicThreadMap(): Promise<TopicThreadMap> {
  * Write the topic -> thread_id map to disk atomically.
  */
 export async function writeTopicThreadMap(map: TopicThreadMap): Promise<void> {
-  await fs.mkdir(ZOE_HOME, { recursive: true });
-  await fs.writeFile(TOPIC_THREAD_MAP_PATH, JSON.stringify(map, null, 2), 'utf8');
+  await fs.mkdir(getZoeHome(), { recursive: true });
+  await fs.writeFile(getTopicThreadMapPath(), JSON.stringify(map, null, 2), 'utf8');
 }
 
 /**
@@ -216,10 +220,6 @@ export async function generateGithubDigest(): Promise<{ text: string; timestamp:
     for (const pr of topPrs) {
       const repoLabel = pr.repository?.includes('ZAOcowork') ? '[ZAOcowork]' : '';
       digestText += `\n#${pr.number}: ${pr.title}${repoLabel ? ` ${repoLabel}` : ''}`;
-    let digestText = `Today's ships (${dateStr}):
-Merged PRs across ZAO repos:`;
-      digestText += `
-#${pr.number}: ${pr.title}${repoLabel ? ` ${repoLabel}` : ''}`;
     }
 
     // Add a closing note summarizing what shipped (keeps it high-signal, not spammy)
@@ -245,9 +245,6 @@ Merged PRs across ZAO repos:`;
 
     if (categorySummary) {
       digestText += `\n\nToday: ${categorySummary} across the ecosystem.`;
-      digestText += `
-
-Today: ${categorySummary} across the ecosystem.`;
     }
 
     return {


### PR DESCRIPTION
## Summary

- **Root cause 1 (5 failing tests)**: `ZOE_HOME` and `TOPIC_THREAD_MAP_PATH` were module-level `const`s captured at import time. Tests set `process.env.ZOE_HOME` in `beforeEach`, but the module had already loaded with the real `~/.zao/zoe` path — so file I/O silently read from the real location instead of the isolated test dir.
- **Root cause 2 (1 failing test — `generateGithubDigest`)**: A duplicate `let digestText` block was left inside the `for` loop from a bad edit. JavaScript's temporal dead zone means the `digestText +=` earlier in the same block hit a ReferenceError at runtime, causing the function to return `null` via the outer `catch`.

## Fix

- Replace `const ZOE_HOME` / `const TOPIC_THREAD_MAP_PATH` with `getZoeHome()` / `getTopicThreadMapPath()` lazy getters that re-read `process.env.ZOE_HOME` on each call.
- Remove the duplicate `let digestText` block inside the `for` loop and the paired duplicate summary-line append at the end of `generateGithubDigest`.

## Test plan

- [ ] `npx vitest run src/zoe/__tests__/curator.test.ts` → 23/23 pass (was 18/23)
- [ ] Full bot test suite: no new failures (pre-existing failures in other test files unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)