### PR TITLE
feat(zoe/hermes): post-action assertion that a pushed branch actually landed on origin

### DIFF
--- a/bot/src/hermes/__tests__/git.test.ts
+++ b/bot/src/hermes/__tests__/git.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:fs', () => ({
 import {
   cleanupWorkdir,
   commitAndPush,
+  assertRemoteBranchPresent,
   diffAgainstMain,
   getRepoProfile,
   listChangedFiles,
@@ -129,8 +130,9 @@ describe('diffAgainstMain', () => {
 
 describe('commitAndPush', () => {
   beforeEach(() => {
-    // commitAndPush makes 7 sequential git calls:
-    // config name, config email, add -A, commit, fetch origin/main, rebase, push
+    // commitAndPush makes 9 sequential git calls: config name, config email,
+    // add -A, commit, fetch origin/main, rebase, push, then the post-push
+    // assertion (rev-parse HEAD + ls-remote to confirm the ref landed on origin).
     mockSpawn
       .mockReturnValueOnce(makeSpawnResult('', '', 0)) // git config user.name
       .mockReturnValueOnce(makeSpawnResult('', '', 0)) // git config user.email
@@ -138,14 +140,35 @@ describe('commitAndPush', () => {
       .mockReturnValueOnce(makeSpawnResult('', '', 0)) // git commit
       .mockReturnValueOnce(makeSpawnResult('', '', 0)) // git fetch origin main
       .mockReturnValueOnce(makeSpawnResult('', '', 0)) // git rebase origin/main
-      .mockReturnValueOnce(makeSpawnResult('', '', 0)); // git push
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // git push
+      .mockReturnValueOnce(makeSpawnResult('deadbeefsha\n', '', 0)) // git rev-parse HEAD
+      .mockReturnValueOnce(makeSpawnResult('deadbeefsha\trefs/heads/fix/branch-name\n', '', 0)); // git ls-remote (post-push verify)
   });
 
   it('resolves successfully when all git commands succeed', async () => {
     await expect(
       commitAndPush('/tmp/wt', 'fix/branch-name', 'fix: update foo'),
     ).resolves.toBeUndefined();
-    expect(mockSpawn).toHaveBeenCalledTimes(7);
+    expect(mockSpawn).toHaveBeenCalledTimes(9);
+  });
+
+  it('throws when the pushed branch is NOT on origin (silent push failure)', async () => {
+    // Push reports success (exit 0) but ls-remote shows the ref never landed -
+    // the exact silent failure the post-push assertion exists to catch.
+    mockSpawn.mockReset();
+    mockSpawn
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // config name
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // config email
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // add
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // commit
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // fetch
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // rebase
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)) // push (lies - exit 0)
+      .mockReturnValueOnce(makeSpawnResult('deadbeefsha\n', '', 0)) // rev-parse HEAD
+      .mockReturnValueOnce(makeSpawnResult('', '', 0)); // ls-remote returns EMPTY
+    await expect(commitAndPush('/tmp/wt', 'fix/branch-name', 'msg')).rejects.toThrow(
+      'is not on origin',
+    );
   });
 
   it('throws when git config user.name fails', async () => {
@@ -175,5 +198,42 @@ describe('commitAndPush', () => {
       .mockReturnValueOnce(makeSpawnResult('', 'CONFLICT', 1)) // rebase fail
       .mockReturnValueOnce(makeSpawnResult('', '', 0)); // rebase --abort
     await expect(commitAndPush('/tmp/wt', 'fix/branch', 'msg')).rejects.toThrow('git rebase origin/main failed');
+  });
+});
+
+// ── assertRemoteBranchPresent (post-push verify, pure) ─────────────────────────
+
+describe('assertRemoteBranchPresent', () => {
+  const SHA = '9f0a4616deadbeef';
+  const lsOut = `${SHA}\trefs/heads/fix/my-branch`;
+
+  it('returns the remote sha when the branch is present', () => {
+    expect(assertRemoteBranchPresent(lsOut, 'fix/my-branch')).toBe(SHA);
+  });
+
+  it('passes when the remote sha matches the expected sha', () => {
+    expect(assertRemoteBranchPresent(lsOut, 'fix/my-branch', SHA)).toBe(SHA);
+  });
+
+  it('throws when the branch is absent (empty ls-remote)', () => {
+    expect(() => assertRemoteBranchPresent('', 'fix/my-branch')).toThrow('is not on origin');
+  });
+
+  it('throws when a DIFFERENT branch is present but not ours', () => {
+    const other = `${SHA}\trefs/heads/fix/other-branch`;
+    expect(() => assertRemoteBranchPresent(other, 'fix/my-branch')).toThrow('is not on origin');
+  });
+
+  it('does not false-match on a branch that is a suffix substring of another', () => {
+    // "feat/a" must NOT match the line for "hotfix/feat/a" - endsWith on the full
+    // refs/heads/<branch> guards against the substring false-positive.
+    const tricky = `${SHA}\trefs/heads/hotfix/feat/a`;
+    expect(() => assertRemoteBranchPresent(tricky, 'feat/a')).toThrow('is not on origin');
+  });
+
+  it('throws when the remote tip diverged from the commit we pushed', () => {
+    expect(() => assertRemoteBranchPresent(lsOut, 'fix/my-branch', 'differentsha00')).toThrow(
+      'does not match local HEAD',
+    );
   });
 });

--- a/bot/src/hermes/__tests__/pr.test.ts
+++ b/bot/src/hermes/__tests__/pr.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockRunCmd = vi.hoisted(() => vi.fn());
-vi.mock('../git', () => ({ runCmd: mockRunCmd }));
+// verifyRemoteBranch is the post-push assertion; default it to a no-op success.
+// It is NOT a runCmd, so the mockRunCmd call ordering below (push=#1, gh=#2) is
+// unchanged by its presence.
+const mockVerify = vi.hoisted(() => vi.fn());
+vi.mock('../git', () => ({ runCmd: mockRunCmd, verifyRemoteBranch: mockVerify }));
 
 import { openPullRequest } from '../pr';
 

--- a/bot/src/hermes/git.ts
+++ b/bot/src/hermes/git.ts
@@ -214,6 +214,66 @@ export async function commitAndPush(
 
   const push = await runCmd('git', ['push', '-u', 'origin', branchName], workdir);
   if (push.exitCode !== 0) throw new Error(`git push failed: ${push.stderr.slice(0, 400)}`);
+
+  // Post-action assertion: a 0 exit code from `git push` does NOT guarantee the
+  // ref actually landed on origin (a push hook, proxy, or branch-protection rule
+  // can reject/rewrite the ref while the local command still reports success).
+  // Re-read reality via ls-remote before returning - otherwise the caller opens a
+  // PR against a branch that is not there and fails cryptically downstream.
+  const head = await runCmd('git', ['rev-parse', 'HEAD'], workdir);
+  const expectedSha = head.exitCode === 0 ? head.stdout.trim() : undefined;
+  await verifyRemoteBranch(workdir, branchName, expectedSha);
+}
+
+/**
+ * Pure assertion over `git ls-remote --heads origin <branch>` output. Confirms
+ * the branch is present on origin and (when expectedSha is given) that its tip
+ * matches the commit we pushed. Split out from verifyRemoteBranch so it is
+ * unit-testable without a real git remote.
+ * @throws if the branch is absent, or present at a different sha.
+ */
+export function assertRemoteBranchPresent(
+  lsRemoteStdout: string,
+  branch: string,
+  expectedSha?: string,
+): string {
+  const line = lsRemoteStdout
+    .trim()
+    .split('\n')
+    .find((l) => l.trimEnd().endsWith(`refs/heads/${branch}`));
+  if (!line) {
+    throw new Error(
+      `post-push verify FAILED: branch '${branch}' is not on origin after a push that reported success. ` +
+        `The push exit code was misleading - a push hook, proxy, or branch-protection rule likely rejected the ref. ` +
+        `Aborting before a PR is opened against a non-existent branch.`,
+    );
+  }
+  const remoteSha = line.split(/\s+/)[0] ?? '';
+  if (expectedSha && remoteSha !== expectedSha) {
+    throw new Error(
+      `post-push verify FAILED: origin/${branch} is at ${remoteSha.slice(0, 8)} but the commit we just pushed is ${expectedSha.slice(0, 8)}. ` +
+        `The remote ref does not match local HEAD - do not open a PR against a diverged branch.`,
+    );
+  }
+  return remoteSha;
+}
+
+/**
+ * Post-action assertion for a push: re-read origin via ls-remote and confirm the
+ * branch (optionally at expectedSha) actually landed. See assertRemoteBranchPresent.
+ */
+export async function verifyRemoteBranch(
+  workdir: string,
+  branch: string,
+  expectedSha?: string,
+): Promise<string> {
+  const ls = await runCmd('git', ['ls-remote', '--heads', 'origin', branch], workdir);
+  if (ls.exitCode !== 0) {
+    throw new Error(
+      `post-push verify failed: git ls-remote errored for '${branch}': ${ls.stderr.slice(0, 300)}`,
+    );
+  }
+  return assertRemoteBranchPresent(ls.stdout, branch, expectedSha);
 }
 
 export async function diffAgainstMain(workdir: string): Promise<string> {

--- a/bot/src/hermes/pr.ts
+++ b/bot/src/hermes/pr.ts
@@ -1,4 +1,4 @@
-import { runCmd } from './git';
+import { runCmd, verifyRemoteBranch } from './git';
 
 export interface OpenedPR {
   number: number;
@@ -27,6 +27,11 @@ export async function openPullRequest(opts: {
   // Belt-and-suspenders: re-push to make sure remote is in sync before gh runs.
   // If the branch tip already matches, this is a no-op.
   await runCmd('git', ['push', '-u', 'origin', opts.branchName], opts.workdir);
+
+  // Post-action assertion: confirm the ref is actually on origin before gh opens
+  // a PR against it. gh's own remote-state detection is flaky (see the note
+  // above), so assert reality via ls-remote rather than trust the push exit code.
+  await verifyRemoteBranch(opts.workdir, opts.branchName);
 
   const r = await runCmd(
     'gh',


### PR DESCRIPTION
## Summary
Agentic-hardening suggestion #1 (post-action assertions). A `git push` can exit 0 while the ref never lands on origin (a push hook, proxy, or branch-protection rule can reject/rewrite it while the local command reports success). The fix-PR pipeline then opens a PR against a branch that is not there and fails cryptically downstream. This re-reads reality via `git ls-remote` after every push.

## Changes
- `bot/src/hermes/git.ts` - `verifyRemoteBranch` (ls-remote re-read) + pure `assertRemoteBranchPresent`; wired into `commitAndPush` (asserts remote tip == pushed commit).
- `bot/src/hermes/pr.ts` - `openPullRequest` re-push had NO result check; now asserts the ref is on origin before `gh pr create`.
- tests - 6 new cases (present/absent/sha-match/sha-mismatch/suffix-false-match + a commitAndPush push-lies-exit-0 case).

## Verification
- All 26 hermes git+pr tests pass (`vitest run`).
- Type-clean: no new tsc errors in the touched files (bot main tsc has pre-existing unrelated errors in discord.ts/index.ts).

First of two agent-hardening PRs (Anthropic writing-effective-tools patterns). #2 = strict tool-input schemas.