### PR TITLE
fix(zoe): canonical env module - kills the env-drift bug class

### DIFF
--- a/bot/src/zoe/env.ts
+++ b/bot/src/zoe/env.ts
@@ -1,0 +1,83 @@
+// env.ts - the ONE place ZOE resolves aliased environment variables.
+//
+// Why this exists: the reliability audit (2026-07-20) found "env-drift" as a
+// recurring bug class - the SAME logical value read under two different names in
+// different files, so a reader silently gets undefined and falls back to the
+// wrong behavior. Real damage this caused:
+//   - the group id (ZAAL_BOTZ_GROUP_ID vs ZAALBOTS_GROUP_CHAT_ID) -> every
+//     status message went to Zaal's DM instead of the group
+//   - the research thread (ZAAL_BOTZ_RESEARCH_THREAD vs ZAALBOTS_STATUS_THREAD_ID)
+//     -> status/research posts landed in the wrong topic
+//
+// The fix for the CLASS (not just each instance): resolve every drifted value
+// HERE, from a canonical name plus its known aliases, and assert at boot so a
+// missing value is loud instead of a silent mis-route. Every other module reads
+// from this - nobody reads process.env for these names directly.
+
+/** Read the first env var that has a value, from a list of accepted names. */
+function firstOf(...names: string[]): string | undefined {
+  for (const n of names) {
+    const v = process.env[n];
+    if (v !== undefined && v !== "") return v;
+  }
+  return undefined;
+}
+
+function numOf(...names: string[]): number | undefined {
+  const raw = firstOf(...names);
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isNaN(n) ? undefined : n;
+}
+
+// --- canonical resolved values ------------------------------------------------
+// The FIRST name in each list is canonical; the rest are tolerated aliases that
+// existed in the wild. New code should set the canonical name.
+
+/** Zaal's personal DM chat id. */
+export const ZAAL_DM_ID = numOf("ZAAL_TELEGRAM_ID", "ZAAL_DM_ID", "ZAAL_CHAT_ID");
+
+/** The ZAAL BOTZ group chat id (status, digests, questions). */
+export const ZAAL_BOTZ_GROUP_ID = numOf("ZAAL_BOTZ_GROUP_ID", "ZAALBOTS_GROUP_CHAT_ID");
+
+/** The Research/status forum topic id within the group. */
+export const ZAAL_BOTZ_RESEARCH_THREAD = numOf(
+  "ZAAL_BOTZ_RESEARCH_THREAD",
+  "ZAALBOTS_STATUS_THREAD_ID",
+);
+
+interface EnvSpec {
+  label: string;
+  value: number | string | undefined;
+  required: boolean;
+  aliases: string;
+}
+
+const SPECS: EnvSpec[] = [
+  { label: "ZAAL_DM_ID", value: ZAAL_DM_ID, required: true, aliases: "ZAAL_TELEGRAM_ID | ZAAL_DM_ID | ZAAL_CHAT_ID" },
+  { label: "ZAAL_BOTZ_GROUP_ID", value: ZAAL_BOTZ_GROUP_ID, required: false, aliases: "ZAAL_BOTZ_GROUP_ID | ZAALBOTS_GROUP_CHAT_ID" },
+  { label: "ZAAL_BOTZ_RESEARCH_THREAD", value: ZAAL_BOTZ_RESEARCH_THREAD, required: false, aliases: "ZAAL_BOTZ_RESEARCH_THREAD | ZAALBOTS_STATUS_THREAD_ID" },
+];
+
+/**
+ * Log what resolved and what is missing, at boot. Call once from index.ts start.
+ * A required value that is missing throws - better a loud boot failure than a
+ * silent mis-route in production. Optional-but-missing values warn (e.g. no
+ * group id means status correctly falls back to DM, which is a real mode).
+ */
+export function assertEnv(): void {
+  const missing: string[] = [];
+  for (const s of SPECS) {
+    const present = s.value !== undefined;
+    if (present) {
+      console.log(`[env] ${s.label} = set`);
+    } else if (s.required) {
+      missing.push(`${s.label} (accepts: ${s.aliases})`);
+    } else {
+      console.warn(`[env] ${s.label} NOT set (accepts: ${s.aliases}) - dependent features degrade`);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`[env] required config missing:\n  - ${missing.join("\n  - ")}`);
+  }
+}

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -9,15 +9,17 @@
  * This centralizes the decision: sendToZaal(text, {kind}) routes based
  * on kind. All message sends flow through this helper.
  *
- * Environment variables (set on VPS):
- * - ZAAL_TELEGRAM_ID: Zaal's personal DM chat id (existing)
- * - ZAALBOTS_GROUP_CHAT_ID: the ZAALBOTS group chat id (new)
- * - ZAALBOTS_STATUS_THREAD_ID: forum topic id within the group for status
- *   messages (new, optional - if group has forum topics)
+ * Environment: all config comes from the canonical env module (./env), which
+ * resolves each value from its canonical name AND known aliases so the
+ * env-drift bug (router reading a different name than the deploy env sets)
+ * cannot recur. Group id -> ZAAL_BOTZ_GROUP_ID, thread -> ZAAL_BOTZ_RESEARCH_THREAD,
+ * DM -> ZAAL_TELEGRAM_ID.
  *
- * Fallback: if group chat id is unset, all messages fall back to Zaal's DM
- * so nothing breaks pre-config.
+ * Fallback: if group id is unset, messages fall back to Zaal's DM so nothing
+ * breaks pre-config.
  */
+
+import { ZAAL_DM_ID, ZAAL_BOTZ_GROUP_ID, ZAAL_BOTZ_RESEARCH_THREAD } from './env';
 
 const TELEGRAM_MAX = 3900;
 
@@ -117,31 +119,21 @@ export async function sendToZaal(
  * Returns deps ready to pass to sendToZaal().
  */
 export function constructRoutingDeps(sendMessageImpl: TelegramRoutingDeps['sendMessage']): TelegramRoutingDeps {
-  const zaalIdRaw = process.env.ZAAL_TELEGRAM_ID;
-  if (!zaalIdRaw) {
+  // All three values now come from the canonical env module (env.ts), which
+  // resolves each from its canonical name AND its known aliases. This is what
+  // stopped the env-drift bug: the router used to read ZAALBOTS_GROUP_CHAT_ID /
+  // ZAALBOTS_STATUS_THREAD_ID while the deploy env set ZAAL_BOTZ_GROUP_ID /
+  // ZAAL_BOTZ_RESEARCH_THREAD, so groupId + threadId came back undefined and
+  // every status message silently fell back to Zaal's DM.
+  const zaalId = ZAAL_DM_ID;
+  if (zaalId === undefined) {
     throw new Error('Missing ZAAL_TELEGRAM_ID env var (required for ZOE)');
-  }
-  const zaalId = Number(zaalIdRaw);
-  if (Number.isNaN(zaalId)) {
-    throw new Error(`Invalid ZAAL_TELEGRAM_ID: ${zaalIdRaw} (must be a number)`);
-  }
-
-  const groupIdRaw = process.env.ZAALBOTS_GROUP_CHAT_ID;
-  const groupId = groupIdRaw ? Number(groupIdRaw) : undefined;
-  if (groupIdRaw && Number.isNaN(groupId)) {
-    console.warn(`Invalid ZAALBOTS_GROUP_CHAT_ID: ${groupIdRaw} (must be a number, will be ignored)`);
-  }
-
-  const threadIdRaw = process.env.ZAALBOTS_STATUS_THREAD_ID;
-  const threadId = threadIdRaw ? Number(threadIdRaw) : undefined;
-  if (threadIdRaw && Number.isNaN(threadId)) {
-    console.warn(`Invalid ZAALBOTS_STATUS_THREAD_ID: ${threadIdRaw} (must be a number, will be ignored)`);
   }
 
   return {
     sendMessage: sendMessageImpl,
     zaalId,
-    groupId,
-    groupThreadId: threadId,
+    groupId: ZAAL_BOTZ_GROUP_ID,
+    groupThreadId: ZAAL_BOTZ_RESEARCH_THREAD,
   };
 }


### PR DESCRIPTION
## What

Kills the **#1 recurring bug class** from today's reliability audit: **env-drift** - the same logical value read under two different names in different files, so a reader silently gets undefined and mis-behaves.

This is the bug that bit **3 separate times today** (fleet failover, zao-ask, routing) and the audit found **5 total** instances across the stack.

## The fix (class, not instance)

Instead of patching each site and waiting for the next alias to drift, one canonical resolver:

- **`bot/src/zoe/env.ts`** - resolves each value from its canonical name **plus known aliases**. Exports `ZAAL_DM_ID`, `ZAAL_BOTZ_GROUP_ID`, `ZAAL_BOTZ_RESEARCH_THREAD`. `assertEnv()` logs what resolved and **throws at boot** on a missing required value - loud failure beats silent mis-route.
- **`telegram-routing.ts`** now reads from `env.ts`, not `process.env` directly. This is what fixes the group-id AND thread-id drift in one move (supersedes the narrower #2467).

## Verified

6 runtime assertions pass - including the exact deploy case that broke (env sets the alias `ZAALBOTS_GROUP_CHAT_ID`, code wanted `ZAAL_BOTZ_GROUP_ID` -> now resolves). `tsc` clean. vitest can't run here (rolldown binding), so assertions ran via tsx.

## Follow-ups (same class, separate PRs)
- wire `assertEnv()` into index.ts boot so config gaps fail loud on start
- the VPS `loops-keepalive.sh` + `skills/meeting` hardcoded-name instances

If merging this, **close #2467** - this contains its fix plus the thread-id one.