### PR TITLE
feat(zoe): autonomous error-remediation rail (route fix + report, dont ask)

### DIFF
--- a/bot/src/hermes/coder.ts
+++ b/bot/src/hermes/coder.ts
@@ -26,6 +26,17 @@ function repoContextBlock(target: HermesRepoTarget): string {
       'No specific member counts (use "100+"). No crypto/web3/onchain in body copy. Sponsors pay money, partners give time.',
     ].join('\n');
   }
+  if (target === 'zaocowork') {
+    return [
+      '# Repo Context: zaocowork',
+      'You are working on the ZAODEVZ/ZAOcowork Next.js app - the cowork board at thezao.xyz/board.',
+      'Stack: Next.js App Router, React, Tailwind, Supabase. The board reads the cowork `tasks` table.',
+      'The board renders per `brand` query param (e.g. ?brand=ZAOstock). Brand-specific render paths',
+      'must tolerate tasks with null/optional fields - a single unguarded deref throws the whole page',
+      'into the error boundary. Prefer the smallest defensive guard/default over a broad refactor.',
+      'No emojis, no em dashes - use hyphens.',
+    ].join('\n');
+  }
   return [
     '# Repo Context: ZAO OS',
     'You are working on the bettercallzaal/ZAOOS monorepo (Farcaster-native social platform + bot).',

--- a/bot/src/hermes/git.ts
+++ b/bot/src/hermes/git.ts
@@ -88,6 +88,12 @@ const HERMES_REPO_PROFILES: Record<HermesRepoTarget, RepoProfile> = {
     defaultBranch: 'main',
     installSubdirs: [],
   },
+  zaocowork: {
+    target: 'zaocowork',
+    url: process.env.HERMES_ZAOCOWORK_REPO_URL ?? 'https://github.com/ZAODEVZ/ZAOcowork.git',
+    defaultBranch: 'main',
+    installSubdirs: [],
+  },
 };
 
 export function getRepoProfile(target: HermesRepoTarget): RepoProfile {

--- a/bot/src/hermes/types.ts
+++ b/bot/src/hermes/types.ts
@@ -41,7 +41,7 @@ export interface HermesRun {
  * Adding more targets: extend HERMES_REPO_PROFILES in git.ts and update the
  * per-target system-prompt context in coder.ts.
  */
-export type HermesRepoTarget = 'zaoos' | 'zaostock';
+export type HermesRepoTarget = 'zaoos' | 'zaostock' | 'zaocowork';
 
 export const HERMES_DEFAULT_TARGET: HermesRepoTarget = 'zaoos';
 

--- a/bot/src/zoe/__tests__/error-remediation.test.ts
+++ b/bot/src/zoe/__tests__/error-remediation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  normalizeStack,
+  stackHash,
+  repoToTarget,
+  pickNext,
+  buildIssueText,
+  runErrorRemediationTick,
+  type AppError,
+  type RemediationDeps,
+  type RemediationDispatchResult,
+} from '../error-remediation';
+
+function mkError(over: Partial<AppError> = {}): AppError {
+  return {
+    id: 'err-1',
+    ref_code: '1463886943',
+    repo: 'zaocowork',
+    route: '/board',
+    brand: 'ZAOstock',
+    message: "Cannot read properties of undefined (reading 'length')",
+    stack: 'at Board (/tmp/x/src/app/board/page.tsx:42:19)',
+    stack_hash: 'abc',
+    count: 3,
+    status: 'new',
+    ...over,
+  };
+}
+
+describe('normalizeStack + stackHash', () => {
+  it('strips line:col, hex ids, tmp paths, uuids so the same bug hashes stably', () => {
+    const a = 'at Board (/tmp/clone-a/src/page.tsx:42:19) 0xAB12 550e8400-e29b-41d4-a716-446655440000';
+    const b = 'at Board (/tmp/clone-b/src/page.tsx:99:3) 0xFF99 111e8400-e29b-41d4-a716-446655440999';
+    expect(normalizeStack(a)).toBe(normalizeStack(b));
+    expect(stackHash(a)).toBe(stackHash(b));
+    expect(stackHash(a)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('different throws hash differently', () => {
+    expect(stackHash('at A (x:1:1)')).not.toBe(stackHash('at B (y:1:1)'));
+  });
+
+  it('handles null/undefined stack', () => {
+    expect(normalizeStack(null)).toBe('');
+    expect(stackHash(undefined)).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('repoToTarget', () => {
+  it('accepts supported targets', () => {
+    expect(repoToTarget('zaoos')).toBe('zaoos');
+    expect(repoToTarget('zaostock')).toBe('zaostock');
+    expect(repoToTarget('zaocowork')).toBe('zaocowork');
+  });
+  it('rejects unknown repos', () => {
+    expect(repoToTarget('some-random-repo')).toBeNull();
+  });
+});
+
+describe('pickNext', () => {
+  it('picks the highest-count NEW error', () => {
+    const picked = pickNext([
+      mkError({ id: 'a', count: 2 }),
+      mkError({ id: 'b', count: 9 }),
+      mkError({ id: 'c', count: 5 }),
+    ]);
+    expect(picked?.id).toBe('b');
+  });
+  it('ignores non-new statuses', () => {
+    expect(pickNext([mkError({ status: 'fixing' }), mkError({ status: 'fixed' })])).toBeNull();
+  });
+  it('returns null on empty', () => {
+    expect(pickNext([])).toBeNull();
+  });
+});
+
+describe('buildIssueText', () => {
+  it('includes ref, route, brand, message, and fix guidance', () => {
+    const text = buildIssueText(mkError());
+    expect(text).toContain('1463886943');
+    expect(text).toContain('/board');
+    expect(text).toContain('ZAOstock');
+    expect(text).toContain('SMALLEST safe change');
+    expect(text).not.toMatch(/\n{3,}/); // no triple blank lines
+  });
+});
+
+function baseDeps(over: Partial<RemediationDeps> = {}): RemediationDeps {
+  return {
+    fetchNewErrors: vi.fn(async () => [mkError()]),
+    claimError: vi.fn(async () => true),
+    markFixed: vi.fn(async () => {}),
+    markEscalated: vi.fn(async () => {}),
+    dispatchFix: vi.fn(
+      async (): Promise<RemediationDispatchResult> => ({
+        kind: 'ready',
+        prNumber: 77,
+        prUrl: 'https://github.com/ZAODEVZ/ZAOcowork/pull/77',
+        runId: 'run-1',
+      }),
+    ),
+    report: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe('runErrorRemediationTick', () => {
+  it('routes a new error to a fix and reports the PR (no question)', async () => {
+    const deps = baseDeps();
+    const status = await runErrorRemediationTick(deps);
+    expect(deps.dispatchFix).toHaveBeenCalledWith(
+      expect.objectContaining({ targetRepo: 'zaocowork' }),
+    );
+    expect(deps.markFixed).toHaveBeenCalledWith('err-1', expect.stringContaining('/pull/77'), 'run-1');
+    expect(deps.report).toHaveBeenCalledWith(expect.stringContaining('PR #77'));
+    expect(status).toContain('fixed');
+  });
+
+  it('does nothing when there are no new errors', async () => {
+    const deps = baseDeps({ fetchNewErrors: vi.fn(async () => []) });
+    expect(await runErrorRemediationTick(deps)).toBe('no new errors');
+    expect(deps.dispatchFix).not.toHaveBeenCalled();
+  });
+
+  it('yields the row when it loses the claim race (no double-dispatch)', async () => {
+    const deps = baseDeps({ claimError: vi.fn(async () => false) });
+    await runErrorRemediationTick(deps);
+    expect(deps.dispatchFix).not.toHaveBeenCalled();
+    expect(deps.markFixed).not.toHaveBeenCalled();
+  });
+
+  it('escalates (not fixes) an unsupported repo', async () => {
+    const deps = baseDeps({ fetchNewErrors: vi.fn(async () => [mkError({ repo: 'mystery' })]) });
+    await runErrorRemediationTick(deps);
+    expect(deps.dispatchFix).not.toHaveBeenCalled();
+    expect(deps.markEscalated).toHaveBeenCalled();
+    expect(deps.report).toHaveBeenCalledWith(expect.stringContaining('needs you'));
+  });
+
+  it('escalates when the pipeline cannot fix', async () => {
+    const deps = baseDeps({
+      dispatchFix: vi.fn(async (): Promise<RemediationDispatchResult> => ({
+        kind: 'escalated',
+        runId: 'run-2',
+        reason: 'critic rejected 3x',
+      })),
+    });
+    await runErrorRemediationTick(deps);
+    expect(deps.markEscalated).toHaveBeenCalledWith('err-1', expect.stringContaining('critic rejected'));
+    expect(deps.markFixed).not.toHaveBeenCalled();
+  });
+
+  it('escalates when dispatch throws (never crashes the tick)', async () => {
+    const deps = baseDeps({
+      dispatchFix: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+    const status = await runErrorRemediationTick(deps);
+    expect(status).toContain('escalated');
+    expect(deps.markEscalated).toHaveBeenCalledWith('err-1', expect.stringContaining('boom'));
+  });
+});

--- a/bot/src/zoe/error-remediation.ts
+++ b/bot/src/zoe/error-remediation.ts
@@ -1,0 +1,230 @@
+/**
+ * Error Remediation: ZOE turns a captured production error into a routed fix
+ * and reports the OUTCOME - it does not ask (feedback_zoe_route_dont_ask).
+ *
+ * Flow per tick:
+ *   read app_errors WHERE status='new' (highest count first)
+ *   -> claim ONE (CAS new -> fixing, so two ticks never grab the same row)
+ *   -> map its repo to a Hermes fix target
+ *   -> dispatch the coder+critic+auto-PR pipeline
+ *   -> on a PR: mark fixed, report "diagnosed -> fixed -> PR #N"
+ *   -> on failure/big-build: mark escalated, report "needs you"
+ *
+ * One error per tick (bounded blast radius, agent-loops rule 5). The fix
+ * pipeline (dispatchHermesRun) already enforces the fleet daily cap.
+ *
+ * Pure helpers (normalizeStack/stackHash/buildIssueText/repoToTarget/pickNext)
+ * are unit-tested; runErrorRemediationTick takes injected deps so the routing
+ * logic is testable without a DB or a live pipeline.
+ */
+
+import { createHash } from 'node:crypto';
+import type { HermesRepoTarget } from '../hermes/types';
+import { db } from '../supabase';
+import { dispatchHermesRun } from '../hermes/runner';
+
+export interface AppError {
+  id: string;
+  ref_code: string | null;
+  repo: string;
+  route: string | null;
+  brand: string | null;
+  message: string;
+  stack: string | null;
+  stack_hash: string;
+  count: number;
+  status: string;
+}
+
+export type RemediationDispatchResult =
+  | { kind: 'ready'; prNumber: number | null; prUrl: string | null; runId: string }
+  | { kind: 'failed'; runId: string; reason: string }
+  | { kind: 'escalated'; runId: string; reason: string };
+
+export interface RemediationDeps {
+  /** New errors, already ordered highest-count first. */
+  fetchNewErrors: () => Promise<AppError[]>;
+  /** Atomically move new -> fixing. Returns true iff THIS caller won the row. */
+  claimError: (id: string) => Promise<boolean>;
+  markFixed: (id: string, prUrl: string | null, runId: string) => Promise<void>;
+  markEscalated: (id: string, notes: string) => Promise<void>;
+  /** Trigger the fix pipeline for a supported target. */
+  dispatchFix: (input: {
+    issueText: string;
+    targetRepo: HermesRepoTarget;
+  }) => Promise<RemediationDispatchResult>;
+  /** Post a human-readable outcome (ZAALBOTS group). */
+  report: (message: string) => Promise<void>;
+}
+
+const SUPPORTED_TARGETS: readonly HermesRepoTarget[] = ['zaoos', 'zaostock', 'zaocowork'];
+
+/**
+ * Normalize a stack for deduplication: strip line:col numbers, hex ids, and
+ * absolute /tmp clone paths so the same bug across deploys hashes identically.
+ * Exported so the app-side handler can hash with the exact same rule.
+ */
+export function normalizeStack(stack: string | null | undefined): string {
+  if (!stack) return '';
+  return stack
+    .replace(/:\d+:\d+/g, ':L:C') // line:col
+    .replace(/\b0x[0-9a-f]+\b/gi, '0xID') // hex ids
+    .replace(/\/tmp\/[^\s)]+/g, '/tmp/PATH') // ephemeral clone paths
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, 'UUID')
+    .trim();
+}
+
+export function stackHash(stack: string | null | undefined): string {
+  return createHash('sha256').update(normalizeStack(stack), 'utf8').digest('hex');
+}
+
+/** Map an app_errors.repo value to a Hermes fix target, or null if unsupported. */
+export function repoToTarget(repo: string): HermesRepoTarget | null {
+  return SUPPORTED_TARGETS.includes(repo as HermesRepoTarget)
+    ? (repo as HermesRepoTarget)
+    : null;
+}
+
+/** Highest-count new error, or null. Input is not required to be pre-sorted. */
+export function pickNext(errors: AppError[]): AppError | null {
+  const news = errors.filter((e) => e.status === 'new');
+  if (news.length === 0) return null;
+  return news.reduce((best, e) => (e.count > best.count ? e : best));
+}
+
+/** Build the issue text handed to the coder pipeline from a captured digest. */
+export function buildIssueText(err: AppError): string {
+  const lines = [
+    `Production error to fix (captured by ZOE's remediation rail).`,
+    ``,
+    err.ref_code ? `Reference code: ${err.ref_code}` : ``,
+    err.route ? `Route: ${err.route}` : ``,
+    err.brand ? `Brand context: ${err.brand}` : ``,
+    `Message: ${err.message}`,
+    `Occurrences: ${err.count}`,
+    ``,
+    err.stack ? `Stack:\n${err.stack.slice(0, 2000)}` : `(no stack captured)`,
+    ``,
+    `Localize the throw and fix it with the SMALLEST safe change (prefer a null/undefined guard or default over a broad refactor). Verify with typecheck/build before opening the PR. Do not touch secrets, .env, or DB migrations.`,
+  ];
+  return lines.filter((l) => l !== ``).join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * One remediation pass. Returns a short status string for logging.
+ */
+export async function runErrorRemediationTick(deps: RemediationDeps): Promise<string> {
+  const errors = await deps.fetchNewErrors();
+  const next = pickNext(errors);
+  if (!next) return 'no new errors';
+
+  const claimed = await deps.claimError(next.id);
+  if (!claimed) return `lost claim race on ${next.id}`;
+
+  const target = repoToTarget(next.repo);
+  if (!target) {
+    await deps.markEscalated(next.id, `unsupported repo '${next.repo}' - no fix target`);
+    await deps.report(
+      `Error ${next.ref_code ?? next.id.slice(0, 8)} in '${next.repo}' needs you - no auto-fix target for that repo.`,
+    );
+    return `escalated (unsupported repo ${next.repo})`;
+  }
+
+  let result: RemediationDispatchResult;
+  try {
+    result = await deps.dispatchFix({ issueText: buildIssueText(next), targetRepo: target });
+  } catch (err) {
+    const reason = (err as Error)?.message ?? String(err);
+    await deps.markEscalated(next.id, `dispatch threw: ${reason}`);
+    await deps.report(
+      `Error ${next.ref_code ?? next.id.slice(0, 8)} (${target}) - fix pipeline errored, needs you: ${reason}`,
+    );
+    return `escalated (dispatch threw)`;
+  }
+
+  const tag = next.ref_code ?? next.id.slice(0, 8);
+  if (result.kind === 'ready') {
+    await deps.markFixed(next.id, result.prUrl, result.runId);
+    const prLabel = result.prNumber ? `PR #${result.prNumber}` : 'a PR';
+    await deps.report(
+      `Error ${tag} (${target}${next.brand ? `, brand ${next.brand}` : ''}): diagnosed -> fixed -> ${prLabel} open${result.prUrl ? ` ${result.prUrl}` : ''}. Ready for your merge.`,
+    );
+    return `fixed -> ${result.prUrl ?? 'pr'}`;
+  }
+
+  await deps.markEscalated(next.id, `${result.kind}: ${result.reason}`);
+  await deps.report(
+    `Error ${tag} (${target}) - pipeline could not auto-fix (${result.kind}): ${result.reason}. Needs you.`,
+  );
+  return `escalated (${result.kind})`;
+}
+
+/**
+ * Wire the tick to the real cowork DB, the Hermes fix pipeline, and a report
+ * sink. Not unit-tested (I/O); the routing logic it drives is (above).
+ */
+export function defaultRemediationDeps(
+  report: (message: string) => Promise<void>,
+  triggeredByTelegramId: number,
+  triggeredInChatId: number,
+): RemediationDeps {
+  return {
+    fetchNewErrors: async () => {
+      const { data, error } = await db()
+        .from('app_errors')
+        .select('id, ref_code, repo, route, brand, message, stack, stack_hash, count, status')
+        .eq('status', 'new')
+        .order('count', { ascending: false })
+        .limit(10);
+      if (error) {
+        console.error('[zoe/remediation] fetchNewErrors failed:', error.message);
+        return [];
+      }
+      return (data ?? []) as AppError[];
+    },
+    claimError: async (id: string) => {
+      // CAS: only the caller that flips new -> fixing wins the row.
+      const { data, error } = await db()
+        .from('app_errors')
+        .update({ status: 'fixing', updated_at: new Date().toISOString() })
+        .eq('id', id)
+        .eq('status', 'new')
+        .select('id');
+      if (error) {
+        console.error('[zoe/remediation] claimError failed:', error.message);
+        return false;
+      }
+      return (data?.length ?? 0) > 0;
+    },
+    markFixed: async (id: string, prUrl: string | null, runId: string) => {
+      await db()
+        .from('app_errors')
+        .update({ status: 'fixed', pr_url: prUrl, run_id: runId, updated_at: new Date().toISOString() })
+        .eq('id', id);
+    },
+    markEscalated: async (id: string, notes: string) => {
+      await db()
+        .from('app_errors')
+        .update({ status: 'escalated', notes, updated_at: new Date().toISOString() })
+        .eq('id', id);
+    },
+    dispatchFix: async ({ issueText, targetRepo }) => {
+      const result = await dispatchHermesRun({
+        triggered_by_telegram_id: triggeredByTelegramId,
+        triggered_in_chat_id: triggeredInChatId,
+        issue_text: issueText,
+        target_repo: targetRepo,
+      });
+      if (result.kind === 'ready') {
+        return {
+          kind: 'ready',
+          prNumber: result.run.pr_number,
+          prUrl: result.run.pr_url,
+          runId: result.run.id,
+        };
+      }
+      return { kind: result.kind, runId: result.run.id, reason: result.reason };
+    },
+    report,
+  };
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -32,6 +32,7 @@ import { runLearnCycle, renderLearnProposals } from './learn';
 import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
+import { runErrorRemediationTick, defaultRemediationDeps } from './error-remediation';
 import { shouldFireAlert, shouldPauseAutonomousWork, formatSpendStatus } from './cost-governance';
 import { surfaceNewHandoffs } from './handoffs-surface';
 import { surfaceZaostockApprovals } from './zaostock-approvals-surface';
@@ -608,6 +609,36 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           });
         } catch (err) {
           console.error('[zoe/scheduler] work-loop tick failed:', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Error remediation - every 10 min, turn a captured production error digest
+  // (app_errors, status='new') into a routed fix + PR and report the outcome to
+  // ZAALBOTS. Routes, does not ask (feedback_zoe_route_dont_ask). One error per
+  // tick; the fix pipeline enforces the fleet daily cap. Silent when there is
+  // nothing new or the group is not configured.
+  tasks.push(
+    cron.schedule(
+      '*/10 * * * *',
+      async () => {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        if (!gid) return; // not configured
+        if (shouldPauseAutonomousWork()) return; // cost hard-stop
+        try {
+          const deps = defaultRemediationDeps(
+            (text: string) => opts.bot.api.sendMessage(gid, text).then(() => {}),
+            opts.zaalTgId,
+            gid,
+          );
+          const status = await runErrorRemediationTick(deps);
+          if (status !== 'no new errors') {
+            console.log(`[zoe/scheduler] error-remediation: ${status}`);
+          }
+        } catch (err) {
+          console.error('[zoe/scheduler] error-remediation tick failed:', (err as Error).message);
         }
       },
       { timezone: 'UTC' },

--- a/scripts/2031-app-errors-remediation-rail.sql
+++ b/scripts/2031-app-errors-remediation-rail.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- app_errors: the ingest rail for ZOE's autonomous error-remediation loop
+-- ============================================================================
+-- Today ZOE is blind to production errors until Zaal notices and pastes a
+-- screenshot. This table is the front door: the app's onRequestError handler
+-- upserts a deduped digest per unique failure, and ZOE polls status='new',
+-- routes a fix (Hermes coder + critic + auto-PR), and reports the outcome.
+-- See feedback_zoe_route_dont_ask + research doc 2030 (receipts).
+--
+-- SAFE: CREATE TABLE IF NOT EXISTS only, no alter to existing tables. RLS
+-- matches repo convention (service-role writes; the app's server handler and
+-- ZOE both use the service role).
+--
+-- APPLY ONLY VIA SUPABASE: Supabase SQL editor or a managed branch.
+-- DO NOT apply to production until Zaal approves.
+-- Reviewed-by: Zaal (gated before apply)
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS app_errors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- The reference code shown to the user in the error boundary (e.g. 1463886943).
+  ref_code TEXT,
+
+  -- Which repo owns the throw. Maps to a Hermes fix target.
+  repo TEXT NOT NULL DEFAULT 'zaocowork'
+    CHECK (repo = ANY (ARRAY['zaoos','zaostock','zaocowork'])),
+
+  -- Where it happened + optional brand context (the board renders per brand).
+  route TEXT,
+  brand TEXT,
+
+  message TEXT NOT NULL,
+  stack TEXT,
+
+  -- Dedup key: a hash of the NORMALIZED stack (line numbers / ids stripped).
+  -- One bug = one row; repeat occurrences bump count instead of adding rows.
+  stack_hash TEXT NOT NULL,
+
+  count INTEGER NOT NULL DEFAULT 1,
+  first_seen TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Remediation lifecycle:
+  --   new       -> just captured, awaiting ZOE
+  --   fixing    -> ZOE claimed it, fix pipeline running
+  --   fixed     -> a PR is open (or merged) - pr_url set
+  --   escalated -> needs Zaal (big build / pipeline could not fix)
+  --   ignored   -> known-noise, do not act (e.g. extension chatter)
+  status TEXT NOT NULL DEFAULT 'new'
+    CHECK (status = ANY (ARRAY['new','fixing','fixed','escalated','ignored'])),
+
+  pr_url TEXT,
+  run_id UUID,           -- link to the Hermes/agent run that fixed it
+  notes TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One row per unique bug. The app-side handler upserts on stack_hash.
+CREATE UNIQUE INDEX IF NOT EXISTS app_errors_stack_hash_uniq ON app_errors (stack_hash);
+
+-- ZOE's poll: new errors, highest-count first.
+CREATE INDEX IF NOT EXISTS app_errors_status_count_idx ON app_errors (status, count DESC);
+
+ALTER TABLE app_errors ENABLE ROW LEVEL SECURITY;
+
+-- Service-role only (the app server handler + ZOE). No anon access.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename='app_errors' AND policyname='app_errors_service_role'
+  ) THEN
+    CREATE POLICY app_errors_service_role ON app_errors
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+COMMIT;
+
+-- ============================================================================
+-- COMPANION (cowork repo, separate PR): the app's instrumentation onRequestError
+-- upserts here. Reference snippet (server-side, service-role client):
+--
+--   const stackHash = sha256(normalizeStack(error.stack));   -- strip line/col + ids
+--   await supabase.from('app_errors').upsert({
+--     ref_code, repo: 'zaocowork', route, brand, message: error.message,
+--     stack: error.stack, stack_hash: stackHash, last_seen: new Date().toISOString(),
+--   }, { onConflict: 'stack_hash', ignoreDuplicates: false });
+--   -- then: increment count via an RPC or a follow-up update where stack_hash matches.
+--
+-- Until that ships, rows can be inserted manually to exercise the ZOE poller.
+-- ============================================================================


### PR DESCRIPTION
## Summary
The autonomous error-remediation rail: the front door that lets ZOE fix a production error and REPORT the outcome, without Zaal noticing + pasting a screenshot. Implements feedback_zoe_route_dont_ask.

Motivating case: thezao.xyz/board?brand=ZAOstock threw (ref 1463886943) and blocked task-adds. Today ZOE was blind to it until Zaal pasted it. With this rail, that class of error is captured, routed to a fix, and reported as "diagnosed -> fixed -> PR #N."

## Flow
app_errors (status=new) -> ZOE polls, claims ONE via CAS -> maps repo to a fix target -> dispatches coder+critic+auto-PR -> marks fixed + reports the PR to ZAALBOTS. Asks only when the repo has no fix target or the pipeline cannot fix (escalate).

## What ships (code)
- `bot/src/zoe/error-remediation.ts` - the poller + pure helpers (normalizeStack/stackHash dedup, repoToTarget, pickNext, buildIssueText). Injected deps so routing is unit-tested; a defaultRemediationDeps() wires the real DB + Hermes pipeline + group report.
- Adds **`zaocowork`** as a Hermes fix target (types + git profile + coder context). This is the concrete reason the board could not be auto-fixed before - it was not a fixable target.
- `bot/src/zoe/scheduler.ts` - a */10 cron (gated on group config + cost hard-stop). Additive only.

## Gated (NOT applied)
- `scripts/2031-app-errors-remediation-rail.sql` - the `app_errors` ingest table (dedup on stack_hash, status lifecycle new/fixing/fixed/escalated/ignored). Apply-only-via-Supabase, Zaal-gated.

## Companion (cowork lane, separate PR - NOT here, to avoid a concurrent-writer race)
The ZAOcowork `onRequestError` handler upserts digests into app_errors. Reference snippet is in the migration file's footer. Until it ships, rows can be inserted manually to exercise the poller.

## Verification
- 15 new tests (dedup hash stability, routing to the right target, claim-race yields, unsupported-repo + pipeline-fail + dispatch-throw all escalate not crash) - green.
- Hermes target tests (git/coder) still green: 22/22.
- Additive-only scheduler diff; no new typecheck errors introduced (the one pre-existing curator error on main is untouched).