### PR TITLE
research: 1506 Devcon 8 tickets + access update July 18 2026 — APPLY NOW

### DIFF
--- a/research/events/1503-devcon8-tickets-access-update-jul2026/README.md
+++ b/research/events/1503-devcon8-tickets-access-update-jul2026/README.md
@@ -1,0 +1,115 @@
+---
+topic: events
+type: action-brief
+status: APPLY NOW
+last-validated: 2026-07-18
+related-docs: 1063-devcon-america-us-builder-community-track, 945-devcon8-mumbai-buildcamp-sponsorship, 954-devcon-history-community-mumbai-guide
+action-owner: Zaal
+action-deadline: 2026-07-18 (Builder Discount — rolling, apply before it sells out)
+original-query: "Devcon 8 ticket access update July 2026 — doc 1063 had 'Builder Discount expected July 2026, not yet open'; checking live status."
+tier: STANDARD
+---
+
+# 1503 — Devcon 8 Tickets + Access Update (July 18, 2026)
+
+> **STATUS: APPLY NOW.** Builder Discount (Sanctuary Tech Builder) opened July 14, 2026 — 4 days ago. Early Bird at $349 with limited quantity. This updates doc 1063 which had this as "expected July 2026, not yet confirmed."
+
+---
+
+## What Just Changed (vs. Doc 1063)
+
+| Item | Doc 1063 status (Jul 13) | Current status (Jul 18) |
+|------|--------------------------|--------------------------|
+| Builder Discount (Sanctuary Tech Builder) | "Expected July 2026, page 403'd" | **OPEN. $349. Apply at tickets.devcon.org.** |
+| Devcon Scholars | "Page not updated for Devcon 8" | Still stale — page references Devconnect 2025, no Devcon 8 cycle announced |
+| Creative Crew | "No page found" | Still no page found |
+| ESP rtd8_india for Hurricane India trip | "Promising lead, not verified against real form" | **Verified: max $300, too small for artist travel. See below.** |
+| General Admission | Not listed in 1063 | **$499** (no application needed) |
+
+---
+
+## Devcon 8 Full Ticket Matrix (Live, Jul 18, 2026)
+
+**Event:** Devcon 8, Nov 3–6, 2026 | Jio World Center, Mumbai, India
+
+| Ticket type | Price | Who qualifies | Application? |
+|-------------|-------|---------------|--------------|
+| General Admission | $499 | Anyone | No |
+| India Resident | $149 | India-based attendees (verified at door) | No |
+| India Early Bird | $99 | India-based, early | No |
+| **Sanctuary Tech Builder** | **$349** | **Developers, designers, builders of open/decentralized tech** | **Yes — apply at tickets.devcon.org** |
+| Ethereum Public Goods | $349 (ETH only) | Public goods contributors | ETH-only payment |
+| Core Devs / Protocol Guild | **Free** | Core Ethereum devs, Protocol Guild members | Verified |
+| Indian Students | $25 | Students, India-based | Yes |
+| International Students | $49 | Students, international | Yes |
+| Past POAP Holders | $449 | Holders of prior Devcon POAPs | No |
+| Youth (3–17) | $19 | Under 18 | No |
+
+---
+
+## ZAO Action: Apply for Sanctuary Tech Builder NOW
+
+The "Sanctuary Tech Builder" ticket at $349 is the relevant lever for ZAO builders:
+
+- **Who qualifies:** Developers, designers, and "everyone building the open, privacy-preserving, decentralized technologies." This is Zaal + any ZAO/ZABAL Games/WaveWarZ devs.
+- **Criteria:** Builders of the decentralized/open web. ZAO OS V1, ZABAL Games, WaveWarZ, ZOL, Sparkz — all qualify.
+- **Process:** Apply at tickets.devcon.org. Verification and valid ID required at check-in.
+- **Rolling batches:** Applications reviewed on a rolling basis; apply early.
+- **Early Bird:** $349 vs General Admission $499 = $150 saved per person.
+
+**Action for Zaal:** Apply at tickets.devcon.org immediately. For each additional ZAO builder attending, send them the same link. No bulk purchase — each person applies individually.
+
+---
+
+## ESP rtd8_india: Closed for WaveWarZ/Hurricane Artist Travel
+
+From the actual application page (esp.ethereum.foundation/applicants/rfp/rtd8_india, fetched July 18):
+
+- **Max grant: $300 USD + up to 5 tickets**
+- **Event window:** August 1 – October 15, 2026 (before Devcon, not at Devcon)
+- **Eligible activities:** Meetups, bootcamps, hackathons, roundtables, academic collaborations — community/educational focus
+- **Geographic requirement:** "Based in India or targeting Indian audiences"
+
+**Verdict on WaveWarZ/Hurricane India track:** NOT a viable funding mechanism for bringing Hurricane from the US to Mumbai for Devcon. Reasons:
+1. $300 cap doesn't cover international flights + accommodation (an India round trip from the US is typically $900–1,400+).
+2. The grant funds community events (meetups, hackathons) happening *before* Devcon — not artist travel to Devcon itself.
+3. A performance at Devcon India (Nov 3–6) doesn't fall within the Aug 1–Oct 15 event window.
+
+**What DOES work for Hurricane going to India:** The separate crowdfunding track (doc 945 model — Juicebox splits, individual campaign). If the WaveWarZ community wants to crowdfund Hurricane's India trip, Juicebox is the right mechanism. The ESP grant can fund a WaveWarZ *meetup in India* (a local Indian community event about WaveWarZ, separate from Devcon attendance) but not the travel itself.
+
+---
+
+## Devcon Scholars: Still Stale — Watch in August
+
+The nxbn.ethereum.foundation/scholars page as of July 18 still references Devconnect 2025 (Buenos Aires). No Devcon 8 application cycle has been announced.
+
+**What to do:** Subscribe to the Ethereum Foundation blog or follow @ethereum on X for the announcement. Scholars applications for Devcon SEA 2024 opened approximately 3 months before the event; Devcon 8 is Nov 3–6, so watch for a Scholars announcement starting August 2026.
+
+Scholars covers: full ticket + round-trip flight + room/board. If this opens, it supersedes the $349 Builder Discount for anyone who needs travel cost coverage, not just the ticket.
+
+---
+
+## Revised Action Table (Updates Doc 1063)
+
+| Action | Owner | Deadline | Status |
+|--------|-------|----------|--------|
+| Apply for Sanctuary Tech Builder ticket ($349) | Zaal | NOW — rolling batches | **DO NOW** |
+| Apply for Builder Discount for each ZAO builder attending | Per-builder | Rolling, before tickets sell out | **DO NOW** |
+| Watch @ethereum for Devcon 8 Scholars announcement | Zaal | Monthly check | Watching |
+| Hurricane India crowdfund: use Juicebox splits model, NOT ESP grant | Hurricane / WaveWarZ community | When Hurricane confirms intent | Unblocked — mechanism clear |
+| Run Build Camp × ZABAL Games roundtable (content, not grant) | Zaal + Claude | 2026-08-10 | Unchanged from 1063 |
+| Named US builder roster | Zaal | ASAP (blocks pooled crowdfund sizing) | **Still blocked on Zaal input** |
+
+---
+
+## Also See
+
+- [Doc 1063 - DevCon America: US builder route into Devcon 8](../1063-devcon-america-us-builder-community-track/) — the full plan this doc updates
+- [Doc 945 - Devcon 8 Mumbai: Buildcamp + Sponsorship](../945-devcon8-mumbai-buildcamp-sponsorship/) — Zaal's India trip funding stack (crowdfund model)
+
+## Sources
+
+- [Ethereum Foundation Blog: Devcon 8 Tickets Are Live (Jul 14, 2026)](https://blog.ethereum.org/2026/07/14/devcon8-tickets) [FULL]
+- [tickets.devcon.org](https://tickets.devcon.org/) [FULL — fetched Jul 18, 2026] — live ticket prices + types
+- [esp.ethereum.foundation/applicants/rfp/rtd8_india](https://esp.ethereum.foundation/applicants/rfp/rtd8_india) [FULL — fetched Jul 18, 2026] — $300 cap, Oct 15 window, eligibility requirements
+- [nxbn.ethereum.foundation/scholars](https://nxbn.ethereum.foundation/scholars) [FULL — fetched Jul 18, 2026] — still stale (Devconnect 2025), no Devcon 8 cycle yet

--- a/research/events/1506-devcon8-tickets-access-update-jul2026/README.md
+++ b/research/events/1506-devcon8-tickets-access-update-jul2026/README.md
@@ -10,7 +10,7 @@ original-query: "Devcon 8 ticket access update July 2026 — doc 1063 had 'Build
 tier: STANDARD
 ---
 
-# 1503 — Devcon 8 Tickets + Access Update (July 18, 2026)
+# 1506 — Devcon 8 Tickets + Access Update (July 18, 2026)
 
 > **STATUS: APPLY NOW.** Builder Discount (Sanctuary Tech Builder) opened July 14, 2026 — 4 days ago. Early Bird at $349 with limited quantity. This updates doc 1063 which had this as "expected July 2026, not yet confirmed."
 


### PR DESCRIPTION
## Summary

**URGENT UPDATE to doc 1063.** Devcon 8 Builder Discount (Sanctuary Tech Builder, $349) opened July 14, 2026 — 4 days ago. Doc 1063 had this as "expected July 2026, not yet open." Apply immediately at tickets.devcon.org.

Also verifies the ESP rtd8_india grant eligibility for the WaveWarZ/Hurricane India crowdfund (spoiler: $300 cap = not viable for international artist travel).

**Key findings (live-fetched Jul 18):**
- Sanctuary Tech Builder ticket: $349, open NOW, rolling batches — builders of open/decentralized tech qualify
- General Admission: $499 (no application)
- India Resident: $149, India Early Bird: $99
- Devcon Scholars: still stale (references Devconnect 2025), watch for Devcon 8 announcement in August
- ESP rtd8_india: $300 max + up to 5 tickets, events must happen Aug 1–Oct 15 (before Devcon), not viable for Hurricane travel to Devcon

**Action for Zaal:** Apply at tickets.devcon.org now.

## Files

- `research/events/1503-devcon8-tickets-access-update-jul2026/README.md`

---
*Warpee research loop — cycle 4 (2026-07-18)*