### PR TITLE
fix(fractals): era filter uses scoring_era field, not notes strings

### DIFF
--- a/src/app/(auth)/fractals/SessionsTab.tsx
+++ b/src/app/(auth)/fractals/SessionsTab.tsx
@@ -89,16 +89,14 @@ export function SessionsTab({ isAdmin }: Props) {
       />
       <div className="flex gap-1 mb-3">
         {(['all', 'og', 'ordao'] as const).map((era) => {
-          const ogCount = sessions.filter(
-            (s) => s.notes?.includes('OG era') || s.notes?.includes('Airtable'),
-          ).length;
-          const ordaoCount = sessions.filter((s) => s.notes?.includes('ORDAO')).length;
+          const ogCount = sessions.filter((s) => s.scoring_era === '1x').length;
+          const ordaoCount = sessions.filter((s) => s.scoring_era === '2x').length;
           const label =
             era === 'all'
               ? `All (${total})`
               : era === 'og'
-                ? `OG (${ogCount})`
-                : `ORDAO (${ordaoCount})`;
+                ? `1x Era (${ogCount})`
+                : `2x Era (${ordaoCount})`;
           return (
             <button
               key={era}
@@ -126,9 +124,8 @@ export function SessionsTab({ isAdmin }: Props) {
             );
             if (!matchName && !matchHost && !matchParticipant) return false;
           }
-          if (eraFilter === 'og')
-            return s.notes?.includes('OG era') || s.notes?.includes('Airtable');
-          if (eraFilter === 'ordao') return s.notes?.includes('ORDAO');
+          if (eraFilter === 'og') return s.scoring_era === '1x';
+          if (eraFilter === 'ordao') return s.scoring_era === '2x';
           return true;
         })
         .map((session) => {


### PR DESCRIPTION
## Bug

Sessions tab era filter (1x / 2x) was counting and filtering by scanning session `notes` for specific strings (`"OG era"`, `"Airtable"`, `"ORDAO"`). Sessions without those exact phrases in their notes were miscounted and filtered incorrectly.

## Root cause

`scoring_era` column (`'1x'` / `'2x'`) exists in `fractal_sessions` for exactly this purpose (per `scripts/archive/old/create-respect-tables.sql`). The filter wasn't using it.

## Fix

- `ogCount` / `ordaoCount`: now counts `scoring_era === '1x'` / `scoring_era === '2x'`
- Era filter: now filters on `scoring_era` instead of `notes` content
- Labels: `OG` → `1x Era`, `ORDAO` → `2x Era` (consistent with the field values and the About tab's Fibonacci table)

## Test plan

- [ ] Load `/fractals?tab=sessions`
- [ ] `1x Era` filter should show sessions where the session row displays `"1x era"` in the subtitle
- [ ] `2x Era` filter should show sessions displaying `"2x era"` in the subtitle  
- [ ] `All (N)` count matches total sessions; `1x Era (N)` + `2x Era (N)` should together account for all sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)