### PR TITLE
fix(zoe): extend Claude cap-failover to the autonomous claude -p judgment callers

### DIFF
--- a/bot/src/hermes/critic.ts
+++ b/bot/src/hermes/critic.ts
@@ -1,9 +1,9 @@
 import {
-  callClaudeCli,
   HERMES_CRITIC_FAST_MODEL,
   HERMES_CRITIC_MODEL,
   HERMES_ROUTING_ENABLED,
 } from './claude-cli';
+import { callClaudeCliCapAware } from '../zoe/models/cli-cap-aware';
 import { runCmd } from './git';
 import { classifyDiffComplexity, type CritiqueInput, type CritiqueOutput } from './types';
 
@@ -98,7 +98,7 @@ export async function runCritic(input: CritiqueInput): Promise<CritiqueOutput> {
   ].join('\n');
 
   const criticModel = selectCriticModel(diff, input.filesChanged);
-  const result = await callClaudeCli({
+  const result = await callClaudeCliCapAware({
     model: criticModel,
     prompt: userPrompt,
     cwd: input.workTreePath,

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -15,7 +15,7 @@
  *   - list
  *   portal.zaoos.com/todos - brain dump
  */
-import { callClaudeCli } from '../hermes/claude-cli';
+import { callClaudeCliCapAware } from './models/cli-cap-aware';
 import { listOpenTasks } from './tasks';
 import { getOpenTeamTasks, summarizeTeamForBrief, zaalFocusForBrief } from './team-tracker';
 import { fleetConsensus } from './fleet-health';
@@ -375,7 +375,7 @@ CONTEXT:
 
 Output the brief now in the exact format from your system prompt.`;
 
-  const result = await callClaudeCli({
+  const result = await callClaudeCliCapAware({
     model: opts.model ?? 'sonnet',
     prompt: userPrompt,
     cwd: opts.repoDir,

--- a/bot/src/zoe/extractors.ts
+++ b/bot/src/zoe/extractors.ts
@@ -16,7 +16,7 @@ import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { callClaudeCli } from '../hermes/claude-cli';
+import { callClaudeCliCapAware } from './models/cli-cap-aware';
 import { remember, bonfireConfigured } from './recall';
 
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
@@ -172,7 +172,7 @@ async function runExtractor(
   today: string,
   cwd: string,
 ): Promise<Candidate[]> {
-  const res = await callClaudeCli({
+  const res = await callClaudeCliCapAware({
     model: 'haiku',
     prompt: message,
     cwd,

--- a/bot/src/zoe/models/__tests__/cli-cap-aware.test.ts
+++ b/bot/src/zoe/models/__tests__/cli-cap-aware.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockCallClaudeCli = vi.hoisted(() => vi.fn());
+const mockCallCapFallback = vi.hoisted(() => vi.fn());
+const mockHasProvider = vi.hoisted(() => vi.fn());
+
+// Keep CliError REAL (the wrapper uses `err instanceof CliError`); mock only the call.
+vi.mock('../../../hermes/claude-cli', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../hermes/claude-cli')>();
+  return { ...actual, callClaudeCli: mockCallClaudeCli };
+});
+vi.mock('../router', () => ({
+  callCapFallback: mockCallCapFallback,
+  hasCapFallbackProvider: mockHasProvider,
+}));
+
+import { callClaudeCliCapAware } from '../cli-cap-aware';
+import { CliError } from '../../../hermes/claude-cli';
+
+afterEach(() => vi.clearAllMocks());
+
+const RESULT = { text: 'ok', raw: '', exitCode: 0 } as never;
+const opts = { cwd: '/tmp', prompt: 'u', appendSystemPrompt: 's' } as never;
+
+describe('callClaudeCliCapAware', () => {
+  it('returns the Claude result when the call succeeds (no fallback)', async () => {
+    mockCallClaudeCli.mockResolvedValue(RESULT);
+    const r = await callClaudeCliCapAware(opts);
+    expect(r).toBe(RESULT);
+    expect(mockCallCapFallback).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a non-Claude provider on a usage_limit (weekly cap)', async () => {
+    mockCallClaudeCli.mockRejectedValue(new CliError('weekly limit', 'usage_limit'));
+    mockHasProvider.mockReturnValue(true);
+    mockCallCapFallback.mockResolvedValue({ provider: 'openrouter', result: RESULT });
+    const r = await callClaudeCliCapAware(opts);
+    expect(r).toBe(RESULT);
+    expect(mockCallCapFallback).toHaveBeenCalledWith('s', 'u');
+  });
+
+  it('falls back on a rate_limit (429) cap too', async () => {
+    mockCallClaudeCli.mockRejectedValue(new CliError('429', 'rate_limit'));
+    mockHasProvider.mockReturnValue(true);
+    mockCallCapFallback.mockResolvedValue({ provider: 'grok', result: RESULT });
+    await callClaudeCliCapAware(opts);
+    expect(mockCallCapFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws the cap error when no fallback provider is configured', async () => {
+    mockCallClaudeCli.mockRejectedValue(new CliError('weekly limit', 'usage_limit'));
+    mockHasProvider.mockReturnValue(false);
+    await expect(callClaudeCliCapAware(opts)).rejects.toThrow('weekly limit');
+    expect(mockCallCapFallback).not.toHaveBeenCalled();
+  });
+
+  it('re-throws a non-cap error without falling back', async () => {
+    mockCallClaudeCli.mockRejectedValue(new CliError('boom', 'unknown'));
+    mockHasProvider.mockReturnValue(true);
+    await expect(callClaudeCliCapAware(opts)).rejects.toThrow('boom');
+    expect(mockCallCapFallback).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/zoe/models/cli-cap-aware.ts
+++ b/bot/src/zoe/models/cli-cap-aware.ts
@@ -1,0 +1,47 @@
+/**
+ * callClaudeCliCapAware - run a Claude CLI call, and if Claude is over its cap
+ * (usage_limit / rate_limit / auth), fall back to a non-Claude provider instead
+ * of surfacing the raw error and losing the turn.
+ *
+ * Use this for JUDGMENT / TEXT calls (critic, recap, reflect, brief, learn,
+ * extractors, reflexion) where a non-Claude model can substitute - the whole
+ * task is in the prompt, and the output is text/JSON.
+ *
+ * Do NOT use it for AGENTIC file-editing calls (the Hermes coder, workers with
+ * Edit/Write tools): a text provider cannot edit files, so those must DEFER on
+ * cap (throw + let the orchestrator retry after the cap resets), not fall back
+ * to a model that cannot do the work.
+ *
+ * This is the shared version of the cap-fallback the concierge already does
+ * inline (bot/src/zoe/concierge.ts callModelWithCliRouting) - extended to the
+ * autonomous claude -p callers that were dying on the weekly cap.
+ */
+import {
+  callClaudeCli,
+  CliError,
+  type ClaudeCliOptions,
+  type ClaudeCliResult,
+} from '../../hermes/claude-cli';
+import { callCapFallback, hasCapFallbackProvider } from './router';
+
+export async function callClaudeCliCapAware(
+  opts: ClaudeCliOptions & { cwd: string },
+): Promise<ClaudeCliResult> {
+  try {
+    return await callClaudeCli(opts);
+  } catch (err: unknown) {
+    const isCap =
+      err instanceof CliError &&
+      (err.kind === 'usage_limit' || err.kind === 'rate_limit' || err.kind === 'auth');
+    if (isCap && hasCapFallbackProvider()) {
+      const kind = (err as CliError).kind;
+      console.warn(
+        `[zoe/cli-cap-aware] Claude capped (${kind}) - falling back to a non-Claude provider`,
+      );
+      const fb = await callCapFallback(opts.appendSystemPrompt ?? '', opts.prompt ?? '');
+      console.log('[zoe/cli-cap-aware] cap-fallback served by', fb.provider);
+      return fb.result;
+    }
+    throw err;
+  }
+}

--- a/bot/src/zoe/recap.ts
+++ b/bot/src/zoe/recap.ts
@@ -16,7 +16,7 @@
  *   RESEARCH DOCS
  *   - list
  */
-import { callClaudeCli } from '../hermes/claude-cli';
+import { callClaudeCliCapAware } from './models/cli-cap-aware';
 import { execSync } from 'node:child_process';
 
 const RECAP_SYSTEM_PROMPT = `You are ZOE writing Zaal's nightly recap at 9pm EST.
@@ -124,7 +124,7 @@ CONTEXT:
 
 Output the recap now in the exact format from your system prompt.`;
 
-  const result = await callClaudeCli({
+  const result = await callClaudeCliCapAware({
     model: opts.model ?? 'sonnet',
     prompt: userPrompt,
     cwd: opts.repoDir,

--- a/bot/src/zoe/reflect.ts
+++ b/bot/src/zoe/reflect.ts
@@ -9,7 +9,7 @@
  * Zaal replies free-form. The next concierge turn parses the answers and
  * captures them as Bonfire-eligible notes (status + priorities update).
  */
-import { callClaudeCli } from '../hermes/claude-cli';
+import { callClaudeCliCapAware } from './models/cli-cap-aware';
 import { recordCall } from './cost-ledger';
 import { listOpenTasks } from './tasks';
 import { listLiveThreads, isOverdue, type OpenThread } from './threads';
@@ -117,7 +117,7 @@ ${
     : '\nOutput the reflection prompt in the exact format from your system prompt. Reference 1-2 specifics from today.'
 }`;
 
-  const result = await callClaudeCli({
+  const result = await callClaudeCliCapAware({
     model: opts.model ?? 'haiku',
     prompt: userPrompt,
     cwd: opts.repoDir,


### PR DESCRIPTION
## Summary
Bot audit finding: ZOE's autonomous tasks still die on the Claude weekly cap ("Youve hit your weekly limit", 429s in the logs). The concierge has cap-fallback to a non-Claude provider, but the `claude -p` callers in the Hermes/ZOE pipeline call `callClaudeCli` directly with no fallback.

## Fix
- **New shared wrapper** `bot/src/zoe/models/cli-cap-aware.ts` (`callClaudeCliCapAware`): runs the Claude CLI, and on a cap error (`usage_limit`/`rate_limit`/`auth`) with a non-Claude provider configured, falls back via the existing router `callCapFallback` (same path the concierge uses) instead of losing the turn.
- **Wired into the judgment / text callers** where a non-Claude model can substitute: `critic` (fix-PR review), `recap`, `reflect`, `brief`, `extractors`.
- **Deliberately NOT wired into the agentic coder / workers** (Edit/Write tools): a text provider cannot edit files, so those correctly DEFER on cap (throw + orchestrator retries after reset). `reflexion` + `learn` skipped (they carry Edit/Write).

## Verification
- 5 unit tests on the wrapper (success passthrough, usage_limit + rate_limit fallback, no-provider re-throw, non-cap re-throw). Run in CI (local vitest has the known rolldown/Mac binding issue).
- Type-clean on all touched files.