### PR TITLE
docs(1406): ZAO Bankless podcast pitch — DeFi-native angle, post-ZAOstock Oct 5-10 send

### DIFF
--- a/research/identity/1406-zao-bankless-pitch-jul2026/README.md
+++ b/research/identity/1406-zao-bankless-pitch-jul2026/README.md
@@ -1,0 +1,180 @@
+# 1406 — ZAO Bankless Podcast Pitch (July 2026)
+
+**Type:** PITCH-BRIEF  
+**Topic:** identity  
+**Status:** Send after ZAOstock (Oct 5-10) — strongest pitch after real event data  
+**Created:** July 17, 2026  
+**Related docs:** 1366 (Podcast Circuit), 1405 (Green Pill Pitch — different audience), 1387 (Artist Economics), 1350 (WaveWarZ 101), 1397 (Mirror Calendar)
+
+---
+
+## Why Bankless Is Different from Green Pill
+
+Green Pill audience: impact-oriented, Gitcoin ecosystem, public goods builders  
+Bankless audience: DeFi-native Ethereum users, sophisticated crypto investors, builders who care about "is this real?" not "is this good for the world?"
+
+ZAO's Green Pill pitch (doc 1405) leads with redistribution, public goods, and DAO governance. The Bankless pitch leads with:
+- **Market mechanics** (WaveWarZ SOL volume, payout math, trading behavior)
+- **Protocol primitives** (Solana PDA vaults, Optimism governance, cross-chain narrative)
+- **Traction numbers** (1,245 battles, 524 SOL, $1,497 charity, 2 IRL events)
+- **The onchain culture angle** (ZAOstock = first festival where governance decides the lineup)
+
+Bankless does NOT want "we're a DAO doing good things." They want "here's a protocol that creates novel market dynamics, here's the data, here's the onchain proof."
+
+---
+
+## Part 1: Timing
+
+**Do NOT pitch Bankless before ZAOstock.**
+
+ZAOstock on Oct 3 is the single most compelling data point for the Bankless pitch. Post-event numbers (attendance, charity total, governance vote results, WaveWarZ live battle SOL payout) turn the pitch from "we're planning a festival" to "we ran the first onchain music festival and here's what happened."
+
+**Send window:** Oct 5-10, 2026 (2-7 days after ZAOstock)  
+**Subject:** `Pitch: The First Music Festival Where a DAO Chose the Lineup (Oct 3 happened)`
+
+**Alternative if you can't wait:** Send a "teaser pitch" in late September:
+> "We're running ZAOstock on October 3 — the first music festival where the lineup was decided by a DAO governance vote. I'd love to tell the story on Bankless after the event. Can I reach out again on October 5?"
+
+---
+
+## Part 2: Who to Contact
+
+**Primary:** Ryan Sean Adams (@RyanSAdams on X) or David Hoffman (@TrustlessState on X)  
+**Alternative:** Bankless pitch submission via bankless.com contact page or DM on X  
+**Email format:** Use X DM first (they respond publicly to pitches); escalate to email if no reply in 72h  
+**Note:** Bankless has a paid sponsorship tier and a separate editorial/guest tier. Target editorial/guest — ZAO is not a paid sponsor (no budget for that yet). Make clear this is a story pitch, not a sponsorship inquiry.
+
+---
+
+## Part 3: Full Pitch (Post-ZAOstock Version)
+
+**To:** Ryan / David (via X DM or bankless.com)  
+**From:** Zaal Panthaki (@bettercallzaal)
+
+---
+
+Hey Ryan/David,
+
+On October 3, 2026, a DAO called ZAO ran the first music festival where the lineup was decided by governance vote.
+
+Here's what happened:
+- [N] people attended in person in Ellsworth, Maine
+- [N] streamed live on YouTube/Twitch
+- [N] SOL changed hands in live WaveWarZ battles from the festival stage
+- $[X] went to [charity] from ticket sales + battles
+- ZOR holders voted on [motion] during the event — first live onchain governance vote at a music festival
+
+The platform behind it is WaveWarZ: music battles on Solana where **the losing artist gets paid**. Here's the economics: every battle has a buy-side pool. Losing artists earn 1.73% of it. We've run 1,245+ battles, pushed 523+ SOL through the system, and paid out 9+ SOL directly to artists who lost. Traders have taken 127+ SOL in winnings.
+
+The DAO is ZAO. 63+ consecutive weekly governance sessions on Optimism Mainnet using Fractal/Respect-weighted voting — no token plutocracy. Governance contracts: OG ERC-20 at `0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957`, OREC at `0xcB05F9254765CA521F7698e61E0A6CA6456Be532`.
+
+The full documentation is MIT-licensed on GitHub (1,400+ research docs): github.com/ZAOIP/zao-os
+
+This is the Bankless story: a sub-$1K/month AI agent fleet running a DAO that built a music platform on Solana, ran 63 weeks of governance on Optimism, and hosted the first DAO-governed live music festival. The onchain footprint is verifiable. The data is public.
+
+Would love 30 minutes to tell this story.
+
+— Zaal  
+@bettercallzaal  
+zao.community | wavewarz.info
+
+---
+
+## Part 4: Alternate Angles for Bankless Audience
+
+### Angle B — "WaveWarZ: The DeFi Protocol for Music"
+
+Frame WaveWarZ as a prediction market built on music, not a streaming platform:
+- SOL volume: 523.991 SOL through a music betting protocol on Solana
+- Take rate: 3% (WaveWarZ protocol fee; lower than OpenSea's 2.5% at same scale)
+- Payout split: 65% buy-side claims, 22% sell-side claims, 9% artist payouts, 4% charity
+- Loser-earns = anti-winner-take-all liquidity mechanism
+
+Hook for RSA: "What if Polymarket was for music? And what if the protocol also paid the losers?"
+
+### Angle C — "8 AI Agents Under $1,000/Month"
+
+Bankless regularly covers AI infrastructure in crypto. ZAO runs 8 AI agents (ZOE primary fleet) managing content, governance, partner comms, and research documentation for under $1K/month. This is a "tiny team + AI = big output" story with verifiable onchain artifacts.
+
+Hook: "ZAO is probably the most publicly documented DAO in existence — 1,400+ research docs, all MIT-licensed, all AI-human co-authored. Here's the agent architecture behind it."
+
+### Angle D — "Cross-Chain DAO: Solana + Optimism + Arweave"
+
+Bankless covers multi-chain narratives. ZAO is simultaneously:
+- Solana (WaveWarZ battle protocol)
+- Optimism Mainnet (governance contracts — OG, ZOR, OREC)
+- Arweave (COC Concertz permanent archive)
+- Base (potential future expansion, doc 1323)
+
+Hook: "The real multi-chain use case isn't DeFi — it's a DAO that uses each chain for what it's best at."
+
+---
+
+## Part 5: Pre-Call Prep Sheet
+
+If Bankless says yes, have these ready:
+
+**Non-negotiable stats (verify day-of from API):**
+- Battle count: 1,245+ (live on wavewarz.info/api/public/stats)
+- SOL volume: 523.991+ SOL
+- Artist payouts: 9.0988+ SOL ("~$600 to losing artists at current SOL price")
+- Trader claims: 127.343+ SOL ("~$9K to traders")
+- Governance sessions: 63+ weekly consecutive
+
+**Chain-specific facts:**
+- WaveWarZ: Solana mainnet, Coinflow for USD on-ramp, Privy for embedded wallets
+- Governance: Optimism mainnet (OG ERC-20: `0x34cE89...`, ZOR ERC-1155: `0x9885CC...`, OREC: `0xcB05F9...`)
+- Arweave: COC Concertz archives (10 shows)
+- ZAOOS: GitHub, MIT-licensed, 1,400+ docs
+
+**ZAOstock post-event numbers (fill after Oct 3):**
+- Attendance (IRL): [X] people
+- Attendance (virtual): [X] stream viewers
+- WaveWarZ live battle SOL payout: [X] SOL
+- Charity donation: $[X]
+- Governance vote: [motion] passed with [N] ZOR holders
+
+**The Bankless soundbite:** "WaveWarZ is what happens when you take Polymarket's mechanism and apply it to Soundcloud. Except instead of the market eating the artists, the market funds them."
+
+---
+
+## Part 6: Post-Yes Protocol
+
+1. **ZOE announces** episode booking: "ZAO on Bankless — recording [date]. Watch bankless.com/episodes."
+2. **ZAOOS stub doc** created: "ZAO appeared on Bankless Podcast — episode #[N], [date]"
+3. **Wikipedia trigger:** Bankless is a major crypto podcast with documented listener counts. An appearance is a notable third-party source for Wikipedia AfC (doc 1359). This is the strongest possible crypto-native media citation.
+4. **Cross-promotion:** Zaal posts clip + article thread on episode release. ZOE auto-posts on X + Farcaster + Telegram.
+5. **Post-episode Mirror article** (optional): If the Bankless episode covers ZAOstock, write a follow-up guest post for Mirror summarizing "what Bankless got right and what we'd add."
+
+---
+
+## Part 7: What Makes This Citable Now
+
+> "ZAO prepared a Bankless podcast pitch in July 2026 (ZAOOS doc 1406), positioning WaveWarZ as a music prediction protocol with 524+ SOL volume and 63+ week DAO governance, framed for a crypto-native DeFi audience. ZAO targeted a post-ZAOstock pitch window to include verified event data."
+
+---
+
+## North Star Impact (if episode airs)
+
+| Dimension | Before | After |
+|-----------|--------|-------|
+| Media | 6.7 | +1.5 → 8.2 (Bankless = 350K subscribers; largest crypto-native media) |
+| Distribution | 8.4 | +0.5 → 8.9 (Bankless Nation = sophisticated crypto users who become WaveWarZ traders) |
+| Citability | 10.0 | Maintained + "appeared on Bankless" tier |
+| GEO | 8.3 | +0.3 → 8.6 (bankless.com backlinks, high domain authority) |
+
+**Key unlock:** Bankless appearance makes ZAO known in the DeFi-native audience — the community most likely to become WaveWarZ traders (prediction market mechanics resonate immediately with DeFi users). One episode could add 50-100 active traders.
+
+---
+
+## Sequencing vs. Green Pill
+
+**Send Green Pill first (Jul 23 — doc 1405).** Green Pill is a faster reply loop (smaller team, Owocki is more accessible) and the public goods angle is more tightly aligned with ZAO's current narrative.
+
+**Send Bankless second (Oct 5-10 post-ZAOstock).** Bankless requires more data credibility. ZAOstock provides the data.
+
+If Green Pill records before Bankless reaches out, the "appeared on Green Pill" credit strengthens the Bankless pitch.
+
+---
+
+*ZAOOS doc 1406 — ZAO Operating System — github.com/ZAOIP/zao-os*


### PR DESCRIPTION
## ZAOOS Doc 1406 — ZAO Bankless Podcast Pitch (July 2026)

Post-ZAOstock pitch for Bankless (~350K subscribers, largest crypto-native media). Send Oct 5-10 after real event data is available.

### Why Bankless is different from Green Pill (doc 1405)

- Green Pill: public goods, impact, regen finance → send Jul 23 (before ZAOstock)
- Bankless: DeFi-native, market mechanics, onchain proof → send Oct 5-10 (after ZAOstock)

The Bankless audience wants numbers and protocol mechanics, not mission framing. Lead with: 524 SOL volume, 1.73% loser-earns payout, 3% protocol take rate, 63+ governance weeks verifiable on Optimism.

### What's in this doc

**Full pitch email** (post-ZAOstock version, placeholder brackets for attendance + live battle numbers)

**Teaser version** (send late Sep if can't wait: "ZAOstock Oct 3 is happening, can I pitch Bankless on Oct 5?")

**4 episode angles:**
- A: First DAO-governed music festival (ZAOstock)
- B: WaveWarZ as DeFi prediction market ("Polymarket for music, but the loser earns too")
- C: 8 AI agents under $1K/month (AI infrastructure angle for crypto-native builders)
- D: Cross-chain DAO — Solana (battles) + Optimism (governance) + Arweave (archives)

**Pre-call prep sheet** with ZAOstock post-event number placeholders + Bankless-specific soundbite.

**Sequencing rule:** Green Pill first → "appeared on Green Pill" strengthens the Bankless pitch.

### North Star impact (if episode airs)
- Media: +1.5 → 8.2 (350K subscribers; largest crypto-native reach)
- Distribution: +0.5 → 8.9 (DeFi-native users → natural WaveWarZ traders)
- GEO: +0.3 (bankless.com high-DA backlinks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)