### PR TITLE
fix(zoe): status went to DM not group - router read the wrong env var name

### DIFF
--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -126,10 +126,15 @@ export function constructRoutingDeps(sendMessageImpl: TelegramRoutingDeps['sendM
     throw new Error(`Invalid ZAAL_TELEGRAM_ID: ${zaalIdRaw} (must be a number)`);
   }
 
-  const groupIdRaw = process.env.ZAALBOTS_GROUP_CHAT_ID;
+  // The rest of the bot (index.ts, scheduler.ts) reads the group id as
+  // ZAAL_BOTZ_GROUP_ID; only this router looked for ZAALBOTS_GROUP_CHAT_ID,
+  // which was never set. Result: groupId stayed undefined and EVERY status
+  // message fell back to Zaal's DM instead of the group - the "ZOE spams my
+  // DM" complaint. Read the canonical name, keep the old one as a fallback.
+  const groupIdRaw = process.env.ZAAL_BOTZ_GROUP_ID ?? process.env.ZAALBOTS_GROUP_CHAT_ID;
   const groupId = groupIdRaw ? Number(groupIdRaw) : undefined;
   if (groupIdRaw && Number.isNaN(groupId)) {
-    console.warn(`Invalid ZAALBOTS_GROUP_CHAT_ID: ${groupIdRaw} (must be a number, will be ignored)`);
+    console.warn(`Invalid group id ${groupIdRaw} (ZAAL_BOTZ_GROUP_ID / ZAALBOTS_GROUP_CHAT_ID must be numeric, will be ignored)`);
   }
 
   const threadIdRaw = process.env.ZAALBOTS_STATUS_THREAD_ID;


### PR DESCRIPTION
## Your "ZOE spams my DM" complaint, root-caused

The routing was already built correctly - questions to DM, status to the group. But the router read the group id from the **wrong env var name**, so it never had a group to send to.

| Reads | Where |
|---|---|
| `ZAALBOTS_GROUP_CHAT_ID` | telegram-routing.ts (the router) |
| `ZAAL_BOTZ_GROUP_ID` | index.ts, scheduler.ts, everything else |

The deploy env has **`ZAAL_BOTZ_GROUP_ID`** and **not** `ZAALBOTS_GROUP_CHAT_ID` (verified on the live clone). So `constructRoutingDeps` got an undefined groupId, and `sendToZaalRouted` fell back to your **DM for every status message** - brief, recap, reflection, nudges. That's the spam.

## Fix

Read the canonical `ZAAL_BOTZ_GROUP_ID`, keep the old name as a fallback. One-line env alias - the same two-names-for-one-thing bug as the fleet failover fixed earlier today.

**After this deploys:** status and digests go to the ZAAL BOTZ group; only real questions reach your DM.

## Verification

Typechecks clean. The behavior change is only observable live (the env var isn't present in CI), so the real proof is the next morning brief landing in the group instead of your DM.