### PR TITLE
test(zoe): fix the always-failing mid-word chunking test (unblocks Bot Tests CI)

### DIFF
--- a/bot/src/zoe/__tests__/telegram-routing.test.ts
+++ b/bot/src/zoe/__tests__/telegram-routing.test.ts
@@ -85,11 +85,17 @@ describe('telegram-routing', () => {
 
       await sendToZaal(deps, text, { kind: 'status' });
 
-      // Verify each chunk ends with a complete word (no mid-word splits)
+      // Verify no word was split across chunks: every whitespace-separated token
+      // in every chunk is the COMPLETE word. (chunkLongMessage trims trailing
+      // whitespace, so a chunk ends with a whole word, not a space - the old
+      // assertion checked for a trailing space that trimEnd() always removes,
+      // so it could never pass.)
       for (const call of sendMessageMock.mock.calls) {
-        const message = call[1].replace(/^\(\d+\/\d+\) /, ''); // Remove prefix
-        // Should end with word boundary or whitespace, not mid-word
-        expect(message).toMatch(/(\s|^)$/);
+        const message = call[1].replace(/^\(\d+\/\d+\) /, ''); // Remove chunk prefix
+        const tokens = message.trim().split(/\s+/).filter(Boolean);
+        for (const token of tokens) {
+          expect(token).toBe(longWord);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
The `does not split mid-word when chunking` test has been failing on **every** bot PR (#2489-#2494), masking real bot-test failures. Its assertion checked each chunk ends with whitespace (`/(\s|^)$/`), but `chunkLongMessage` `trimEnd()`s every chunk - so a chunk always ends with a whole word, never a space. The test could never pass.

## Fix
Assert the actual intent: no word is split across chunks - every whitespace-separated token in every chunk is the complete word.

## Verification
Ran the real chunker on a 500-word input: 5 chunks, **0 mid-word splits**. Corrected assertion passes.