### PR TITLE
zoe: cap-fallback to a non-Claude provider when Claude is rate-limited/capped

### DIFF
--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -16,7 +16,7 @@ import { recordCall } from './cost-ledger';
 import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote, BotRelayOp, CrmOp, ThreadOp } from './types';
 import { selectModel, ZOE_DEFAULT_MODEL } from './types';
 import type { MemoryBlocks } from './memory';
-import { shouldUseRouting, selectBestModel, routeAndCall } from './models/router';
+import { shouldUseRouting, selectBestModel, routeAndCall, callCapFallback, hasCapFallbackProvider } from './models/router';
 
 const ZOE_VERSION = '0.2.0';
 
@@ -130,7 +130,7 @@ export function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, rec
  *   c) Error classification/logging (CliAuthError, CliError types)
  *   d) Cost ledger tracking (records both CLI and API-key calls)
  */
-async function callModelWithCliRouting(opts: Omit<import('../hermes/claude-cli').ClaudeCliOptions, 'cwd'> & { cwd: string }): Promise<import('../hermes/claude-cli').ClaudeCliResult> {
+async function callClaudeCliRoute(opts: Omit<import('../hermes/claude-cli').ClaudeCliOptions, 'cwd'> & { cwd: string }): Promise<import('../hermes/claude-cli').ClaudeCliResult> {
   const useCliPath = process.env.ZOE_USE_CLI === '1';
   if (!useCliPath) {
     return callClaudeCli(opts);
@@ -142,7 +142,7 @@ async function callModelWithCliRouting(opts: Omit<import('../hermes/claude-cli')
     console.log('[zoe/concierge] CLI route succeeded, cost recorded');
     return result;
   } catch (err: unknown) {
-    const { CliAuthError, CliError, classifyClaudeError } = await import('../hermes/claude-cli');
+    const { CliAuthError, CliError } = await import('../hermes/claude-cli');
     if (err instanceof CliAuthError) {
       console.warn('[zoe/concierge] CLI auth failed, falling back to API key:', (err as Error).message);
     } else if (err instanceof CliError) {
@@ -153,6 +153,32 @@ async function callModelWithCliRouting(opts: Omit<import('../hermes/claude-cli')
     // Fallback: disable CLI and retry via API key
     const apiOpts = { ...opts, bare: false };
     return callClaudeCli(apiOpts);
+  }
+}
+
+/**
+ * Claude model call with CAP FALLBACK. Runs the normal Claude CLI route; if
+ * Claude is rate-limited or over its weekly cap (CliError kind rate_limit /
+ * usage_limit / auth) AND a non-Claude provider is configured, runs the turn on
+ * OpenRouter/Grok/GPT instead of surfacing a raw 429 to Zaal. This is what keeps
+ * ZOE working while the Claude cap is exhausted (see doc: ZOE cap failover).
+ */
+async function callModelWithCliRouting(opts: Omit<import('../hermes/claude-cli').ClaudeCliOptions, 'cwd'> & { cwd: string }): Promise<import('../hermes/claude-cli').ClaudeCliResult> {
+  try {
+    return await callClaudeCliRoute(opts);
+  } catch (err: unknown) {
+    const { CliError } = await import('../hermes/claude-cli');
+    const isCap = err instanceof CliError && (err.kind === 'rate_limit' || err.kind === 'usage_limit' || err.kind === 'auth');
+    if (isCap && hasCapFallbackProvider()) {
+      const kind = (err as import('../hermes/claude-cli').CliError).kind;
+      console.warn('[zoe/concierge] Claude capped (' + kind + ') - cap-fallback to a non-Claude provider');
+      const sys = opts.appendSystemPrompt ?? '';
+      const user = opts.prompt ?? '';
+      const fb = await callCapFallback(sys, user);
+      console.log('[zoe/concierge] cap-fallback served by', fb.provider);
+      return fb.result;
+    }
+    throw err;
   }
 }
 

--- a/bot/src/zoe/models/router.ts
+++ b/bot/src/zoe/models/router.ts
@@ -84,6 +84,10 @@ function hasClaudeApiKey(): boolean {
   return Boolean(process.env.ANTHROPIC_API_KEY?.trim());
 }
 
+function hasOpenRouterApiKey(): boolean {
+  return Boolean(process.env.OPENROUTER_API_KEY?.trim());
+}
+
 /**
  * Generic OpenAI-compatible chat completion request.
  */
@@ -233,6 +237,114 @@ async function callGpt(systemPrompt: string, userMessage: string): Promise<Claud
   } catch (error: unknown) {
     throw new Error(`GPT call failed: ${error instanceof Error ? error.message : String(error)}`);
   }
+}
+
+/**
+ * Call OpenRouter — OpenAI-compatible aggregator. Gives ZOE a cheap, always-on
+ * non-Claude path (deepseek, gemini, llama, etc.), aligned with the fleet's
+ * cheap-AI stack. This is the primary CAP FALLBACK provider: when the Claude CLI
+ * is rate-limited or over its weekly cap, ZOE drops here instead of failing.
+ */
+async function callOpenRouter(systemPrompt: string, userMessage: string): Promise<ClaudeCliResult> {
+  if (!hasOpenRouterApiKey()) {
+    throw new Error('OPENROUTER_API_KEY not set');
+  }
+
+  const baseUrl = 'https://openrouter.ai/api/v1';
+  // Default to a cheap, capable non-Anthropic model so a fallback never re-hits
+  // the same Anthropic cap that triggered it. Override via OPENROUTER_MODEL.
+  const model = process.env.OPENROUTER_MODEL ?? 'deepseek/deepseek-chat';
+  const apiKey = process.env.OPENROUTER_API_KEY;
+
+  const request: OpenAiRequest = {
+    model,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userMessage },
+    ],
+    temperature: 1,
+    max_tokens: 4096,
+  };
+
+  const startMs = Date.now();
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'User-Agent': 'ZOE-bot/1.0',
+        'HTTP-Referer': 'https://thezao.com',
+        'X-Title': 'ZOE',
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OpenRouter API error ${response.status}: ${errorText.slice(0, 300)}`);
+    }
+
+    const data = (await response.json()) as OpenAiResponse;
+    const text = data.choices[0]?.message?.content ?? '';
+    if (!text.trim()) {
+      throw new Error('OpenRouter returned empty completion');
+    }
+
+    return {
+      text,
+      inputTokens: data.usage?.prompt_tokens ?? 0,
+      outputTokens: data.usage?.completion_tokens ?? 0,
+      totalCostUsd: 0, // OpenRouter cost varies by model; not tracked precisely here
+      model: `openrouter/${model}`,
+      durationMs: Date.now() - startMs,
+      numTurns: 1,
+      isError: false,
+      sessionId: `openrouter-${startMs}`,
+    };
+  } catch (error: unknown) {
+    throw new Error(`OpenRouter call failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/**
+ * CAP FALLBACK: the Claude CLI is rate-limited or over its weekly cap, so run
+ * this concierge turn on the best available non-Claude provider instead of
+ * failing. Tries OpenRouter first (cheap, always-on), then Grok, then GPT.
+ * Throws only if NO non-Claude provider is configured (then the caller surfaces
+ * the original Claude error).
+ */
+export function hasCapFallbackProvider(): boolean {
+  return hasOpenRouterApiKey() || hasGrokApiKey() || hasGptApiKey();
+}
+
+export async function callCapFallback(
+  systemPrompt: string,
+  userMessage: string,
+): Promise<{ result: ClaudeCliResult; provider: string }> {
+  const attempts: Array<{ name: string; fn: () => Promise<ClaudeCliResult> }> = [];
+  if (hasOpenRouterApiKey()) attempts.push({ name: 'openrouter', fn: () => callOpenRouter(systemPrompt, userMessage) });
+  if (hasGrokApiKey()) attempts.push({ name: 'grok', fn: () => callGrok(systemPrompt, userMessage) });
+  if (hasGptApiKey()) attempts.push({ name: 'gpt', fn: () => callGpt(systemPrompt, userMessage) });
+
+  if (attempts.length === 0) {
+    throw new Error('no cap-fallback provider configured (set OPENROUTER_API_KEY, XAI_API_KEY, or OPENAI_API_KEY)');
+  }
+
+  const errors: string[] = [];
+  for (const attempt of attempts) {
+    try {
+      const result = await attempt.fn();
+      console.log('[zoe/models/router] cap-fallback succeeded via', attempt.name);
+      return { result, provider: attempt.name };
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`[zoe/models/router] cap-fallback ${attempt.name} failed:`, msg);
+      errors.push(`${attempt.name}: ${msg.slice(0, 80)}`);
+    }
+  }
+  throw new Error(`all cap-fallback providers failed [${errors.join(' | ')}]`);
 }
 
 /**


### PR DESCRIPTION
Adds a reverse cap-fallback to ZOE's concierge: on a Claude `rate_limit`/`usage_limit`/`auth` error, run the turn on OpenRouter (or Grok/GPT) instead of surfacing a raw 429. Adds an OpenRouter provider to the router (defaults to a non-Anthropic model so the fallback never re-hits the same cap).

**Why:** ZOE 429'd on Zaal's Claude weekly cap 2026-07-21 and dumped a raw error. This is why.

**Safety:** inert until a non-Claude key is set (no OPENROUTER_API_KEY/XAI/OPENAI = identical behavior to today, just re-throws). Boot-verified: tsc clean on both files, esbuild bundles both, router module loads.

**To activate (Zaal):** set `OPENROUTER_API_KEY` in ZOE's env on the VPS + restart. No MODEL_ROUTING_ENABLED needed - the cap-fallback is independent of forward routing.