### PR TITLE
docs: ZAO member services directory (1522)

### DIFF
--- a/research/community/1522-zao-member-services-directory/README.md
+++ b/research/community/1522-zao-member-services-directory/README.md
@@ -1,0 +1,133 @@
+---
+topic: community
+type: reference
+status: LIVE — update after each new service launch
+last-validated: 2026-07-18
+related-docs: 1094b-empire-builder, 1476-viniapp-sparkz-evaluation, 1494-miniapp-analytics-distribution, 1269-zol-farcaster-music-scout-jul2026, 1281-zao-member-journey-jul2026
+board-task: Compile a list of community-member services members can tap
+action-owner: ZOE (post this to Farcaster /zao and Telegram as a pinned directory)
+---
+
+# 1522 — ZAO Member Services Directory (July 2026)
+
+> **Purpose:** Single reference for what ZAO community members can access, create, and earn. For ZOE to post + pin, and for Zaal to onboard new members with.
+
+---
+
+## For Artists
+
+### Earn from Your Music
+
+| Service | What it is | How to start |
+|---------|-----------|-------------|
+| **WaveWarZ** | Live-traded music battles. Fans stake SOL on who wins. Both artists earn from the pool — win or lose. | Register at `wavewarz.info`. Free to join. Battles run weeknight 8:30pm EST (X Spaces + YouTube). |
+| **COC Concertz** | Monthly livestreamed concerts (7 episodes, unbroken). Every show on YouTube. | Contact Zaal or ZOE (@zaoclaw_bot on Telegram) to be considered for a future slot. |
+| **JubJub** (coming) | Per-second streaming revenue on your media archive. Pay-per-second USDC on Base, 97% to you. | Partnership doc 1274. COC archive integration planned for July. Contact Tom McCarthy via ZAO to get listed early. |
+
+### Get Your Name Out
+
+| Service | What it is | How to start |
+|---------|-----------|-------------|
+| **ZOL Artist Spotlight** | @zolbot (FID 3338501) posts artist spotlights on Farcaster — curated, human-gated. Once live (ZOL PR #61 merging), weekly drafts go to Zaal for approval. | Be active in ZAO spaces. ZOL reads `neynar-learnings.md` to find artists to spotlight. |
+| **ZABAL token** | ZAO's reputation currency. Earn ZABAL by contributing: music, art, code, governance. | Participate in the weekly Fractal Respect Game. |
+| **Africa Battle Week** | Sep 26, 2026. ZAO hosts a community WaveWarZ battle (US vs. West Africa) where 100% of the payout goes to a charity voted on by ZOR holders. | West African artists: DM @wavewarz or reply to the Jul 20 nomination post in Farcaster /zao. |
+
+---
+
+## For Builders
+
+### Build on ZAO Infrastructure
+
+| Service | What it is | How to start |
+|---------|-----------|-------------|
+| **ZAO OS (ZAOOS)** | Open-source monorepo. Rails for ZAO's apps and experiments. Next.js 14, Supabase, Solana, Base. | `gh repo clone bettercallzaal/ZAOOS`. Docs in `research/`. PRs welcome. |
+| **ZABAL Games** | 3-month free build-a-thon. Three tracks: Artist, Builder, Creator. Prizes in USDC + Respect. July is open build month (goal: 200 builders). | Sign up at `zabalgamez.com`. Submissions tracked via Bonfire + app.magnetiq.xyz. |
+| **Empire Builder write API** | Fully public API for Clanker-based token creation. Post casts that launch or interact with creator tokens. | Public API — no auth needed for reads. See doc 1094b for endpoint catalog. |
+| **Viniapp × Sparkz** (coming) | Sparkz integration block in Viniapp's Ideas UI — when Sparkz V1 ships, builders in Viniapp can hook into Sparkz access coins. | Track Sparkz V1 timeline via ZAOOS. ZABAL Games compute credits pot already configured. |
+| **WaveWarZ Mini App** | Battle-native Farcaster miniapp. When live: vote on battles directly in Farcaster feed. Manifest target: before Jul 25. | Follow `wavewarz.info` and Farcaster /wavewarz channel. |
+
+### Governance + Voting
+
+| Service | What it is | How to start |
+|---------|-----------|-------------|
+| **ZOR (ZAO governance token)** | ERC-1155 on Optimism. 55+ holders. Gives you a vote on ZAO's on-chain decisions via OREC (72h vote + 72h veto window). | Earn Respect in the weekly Fractal game. ZOR holders also decide Africa Battle Week charity. |
+| **Weekly Fractal Respect Game** | Weekly ZAO meeting where contributors earn Fibonacci-curve Respect scores. 104+ unbroken weeks as of Jul 2026. | Join the ZAO Telegram group and attend Friday session. |
+| **Whitepaper Hat** | A Hats Protocol Hat on Optimism for ZAO Whitepaper authors. Signifies co-authorship of ZAO's founding documents. | Contribute to the whitepaper v1.0 effort (3 docs → permaweb). See governance board. |
+
+---
+
+## For Community Members
+
+### Stay Informed
+
+| Service | What it is | How to access |
+|---------|-----------|-------------|
+| **Farcaster /zao channel** | ZAO's primary Farcaster channel. Battle results, governance votes, product updates, artist spotlights. | Follow at `warpcast.com/~/channel/zao` |
+| **Farcaster /wavewarz channel** | Dedicated WaveWarZ channel. Battle results after every MAIN battle. Governance recaps. | Follow at `warpcast.com/~/channel/wavewarz` |
+| **ZAO Telegram** | Main ZAO group + ZOE bot (@zaoclaw_bot). Morning briefs, evening recaps, governance nudges. | DM Zaal or ZOE on Telegram to be added. |
+| **ZOL (@zolbot)** | Autonomous Farcaster music curator. Posts daily music finds + weekly curated recaps (once activated). | Follow @zolbot on Warpcast (FID 3338501). |
+| **Bonfire (zabal.bonfires.ai)** | ZAO's knowledge graph. Every meeting, decision, and research doc fed into episodic memory. ZOE uses it for recall. | Read-only public; ZAO members can suggest topics to feed. |
+
+### Attend Events
+
+| Event | When | Where | Cost |
+|-------|------|-------|------|
+| **Clanker + Empire Farcaster Space** | Jul 23, 2026, 10am ET | Warpcast Farcaster Spaces | Free |
+| **COC Concertz #8** | Date TBD (decision Jul 21) | YouTube + X Spaces | Free |
+| **Africa Battle Week** | Sep 26, 2026 | WaveWarZ platform (online) | Free |
+| **ZAOstock 2026** | Oct 3, 2026 | Ellsworth, ME (venue TBD) | $20 GA via Eventbrite |
+| **Devcon 8** | Nov 3-6, 2026 | Jiu World Center, Mumbai | $349 Builder Discount (ZAO members eligible) |
+
+---
+
+## What ZAO Doesn't Do (for Clarity)
+
+| Not ZAO | Why |
+|---------|-----|
+| Pay-to-play | All ZAO services are free to join. Artists earn from contribution, not from buying in. |
+| Hold your keys | ZAO uses SIWE (sign-in with wallet) + Hats Protocol. No private key custody. |
+| "Community" for its own sake | ZAO is an impact network. The priority stack is: music first, community second, technology third. |
+| Creator coins as speculation | Sparkz access coins are designed as cultural membership, not meme tokens. |
+
+---
+
+## How to Share This
+
+**Suggested ZOE Farcaster cast (for /zao channel):**
+> What ZAO community members can tap into — July 2026:
+>
+> Artists: WaveWarZ battles, COC Concertz, ZOL artist spotlight (coming), Africa Battle Week
+> Builders: ZABAL Games (open build month), ZAOOS, Empire Builder API, WaveWarZ Mini App
+> Community: /zao + /wavewarz channels, ZAO Telegram, ZOL, ZAOstock Oct 3
+>
+> Full directory: [link to ZAOOS doc 1522]
+
+**Suggested Telegram pin (ZAO group):**
+
+> ZAO member services — Jul 2026:
+> Artists → WaveWarZ battles + COC shows + Africa Battle Week (Sep 26)
+> Builders → ZABAL Games (zabalgamez.com) + ZAOOS + Empire Builder API
+> Community → /zao channel + ZOL (@zolbot) + ZAOstock Oct 3 ($20)
+> Governance → Weekly Fractal + ZOR token + OREC
+
+---
+
+## Update Cadence
+
+This doc should be updated after:
+- A new service launches (e.g., JubJub COC integration, Sparkz V1)
+- A service goes offline or pauses
+- ZAOstock date/lineup is confirmed
+- New Farcaster channels launch (e.g., /zabal)
+
+**Next update trigger:** Aug 1, after July ZABAL Games build month closes and COC #8 date is confirmed.
+
+---
+
+## Related Docs
+
+- [Doc 1281 — ZAO member journey](./1281-zao-member-journey-jul2026/) — onboarding path from first contact → ZOR holder
+- [Doc 1476 — Viniapp × Sparkz partnership](../../business/1476-viniapp-sparkz-sparkz-evaluation/) — ZABAL Games compute credits + Sparkz integration plan
+- [Doc 1269 — ZOL music scout](../../identity/1269-zol-farcaster-music-scout-jul2026/) — ZOL architecture, capability lanes
+- [Doc 1094b — Empire Builder API](../../farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094b-empire-builder-write-api/) — builder API catalog
+- [Doc 1274 — JubJub × ZAO partnership brief](../../business/1274-jubjub-zao-partnership-brief/) — per-second streaming revenue tiers


### PR DESCRIPTION
## Summary

- Doc 1522: catalog of all ZAO community services organized by role (artist, builder, community member)
- Closes board task: "Compile a list of community-member services members can tap"
- Designed to be posted by ZOE as a pinned Farcaster /zao cast + Telegram pin

## What's covered

**Artists:** WaveWarZ battles, COC Concertz, ZOL artist spotlight, Africa Battle Week (Sep 26), JubJub (coming)

**Builders:** ZABAL Games (zabalgamez.com, open build month), ZAOOS, Empire Builder write API, Viniapp × Sparkz (coming), WaveWarZ Mini App (target Jul 25)

**Community:** Farcaster /zao + /wavewarz channels, ZAO Telegram, ZOL @zolbot, Bonfire knowledge graph

**Events:** Clanker+Empire Space (Jul 23), COC #8 (TBD), Africa Battle Week (Sep 26), ZAOstock (Oct 3, $20), Devcon 8 (Nov 3-6, $349)

## Includes

- "What ZAO doesn't do" clarity section (no key custody, no pay-to-play)
- Paste-ready ZOE cast templates for Farcaster + Telegram
- Update cadence (next refresh: Aug 1 after ZABAL Games build month + COC #8 date)

## Test plan

- [ ] ZOE posts or prepares the `/zao` Farcaster cast
- [ ] Pin to ZAO Telegram group
- [ ] Update after Aug 1 (COC #8 date, ZABAL Games count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
