### PR TITLE
fix(fractals): member history source field uses scoring_era not notes strings

### DIFF
--- a/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
+++ b/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
@@ -370,7 +370,7 @@ describe('GET /api/fractals/member/[wallet]', () => {
       expect(body.history[0].sessionName).toBe('Session B');
     });
 
-    it('detects ORDAO sessions from notes', async () => {
+    it('detects ORDAO sessions from scoring_era field', async () => {
       const member = {
         name: 'Henry',
         wallet_address: VALID_WALLET.toLowerCase(),
@@ -393,11 +393,11 @@ describe('GET /api/fractals/member/[wallet]', () => {
           member_name: member.name,
           fractal_sessions: {
             id: 's1',
-            name: 'ORDAO',
+            name: 'Fractal 80',
             session_date: '2024-03-10',
-            scoring_era: '3x',
+            scoring_era: '2x',
             participant_count: 12,
-            notes: 'ORDAO test',
+            notes: null,
           },
         },
         {

--- a/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
+++ b/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
@@ -524,7 +524,7 @@ describe('GET /api/fractals/member/[wallet]', () => {
             id: 's1',
             name: 'Session 1',
             session_date: '2024-01-01',
-            scoring_era: '2x',
+            scoring_era: '1x',
             participant_count: 10,
             notes: 'og',
           },

--- a/src/app/api/fractals/member/[wallet]/route.ts
+++ b/src/app/api/fractals/member/[wallet]/route.ts
@@ -76,7 +76,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ wall
 
     const history = (scores ?? []).map((s) => {
       const sess = Array.isArray(s.fractal_sessions) ? s.fractal_sessions[0] : s.fractal_sessions;
-      const isOrdao = sess?.notes?.includes('ORDAO') || sess?.notes?.includes('on-chain');
+      const isOrdao = sess?.scoring_era === '2x';
       const txMatch = sess?.notes?.match(/Tx: (0x[a-fA-F0-9]+)/);
       return {
         sessionName: sess?.name ?? 'Unknown',

--- a/src/app/api/members/[username]/route.ts
+++ b/src/app/api/members/[username]/route.ts
@@ -321,7 +321,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
     const history = (fractalScores || [])
       .map((s) => {
         const sess = Array.isArray(s.fractal_sessions) ? s.fractal_sessions[0] : s.fractal_sessions;
-        const isOrdao = (sess as Record<string, unknown>)?.notes?.toString().includes('ORDAO');
+        const isOrdao = (sess as Record<string, unknown>)?.scoring_era === '2x';
         return {
           sessionName: (sess as Record<string, unknown>)?.name ?? 'Unknown',
           sessionDate: (sess as Record<string, unknown>)?.session_date ?? null,


### PR DESCRIPTION
## Bug

Two member-profile API routes determined whether a fractal session was in the ORDAO era by scanning `session.notes` for keywords:

- `members/[username]/route.ts:324` — `notes.includes('ORDAO')`
- `fractals/member/[wallet]/route.ts:79` — `notes.includes('ORDAO') || notes.includes('on-chain')`

This `isOrdao` flag sets `source: 'ordao' | 'og'` on each history entry, which the AnalyticsTab uses to display an "on-chain" badge next to sessions and in the member drill-down panel.

Same root cause as:
- PR #2154 — SessionsTab era filter
- PR #2165 — analytics route ogSessions count

## Fix

Both routes already select `scoring_era` from `fractal_sessions` in the DB query. Switch `isOrdao` to use `scoring_era === '2x'`.

`txHash` extraction from notes is unchanged (still needed for Etherscan links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
