### PR TITLE
fix(fractals): analytics chart coloring uses era field, removes brittle index heuristic

### DIFF
--- a/src/app/(auth)/fractals/AnalyticsTab.tsx
+++ b/src/app/(auth)/fractals/AnalyticsTab.tsx
@@ -185,8 +185,7 @@ export function AnalyticsTab() {
         <div className="flex items-end gap-px h-24 overflow-x-auto">
           {participationTimeline.map((entry, i) => {
             const height = (entry.participants / maxParticipants) * 100;
-            const isOrdao =
-              entry.era === '2x' && i >= participationTimeline.length - overview.ordaoSessions;
+            const isOrdao = entry.era === '2x';
             return (
               <div
                 key={`${entry.name}-${i}`}
@@ -515,7 +514,7 @@ export function AnalyticsTab() {
       )}
 
       <p className="text-[10px] text-gray-600 text-center">
-        Data from Airtable (OG era) + ORDAO on-chain (Optimism). All on-chain data verifiable.
+        OG era records (scoring_era 1x) + ORDAO on-chain results (scoring_era 2x, Optimism). All on-chain data verifiable.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

- `AnalyticsTab.tsx` line 188: removes the redundant `&& i >= participationTimeline.length - overview.ordaoSessions` index check from `isOrdao`
- `isOrdao = entry.era === '2x'` is sufficient and correct — the era field already comes from `scoring_era` in the API response (fixed in open PR #2165)
- The old index check was brittle: if `overview.ordaoSessions` was wrong (it is, due to the notes bug that PR #2165 fixes), bar coloring on the participation timeline would be off
- Also updates the footer attribution text from "Data from Airtable (OG era)" to reference `scoring_era` fields directly

## What changed

- `src/app/(auth)/fractals/AnalyticsTab.tsx` — 3 lines changed (2 removed)

## Related PRs

- #2165 (ws/analytics-era-fix-0718): fixes `ogSessions`/`ordaoSessions` counting in the API route — this PR removes the UI's dependency on that count for chart coloring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
