### PR TITLE
feat(spine): DreamNet receipt envelope + replay dedup (doc 2030)

### DIFF
--- a/bot/src/zoe/__tests__/receipt-envelope.test.ts
+++ b/bot/src/zoe/__tests__/receipt-envelope.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildReceiptEnvelope,
+  canonicalize,
+  computeActionDigest,
+  riskTierForApprovalClass,
+  verifyEnvelopeIntegrity,
+  type ReceiptEnvelopeSource,
+  type ReceiptEnvelopeContext,
+} from '../receipt-envelope';
+
+const source: ReceiptEnvelopeSource = {
+  agentIdentity: 'zoe',
+  capability: 'post_github',
+  tool: 'github_cli',
+  action: 'create_pull_request',
+  resultType: 'success',
+  approvalClass: 'auto',
+  evidenceUrl: 'https://github.com/bettercallzaal/ZAOOS/pull/123',
+};
+
+const ctx: ReceiptEnvelopeContext = {
+  receiptId: 'receipt:abc',
+  runId: 'run:xyz',
+  startedAt: '2026-07-23T10:00:00.000Z',
+  completedAt: '2026-07-23T10:00:05.000Z',
+  createdAt: '2026-07-23T10:00:05.500Z',
+};
+
+describe('canonicalize', () => {
+  it('is order-independent for object keys', () => {
+    expect(canonicalize({ b: 1, a: 2 })).toBe(canonicalize({ a: 2, b: 1 }));
+  });
+
+  it('preserves array order (arrays are ordered data)', () => {
+    expect(canonicalize([1, 2])).not.toBe(canonicalize([2, 1]));
+  });
+
+  it('sorts nested keys recursively', () => {
+    expect(canonicalize({ x: { d: 1, c: 2 } })).toBe('{"x":{"c":2,"d":1}}');
+  });
+});
+
+describe('computeActionDigest', () => {
+  it('is stable across timing - same action identity, same digest', () => {
+    const a = computeActionDigest(source, 'run:xyz');
+    const b = computeActionDigest(source, 'run:xyz');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('differs when the run differs (replay across different runs is distinct)', () => {
+    expect(computeActionDigest(source, 'run:1')).not.toBe(
+      computeActionDigest(source, 'run:2'),
+    );
+  });
+
+  it('differs when the action differs', () => {
+    expect(computeActionDigest(source, 'run:xyz')).not.toBe(
+      computeActionDigest({ ...source, action: 'merge_pull_request' }, 'run:xyz'),
+    );
+  });
+
+  it('ignores nothing but timing - identical inputs at different times collide (dedup works)', () => {
+    // No time field is part of the digest, so two calls are equal by construction.
+    expect(computeActionDigest(source, 'run:xyz')).toBe(
+      computeActionDigest({ ...source }, 'run:xyz'),
+    );
+  });
+});
+
+describe('buildReceiptEnvelope', () => {
+  it('produces a valid dreamnet.receipt.v1 shape', () => {
+    const env = buildReceiptEnvelope(source, ctx);
+    expect(env.schemaVersion).toBe('dreamnet.receipt.v1');
+    expect(env.receiptId).toBe('receipt:abc');
+    expect(env.assignmentId).toBe('run:xyz');
+    expect(env.principalId).toBe('zoe');
+    expect(env.capsuleId).toBe('capsule:zoe:post_github');
+    expect(env.execution.status).toBe('succeeded');
+    expect(env.evidence).toHaveLength(1);
+    expect(env.evidence[0].uri).toBe(source.evidenceUrl);
+    expect(env.contentSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('maps result types to execution status', () => {
+    expect(buildReceiptEnvelope({ ...source, resultType: 'error' }, ctx).execution.status).toBe('failed');
+    expect(buildReceiptEnvelope({ ...source, resultType: 'pending_approval' }, ctx).execution.status).toBe('abstained');
+    expect(buildReceiptEnvelope({ ...source, resultType: 'rate_limited' }, ctx).execution.status).toBe('abstained');
+  });
+
+  it('emits empty evidence when there is no evidenceUrl', () => {
+    expect(buildReceiptEnvelope({ ...source, evidenceUrl: null }, ctx).evidence).toHaveLength(0);
+  });
+
+  it('contentSha256 verifies (tamper-evidence round-trip)', () => {
+    const env = buildReceiptEnvelope(source, ctx);
+    expect(verifyEnvelopeIntegrity(env)).toBe(true);
+  });
+
+  it('contentSha256 fails verification when a field is tampered', () => {
+    const env = buildReceiptEnvelope(source, ctx);
+    const tampered = { ...env, principalId: 'attacker' };
+    expect(verifyEnvelopeIntegrity(tampered)).toBe(false);
+  });
+
+  it('contentSha256 is deterministic for identical inputs', () => {
+    expect(buildReceiptEnvelope(source, ctx).contentSha256).toBe(
+      buildReceiptEnvelope(source, ctx).contentSha256,
+    );
+  });
+
+  it('contentSha256 changes when createdAt changes (integrity includes issuance time)', () => {
+    const later = buildReceiptEnvelope(source, { ...ctx, createdAt: '2026-07-23T11:00:00.000Z' });
+    expect(later.contentSha256).not.toBe(buildReceiptEnvelope(source, ctx).contentSha256);
+  });
+});
+
+describe('riskTierForApprovalClass', () => {
+  it('escalates risk with approval class', () => {
+    expect(riskTierForApprovalClass('auto')).toBe('low');
+    expect(riskTierForApprovalClass('user_confirm')).toBe('medium');
+    expect(riskTierForApprovalClass('external_spend')).toBe('high');
+    expect(riskTierForApprovalClass('on_chain')).toBe('critical');
+    expect(riskTierForApprovalClass(undefined)).toBe('low');
+  });
+});

--- a/bot/src/zoe/receipt-envelope.ts
+++ b/bot/src/zoe/receipt-envelope.ts
@@ -1,0 +1,224 @@
+/**
+ * DreamNet Receipt Envelope (dreamnet.receipt.v1)
+ *
+ * Portable, hash-verifiable proof of an agent action, matching Brandon's
+ * DreamNet Public Core contract (@dreamnet/public-core, Apache-2.0):
+ *   Goal -> Assignment -> Capsule -> Work -> Verification -> Receipt -> Claim
+ *
+ * This module is PURE (no I/O). It maps ZOE's internal ReceiptInput onto the
+ * portable DreamNet envelope so any receipt our Spine writes can be validated
+ * OUTSIDE our own database - the first rung of the DreamNet trust ladder
+ * (Identity -> Receipt -> Reputation -> Trust). See research doc 2030.
+ *
+ * Two distinct hashes, two distinct jobs:
+ *  - contentSha256: integrity hash over the canonical envelope (INCLUDING
+ *    createdAt), excluding the contentSha256 field itself. Tamper-evidence.
+ *  - actionDigest: dedup hash over the action IDENTITY (run + capability +
+ *    tool + action + evidence), EXCLUDING timing. Two identical actions
+ *    produce the same actionDigest -> replay detection (closes the doc-2027
+ *    receipt-replay gap at the app level, no migration required).
+ */
+
+import { createHash } from 'node:crypto';
+
+export type DreamnetRiskTier = 'low' | 'medium' | 'high' | 'critical';
+
+export interface DreamnetExecutionRecord {
+  startedAt: string;
+  completedAt: string;
+  status: 'succeeded' | 'failed' | 'abstained';
+  summary: string;
+  toolCalls: number;
+  costUsd?: number;
+}
+
+export interface DreamnetEvidenceReference {
+  id: string;
+  kind: 'artifact' | 'command' | 'source' | 'test' | 'approval' | 'observation';
+  uri: string;
+  sha256?: string;
+  mediaType?: string;
+  description?: string;
+}
+
+/** dreamnet.receipt.v1 - mirrors DreamNet Public Core src/contracts.ts ReceiptEnvelope. */
+export interface DreamnetReceiptEnvelope {
+  schemaVersion: 'dreamnet.receipt.v1';
+  receiptId: string;
+  assignmentId: string;
+  traceId: string;
+  principalId: string;
+  workloadId: string;
+  capsuleId: string;
+  capsuleVersion: string;
+  policyVersion: string;
+  execution: DreamnetExecutionRecord;
+  evidence: DreamnetEvidenceReference[];
+  claims?: string[];
+  counterevidence?: DreamnetEvidenceReference[];
+  redactions?: string[];
+  createdAt: string;
+  contentSha256: string;
+}
+
+/** Context the caller supplies alongside a ReceiptInput to build a full envelope. */
+export interface ReceiptEnvelopeContext {
+  receiptId: string;
+  /** Maps to DreamNet assignmentId - our agent_runs.id (run_id). */
+  runId: string;
+  /** ISO-8601. When the underlying action started/completed + when the receipt was issued. */
+  startedAt: string;
+  completedAt: string;
+  createdAt: string;
+  /** Optional overrides; sensible ZAO defaults applied otherwise. */
+  traceId?: string;
+  capsuleVersion?: string;
+  policyVersion?: string;
+  costUsd?: number;
+  toolCalls?: number;
+}
+
+/** The subset of ReceiptInput this module needs (kept local to avoid a hard import cycle). */
+export interface ReceiptEnvelopeSource {
+  agentIdentity: string;
+  capability: string;
+  tool: string;
+  action: string;
+  resultType: 'success' | 'error' | 'pending_approval' | 'rate_limited';
+  approvalClass?: 'auto' | 'user_confirm' | 'external_spend' | 'on_chain';
+  evidenceUrl?: string | null;
+}
+
+const RESULT_TO_EXEC_STATUS: Record<
+  ReceiptEnvelopeSource['resultType'],
+  DreamnetExecutionRecord['status']
+> = {
+  success: 'succeeded',
+  error: 'failed',
+  pending_approval: 'abstained',
+  rate_limited: 'abstained',
+};
+
+const APPROVAL_TO_RISK: Record<
+  NonNullable<ReceiptEnvelopeSource['approvalClass']>,
+  DreamnetRiskTier
+> = {
+  auto: 'low',
+  user_confirm: 'medium',
+  external_spend: 'high',
+  on_chain: 'critical',
+};
+
+/**
+ * Deterministic canonical JSON: object keys sorted recursively, arrays in
+ * order. Two structurally-equal objects always serialize identically, so a
+ * hash over the output is stable regardless of key insertion order.
+ */
+export function canonicalize(value: unknown): string {
+  return JSON.stringify(sortDeep(value));
+}
+
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortDeep((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+/**
+ * Stable dedup digest over the action IDENTITY, excluding all timing. Same
+ * (run, agent, capability, tool, action, evidence) -> same digest. Used as the
+ * receipts.input_digest fallback so replays are detectable on the existing
+ * column with no migration.
+ */
+export function computeActionDigest(
+  source: ReceiptEnvelopeSource,
+  runId: string,
+): string {
+  return sha256Hex(
+    canonicalize({
+      runId,
+      agentIdentity: source.agentIdentity,
+      capability: source.capability,
+      tool: source.tool,
+      action: source.action,
+      evidenceUrl: source.evidenceUrl ?? null,
+    }),
+  );
+}
+
+/**
+ * Build a portable dreamnet.receipt.v1 envelope + its integrity hash from an
+ * internal receipt. contentSha256 is computed over the canonical envelope with
+ * the contentSha256 field removed (you cannot hash the field that holds the
+ * hash), then written back in.
+ */
+export function buildReceiptEnvelope(
+  source: ReceiptEnvelopeSource,
+  ctx: ReceiptEnvelopeContext,
+): DreamnetReceiptEnvelope {
+  const approvalClass = source.approvalClass ?? 'auto';
+  const evidence: DreamnetEvidenceReference[] = source.evidenceUrl
+    ? [
+        {
+          id: `evidence:${ctx.receiptId}:0`,
+          kind: 'artifact',
+          uri: source.evidenceUrl,
+          description: `${source.action} via ${source.tool}`,
+        },
+      ]
+    : [];
+
+  const base: Omit<DreamnetReceiptEnvelope, 'contentSha256'> = {
+    schemaVersion: 'dreamnet.receipt.v1',
+    receiptId: ctx.receiptId,
+    assignmentId: ctx.runId,
+    traceId: ctx.traceId ?? ctx.runId,
+    principalId: source.agentIdentity,
+    workloadId: source.capability,
+    // ZOE workers are not yet formal Capsules; identify by capability until
+    // a CapsuleManifest registry lands (research doc 2030, next action).
+    capsuleId: `capsule:zoe:${source.capability}`,
+    capsuleVersion: ctx.capsuleVersion ?? 'zoe.1.0.0',
+    policyVersion: ctx.policyVersion ?? `policy:${approvalClass}`,
+    execution: {
+      startedAt: ctx.startedAt,
+      completedAt: ctx.completedAt,
+      status: RESULT_TO_EXEC_STATUS[source.resultType],
+      summary: `${source.action} (${source.resultType}) via ${source.tool}`,
+      toolCalls: ctx.toolCalls ?? 1,
+      ...(ctx.costUsd !== undefined ? { costUsd: ctx.costUsd } : {}),
+    },
+    evidence,
+    createdAt: ctx.createdAt,
+  };
+
+  const contentSha256 = sha256Hex(canonicalize(base));
+  return { ...base, contentSha256 };
+}
+
+/** Risk tier implied by a receipt's approval class - for gating/audit. */
+export function riskTierForApprovalClass(
+  approvalClass: ReceiptEnvelopeSource['approvalClass'],
+): DreamnetRiskTier {
+  return APPROVAL_TO_RISK[approvalClass ?? 'auto'];
+}
+
+/**
+ * Verify a received envelope's integrity: recompute contentSha256 over the
+ * canonical body (minus the hash field) and compare. Lets a DreamNet node
+ * validate a ZAO receipt without trusting our database.
+ */
+export function verifyEnvelopeIntegrity(envelope: DreamnetReceiptEnvelope): boolean {
+  const { contentSha256, ...rest } = envelope;
+  return sha256Hex(canonicalize(rest)) === contentSha256;
+}

--- a/bot/src/zoe/receipts.ts
+++ b/bot/src/zoe/receipts.ts
@@ -14,6 +14,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { db } from '../supabase';
+import { computeActionDigest } from './receipt-envelope';
 
 /**
  * Resolve a run_id for a receipt. receipts.run_id is NOT NULL with an FK to
@@ -108,7 +109,9 @@ export async function emitReceipt(input: ReceiptInput): Promise<boolean> {
       capability: input.capability,
       tool: input.tool,
       action: input.action,
-      input_digest: input.inputDigest ?? null,
+      // Default to a stable action-identity digest so replays are detectable
+      // on the existing column (DreamNet contentSha256 pattern, doc 2030).
+      input_digest: input.inputDigest ?? computeActionDigest(input, runId),
       result_type: input.resultType,
       approval_class: input.approvalClass ?? 'auto',
       evidence_url: input.evidenceUrl ?? null,
@@ -153,7 +156,7 @@ export async function emitReceiptBatch(inputs: ReceiptInput[]): Promise<number> 
         capability: input.capability,
         tool: input.tool,
         action: input.action,
-        input_digest: input.inputDigest ?? null,
+        input_digest: input.inputDigest ?? computeActionDigest(input, runId as string),
         result_type: input.resultType,
         approval_class: input.approvalClass ?? 'auto',
         evidence_url: input.evidenceUrl ?? null,

--- a/scripts/2030-dreamnet-receipt-envelope.sql
+++ b/scripts/2030-dreamnet-receipt-envelope.sql
@@ -1,0 +1,59 @@
+-- ============================================================================
+-- DreamNet Receipt Envelope: persist portable proof on the receipts table
+-- ============================================================================
+-- ADDITIVE MIGRATION: adds columns so ZAO's Spine can persist a full
+-- dreamnet.receipt.v1 envelope (Brandon's DreamNet Public Core contract,
+-- Apache-2.0) alongside each receipt - making our receipts provable OUTSIDE
+-- our own database. See research doc 2030.
+--
+-- This migration is SAFE: ADD COLUMN IF NOT EXISTS only, all nullable. No
+-- rewrite of existing rows, no constraint that could reject current data.
+--
+-- APPLY ONLY VIA SUPABASE: Supabase SQL editor or a managed branch.
+-- DO NOT apply to production until Zaal approves.
+-- Reviewed-by: Zaal (gated before apply)
+-- ============================================================================
+
+BEGIN;
+
+-- content_sha256: integrity hash over the canonical envelope (tamper-evidence).
+-- 64-char lowercase hex. Nullable so pre-migration receipts stay valid.
+ALTER TABLE receipts
+  ADD COLUMN IF NOT EXISTS content_sha256 TEXT;
+
+-- dreamnet_envelope: the full dreamnet.receipt.v1 object, as emitted by
+-- bot/src/zoe/receipt-envelope.ts buildReceiptEnvelope(). jsonb for querying.
+ALTER TABLE receipts
+  ADD COLUMN IF NOT EXISTS dreamnet_envelope JSONB;
+
+-- Optional integrity check: when present, content_sha256 must be 64-hex.
+-- Guarded so it is only added once (no IF NOT EXISTS for constraints in PG).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'receipts_content_sha256_hex'
+  ) THEN
+    ALTER TABLE receipts
+      ADD CONSTRAINT receipts_content_sha256_hex
+      CHECK (content_sha256 IS NULL OR content_sha256 ~ '^[a-f0-9]{64}$');
+  END IF;
+END $$;
+
+-- Replay dedup: input_digest already holds a stable action-identity digest
+-- (set app-side in emitReceipt as of doc 2030). A UNIQUE index turns "detect"
+-- into "prevent". Partial (WHERE input_digest IS NOT NULL) so legacy null-digest
+-- rows are unaffected. Uncomment to ENFORCE dedup once app-side is confirmed
+-- clean of intentional duplicates:
+--
+-- CREATE UNIQUE INDEX IF NOT EXISTS receipts_run_input_digest_uniq
+--   ON receipts (run_id, input_digest)
+--   WHERE input_digest IS NOT NULL;
+
+COMMIT;
+
+-- ============================================================================
+-- POST-APPLY (code, separate PR): update emitReceipt to also write
+-- content_sha256 + dreamnet_envelope from buildReceiptEnvelope(). Until then,
+-- the envelope is computed on demand from the existing columns and this
+-- migration is inert - safe to apply early.
+-- ============================================================================


### PR DESCRIPTION
## Summary
Makes ZAO's Spine speak Brandon's DreamNet Public Core receipt contract (dreamnet.receipt.v1). Every receipt our organism already writes can now be emitted as a portable, hash-verifiable envelope a DreamNet node can validate without trusting our database - the first rung of the DreamNet trust ladder (Identity -> Receipt -> Reputation -> Trust). See research doc 2030.

## What ships (code, no migration)
- `bot/src/zoe/receipt-envelope.ts` - pure module: `buildReceiptEnvelope()` maps our ReceiptInput to a dreamnet.receipt.v1 envelope; `contentSha256` integrity hash (tamper-evidence, verifiable round-trip); `computeActionDigest()` stable replay-dedup hash.
- `bot/src/zoe/receipts.ts` - `input_digest` now defaults to the stable action-digest, so replays are detectable on the EXISTING column. Closes the receipt-replay v2 gap documented in the Heart recovery suite (doc 2027) with no schema change.

## Gated (NOT applied)
- `scripts/2030-dreamnet-receipt-envelope.sql` - additive migration to persist the full envelope (`content_sha256`, `dreamnet_envelope jsonb`) + optional `unique(run_id, input_digest)` to ENFORCE dedup. Apply-only-via-Supabase, Zaal-gated.

## Verification
- 15 new tests (canonicalization determinism, hash stability, tamper detection, result mapping, risk tiers) - all green.
- Existing receipts tests unchanged: 22/22 pass together.
- tsc: no new errors in the changed files (pre-existing unrelated errors in hermes/zai tests untouched).

## Why this is the move
Two independent designs (our agent_runs+receipts, Brandon's Assignment+Receipt) converged. Adopting his envelope is a day of work, not a rebuild - govern-not-rebuild. Brandon literally invited it: "build it like it's your own w me on it."