### PR TITLE
fix(zoe/calendar): use the live Luma ICS API - the old lu.ma/event path 404s

### DIFF
--- a/bot/src/zoe/calendar.ts
+++ b/bot/src/zoe/calendar.ts
@@ -62,8 +62,12 @@ function getCalendarUrl(): string | null {
 
   // Default to ZAO Luma public ICS feed.
   // luma.com/zao has cal id cal-jPH4al7AMlXzdNN.
-  // The public ICS endpoint is: https://lu.ma/event/cal-<ID>/ics
-  return 'https://lu.ma/event/cal-jPH4al7AMlXzdNN/ics';
+  // The public ICS endpoint is the Luma ICS API:
+  //   https://api.lu.ma/ics/get?entity=calendar&id=cal-<ID>
+  // (the old https://lu.ma/event/cal-<ID>/ics path now 404s - returns the SPA
+  // HTML shell, which failed the VCALENDAR check and left the brief with no
+  // calendar section. Verified 2026-07-22: api.lu.ma returns BEGIN:VCALENDAR.)
+  return 'https://api.lu.ma/ics/get?entity=calendar&id=cal-jPH4al7AMlXzdNN';
 }
 
 /**


### PR DESCRIPTION
## Summary
The ZOE morning brief has silently had NO calendar section - the default Luma ICS feed URL (`https://lu.ma/event/cal-<ID>/ics`) now 404s (returns the SPA HTML shell), failing the VCALENDAR check, and `getCalendarEvents()` swallows the error and returns `[]`.

## Fix
Point at the live Luma ICS API: `https://api.lu.ma/ics/get?entity=calendar&id=cal-<ID>`.

## Verification
- Verified 2026-07-22: the new URL returns `BEGIN:VCALENDAR` with 135 events that parse cleanly.
- A live fetch returns 0 events *right now* only because the 14-day lookahead window is empty (next event is Aug 31, ZABAL GAMEZ) - correct behavior.
- All 11 existing calendar tests pass.

First of the ZOE pipeline fixes (calendar 404, meeting->Telegram visibility, CRM unify, task source-tracing).