### PR TITLE
fix(fractals): live tab polls 60s idle / 10s during active sessions

### DIFF
--- a/src/components/governance/LiveFractalDashboard.tsx
+++ b/src/components/governance/LiveFractalDashboard.tsx
@@ -216,13 +216,11 @@ export function LiveFractalDashboard() {
   useEffect(() => {
     fetchData();
 
-    // Auto-refresh every 10 seconds when there are active sessions
-    const interval = setInterval(() => {
-      fetchData();
-    }, 10_000);
+    // 10s when a session is live, 60s otherwise (saves API calls between Mondays)
+    const interval = setInterval(fetchData, data?.has_active ? 10_000 : 60_000);
 
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, data?.has_active]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Bug

`LiveFractalDashboard` polled `/api/discord/fractal-live` every 10 seconds unconditionally. The comment said *"Auto-refresh every 10 seconds when there are active sessions"* but the condition was never implemented — it polled every 10s including the 6 days 23 hours per week when no fractal is live (Monday sessions run ~60–90 min).

## Fix

- `data?.has_active === true` → poll every **10s** (Monday 6pm EST while fractal is live)
- `data?.has_active === false/undefined` → poll every **60s** (rest of the week)

Adding `data?.has_active` to the `useEffect` dependency array means the interval automatically switches when a session goes live or ends.

~6× reduction in API calls during off-hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
