### PR TITLE
fix(members): use scoring_era for fractal history source detection

### DIFF
--- a/src/app/api/members/[username]/route.ts
+++ b/src/app/api/members/[username]/route.ts
@@ -321,15 +321,15 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
     const history = (fractalScores || [])
       .map((s) => {
         const sess = Array.isArray(s.fractal_sessions) ? s.fractal_sessions[0] : s.fractal_sessions;
-        const isOrdao = (sess as Record<string, unknown>)?.notes?.toString().includes('ORDAO');
+        const scoringEra = (sess as Record<string, unknown>)?.scoring_era as string | undefined;
         return {
           sessionName: (sess as Record<string, unknown>)?.name ?? 'Unknown',
           sessionDate: (sess as Record<string, unknown>)?.session_date ?? null,
-          era: (sess as Record<string, unknown>)?.scoring_era ?? '2x',
+          era: scoringEra ?? '2x',
           rank: Math.min(Math.max(s.rank, 1), 6),
           score: s.score,
           participants: (sess as Record<string, unknown>)?.participant_count ?? 0,
-          source: isOrdao ? 'ordao' : 'og',
+          source: scoringEra === '2x' ? 'ordao' : 'og',
         };
       })
       .sort((a, b) => {


### PR DESCRIPTION
## Members profile route: fractal history era detection fix

**Bug:** `GET /api/members/[username]` builds a fractal history where `source` was derived from `notes.includes('ORDAO')` (line 324). This is the same bug pattern fixed across other fractal routes. `notes` is unreliable; `scoring_era` is the authoritative field.

**The inconsistency:** `era` was already using `scoring_era` correctly (line 328). Only `source` used the broken `notes` check. A session with `scoring_era: '2x'` but no 'ORDAO' in notes would have `era: '2x'` but `source: 'og'` — contradictory.

**Fix:** Extract `scoring_era` once, use it for both `era` and `source`. OG = `scoring_era !== '2x'`, ORDAO = `scoring_era === '2x'`.

**Not covered by:** PR #2171 (fixes `fractals/member/[wallet]`), PR #2165, PR #2192. This is `api/members/[username]` — a different route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
