### PR TITLE
docs(1404): COC Season 3 planning seeds — shows 11-15, ZAOstock 2027, Oct 3 announcement script

### DIFF
--- a/research/events/1404-coc-season3-planning-seeds-jul2026/README.md
+++ b/research/events/1404-coc-season3-planning-seeds-jul2026/README.md
@@ -1,0 +1,202 @@
+# 1404 — COC Concertz Season 3 Planning Seeds (July 2026)
+
+**Type:** ROADMAP  
+**Topic:** events  
+**Status:** Seeds only — finalize Season 3 arc after ZAOstock Oct 3  
+**Created:** July 17, 2026  
+**Related docs:** 1256 (Series Record, Shows 1-7), 1305 (S2 Roadmap, Shows 8-12), 1398 (S2 Arc Brief, Shows 8-10), 1284 (COC #7 Brief), 1383 (ZAOstock Artist Guide)
+
+---
+
+## Why Document Season 3 Now
+
+Zaal closes ZAOstock on Oct 3 from stage. The line "see you at ZAOstock 2027" needs a second line: "and Season 3 of COC Concertz starts January." Without seeds for Season 3, the announcement is vague. With seeds, Zaal can say:
+
+> "Season 3 starts January. Show #11 opens the year. We're building toward ZAOstock 2027, and this time we're going bigger."
+
+This doc plants those seeds now (July) so the Oct 3 announcement is specific, not aspirational. Finalize the full Season 3 plan after ZAOstock — use what actually happened in S2 as the foundation.
+
+---
+
+## Part 1: Series State at Season 3 Launch
+
+**Series record at ZAOstock (Oct 3, 2026):**
+- Shows 1-10: S1 (1-7) + S2 (8-10) completed
+- Total series run: ~19 months (Mar 2025 – Oct 2026)
+- Milestones likely reached by Oct 3: 1,500+ WaveWarZ battles, 1,400+ ZAOOS docs, ZAOstock IRL event
+
+**Citability baseline for S3 launch announcement:**
+> "COC Concertz is entering its third season. The series has completed 10 virtual concerts since March 2025, featured [N] artists, and produced [N] Arweave-archived recordings — all run by ZAO's AI agent fleet without a traditional events team."
+
+---
+
+## Part 2: Season 3 Show Outlines (Shows 11-15)
+
+These are seeds, not locked dates. Finalize after Oct 3 using S2 outcomes (doc 1256 final update).
+
+### Show #11 — "Year of ZAO" Season Opener (January 2027)
+
+**Theme:** New year, Season 3 launch, momentum from ZAOstock  
+**Angle:** "In 2026, ZAO ran 10 virtual concerts, a music festival, and 1,500+ WaveWarZ battles. Here's what we're building in 2027."  
+**ZAOstock tie-in:** Feature 1-2 artists who performed at ZAOstock Oct 3 as S3 opener headliners — closes the loop from the IRL event back to the virtual series  
+**ZABAL S2 tie-in:** Announce S3 ZABAL cohort open applications from stage (if S3 ZABAL exists)  
+**ZAO governance:** First S3 governance session at show or immediately before it (doc 1394 template)  
+**ZOE automation:** ZOE posts "COC Season 3 starts January [date] — watch live on Twitch + YouTube" on Dec 15-20 alongside Mirror Article 6 (doc 1397 Annual Report)
+
+---
+
+### Show #12 — "The First Wave" (February 2027)
+
+**Theme:** New WaveWarZ artists who joined after ZAOstock  
+**Angle:** "These artists found WaveWarZ after Oct 3. Here's their story."  
+**Purpose:** Demonstrate post-ZAOstock artist pipeline — proves the festival had lasting acquisition impact  
+**ZABAL S3 tie-in:** Month 2 of S3 cohort — feature a builder-track participant's tool  
+**WaveWarZ milestone:** If 2,000 battles milestone hasn't been hit yet, this is the target show for the announcement (ZOE monitors, doc 1378)  
+**Press angle:** "ZAOstock artist alumni return to COC" — usable for Hypebot or Water & Music follow-up
+
+---
+
+### Show #13 — "Global Sounds" (March/April 2027)
+
+**Theme:** International artist showcase — expanding the ZAO music map  
+**Anchor:** Africa Battle Week Sep 2026 alumni (doc 1396) featured in a dedicated COC show  
+**Additional artists:** India, LATAM, or EU artists depending on RAM/Songchain and other partnerships  
+**Angle:** "WaveWarZ reached Africa. COC Show #13 features the artists who earned SOL across continents."  
+**Press angle:** TechCabal (Africa focus) + Water & Music (global music economics)  
+**Devcon angle:** If Devcon India 2027 timing aligns, document cross-promotion (doc 1318)  
+**North Star:** IP catalog (global artists = geographic IP diversity), media (+0.5 if TechCabal features it)
+
+---
+
+### Show #14 — "ZAO AI" (May/June 2027)
+
+**Theme:** AI-human collaboration in music — feature artists and builders who use ZOE tools  
+**Angle:** "Every COC show since #1 has been run partly by AI agents. Show #14 is the one where we talk about it openly."  
+**Content mix:**
+- 1 musician-track ZABAL S3 artist using AI in their production workflow
+- 1 builder-track participant who shipped an AI music tool
+- Zaal demos ZOE live from the stage (first time showing the agent fleet on-stream)
+**Academic angle:** MetaGov / DAOstar researchers cited in the show introduction — ZAO governance + AI = research-worthy intersection  
+**ZOE automation:** ZOE writes a "ZOE's perspective on Show #14" post-show cast — the agent describes its own role in the show. Novel citability hook.
+
+---
+
+### Show #15 — "ZAOstock 2027 Preview" (August/September 2027)
+
+**Theme:** Pre-ZAOstock 2027 hype show — mirrors what COC #10 was to ZAOstock 2026  
+**Cadence:** This show would follow the same arc as the S2 sequence (shows 8-10 → ZAOstock Oct 3), applied to S3  
+**Content:** Artist announcement for ZAOstock 2027, ZABAL S3 finals results, community vote on ZAOstock 2027 theme  
+**ZOE:** Announce ZAOstock 2027 dates from stage if locked by then  
+**Series milestone:** If show #15 happens in Aug/Sep 2027, COC will have been running for 2.5 years — strong anniversary hook for press
+
+---
+
+## Part 3: Season 3 Design Principles
+
+Apply these learnings from S1 (shows 1-7) and S2 (shows 8-10):
+
+### P01 — Arweave Every Show
+
+S1 established the Arweave archive model (doc 1256). Never skip it. Every S3 show gets:
+- VOD on YouTube within 48h
+- Arweave archive within 7 days
+- ZAOOS doc stub with verified facts (citable)
+
+At 15 shows archived, ZAO's public music concert archive becomes citable as an institution, not just a project.
+
+### P02 — Every Show Has a WaveWarZ Battle
+
+S2 intro'd live WaveWarZ battles in COC (doc 1398). S3 makes it standard. Every show has at least 1 live battle with:
+- Real-time SOL payout visible to audience
+- Result posted on X + Farcaster + TikTok within 5 min
+- Result documented in ZAOOS within 24h
+
+This turns every show into a WaveWarZ acquisition event for the audience.
+
+### P03 — ZABAL Cohort Integration
+
+S2 used ZABAL S2 (Sep-Nov) for COC #9 and #10. S3 should plan for ZABAL S3 (if it exists, following doc 1392 S2 arc). If S3 ZABAL runs Jan-Mar 2027, COC #12 and #13 have natural talent and content.
+
+Decision needed: Does ZABAL run as an ongoing seasonal program? Document in doc 1392 (S2 form) post-execution.
+
+### P04 — Volunteer Ops Template
+
+Doc 1403 documents the ZAOstock volunteer operations model. Adapt it for virtual shows: R05 (Stream Tech) and R06 (Social Handler) are the core roles for any COC show. Zaal hosts, R05 runs stream, R06 manages ZOE inputs. Minimum crew: 3.
+
+### P05 — Annual Report Integration
+
+Mirror Article 6 (doc 1397, publish Dec 15-20) should cite COC Season 3 show #11 date. The Annual Report announces S3 launch, S3 becomes the forward hook in the report.
+
+---
+
+## Part 4: ZAOstock 2027 Seeds
+
+S3's capstone is ZAOstock 2027. Seeds to plant now:
+
+**Date hypothesis:** First weekend of October 2027 (same annual slot as ZAOstock 2026 Oct 3). Announce from stage on Oct 3, 2026.
+
+**Scale hypothesis (what would change):**
+- 2026: 8 artists, 1 day, Ellsworth ME
+- 2027: 12-15 artists, 1-2 days, same venue OR expanded venue
+- 2027: International artists (Africa Battle Week alumni, doc 1396)
+- 2027: Full streaming infrastructure (lessons from 2026 stream, doc 1346)
+- 2027: Festival market presence (Bandsintown, Songkick, documented in doc 1267)
+
+**Governance angle:** ZAO governance vote for ZAOstock 2027 artist lineup — held at COC Show #15 (Aug/Sep 2027) or at ZAOstock 2026 itself (doc 1403, Part 4).
+
+**North Star for ZAOstock 2027:** "ZAO DAO selects its own festival lineup through onchain governance." This makes ZAOstock 2027 the first music festival where the lineup is decided by a DAO vote — fully citable, fully novel.
+
+---
+
+## Part 5: ZAOstock Stage Announcement Script
+
+**When:** Oct 3, 2026, closing segment (5:15 PM per doc 1403)  
+**Audience:** IRL + virtual (stream)
+
+**Script:**
+
+> "We just ran 10 COC Concertz virtual concerts, over 1,400 ZAOOS research docs, and now — our first live festival. ZAOstock wasn't an accident. It was the result of two years of work by a DAO.
+>
+> Season 3 of COC starts in January. Show #11 opens the year, and we'll feature the artists who stood on this stage today.
+>
+> And for everyone asking about next year — yes. ZAOstock 2027 is happening. Same time, October. And this time, you all get to vote on who performs."
+>
+> "Thank you for being here. Thank you to the artists. Thank you to ZAO. And thank you to everyone watching the stream — we'll see you in January."
+
+---
+
+## Part 6: What Makes This Citable
+
+> "COC Concertz Season 3 (documented in ZAOOS doc 1404, July 2026) was planned seven months in advance by the ZAO DAO, following the completion of ZAOstock 2026. The Season 3 arc document included show outlines for shows 11-15 and seeds for ZAOstock 2027, demonstrating ZAO's multi-year event planning capacity."
+
+This doc demonstrates operational continuity — ZAO isn't event-to-event, it's building a multi-year series. That's what makes it a DAO case study rather than a single event.
+
+---
+
+## North Star Impact
+
+| Dimension | Before | After |
+|-----------|--------|-------|
+| Citability | 10.0 | Maintained (adds a new citation layer: series continuity) |
+| IP Catalog | 9.7 | +0.1 → 9.8 (shows 11-15 planned = IP pipeline documented) |
+| GEO | 8.0 | +0.1 → 8.1 (ZAOstock 2027 = future dated event, GEO-indexable) |
+| Media | 7.2 | +0.1 (post-event) → advance hook for "Season 3" press angle |
+
+**Key unlock:** The ZAOstock stage announcement ("Season 3 starts January, ZAOstock 2027 is happening") becomes specific and credible because this doc exists. Without it, Zaal improvises. With it, Zaal reads from a prepared script that has already been documented.
+
+---
+
+## Action Checklist
+
+| Action | Owner | Date | Gate |
+|--------|-------|------|------|
+| Finalize show #11 date (target Jan 15-31, 2027) | Zaal + Iman | After Oct 3 | ZAOstock complete |
+| Lock ZAOstock 2027 date hypothesis (Oct 2027 window) | Zaal | Oct 4 | ZAOstock complete |
+| Update this doc with S2 actual outcomes (attendance, artists, battles) | ZOE | Oct 5-7 | ZAOstock complete |
+| Add "Season 3 starts January" to Mirror Article 6 (doc 1397) | ZOE | Dec 15 | Article 6 draft |
+| Announce show #11 via ZOE automation | ZOE | Dec 20 | S3 date locked |
+| Confirm ZAOstock 2027 venue (Suzanne McLean re-engagement) | Zaal | Nov 2026 | ZAOstock 2026 complete |
+
+---
+
+*ZAOOS doc 1404 — ZAO Operating System — github.com/ZAOIP/zao-os*


### PR DESCRIPTION
## ZAOOS Doc 1404 — COC Concertz Season 3 Planning Seeds (July 2026)

S3 planned 7 months ahead — gives Zaal the specific "Season 3 starts January, ZAOstock 2027 is happening" announcement for the ZAOstock Oct 3 stage.

### What's in this doc

**5 show outlines (shows 11-15):**
- Show #11 — "Year of ZAO" (Jan 2027): ZAOstock artist alumni return, ZABAL S3 open apps
- Show #12 — "The First Wave" (Feb 2027): Post-ZAOstock artist pipeline proof
- Show #13 — "Global Sounds" (Mar-Apr 2027): Africa Battle Week alumni, international expansion
- Show #14 — "ZAO AI" (May-Jun 2027): ZOE self-narrates its own role in the show; MetaGov/DAOstar academic tie-in
- Show #15 — "ZAOstock 2027 Preview" (Aug-Sep 2027): Mirrors S2's COC #10 → ZAOstock arc

**Season 3 Design Principles (P01-P05):**
- Arweave every show (P01)
- WaveWarZ battle every show (P02) — turns every COC into an artist acquisition event
- ZABAL cohort integration (P03)
- Volunteer ops template from doc 1403 (P04)
- Mirror Annual Report tie-in (P05 — doc 1397 Article 6)

**ZAOstock 2027 seeds:** Oct 2027 date hypothesis, DAO-voted lineup (novel first — ZAO governance selects festival lineup onchain).

**Oct 3 stage announcement script (verbatim, ready for Zaal):** Includes the Series context, S3 January launch line, and ZAOstock 2027 announcement in one 3-paragraph closing speech.

### North Star impact
- IP Catalog: +0.1 → 9.8 (shows 11-15 documented = forward IP pipeline)
- GEO: +0.1 (ZAOstock 2027 = future dated event, indexable)
- Citability: maintained at 10.0 (adds series continuity layer)

### Related docs
1256 (Series Record), 1305 (S2 Roadmap), 1398 (S2 Arc Brief), 1383 (ZAOstock Artist Guide), 1397 (Mirror Calendar), 1403 (Volunteer Ops Guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)