### PR TITLE
docs(events): ZAOville Jul 25 Farcaster posting schedule — cast-by-cast plan (doc 1578)

### DIFF
--- a/research/events/1578-zaoville-jul25-farcaster-posting-schedule/README.md
+++ b/research/events/1578-zaoville-jul25-farcaster-posting-schedule/README.md
@@ -1,0 +1,302 @@
+---
+topic: events, farcaster, community
+type: activation-schedule
+status: DO NOW — ZAOville is Jul 25 (5 days). Pre-event posts start Jul 23.
+last-validated: 2026-07-20
+related-docs: 1228-zaoville-jul25-day-of-runbook, 1572-wavewarz-zabal-farcaster-channel-growth, 993-zol-farcaster-upgrades
+board-tasks: None (event Farcaster strategy supporting channel growth)
+action-owner: ZOL (automated posts); Zaal (photo/video posts from phone during event); ZOE (schedules pre-event posts)
+---
+
+# 1578 — ZAOville Jul 25: Farcaster Posting Schedule
+
+> **What this is:** A cast-by-cast plan for Farcaster on ZAOville day (Jul 25) and the 2 pre-event days. Every cast is written and ready — ZOE queues the scheduled ones, Zaal sends the real-time ones from DCoop's pool party. Goal: convert ZAOville attendees and Farcaster viewers into /wavewarz and /zabal followers.
+
+---
+
+## Why This Matters
+
+ZAOville is the first major live event since ZAO's Farcaster presence was established. It's a direct opportunity to:
+- Grow /wavewarz from 2 → 30+ followers (from the performance footage alone)
+- Grow /zabal from 32 → 50+ members (by showing the community in action)
+- Document the first live WaveWarZ battle footage for future promotion
+
+Doc 1572 establishes the long-term channel growth playbook. This doc is the event-specific execution.
+
+---
+
+## Pre-Event Posts (ZOE Queues, Zaal Approves)
+
+### Thursday Jul 23 — Hype Cast
+
+**Posted in:** /wavewarz and /zabal  
+**From:** @bettercallzaal  
+**Time:** 12pm ET
+
+```
+ZAOville is Saturday.
+
+Pool party. Live music. WaveWarZ battles.
+Laurel MD — free entry.
+
+If you're in the DMV, this is the vibe.
+@dcoopofficial's house, 11AM–10PM.
+
+RSVP: [Eventbrite or DM link]
+
+Casting it live on Farcaster /wavewarz all day.
+```
+
+**Why this cast:** Announces the event, sets the tone, drives RSVPs. Tags /wavewarz so anyone who follows the channel sees it.
+
+---
+
+### Friday Jul 24 — Prep Cast
+
+**Posted in:** /wavewarz  
+**From:** @bettercallzaal  
+**Time:** 5pm ET
+
+```
+24 hours until ZAOville.
+
+Running a 9-hour livestream from the pool.
+Open mic at 3PM, performances at 5PM, DJ night swim at 9:30PM.
+
+If you can't make it in person — follow /wavewarz on Farcaster.
+I'll be casting from the venue all day.
+```
+
+**Why this cast:** Converts remote Farcaster viewers into /wavewarz followers who want to follow the live event narrative.
+
+---
+
+## Day-Of Posts (Zaal Posts from Phone)
+
+### 10:00 AM — Setup Shot
+
+**Channel:** /wavewarz  
+**From:** @bettercallzaal  
+**Type:** Photo or short video (ATEM setup, pool view, crew arriving)
+
+```
+Setting up for ZAOville.
+
+Pool looks different when it's about to have 80 people and a live stage.
+
+Follow along in /wavewarz today. 📍 Laurel MD
+```
+
+**Why:** First post of the day from venue sets the scene. Drives people to follow /wavewarz for the day's narrative.
+
+---
+
+### 11:00 AM — Doors Open
+
+**Channel:** /zabal  
+**From:** @bettercallzaal  
+**Type:** Short clip (first arrivals at the pool)
+
+```
+ZAOville is open.
+
+First crew just pulled up. Pool's ready, music's on.
+If you're coming, come.
+
+11AM–10PM, free entry. Dcoop's house, Laurel MD.
+```
+
+---
+
+### 3:00 PM — Open Mic Announcement
+
+**Channel:** /wavewarz and /zabal  
+**From:** @bettercallzaal  
+**Type:** Video clip (performer stepping up, crowd gathering)
+
+```
+Open mic is live at ZAOville.
+
+Anyone can step up — no set limits, no gate.
+This is what ZAO sounds like.
+
+/wavewarz
+```
+
+**Why:** Open mic is the most community-forward part of ZAOville. Shows the "anyone can participate" energy.
+
+---
+
+### 5:00 PM — Performance Starts (Most Important Post of the Day)
+
+**Channel:** /wavewarz  
+**From:** @bettercallzaal  
+**Type:** Video clip (30–60 seconds, first main performance)
+
+```
+Performances are live at ZAOville.
+
+This is what we're building toward at ZAOstock Oct 3.
+Today is the proof of concept.
+
+/wavewarz — every performance, every battle, all day.
+```
+
+**Why:** Peak engagement time. Video of a live performance in /wavewarz gives viewers who've never seen ZAO a clear picture of what it is. Performance clip is the most shareable asset.
+
+---
+
+### 5:30 PM — ZOL Automated Battle Result (If WaveWarZ Battle Happens)
+
+**Channel:** /wavewarz  
+**From:** @zolbot  
+**Type:** Automated (if connected) or Zaal manual
+
+```
+Battle result from ZAOville —
+@[winner] beats @[loser] in round [N].
+
+Live on the pool party stage. Community voted.
+/wavewarz
+```
+
+**Why:** This is the money post. A live battle result with the audience in the background is the core ZAO narrative. @mentions of both artists = their followers see it.
+
+**If ZOL can't auto-post:** Zaal posts this manually — it's the highest-priority cast of the day.
+
+---
+
+### 7:00 PM — Evening Transition
+
+**Channel:** /zabal  
+**From:** @bettercallzaal  
+**Type:** Photo (mood shift — lights on, evening vibes)
+
+```
+ZAOville at golden hour.
+
+9 hours in. Still going.
+Night swim DJ set at 9:30 if you're in Laurel.
+```
+
+---
+
+### 8:40 PM — Finale Announcement
+
+**Channel:** /wavewarz  
+**From:** @bettercallzaal  
+**Type:** Short clip or photo
+
+```
+Finale set starting at ZAOville.
+
+Best performance of the night is about to drop.
+
+/wavewarz — follow for the ZAOstock version Oct 3.
+```
+
+---
+
+### 9:30 PM — Night Swim
+
+**Channel:** /zabal  
+**From:** @bettercallzaal  
+**Type:** Meta Glasses POV or phone video (DJ + pool at night)
+
+```
+Night swim DJ set. ZAOville is running deep.
+
+Neon lights, pool, live music.
+
+This is the ZAO.
+```
+
+---
+
+### 11:00 PM — Wrap Cast
+
+**Channel:** /wavewarz and /zabal  
+**From:** @bettercallzaal  
+**Type:** Text only (from phone, exhausted but proud)
+
+```
+ZAOville is a wrap.
+
+11AM–10PM, full crowd, live music, live battles, night swim.
+
+Thank you to everyone who came, and everyone who followed along on Farcaster.
+
+ZAOstock Oct 3 is next. Same energy, bigger stage.
+→ ZAOstock RSVP: [Eventbrite link]
+```
+
+**Why:** The wrap cast is the most important conversion post. It thanks attendees AND followers, then immediately redirects to ZAOstock sign-up. This is how one event converts viewers into future attendees.
+
+---
+
+## Day-After Recap (Jul 26)
+
+### Morning — Highlights Thread
+
+**Channel:** /wavewarz  
+**From:** @bettercallzaal  
+**Type:** 3-post thread with best clips
+
+```
+Post 1: "ZAOville recap (thread 🧵)"
+Post 2: Best performance clip + "This is what ZAO sounds like live"
+Post 3: "Next stop: ZAOstock Oct 3, Ellsworth ME. Free festival. Same WaveWarZ energy. 
+         RSVP → [Eventbrite link]"
+```
+
+**Why:** A 3-post recap thread reaches people who weren't watching on the day. Recap + CTA to ZAOstock is the full funnel.
+
+---
+
+## ZOL Automation Checklist (Before Jul 25)
+
+For ZOL to auto-post the battle result, the following must be set up:
+
+| Item | Status | Action needed |
+|------|--------|---------------|
+| ZOL can receive battle data from wwtracker | Unknown | Verify wwtracker outputs battle results to ZOL |
+| ZOL has /wavewarz as posting channel | Not yet | Add `channel_id: 'wavewarz'` to battle-result handler (doc 1572 A1) |
+| ZOL has @mentions of battle participants | Not yet | Add FID lookup to battle-result handler (doc 1572 A2) |
+
+**If ZOL automation isn't ready by Jul 25:** Zaal posts battle results manually from phone. The manual version is:
+```
+Battle result: @[winner] beats @[loser]
+Live at ZAOville pool party. ZOR holders voted.
+/wavewarz
+```
+
+---
+
+## What NOT to Post
+
+- Don't over-caption videos. The video speaks. Short caption, channel tag, done.
+- Don't post every 15 minutes — quality over quantity. The 7 key casts above are enough.
+- Don't post venue logistics (parking, address) on Farcaster — that belongs in TG/DM for security reasons.
+- Don't post personal faces without consent. Pool party context = be selective.
+
+---
+
+## Success Metrics for Jul 25
+
+| Metric | Baseline (Jul 24) | Target (Jul 26) |
+|--------|------------------|-----------------|
+| /wavewarz followers | ~2-10 (from activation week) | 30+ |
+| /zabal members | ~32 | 45+ |
+| Best cast likes | ~2 | 15+ |
+| Best cast recasts | 0 | 3+ |
+| ZAOstock Eventbrite signups from Farcaster | 0 | 10+ |
+
+Track: after the wrap cast on Jul 25, note the /wavewarz follower count in the ZAO Telegram. Compare to baseline.
+
+---
+
+## Sources
+
+- Doc 1228: ZAOville Jul 25 day-of runbook (operational guide; this doc = Farcaster strategy layer)
+- Doc 1572: /wavewarz + /zabal Farcaster channel growth playbook
+- Doc 993: ZOL Farcaster upgrade strategy (background)


### PR DESCRIPTION
## What

Complete Farcaster posting schedule for ZAOville Jul 25 pool party — every cast written and ready. Goal: convert ZAOville attendees and viewers into /wavewarz and /zabal followers, then funnel them to ZAOstock Oct 3 RSVPs.

## Schedule overview

- **Jul 23 (Thu):** Hype cast in /wavewarz + /zabal
- **Jul 24 (Fri):** Pre-event 24h countdown
- **Jul 25 Day-of:** Setup (10am), doors (11am), open mic (3pm), performances (5pm), battle result (5:30pm), evening (7pm), finale (8:40pm), night swim (9:30pm), wrap (11pm)
- **Jul 26:** 3-post highlights recap thread → ZAOstock CTA

## Key targets

| Metric | Baseline | Target after Jul 25 |
|--------|----------|-------------------|
| /wavewarz followers | ~2 | 30+ |
| /zabal members | ~32 | 45+ |
| ZAOstock RSVPs from Farcaster | 0 | 10+ |

## Complements

- doc 1228 (ZAOville runbook — operational guide)
- doc 1572 (/wavewarz + /zabal growth playbook — 30-day strategy)
- doc 993 (ZOL Farcaster upgrade strategy)