### PR TITLE
fix(fractals): guard fetch calls with response.ok; add empty Respect card

### DIFF
--- a/src/app/(auth)/fractals/AnalyticsTab.tsx
+++ b/src/app/(auth)/fractals/AnalyticsTab.tsx
@@ -93,7 +93,7 @@ export function AnalyticsTab() {
 
   useEffect(() => {
     fetch('/api/fractals/analytics')
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((d) => setData(d))
       .catch(console.error)
       .finally(() => setLoading(false));
@@ -103,7 +103,7 @@ export function AnalyticsTab() {
     setSelectedMember(walletOrName);
     setMemberLoading(true);
     fetch(`/api/fractals/member/${encodeURIComponent(walletOrName)}`)
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((d) => setMemberProfile(d))
       .catch(console.error)
       .finally(() => setMemberLoading(false));

--- a/src/app/(auth)/fractals/FractalLeaderboardTab.tsx
+++ b/src/app/(auth)/fractals/FractalLeaderboardTab.tsx
@@ -31,7 +31,7 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
 
   useEffect(() => {
     fetch('/api/respect/leaderboard')
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((d) => {
         const seen = new Map<string, LeaderboardEntry>();
         for (const e of d.leaderboard ?? []) {
@@ -94,6 +94,11 @@ export function FractalLeaderboardTab({ currentFid }: Props) {
   return (
     <div className="pt-2 space-y-3">
       {/* My Stats Card */}
+      {!me && !loading && (
+        <div className="bg-[#0d1b2a] rounded-xl border border-white/10 p-4 text-center text-gray-500 text-sm">
+          No stats yet — join the next Fractal session to earn Respect
+        </div>
+      )}
       {me && (
         <div className="bg-gradient-to-br from-[#f5a623]/10 to-[#0d1b2a] rounded-xl border border-[#f5a623]/20 p-4">
           <div className="flex items-center justify-between mb-3">

--- a/src/app/(auth)/fractals/SessionsTab.tsx
+++ b/src/app/(auth)/fractals/SessionsTab.tsx
@@ -45,7 +45,7 @@ export function SessionsTab({ isAdmin }: Props) {
 
   useEffect(() => {
     fetch('/api/fractals/sessions?limit=200')
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((d) => {
         setSessions(d.sessions ?? []);
         setTotal(d.total ?? 0);

--- a/src/app/(auth)/fractals/WeeksTab.tsx
+++ b/src/app/(auth)/fractals/WeeksTab.tsx
@@ -39,7 +39,7 @@ export function WeeksTab() {
 
   useEffect(() => {
     fetch('/api/fractals/matrix')
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((d) => setData(d))
       .catch(console.error)
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Summary

Fractal dashboard audit fixes (from dashboard UX audit 2026-07-18):

- **response.ok guard on 4 fetch calls** — `SessionsTab`, `FractalLeaderboardTab`, `AnalyticsTab` (×2) now reject on non-2xx before calling `.json()`. Previously an API error (404, 500) would silently parse the error payload as success data, causing blank charts or corrupted state.
- **Empty "me" card in leaderboard** — when `currentFid` is not in the leaderboard (new member, no Respect yet), shows a friendly "No stats yet" prompt instead of leaving a blank gap.

## Test plan
- [ ] Load `/fractals` Leaderboard tab — new users see "No stats yet" card
- [ ] Kill API temporarily (or check network tab) — fetch errors are caught and logged, no silent data corruption
- [ ] Existing leaderboard data unaffected for members with Respect