### PR TITLE
fix(fractals): leaderboard on-chain column includes ZOR (OG+ZOR combined)

### DIFF
--- a/src/app/(auth)/fractals/FractalLeaderboardTab.tsx
+++ b/src/app/(auth)/fractals/FractalLeaderboardTab.tsx
@@ -12,12 +12,13 @@ interface LeaderboardEntry {
   fractalCount: number;
   onchainOG: number;
   onchainZOR: number;
+  onchainTotal: number;
   eventRespect: number;
   hostingRespect: number;
   bonusRespect: number;
 }
 
-type SortKey = 'totalRespect' | 'fractalRespect' | 'onchainOG' | 'fractalCount';
+type SortKey = 'totalRespect' | 'fractalRespect' | 'onchainTotal' | 'fractalCount';
 
 interface Props {
   currentFid: number;
@@ -35,9 +36,10 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
       .then((d) => {
         const seen = new Map<string, LeaderboardEntry>();
         for (const e of d.leaderboard ?? []) {
+          const entry = { ...e, onchainTotal: (e.onchainOG ?? 0) + (e.onchainZOR ?? 0) };
           const existing = seen.get(e.name);
-          if (!existing || e.totalRespect > existing.totalRespect) {
-            seen.set(e.name, e);
+          if (!existing || entry.totalRespect > existing.totalRespect) {
+            seen.set(e.name, entry);
           }
         }
         setEntries([...seen.values()]);
@@ -84,7 +86,7 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
   const SORT_OPTIONS: { key: SortKey; label: string }[] = [
     { key: 'totalRespect', label: 'Total' },
     { key: 'fractalRespect', label: 'Fractal' },
-    { key: 'onchainOG', label: 'On-Chain' },
+    { key: 'onchainTotal', label: 'On-Chain' },
     { key: 'fractalCount', label: 'Sessions' },
   ];
 
@@ -123,7 +125,7 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
               <p className="text-[10px] text-gray-500">Fractal R</p>
             </div>
             <div className="bg-[#0a1628]/60 rounded-lg p-2 text-center">
-              <p className="text-lg font-bold text-white">{me.onchainOG.toLocaleString()}</p>
+              <p className="text-lg font-bold text-white">{me.onchainTotal.toLocaleString()}</p>
               <p className="text-[10px] text-gray-500">On-Chain</p>
             </div>
           </div>
@@ -218,7 +220,7 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
         <span className="w-7">#</span>
         <span className="flex-1">Name</span>
         <span className="w-16 text-right">Fractal</span>
-        <span className="w-16 text-right">OG</span>
+        <span className="w-16 text-right">On-Chain</span>
         <span className="w-14 text-right">Total</span>
       </div>
 
@@ -251,7 +253,7 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
                 <p className="text-xs font-mono text-[#f5a623]">{entry.fractalRespect}</p>
               </div>
               <div className="w-16 text-right">
-                <p className="text-xs font-mono text-gray-400">{entry.onchainOG}</p>
+                <p className="text-xs font-mono text-gray-400">{entry.onchainTotal}</p>
               </div>
               <div className="w-14 text-right">
                 <p className="text-xs font-mono font-bold text-white">{entry.totalRespect}</p>


### PR DESCRIPTION
## Bug

The leaderboard "OG" column showed only `onchainOG` (Fractals 1–73 era Respect). Members who joined in the ZOR era (Fractal 74+, current era) had `onchainZOR` Respect but it was never displayed — they appeared to have **zero on-chain Respect** in the table and when sorting by "On-Chain".

## Fix

- Compute `onchainTotal = onchainOG + onchainZOR` when loading entries
- Rename sort key `onchainOG` → `onchainTotal` — "On-Chain" sort now covers both eras
- Rename table column header "OG" → "On-Chain", show combined total
- Fix "My Stats" card: "On-Chain" stat now shows `onchainTotal` instead of `onchainOG`

Both fields are already returned by `/api/respect/leaderboard`; this was a display-only gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
