### PR TITLE
docs(1419): ZABAL S2 cohort kickoff + week 1 playbook — 20 participants, Sep 1 execute

### DIFF
--- a/research/zabal/1419-zabal-s2-cohort-kickoff-sep2026/README.md
+++ b/research/zabal/1419-zabal-s2-cohort-kickoff-sep2026/README.md
@@ -1,0 +1,287 @@
+# 1419 — ZABAL S2 Cohort Kickoff + Week 1 Onboarding Playbook (September 2026)
+
+**Type:** PLAYBOOK  
+**Topic:** zabal  
+**Status:** Ready — execute Sep 1, 2026  
+**Created:** July 17, 2026  
+**Related docs:** 1355 (ZABAL S2 Strategy), 1392 (ZABAL S2 Application Form), 1409 (S2 Review Rubric — Aug 22-29), 1403 (ZAOstock Ops — S2 builder role), 1412 (Community Infrastructure Map — send to participants), 1302 (WaveWarZ Artist Onboarding), 1398 (COC Season 2 Arc Brief — S2 musicians in shows #9 and #10)
+
+---
+
+## Overview
+
+ZABAL S2 runs September 1 – November 30, 2026. 20 participants: 10 builders + 10 musicians.
+
+The goal of Week 1 is to get every participant:
+1. Into the ZAO Telegram community (CH05 from doc 1412)
+2. With a WaveWarZ wallet connected (builders and musicians both)
+3. Attending Monday governance (Fractal session)
+4. Clear on what they're building/doing for 12 weeks
+
+This doc is the Sep 1 execution guide. Zaal and ZOE execute it together.
+
+---
+
+## Sep 1: Kickoff Day Protocol (ZOE executes, Zaal approves each step)
+
+### 9:00 AM — Send acceptance confirmations
+
+ZOE sends each accepted participant an individual DM (via X or Telegram, whichever they listed on application):
+
+**Builder welcome template:**
+```
+Welcome to ZABAL S2, [NAME].
+
+You're in the builder cohort. Here's what happens next:
+
+1. Join ZAO Telegram: [LINK] — post "I'm in S2: [NAME]" to introduce yourself
+2. Connect your wallet at wavewarz.info (you need this even as a builder)
+3. Join Monday governance: [Fractal session link] — next session is [DATE]
+4. Read: ZAO Community Map (ZAOOS doc 1412 — [LINK])
+5. Week 1 assignment: complete the builder intake form by Sep 5 (link below)
+
+Your S2 guide: Zaal (@bettercallzaal on X) + ZOE (AI, accessible via Telegram)
+
+ZAOstock is Oct 3 in Baltimore. You're expected to attend and support the tech/stream team.
+
+— ZAO + ZOE
+```
+
+**Musician welcome template:**
+```
+Welcome to ZABAL S2, [NAME].
+
+You're in the musician cohort. Here's what happens next:
+
+1. Join ZAO Telegram: [LINK] — post "I'm in S2: [NAME]" + share a track you're working on
+2. Register on WaveWarZ: wavewarz.info — this is required for the program. Doc 1302 has the full guide: [LINK]
+3. Join Monday governance: [Fractal session link] — next session is [DATE]
+4. Read: ZAO Community Map (ZAOOS doc 1412 — [LINK])
+5. Week 1 assignment: set up WaveWarZ and reply with your handle by Sep 5
+
+ZAOstock is Oct 3 in Baltimore. S2 musicians are invited to perform. Express interest by replying to this message.
+
+— ZAO + ZOE
+```
+
+### 10:00 AM — Announce S2 publicly
+
+ZOE posts on X + Farcaster + ZAO Telegram:
+
+```
+ZABAL S2 is live.
+
+20 participants selected: 10 builders + 10 musicians.
+
+For 12 weeks, they'll build inside ZAO — governance sessions, WaveWarZ battles, 
+COC Concertz performances, and the ZAOstock build-up.
+
+Builders. Musicians. The ZAO way.
+
+#ZABAL #ZAO #WaveWarZ
+```
+
+### 12:00 PM — Create S2 cohort channel
+
+Zaal creates a dedicated ZABAL S2 Telegram group:
+- Add all 20 participants
+- Add Zaal + ZOE bot (Hurricane confirms ZOE can post)
+- Pin the welcome message (below)
+
+**Pinned welcome message:**
+```
+Welcome to ZABAL S2.
+
+This is your cohort channel. 12 weeks. Sep 1 – Nov 30, 2026.
+
+Ground rules:
+- Be in Monday governance (Fractal sessions) — it's 45 minutes, non-negotiable
+- Complete week-end check-ins (ZOE will ping you every Friday)
+- Builders: ship something (feature, ZAOOS doc, or research)
+- Musicians: battle at least once on WaveWarZ + perform at COC or ZAOstock
+
+Resources:
+- ZAO Community Map: [ZAOOS doc 1412 link]
+- WaveWarZ guide: [ZAOOS doc 1302 link]
+- Governance: [Fractal link]
+
+ZAOstock is Oct 3. You are all invited.
+
+— Zaal + ZOE
+```
+
+---
+
+## Week 1 (Sep 1-7): Builder Track
+
+### Week 1 Builder Assignment (send Sep 1, due Sep 5)
+
+```
+ZABAL S2 Builder — Week 1 Brief
+
+Due: Friday Sep 5, reply in this channel
+
+Answer these 3 questions (1-3 sentences each):
+
+1. What are you building for ZAO during ZABAL S2? (one sentence — specific)
+2. What's the one thing you'll have shipped or researched by Oct 3 (ZAOstock)?
+3. What do you need from Zaal or ZOE in the first week?
+```
+
+### Builder Week 1-12 Milestones
+
+| Week | Builder milestone |
+|------|------------------|
+| 1 | Intake brief submitted; WaveWarZ wallet connected |
+| 2 | First governance session attended; project brief reviewed with Zaal |
+| 4 | Check-in #1: demo or doc submitted for Zaal review |
+| 6 | Mid-cohort pivot check — is the project still on track? |
+| 8 | Check-in #2: second deliverable or research finding |
+| 10 | ZAOstock build-out (stream tech support, ZOE deployment, on-site tech) |
+| 12 | Graduation: shipped feature OR published ZAOOS research doc; presented at COC #11 or ZABAL showcase |
+
+### ZOE Builder Automation
+
+```
+[TRIGGER: Every Friday, ZABAL S2 weeks 1-12]
+
+ZOE pings builder cohort in S2 Telegram group:
+"Builder check-in: what did you ship this week? Reply with 1-2 sentences.
+Zaal reviews all check-ins Sunday evening."
+```
+
+---
+
+## Week 1 (Sep 1-7): Musician Track
+
+### Week 1 Musician Assignment (send Sep 1, due Sep 5)
+
+```
+ZABAL S2 Musician — Week 1 Brief
+
+Due: Friday Sep 5, reply in this channel
+
+1. Connect your wallet at wavewarz.info and reply with your WaveWarZ handle
+2. Share one track (SoundCloud/YouTube/Audius link) that represents your current sound
+3. One sentence: what do you want to do at ZAOstock on Oct 3?
+```
+
+### Musician Week 1-12 Milestones
+
+| Week | Musician milestone |
+|------|------------------|
+| 1 | WaveWarZ wallet connected; handle shared; track shared |
+| 2 | Attended first governance session; selected first WaveWarZ battle target (artist to battle) |
+| 3-4 | First WaveWarZ battle (required) |
+| 5-6 | Second battle OR COC #9 performance (Week 4 check-in) |
+| 7-8 | Africa Battle Week Sep 15-26: encouraged to participate as one of the Africa Battle Week artists if eligible |
+| 9 | COC #10 performance slot (S2 musician spotlight, per doc 1398) |
+| 10-11 | ZAOstock build-up: promote their own ZAOstock appearance/set; create WaveWarZ content with ZOE templates |
+| 12 | Graduation: 1 WaveWarZ battle + 1 COC/ZAOstock performance + 1 piece of ZAO-published content |
+
+### ZOE Musician Automation
+
+```
+[TRIGGER: Every Friday, ZABAL S2 weeks 1-12]
+
+ZOE pings musician cohort in S2 Telegram group:
+"Musician check-in: battle or performance update this week? Share the WaveWarZ link 
+or VOD clip. ZOE will cross-post to ZAO channels if you want it amplified."
+```
+
+---
+
+## Monthly Check-ins (Zaal + All S2)
+
+### Week 4 Check-in (Sep 26 — same week as Africa Battle Week close)
+
+- 30-minute group call (Telegram voice chat or X Space)
+- Each participant: 60-second update on what they've done and what's next
+- Zaal: feedback on mid-cohort direction
+- Announce: S2 musicians performing at COC #9 and #10
+
+### Week 8 Check-in (Oct 24)
+
+- 30-minute group call
+- ZAOstock debrief: what did each participant contribute?
+- Builders: demo or doc presentation (2 min each)
+- Musicians: WaveWarZ stats recap (battles, volume, payouts)
+
+### Week 12 Graduation (Nov 28-30)
+
+- Group call or in-person (Baltimore if practical)
+- Each participant presents their S2 work (3 min each)
+- Graduation criteria check (see below)
+- S3 preview: who wants to stay involved? Any S2 participants applying to S3?
+- ZOE creates ZAOOS graduation doc with all participant names and deliverables
+
+---
+
+## Graduation Criteria
+
+### Builder track (10 participants)
+- Minimum: 1 shipped feature OR 1 ZAOOS research doc (merged PR)
+- Required: Attended at least 6 of 12 weekly governance sessions
+- Strong: Presented at COC or ZAOstock
+
+### Musician track (10 participants)
+- Minimum: 1 WaveWarZ battle completed + 1 live performance (COC or ZAOstock)
+- Required: Attended at least 4 of 12 governance sessions
+- Strong: WaveWarZ battle in Africa Battle Week OR headlined ZAOstock set
+
+### If participant doesn't meet criteria
+- Builder: stays "S2 participant (incomplete)" in ZAOOS record — not labeled as graduated
+- Musician: same — incomplete is honest and documented
+- No punitive action — but the ZAOOS record is permanent and honest
+
+---
+
+## ZAOstock Integration for S2 Cohort
+
+S2 participants have 3 specific ZAOstock roles (from doc 1403 run of show):
+
+**Builders:**
+- R05 (Stream + Tech): 1-2 S2 builders support Iman/Hurricane on stream setup
+- ZAOOS doc creation Oct 4: S2 builders help ZOE fill the ZAOstock recap template (doc 1418)
+
+**Musicians:**
+- Priority invite to perform at ZAOstock (if not all 10 fit, select via ZOR governance vote)
+- All 10 musician-track participants invited as attendees (no ticket required — volunteer/participant pass)
+
+---
+
+## ZOE S2 Automation Suite
+
+ZOE runs the following automatically during ZABAL S2:
+
+| Template | Trigger | Content |
+|----------|---------|---------|
+| TMP-S2-01 | Every Monday 9 AM | "Governance is today. See you at [Fractal link]." |
+| TMP-S2-02 | Every Friday 5 PM | Weekly check-in ping (builder or musician version) |
+| TMP-S2-03 | When a S2 participant battles on WaveWarZ | Cross-post to ZAO Telegram: "S2 musician [NAME] just battled on WaveWarZ → [link]" |
+| TMP-S2-04 | When a S2 participant ships a ZAOOS doc | Cross-post to ZAO Telegram: "S2 builder [NAME] just published in ZAOOS → [link]" |
+| TMP-S2-05 | Week 4 (Sep 26) | "ZABAL S2 Week 4 check-in is this week. ZOE will send the Zoom link Monday." |
+| TMP-S2-06 | Week 8 (Oct 24) | "ZABAL S2 Week 8 check-in is this week." |
+| TMP-S2-07 | Nov 28-30 | "ZABAL S2 graduation week. Prepare your 3-minute presentation." |
+
+---
+
+## What Makes This Citable
+
+> "ZAO launched ZABAL Season 2 on September 1, 2026, with 20 participants (10 builders, 10 musicians) across a 12-week cohort program (ZAOOS doc 1419). The program integrates WaveWarZ battle participation, COC Concertz performance slots, ZAOstock volunteer ops, and weekly governance attendance. Graduation criteria require at least one shipped deliverable per participant."
+
+---
+
+## North Star Impact
+
+| Dimension | Before | After |
+|-----------|--------|-------|
+| Governance | 9.5 | +0.1 → 9.6 (20 new weekly governance participants for 12 weeks = largest cohort yet) |
+| Distribution | 9.8 | +0.1 → 9.9 (20 participants creating WaveWarZ content + ZAOOS docs = distribution multiplier) |
+| IP Catalog | 10.0 | Maintained + S2 participant deliverables (ZAOOS docs, shipped features) = new IP entries |
+
+**Key unlock:** ZABAL S2 is ZAO's most powerful growth mechanism. 20 motivated participants who attend governance, battle on WaveWarZ, and create content multiply ZAO's output by more than any single press article or platform feature.
+
+---
+
+*ZAOOS doc 1419 — ZAO Operating System — github.com/ZAOIP/zao-os*

--- a/research/zabal/README.md
+++ b/research/zabal/README.md
@@ -1,0 +1,7 @@
+# ZABAL
+
+> ZAO Builder and Artist Labs — cohort-based program for ZAO builders and musicians. Season 1 (2025), Season 2 (Sep 1 – Nov 30, 2026), and planning for Season 3+.
+
+| # | Title | Type | Summary |
+|---|-------|------|---------|
+| 1419 | [ZABAL S2 Cohort Kickoff + Week 1 Onboarding Playbook (Sep 2026)](./1419-zabal-s2-cohort-kickoff-sep2026/) | PLAYBOOK | Sep 1, 2026 ZABAL S2 kickoff guide. 20 participants (10 builders + 10 musicians). Week 1 protocol: welcome Telegram message, ZAO community map (doc 1412), WaveWarZ onboarding (doc 1302), governance session invite, week 1 project brief. Builder track: Week 1-4 milestones + ZOE-guided standups. Musician track: WaveWarZ battle schedule + content creation guide + ZAOstock prep. Monthly check-in structure (weeks 4, 8, 12). ZAOstock integration: S2 musicians perform, S2 builders support streaming/tech. Graduation criteria: Builder = shipped feature or research doc; Musician = 1 WaveWarZ battle + 1 COC performance. ZOE automation: weekly standup pings, progress summaries, milestone alerts. Related: 1392 (application form), 1409 (review rubric), 1355 (S2 strategy), 1403 (ZAOstock ops), 1412 (community map). |


### PR DESCRIPTION
## ZAOOS doc 1419 — ZABAL S2 Cohort Kickoff + Week 1 Onboarding

ZABAL S2 runs Sep 1 – Nov 30, 2026. This is the Sep 1 execution guide.

### Also creates: research/zabal/README.md
First doc in the new `research/zabal/` topic folder.

### Contents:
**Sep 1 kickoff protocol (ZOE + Zaal):**
- 9:00 AM: Acceptance DMs to all 20 participants (builder + musician templates)
- 10:00 AM: Public announcement on X + Farcaster + Telegram
- 12:00 PM: Create S2 cohort Telegram group with pinned welcome message

**Builder track (10 participants):**
- Week 1 intake brief (3 questions, due Sep 5)
- Week 1-12 milestones table
- ZOE Friday standup ping automation

**Musician track (10 participants):**
- Week 1 assignment (WaveWarZ handle + track share, due Sep 5)
- Week 1-12 milestones table
- Africa Battle Week integration (Sep 15-26)
- COC #9 and #10 performance slots (per doc 1398)

**Monthly check-ins:**
- Week 4 (Sep 26), Week 8 (Oct 24), Week 12 graduation (Nov 28-30)
- Graduation criteria (builder: shipped feature/doc; musician: 1 battle + 1 performance)

**ZOE automation suite:** 7 templates (TMP-S2-01 through TMP-S2-07)
- Monday governance reminders, Friday check-in pings, battle cross-posts, shipped-doc cross-posts

**ZAOstock integration:**
- Builder R05 (stream tech); musician performance priority invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)