### PR TITLE
feat(zoe): add 'whisper' message kind - private DM notifications, zero group noise

### DIFF
--- a/bot/src/zoe/__tests__/telegram-routing.test.ts
+++ b/bot/src/zoe/__tests__/telegram-routing.test.ts
@@ -180,4 +180,45 @@ describe('telegram-routing', () => {
       });
     });
   });
+
+  describe('sendToZaal routing by kind', () => {
+    const makeDeps = (mock: ReturnType<typeof vi.fn>): TelegramRoutingDeps => ({
+      sendMessage: mock,
+      zaalId: 123,
+      groupId: 456,
+    });
+
+    it("routes kind='whisper' to Zaal's DM, never the group", async () => {
+      const mock = vi.fn();
+      await sendToZaal(makeDeps(mock), 'Approve PR #123?', { kind: 'whisper' });
+      expect(mock).toHaveBeenCalledWith(123, 'Approve PR #123?', {});
+      expect(mock).not.toHaveBeenCalledWith(456, expect.anything(), expect.anything());
+    });
+
+    it("routes kind='question' to Zaal's DM", async () => {
+      const mock = vi.fn();
+      await sendToZaal(makeDeps(mock), 'Which option?', { kind: 'question' });
+      expect(mock).toHaveBeenCalledWith(123, 'Which option?', {});
+    });
+
+    it("routes kind='status' to the group", async () => {
+      const mock = vi.fn();
+      await sendToZaal(makeDeps(mock), 'FYI deploy done', { kind: 'status' });
+      expect(mock).toHaveBeenCalledWith(456, 'FYI deploy done', {});
+    });
+
+    it('passes reply_markup through on a whisper (approval buttons stay private)', async () => {
+      const mock = vi.fn();
+      const markup = { inline_keyboard: [[{ text: 'Approve', callback_data: 'ok' }]] };
+      await sendToZaal(makeDeps(mock), 'Approve?', { kind: 'whisper', replyMarkup: markup });
+      expect(mock).toHaveBeenCalledWith(123, 'Approve?', { reply_markup: markup });
+    });
+
+    it('whispers fall back to the DM even when no group is configured', async () => {
+      const mock = vi.fn();
+      const deps: TelegramRoutingDeps = { sendMessage: mock, zaalId: 123 };
+      await sendToZaal(deps, 'private note', { kind: 'whisper' });
+      expect(mock).toHaveBeenCalledWith(123, 'private note', {});
+    });
+  });
 });

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -44,7 +44,7 @@ function chunkLongMessage(text: string, max = TELEGRAM_MAX): string[] {
   return chunks;
 }
 
-export type MessageKind = 'question' | 'status';
+export type MessageKind = 'question' | 'status' | 'whisper';
 
 export interface SendToZaalOptions {
   kind?: MessageKind; // defaults to 'status'
@@ -70,6 +70,9 @@ export interface TelegramRoutingDeps {
  * reply_markup is applied only to the first chunk.
  *
  * kind='question': DM Zaal directly (personal chat). These need his answer/decision.
+ * kind='whisper':  DM Zaal directly, but no answer required - a private
+ *   notification (approval prompts, private alerts). Keeps it out of the group
+ *   so the ZAALBOTS group stays status-only; only Zaal sees it.
  * kind='status': ZAALBOTS group (+ thread if configured). Informational.
  *
  * Fallback: if groupId is not set, all messages go to Zaal's DM to avoid
@@ -83,8 +86,11 @@ export async function sendToZaal(
   const kind = opts.kind ?? 'status';
   const chunks = chunkLongMessage(text);
 
-  // Determine target chat id based on message kind
-  const targetChatId = kind === 'question' ? deps.zaalId : (deps.groupId ?? deps.zaalId);
+  // Determine target chat id based on message kind. Questions AND whispers both
+  // go to Zaal's DM (questions need a reply, whispers are private notifications);
+  // only status goes to the group.
+  const targetChatId =
+    kind === 'question' || kind === 'whisper' ? deps.zaalId : (deps.groupId ?? deps.zaalId);
 
   // For status messages, also use group thread id if configured
   const messageOpts = (chatId: number) => {


### PR DESCRIPTION
## Summary
Adds a third `MessageKind` - **whisper** - for private DM notifications with zero group noise. ZOE had `question` (DM, needs reply) and `status` (ZAALBOTS group); there was no way to send a PRIVATE notification that needs no reply and must stay out of the group (approval prompts, private alerts).

## Change
- `whisper` routes to Zaal DM like `question`, but is a no-reply notification. Group stays status-only.
- `reply_markup` passes through so approval prompts keep their tap buttons, privately.
- Falls back to DM when no group configured.

## Verification
- 5 new routing tests, all pass (whisper->DM, question->DM, status->group, whisper+markup, whisper fallback).
- Type-clean on telegram-routing.ts.
- Note: the pre-existing `does not split mid-word when chunking` test fails on main independently of this change - unrelated, left for a separate fix.

Re-implemented fresh on current main; **supersedes #1862** (which conflicted after the env-module + chunking refactors).