### PR TITLE
fix(fractals): webhook writes scoring_era '2x' not 'ORDAO' for live sessions

### DIFF
--- a/src/app/api/fractals/webhook/route.ts
+++ b/src/app/api/fractals/webhook/route.ts
@@ -254,7 +254,7 @@ async function handleFractalStarted(
       session_date: new Date().toISOString().split('T')[0],
       host_name: data.facilitatorDiscordId,
       participant_count: data.participantDiscordIds.length,
-      scoring_era: 'ORDAO',
+      scoring_era: '2x',
       status: 'active',
       notes: JSON.stringify({
         guildId: data.guildId,


### PR DESCRIPTION
## Summary

The `fractal_started` webhook handler (`src/app/api/fractals/webhook/route.ts:257`) was writing `scoring_era: 'ORDAO'` when inserting new live fractal sessions. The canonical value is `'2x'` (ORDAO era).

**Impact:** Any session created via the Discord bot webhook would have `scoring_era = 'ORDAO'`, causing it to:
- Not match the `s.scoring_era === '2x'` filter in PR #2165 (analytics era fix) → invisible to ORDAO session count
- Not match `entry.era === '2x'` in AnalyticsTab → rendered in OG color (dimmed gold) instead of full gold in the participation chart
- Potentially show wrong era label in SessionsTab after PR #2154 merges

## What changed

- `src/app/api/fractals/webhook/route.ts` — 1 line changed: `'ORDAO'` → `'2x'`

## Related PRs

- #2165: fixes analytics route era counting (uses `scoring_era === '1x'`/`'2x'`)
- #2192: fixes analytics chart coloring (uses `entry.era === '2x'`)
- #2154: fixes SessionsTab era filter (uses `s.scoring_era === '1x'`/`'2x'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
