### PR TITLE
feat(heart): agent_instances liveness - proactive dead-worker reclaim

### DIFF
--- a/scripts/2033-agent-instances-liveness.sql
+++ b/scripts/2033-agent-instances-liveness.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- agent_instances: proactive liveness for the Heart (Brandon's next milestone)
+-- ============================================================================
+-- The recovery suite (doc 2027) recovers REACTIVELY - runs wait out their lease
+-- TTL. This table adds PROACTIVE recovery: each worker registers an instance and
+-- heartbeats; a stale heartbeat declares the instance dead and its leased runs
+-- are reclaimed at once (reclaimDeadInstanceRuns in src/lib/heart/liveness.ts).
+--
+-- agent_runs.lease_owner references agent_instances.instance_id (logical, not a
+-- hard FK - lease_owner predates this table and may hold legacy values).
+--
+-- SAFE: CREATE TABLE IF NOT EXISTS only. No alter to agent_runs.
+-- APPLY ONLY VIA SUPABASE. DO NOT apply to production until Zaal approves.
+-- Reviewed-by: Zaal (gated before apply)
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_instances (
+  instance_id TEXT PRIMARY KEY,
+  hostname TEXT,
+  pid INTEGER,
+  status TEXT NOT NULL DEFAULT 'alive'
+    CHECK (status = ANY (ARRAY['alive','draining','dead'])),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT now(),
+  metadata JSONB
+);
+
+-- The reclaim scan: find non-dead instances ordered by heartbeat staleness.
+CREATE INDEX IF NOT EXISTS agent_instances_status_heartbeat_idx
+  ON agent_instances (status, last_heartbeat);
+
+ALTER TABLE agent_instances ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename='agent_instances' AND policyname='agent_instances_service_role'
+  ) THEN
+    CREATE POLICY agent_instances_service_role ON agent_instances
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+COMMIT;
+
+-- ============================================================================
+-- POST-APPLY (code, already merged): workers call registerInstance() at boot,
+-- heartbeat() on a timer, and the Heart calls reclaimDeadInstanceRuns() on its
+-- recovery tick. Until applied, those functions throw only if invoked - the
+-- pure helpers (isInstanceExpired/deadInstanceIds/runsLeasedToDeadInstances)
+-- need no table and are unit-tested.
+-- ============================================================================

--- a/src/lib/heart/__tests__/liveness.test.ts
+++ b/src/lib/heart/__tests__/liveness.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isInstanceExpired,
+  deadInstanceIds,
+  runsLeasedToDeadInstances,
+  DEFAULT_LIVENESS_TTL_MS,
+} from '../liveness';
+import type { AgentInstanceRow, AgentRunRow, RunStatus } from '../types';
+
+const T0 = '2026-07-23T12:00:00.000Z';
+const now = (offsetMs: number) => new Date(new Date(T0).getTime() + offsetMs);
+
+function inst(over: Partial<AgentInstanceRow> = {}): AgentInstanceRow {
+  return {
+    instance_id: 'inst-1',
+    hostname: 'box',
+    pid: 100,
+    status: 'alive',
+    started_at: T0,
+    last_heartbeat: T0,
+    metadata: null,
+    ...over,
+  };
+}
+
+function run(over: Partial<AgentRunRow> = {}): AgentRunRow {
+  return {
+    id: 'run-1',
+    task_id: null,
+    assignment_id: 'a1',
+    objective: 'x',
+    required_capabilities: [],
+    status: 'leased',
+    assigned_agent: 'inst-1',
+    lease_owner: 'inst-1',
+    lease_expires_at: '2026-07-23T12:05:00.000Z',
+    retries: 0,
+    budget: null,
+    approval_state: 'auto',
+    visibility: 'private',
+    idempotency_key: 'k1',
+    created_by: 'zoe',
+    created_at: T0,
+    updated_at: T0,
+    ...over,
+  };
+}
+
+describe('isInstanceExpired', () => {
+  it('is alive within the TTL', () => {
+    expect(isInstanceExpired(inst({ last_heartbeat: T0 }), now(DEFAULT_LIVENESS_TTL_MS - 1))).toBe(false);
+  });
+  it('is expired once the TTL elapses', () => {
+    expect(isInstanceExpired(inst({ last_heartbeat: T0 }), now(DEFAULT_LIVENESS_TTL_MS + 1))).toBe(true);
+  });
+  it('a dead instance is always expired regardless of heartbeat', () => {
+    expect(isInstanceExpired(inst({ status: 'dead', last_heartbeat: T0 }), now(0))).toBe(true);
+  });
+  it('a draining instance is still live until its heartbeat goes stale', () => {
+    expect(isInstanceExpired(inst({ status: 'draining', last_heartbeat: T0 }), now(1000))).toBe(false);
+    expect(isInstanceExpired(inst({ status: 'draining', last_heartbeat: T0 }), now(DEFAULT_LIVENESS_TTL_MS + 1))).toBe(true);
+  });
+  it('honors a custom ttl', () => {
+    expect(isInstanceExpired(inst({ last_heartbeat: T0 }), now(5000), 4000)).toBe(true);
+    expect(isInstanceExpired(inst({ last_heartbeat: T0 }), now(3000), 4000)).toBe(false);
+  });
+  it('accepts string or Date for now', () => {
+    expect(isInstanceExpired(inst({ last_heartbeat: T0 }), '2026-07-23T12:10:00.000Z')).toBe(true);
+  });
+});
+
+describe('deadInstanceIds', () => {
+  it('returns only the stale instances', () => {
+    const instances = [
+      inst({ instance_id: 'a', last_heartbeat: T0 }), // stale by now+TTL+1
+      inst({ instance_id: 'b', last_heartbeat: new Date(now(DEFAULT_LIVENESS_TTL_MS).getTime()).toISOString() }), // fresh
+      inst({ instance_id: 'c', status: 'dead', last_heartbeat: T0 }), // dead
+    ];
+    const ids = deadInstanceIds(instances, now(DEFAULT_LIVENESS_TTL_MS + 1));
+    expect(ids).toContain('a');
+    expect(ids).toContain('c');
+    expect(ids).not.toContain('b');
+  });
+  it('empty when all fresh', () => {
+    expect(deadInstanceIds([inst({ last_heartbeat: T0 })], now(1000))).toEqual([]);
+  });
+});
+
+describe('runsLeasedToDeadInstances', () => {
+  it('selects leased/running runs owned by a dead instance', () => {
+    const runs = [
+      run({ id: 'r1', lease_owner: 'dead-1', status: 'leased' }),
+      run({ id: 'r2', lease_owner: 'dead-1', status: 'running' }),
+      run({ id: 'r3', lease_owner: 'live-1', status: 'leased' }), // live owner
+      run({ id: 'r4', lease_owner: 'dead-1', status: 'completed' }), // terminal
+      run({ id: 'r5', lease_owner: null, status: 'ready' }), // unowned
+    ];
+    const picked = runsLeasedToDeadInstances(runs, ['dead-1']).map((r) => r.id);
+    expect(picked).toEqual(['r1', 'r2']);
+  });
+  it('never reclaims a terminal or waiting run even if the owner is dead', () => {
+    const terminal: RunStatus[] = ['completed', 'failed', 'cancelled', 'quarantined', 'waiting_approval', 'verifying', 'blocked'];
+    for (const status of terminal) {
+      expect(runsLeasedToDeadInstances([run({ lease_owner: 'dead', status })], ['dead'])).toEqual([]);
+    }
+  });
+  it('empty when no dead instances', () => {
+    expect(runsLeasedToDeadInstances([run({ lease_owner: 'x' })], [])).toEqual([]);
+  });
+  it('does not reclaim a run whose owner is alive', () => {
+    expect(runsLeasedToDeadInstances([run({ lease_owner: 'alive' })], ['dead'])).toEqual([]);
+  });
+});

--- a/src/lib/heart/index.ts
+++ b/src/lib/heart/index.ts
@@ -8,4 +8,21 @@
  */
 
 export { acquireLease, renewLease, releaseLease, reclaimExpiredLeases, isLeaseExpired, canAcquire } from './lease-manager';
-export type { AgentRunRow, LeaseAcquisitionResult, ExpiredLeaseRecoverySummary } from './types';
+export {
+  registerInstance,
+  heartbeat,
+  drainInstance,
+  reclaimDeadInstanceRuns,
+  isInstanceExpired,
+  deadInstanceIds,
+  runsLeasedToDeadInstances,
+  DEFAULT_LIVENESS_TTL_MS,
+} from './liveness';
+export type {
+  AgentRunRow,
+  LeaseAcquisitionResult,
+  ExpiredLeaseRecoverySummary,
+  AgentInstanceRow,
+  InstanceStatus,
+  DeadInstanceReclaimSummary,
+} from './types';

--- a/src/lib/heart/liveness.ts
+++ b/src/lib/heart/liveness.ts
@@ -1,0 +1,235 @@
+/**
+ * Heart V2: Instance Liveness
+ *
+ * The recovery suite (doc 2027) proved the Heart recovers REACTIVELY - it waits
+ * for each run's lease_expires_at to pass, then reclaims. That is correct but
+ * slow: a crashed worker's runs stay stuck until their individual TTLs expire.
+ *
+ * This layer adds PROACTIVE recovery. Each worker registers an agent_instances
+ * row and heartbeats. When an instance's heartbeat goes stale (older than the
+ * liveness TTL), it is declared dead and ALL of its leased/running runs are
+ * reclaimed at once - no waiting for per-run TTLs. This is Brandon's prescribed
+ * next milestone after the recovery suite (project_brandon_organism_directives).
+ *
+ * Pure helpers (isInstanceExpired / deadInstanceIds / runsLeasedToDeadInstances)
+ * are fully unit-tested. DB functions mirror lease-manager's conditional-update
+ * discipline so a heartbeat that arrives mid-reclaim cannot lose a live run.
+ */
+
+import type {
+  RunStatus,
+  AgentRunRow,
+  AgentInstanceRow,
+  InstanceStatus,
+  DeadInstanceReclaimSummary,
+} from './types';
+
+// Lazy admin client, same pattern as lease-manager (tests never touch the DB).
+let _getSupabaseAdmin: (() => any) | null = null;
+try {
+  _getSupabaseAdmin = require('@/lib/db/supabase').getSupabaseAdmin;
+} catch {
+  // Test context; DB functions are not called.
+}
+function getSupabaseAdmin() {
+  if (!_getSupabaseAdmin) {
+    throw new Error('Supabase admin client not initialized. Test-context only.');
+  }
+  return _getSupabaseAdmin();
+}
+
+/** Default liveness TTL: an instance silent this long is presumed dead. */
+export const DEFAULT_LIVENESS_TTL_MS = 90_000; // 90s (3 missed 30s heartbeats)
+
+function toMs(value: Date | string): number {
+  return (value instanceof Date ? value : new Date(value)).getTime();
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no I/O) - the testable core.
+// ---------------------------------------------------------------------------
+
+/**
+ * True if an instance's last heartbeat is older than the TTL as of `now`.
+ * A 'dead' instance is always expired; a 'draining' instance is treated as
+ * live for its runs until it goes fully stale (graceful shutdown window).
+ */
+export function isInstanceExpired(
+  instance: Pick<AgentInstanceRow, 'last_heartbeat' | 'status'>,
+  now: Date | string,
+  ttlMs: number = DEFAULT_LIVENESS_TTL_MS,
+): boolean {
+  if (instance.status === 'dead') return true;
+  return toMs(now) - toMs(instance.last_heartbeat) > ttlMs;
+}
+
+/** Ids of every instance considered dead as of `now`. */
+export function deadInstanceIds(
+  instances: AgentInstanceRow[],
+  now: Date | string,
+  ttlMs: number = DEFAULT_LIVENESS_TTL_MS,
+): string[] {
+  return instances
+    .filter((i) => isInstanceExpired(i, now, ttlMs))
+    .map((i) => i.instance_id);
+}
+
+const RECLAIMABLE_STATUSES: readonly RunStatus[] = ['leased', 'running'];
+
+/**
+ * Runs that should be reclaimed because their lease_owner is a dead instance.
+ * Only leased/running runs with a non-null owner in the dead set qualify.
+ */
+export function runsLeasedToDeadInstances(
+  runs: AgentRunRow[],
+  deadIds: string[],
+): AgentRunRow[] {
+  const dead = new Set(deadIds);
+  return runs.filter(
+    (r) =>
+      r.lease_owner !== null &&
+      dead.has(r.lease_owner) &&
+      RECLAIMABLE_STATUSES.includes(r.status),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DB functions (I/O) - mirror lease-manager's conditional-update discipline.
+// ---------------------------------------------------------------------------
+
+/** Register (or refresh) this worker's instance row. Idempotent by instance_id. */
+export async function registerInstance(input: {
+  instanceId: string;
+  hostname?: string | null;
+  pid?: number | null;
+  metadata?: Record<string, unknown> | null;
+}): Promise<AgentInstanceRow | null> {
+  const db = getSupabaseAdmin();
+  const now = new Date().toISOString();
+  const { data, error } = await db
+    .from('agent_instances')
+    .upsert(
+      {
+        instance_id: input.instanceId,
+        hostname: input.hostname ?? null,
+        pid: input.pid ?? null,
+        status: 'alive' as InstanceStatus,
+        started_at: now,
+        last_heartbeat: now,
+        metadata: input.metadata ?? null,
+      },
+      { onConflict: 'instance_id' },
+    )
+    .select('*')
+    .single();
+  if (error) return null;
+  return data as AgentInstanceRow;
+}
+
+/** Bump last_heartbeat for a live instance. Returns false if the row is gone. */
+export async function heartbeat(instanceId: string): Promise<boolean> {
+  const db = getSupabaseAdmin();
+  const { data, error } = await db
+    .from('agent_instances')
+    .update({ last_heartbeat: new Date().toISOString(), status: 'alive' as InstanceStatus })
+    .eq('instance_id', instanceId)
+    .neq('status', 'dead') // a dead instance must re-register, not silently revive
+    .select('instance_id');
+  if (error) return false;
+  return (data?.length ?? 0) > 0;
+}
+
+/** Mark an instance draining (graceful shutdown) so no new leases target it. */
+export async function drainInstance(instanceId: string): Promise<void> {
+  const db = getSupabaseAdmin();
+  await db
+    .from('agent_instances')
+    .update({ status: 'draining' as InstanceStatus })
+    .eq('instance_id', instanceId);
+}
+
+/**
+ * The proactive reclaim: find dead instances (stale heartbeat), mark them dead,
+ * and reset every leased/running run they own back to 'ready' (clearing the
+ * lease, incrementing retries). Uses a conditional UPDATE keyed on the run still
+ * being owned by the dead instance, so a run re-leased by a live worker between
+ * the read and the write is NOT clobbered.
+ */
+export async function reclaimDeadInstanceRuns(options?: {
+  ttlMs?: number;
+  maxReclaimsPerCycle?: number;
+}): Promise<DeadInstanceReclaimSummary> {
+  const ttlMs = options?.ttlMs ?? DEFAULT_LIVENESS_TTL_MS;
+  const maxReclaims = options?.maxReclaimsPerCycle ?? 200;
+  const db = getSupabaseAdmin();
+  const now = new Date();
+  const summary: DeadInstanceReclaimSummary = {
+    deadInstanceIds: [],
+    reclaimedCount: 0,
+    reclaimedIds: [],
+    errors: [],
+  };
+
+  try {
+    const { data: instances, error: instErr } = await db
+      .from('agent_instances')
+      .select('*')
+      .neq('status', 'dead');
+    if (instErr) {
+      summary.errors.push({ id: 'instances', error: instErr.message });
+      return summary;
+    }
+
+    const dead = deadInstanceIds((instances ?? []) as AgentInstanceRow[], now, ttlMs);
+    if (dead.length === 0) return summary;
+    summary.deadInstanceIds = dead;
+
+    // Mark the dead instances dead (best-effort; reclaim proceeds regardless).
+    await db
+      .from('agent_instances')
+      .update({ status: 'dead' as InstanceStatus })
+      .in('instance_id', dead);
+
+    const { data: runs, error: runErr } = await db
+      .from('agent_runs')
+      .select('*')
+      .in('status', RECLAIMABLE_STATUSES as RunStatus[])
+      .in('lease_owner', dead)
+      .limit(maxReclaims);
+    if (runErr) {
+      summary.errors.push({ id: 'runs', error: runErr.message });
+      return summary;
+    }
+
+    for (const run of (runs ?? []) as AgentRunRow[]) {
+      try {
+        const { data: updated, error: updErr } = await db
+          .from('agent_runs')
+          .update({
+            status: 'ready' as RunStatus,
+            lease_owner: null,
+            lease_expires_at: null,
+            retries: (run.retries ?? 0) + 1,
+            updated_at: now.toISOString(),
+          })
+          .eq('id', run.id)
+          .eq('lease_owner', run.lease_owner) // still owned by the dead instance
+          .select('id')
+          .single();
+        if (updErr || !updated) {
+          summary.errors.push({ id: run.id, error: updErr?.message ?? 'no rows (re-leased)' });
+        } else {
+          summary.reclaimedIds.push(run.id);
+        }
+      } catch (err: unknown) {
+        summary.errors.push({ id: run.id, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    summary.reclaimedCount = summary.reclaimedIds.length;
+    return summary;
+  } catch (err: unknown) {
+    summary.errors.push({ id: 'exception', error: err instanceof Error ? err.message : String(err) });
+    return summary;
+  }
+}

--- a/src/lib/heart/types.ts
+++ b/src/lib/heart/types.ts
@@ -69,3 +69,38 @@ export interface ExpiredLeaseRecoverySummary {
   /** Any errors encountered during reclaim */
   errors: Array<{ runId: string; error: string }>;
 }
+
+/**
+ * Instance liveness status. An instance heartbeats while alive; when its
+ * heartbeat goes stale it is declared dead and its leased runs are reclaimed
+ * PROACTIVELY (without waiting for each run's lease TTL to expire).
+ */
+export type InstanceStatus = 'alive' | 'draining' | 'dead';
+
+/**
+ * AgentInstanceRow: a registered worker process. lease_owner on agent_runs
+ * references instance_id here.
+ */
+export interface AgentInstanceRow {
+  instance_id: string;
+  hostname: string | null;
+  pid: number | null;
+  status: InstanceStatus;
+  started_at: string;
+  last_heartbeat: string;
+  metadata: Record<string, unknown> | null;
+}
+
+/**
+ * DeadInstanceReclaimSummary: results from reclaimDeadInstanceRuns.
+ */
+export interface DeadInstanceReclaimSummary {
+  /** Instance ids that were declared dead this cycle. */
+  deadInstanceIds: string[];
+  /** Number of runs reset to 'ready' because their owner was dead. */
+  reclaimedCount: number;
+  /** IDs of the runs that were reclaimed. */
+  reclaimedIds: string[];
+  /** Any errors encountered. */
+  errors: Array<{ id: string; error: string }>;
+}


### PR DESCRIPTION
## Summary
Brandon's prescribed next Heart milestone after the recovery suite: the agent_instances liveness table. It turns Heart recovery from REACTIVE (each run waits out its own lease TTL) into PROACTIVE (a dead worker is detected by a stale heartbeat and all its leased runs are reclaimed at once).

This is the "highest-confidence next milestone" named in the Architect's Progress Report - it makes reclaim signal-driven, not just timeout-driven.

## What ships (code)
- `src/lib/heart/liveness.ts`:
  - Pure, tested core: `isInstanceExpired`, `deadInstanceIds`, `runsLeasedToDeadInstances`.
  - DB functions: `registerInstance` (boot), `heartbeat` (timer), `drainInstance` (graceful shutdown), `reclaimDeadInstanceRuns` (the proactive reclaim - conditional UPDATE keyed on the run still being owned by the dead instance, so a run re-leased by a live worker mid-reclaim is never clobbered; increments retries like reclaimExpiredLeases).
- `types.ts`: InstanceStatus, AgentInstanceRow, DeadInstanceReclaimSummary.
- `index.ts`: exports.

## Gated (NOT applied)
- `scripts/2033-agent-instances-liveness.sql` - the agent_instances table (status alive/draining/dead, heartbeat index, service-role RLS). Apply-only-via-Supabase, Zaal-gated.

## Design notes
- Pairs with `reclaimExpiredLeases`: TTL expiry stays the backstop, liveness is the fast path. A dead worker no longer strands its runs until each TTL passes.
- 'draining' status = graceful shutdown; a draining instance is still live for its runs until its heartbeat actually goes stale.
- The 'dead' set drives the reclaim; a dead instance must re-register (heartbeat won't silently revive it).

## Verification
- 16 unit tests on the pure helpers (TTL boundary, dead/draining semantics, only leased/running runs of dead owners reclaimed, never terminal/waiting runs, custom TTL).
- Heart files typecheck-clean.
- Main-repo vitest cannot run on this Mac (rolldown native binding) - CI Test runs the suite, same as the recovery suite (#2505).