### PR TITLE
feat(zoe): repo-improver scout - cheap-AI audit, ZOE self-gates + learns

### DIFF
--- a/bot/src/zoe/__tests__/repo-improver.test.ts
+++ b/bot/src/zoe/__tests__/repo-improver.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  nextRepoIndex,
+  repoToHermesTarget,
+  parseFinding,
+  parseVerdict,
+  runRepoImproverScout,
+  reviewProposedImprovements,
+  SCOUT_REPOS,
+  type ScoutDeps,
+  type ReviewDeps,
+  type ImprovementRow,
+} from '../repo-improver';
+
+describe('nextRepoIndex', () => {
+  it('rotates and wraps', () => {
+    expect(nextRepoIndex(3, -1)).toBe(0);
+    expect(nextRepoIndex(3, 0)).toBe(1);
+    expect(nextRepoIndex(3, 2)).toBe(0);
+  });
+  it('handles empty', () => {
+    expect(nextRepoIndex(0, 5)).toBe(0);
+  });
+});
+
+describe('repoToHermesTarget', () => {
+  it('maps known repos to targets', () => {
+    expect(repoToHermesTarget('bettercallzaal/ZAOOS')).toBe('zaoos');
+    expect(repoToHermesTarget('ZAODEVZ/ZAOcowork')).toBe('zaocowork');
+  });
+  it('returns null for surface-only repos', () => {
+    expect(repoToHermesTarget('bettercallzaal/zao-website')).toBeNull();
+  });
+  it('returns null for unknown repos', () => {
+    expect(repoToHermesTarget('someone/else')).toBeNull();
+  });
+});
+
+describe('parseFinding', () => {
+  const valid = '{"area":"auth","problem":"no guard","proposed_fix":"add guard","files":["a.ts"],"risk":"low","confidence":"high"}';
+  it('parses a valid finding', () => {
+    expect(parseFinding(valid)?.area).toBe('auth');
+  });
+  it('parses out of a ```json fence with prose', () => {
+    const wrapped = 'Here is the finding:\n```json\n' + valid + '\n```\nThanks';
+    expect(parseFinding(wrapped)?.problem).toBe('no guard');
+  });
+  it('returns null on {"none":true}', () => {
+    expect(parseFinding('{"none":true}')).toBeNull();
+  });
+  it('returns null on malformed / missing fields', () => {
+    expect(parseFinding('not json')).toBeNull();
+    expect(parseFinding('{"area":"x"}')).toBeNull(); // missing required fields
+    expect(parseFinding('')).toBeNull();
+  });
+  it('defaults files to []', () => {
+    const noFiles = '{"area":"a","problem":"b","proposed_fix":"c","risk":"low","confidence":"low"}';
+    expect(parseFinding(noFiles)?.files).toEqual([]);
+  });
+});
+
+describe('parseVerdict', () => {
+  it('parses an approve verdict', () => {
+    const v = parseVerdict('{"approve":true,"reasoning":"clear + safe"}');
+    expect(v.approve).toBe(true);
+  });
+  it('defaults to REJECT on malformed output (conservative)', () => {
+    const v = parseVerdict('garbage');
+    expect(v.approve).toBe(false);
+    expect(v.reasoning).toContain('reject');
+  });
+});
+
+function row(over: Partial<ImprovementRow> = {}): ImprovementRow {
+  return {
+    id: 'imp-1',
+    repo: 'bettercallzaal/ZAOOS',
+    hermes_target: 'zaoos',
+    area: 'auth',
+    problem: 'no guard',
+    proposed_fix: 'add guard',
+    files: ['a.ts'],
+    risk: 'low',
+    confidence: 'high',
+    status: 'proposed',
+    model: 'deepseek/deepseek-chat',
+    zoe_reasoning: null,
+    pr_url: null,
+    run_id: null,
+    ...over,
+  };
+}
+
+describe('runRepoImproverScout', () => {
+  function deps(over: Partial<ScoutDeps> = {}): ScoutDeps {
+    return {
+      pickNextRepo: vi.fn(async () => SCOUT_REPOS[0]),
+      gatherContext: vi.fn(async () => 'README + tree'),
+      audit: vi.fn(async () => ({
+        text: '{"area":"auth","problem":"p","proposed_fix":"f","files":[],"risk":"low","confidence":"high"}',
+        model: 'deepseek/deepseek-chat',
+      })),
+      saveProposed: vi.fn(async () => {}),
+      ...over,
+    };
+  }
+  it('audits and saves a proposed finding', async () => {
+    const d = deps();
+    const status = await runRepoImproverScout(d);
+    expect(d.saveProposed).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: 'bettercallzaal/ZAOOS', hermes_target: 'zaoos', area: 'auth' }),
+    );
+    expect(status).toContain('proposed');
+  });
+  it('skips (no save) when the model finds nothing', async () => {
+    const d = deps({ audit: vi.fn(async () => ({ text: '{"none":true}', model: 'm' })) });
+    const status = await runRepoImproverScout(d);
+    expect(d.saveProposed).not.toHaveBeenCalled();
+    expect(status).toContain('no finding');
+  });
+  it('skips gracefully when context gathering fails', async () => {
+    const d = deps({ gatherContext: vi.fn(async () => { throw new Error('clone failed'); }) });
+    const status = await runRepoImproverScout(d);
+    expect(d.audit).not.toHaveBeenCalled();
+    expect(status).toContain('context failed');
+  });
+});
+
+describe('reviewProposedImprovements (ZOE self-gate + learn)', () => {
+  function deps(over: Partial<ReviewDeps> = {}): ReviewDeps {
+    return {
+      fetchProposed: vi.fn(async () => [row()]),
+      judge: vi.fn(async () => '{"approve":true,"reasoning":"clear and safe"}'),
+      markStatus: vi.fn(async () => {}),
+      dispatchFix: vi.fn(async () => ({ kind: 'ready' as const, prUrl: 'https://x/pull/9', runId: 'r1' })),
+      log: vi.fn(async () => {}),
+      ...over,
+    };
+  }
+  it('approves -> dispatches -> marks fixed + logs the outcome', async () => {
+    const d = deps();
+    const status = await reviewProposedImprovements(d);
+    expect(d.dispatchFix).toHaveBeenCalledWith(expect.objectContaining({ targetRepo: 'zaoos' }));
+    expect(d.markStatus).toHaveBeenCalledWith('imp-1', 'fixing', expect.objectContaining({ zoe_reasoning: 'clear and safe' }));
+    expect(d.markStatus).toHaveBeenCalledWith('imp-1', 'fixed', expect.objectContaining({ pr_url: 'https://x/pull/9' }));
+    expect(d.log).toHaveBeenCalledWith(expect.stringContaining('fixed'));
+    expect(status).toContain('1 approved');
+  });
+  it('rejects -> marks rejected + logs the reasoning (learning), never dispatches', async () => {
+    const d = deps({ judge: vi.fn(async () => '{"approve":false,"reasoning":"too vague"}') });
+    await reviewProposedImprovements(d);
+    expect(d.dispatchFix).not.toHaveBeenCalled();
+    expect(d.markStatus).toHaveBeenCalledWith('imp-1', 'rejected', expect.objectContaining({ zoe_reasoning: 'too vague' }));
+    expect(d.log).toHaveBeenCalledWith(expect.stringContaining('rejected'));
+  });
+  it('malformed verdict defaults to reject (never dispatches on garbage)', async () => {
+    const d = deps({ judge: vi.fn(async () => 'not json at all') });
+    await reviewProposedImprovements(d);
+    expect(d.dispatchFix).not.toHaveBeenCalled();
+    expect(d.markStatus).toHaveBeenCalledWith('imp-1', 'rejected', expect.anything());
+  });
+  it('approved but no fix target -> escalates (manual), no dispatch', async () => {
+    const d = deps({ fetchProposed: vi.fn(async () => [row({ hermes_target: null, repo: 'bettercallzaal/zao-website' })]) });
+    await reviewProposedImprovements(d);
+    expect(d.dispatchFix).not.toHaveBeenCalled();
+    expect(d.markStatus).toHaveBeenCalledWith('imp-1', 'escalated', expect.anything());
+  });
+  it('dispatch throw -> escalates, never crashes the loop', async () => {
+    const d = deps({ dispatchFix: vi.fn(async () => { throw new Error('boom'); }) });
+    const status = await reviewProposedImprovements(d);
+    expect(d.markStatus).toHaveBeenCalledWith('imp-1', 'escalated', expect.anything());
+    expect(status).toContain('reviewed 1');
+  });
+  it('nothing to review is a no-op', async () => {
+    const d = deps({ fetchProposed: vi.fn(async () => []) });
+    expect(await reviewProposedImprovements(d)).toBe('nothing to review');
+  });
+});

--- a/bot/src/zoe/repo-improver-io.ts
+++ b/bot/src/zoe/repo-improver-io.ts
@@ -1,0 +1,175 @@
+/**
+ * Repo Improver Scout: I/O wiring (default deps + the tick).
+ *
+ * Keeps the orchestration in repo-improver.ts pure/injected; this file supplies
+ * the real cheap-model call (callCapFallback - OpenRouter, off the Claude cap),
+ * git clone context gathering, Supabase persistence, and the Hermes dispatch.
+ */
+
+import { promisify } from 'node:util';
+import { execFile as execFileCb } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { db } from '../supabase';
+import { ZOE_PATHS } from './memory';
+import { callCapFallback } from './models/router';
+import { dispatchHermesRun } from '../hermes/runner';
+import type { HermesRepoTarget } from '../hermes/types';
+import {
+  SCOUT_REPOS,
+  nextRepoIndex,
+  runRepoImproverScout,
+  reviewProposedImprovements,
+  type ScoutRepo,
+  type ScoutDeps,
+  type ReviewDeps,
+  type ImprovementRow,
+  type ImprovementStatus,
+} from './repo-improver';
+
+const execFile = promisify(execFileCb);
+const CURSOR_PATH = join(ZOE_PATHS.home, 'repo-improver-cursor');
+
+async function readCursor(): Promise<number> {
+  try {
+    const raw = await fs.readFile(CURSOR_PATH, 'utf8');
+    const n = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(n) ? n : -1;
+  } catch {
+    return -1;
+  }
+}
+
+async function writeCursor(index: number): Promise<void> {
+  try {
+    await fs.mkdir(ZOE_PATHS.home, { recursive: true });
+    await fs.writeFile(CURSOR_PATH, String(index), 'utf8');
+  } catch {
+    // best-effort; a lost cursor just re-audits from the top next cycle
+  }
+}
+
+/** Shallow-clone a repo and summarize it into an audit context string. */
+async function gatherContext(repo: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'zoe-scout-'));
+  try {
+    await execFile('git', ['clone', '--depth', '1', `https://github.com/${repo}.git`, dir], {
+      timeout: 60_000,
+    });
+    const parts: string[] = [];
+    for (const name of ['README.md', 'package.json']) {
+      try {
+        const body = await fs.readFile(join(dir, name), 'utf8');
+        parts.push(`=== ${name} ===\n${body.slice(0, 4000)}`);
+      } catch {
+        // file absent - fine
+      }
+    }
+    try {
+      const { stdout } = await execFile('git', ['-C', dir, 'ls-files'], { timeout: 20_000 });
+      parts.push(`=== file tree (first 200) ===\n${stdout.split('\n').slice(0, 200).join('\n')}`);
+    } catch {
+      // ignore
+    }
+    return parts.join('\n\n');
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function defaultScoutDeps(): ScoutDeps {
+  return {
+    pickNextRepo: async (): Promise<ScoutRepo> => {
+      const idx = nextRepoIndex(SCOUT_REPOS.length, await readCursor());
+      await writeCursor(idx);
+      return SCOUT_REPOS[idx];
+    },
+    gatherContext,
+    audit: async (systemPrompt, userPrompt) => {
+      const { result } = await callCapFallback(systemPrompt, userPrompt);
+      return { text: result.text, model: result.model };
+    },
+    saveProposed: async (r) => {
+      const { error } = await db().from('repo_improvements').insert([
+        {
+          repo: r.repo,
+          hermes_target: r.hermes_target,
+          area: r.area,
+          problem: r.problem,
+          proposed_fix: r.proposed_fix,
+          files: r.files,
+          risk: r.risk,
+          confidence: r.confidence,
+          model: r.model,
+          status: 'proposed' as ImprovementStatus,
+        },
+      ]);
+      if (error) console.error('[repo-improver] saveProposed failed:', error.message);
+    },
+  };
+}
+
+function defaultReviewDeps(log: (m: string) => Promise<void>): ReviewDeps {
+  return {
+    fetchProposed: async (): Promise<ImprovementRow[]> => {
+      const { data, error } = await db()
+        .from('repo_improvements')
+        .select('*')
+        .eq('status', 'proposed')
+        .order('created_at', { ascending: true })
+        .limit(10);
+      if (error) {
+        console.error('[repo-improver] fetchProposed failed:', error.message);
+        return [];
+      }
+      return (data ?? []) as ImprovementRow[];
+    },
+    judge: async (systemPrompt, userPrompt) => {
+      const { result } = await callCapFallback(systemPrompt, userPrompt);
+      return result.text;
+    },
+    markStatus: async (id, status, extra) => {
+      await db()
+        .from('repo_improvements')
+        .update({
+          status,
+          ...(extra?.zoe_reasoning !== undefined ? { zoe_reasoning: extra.zoe_reasoning } : {}),
+          ...(extra?.pr_url !== undefined ? { pr_url: extra.pr_url } : {}),
+          ...(extra?.run_id !== undefined ? { run_id: extra.run_id } : {}),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', id);
+    },
+    dispatchFix: async ({ issueText, targetRepo }) => {
+      const res = await dispatchHermesRun({
+        triggered_by_telegram_id: 0,
+        triggered_in_chat_id: 0,
+        issue_text: issueText,
+        target_repo: targetRepo as HermesRepoTarget,
+      });
+      if (res.kind === 'ready') {
+        return { kind: 'ready', prUrl: res.run.pr_url, runId: res.run.id };
+      }
+      return { kind: res.kind, prUrl: null, runId: res.run.id, reason: res.reason };
+    },
+    log,
+  };
+}
+
+/**
+ * One repo-improver tick: scout the next repo (cheap), then have ZOE review all
+ * proposed findings (its own gate) and route approved fixes. `log` posts status
+ * to the group (not a question) and is the durable learning trail.
+ */
+export async function runRepoImproverTick(log: (m: string) => Promise<void>): Promise<void> {
+  try {
+    const scoutStatus = await runRepoImproverScout(defaultScoutDeps());
+    console.log(`[repo-improver] scout: ${scoutStatus}`);
+    const reviewStatus = await reviewProposedImprovements(defaultReviewDeps(log));
+    console.log(`[repo-improver] review: ${reviewStatus}`);
+  } catch (err) {
+    console.error('[repo-improver] tick failed:', (err as Error)?.message ?? err);
+  }
+}

--- a/bot/src/zoe/repo-improver.ts
+++ b/bot/src/zoe/repo-improver.ts
@@ -1,0 +1,284 @@
+/**
+ * Repo Improver Scout: cheap-AI audit loop that ZOE self-gates and learns from.
+ *
+ * A scout rotates through the ZAO repos, one per cycle. It audits that repo with
+ * a CHEAP OpenRouter model (via callCapFallback - OpenRouter/grok/gpt, never the
+ * Claude cap) and proposes ONE high-value, safe improvement, saved to
+ * repo_improvements as 'proposed'.
+ *
+ * Then ZOE reviews the finding with its OWN judgment (its own yes/no - not
+ * Zaal's) and LOGS the decision + reasoning + outcome, so it accumulates a
+ * corpus it can learn from. On a ZOE-yes it routes the fix through the Hermes
+ * coder pipeline (the same dispatchHermesRun the error-remediation rail uses).
+ * The human gate stays ONLY at PR merge (agent-loops rule 8) - ZOE opens the PR,
+ * Zaal merges. ZOE reports its decisions to the group as status, not questions.
+ *
+ * Cost ladder (claude-usage.md): scouting is cheap; the grounded fix spends the
+ * Claude cap only after ZOE's own confirm. Twin of the error-remediation rail:
+ * trigger is a cheap-scout finding, gate is ZOE's judgment.
+ *
+ * Pure helpers (nextRepoIndex/repoToHermesTarget/parseFinding/parseVerdict/
+ * findingToLog) are unit-tested; the orchestration takes injected deps.
+ */
+
+import { z } from 'zod';
+import type { HermesRepoTarget } from '../hermes/types';
+
+/** The repos the scout rotates through. hermesTarget=null => surface-only (no auto-fix target yet). */
+export interface ScoutRepo {
+  repo: string; // owner/name
+  hermesTarget: HermesRepoTarget | null;
+}
+
+export const SCOUT_REPOS: ScoutRepo[] = [
+  { repo: 'bettercallzaal/ZAOOS', hermesTarget: 'zaoos' },
+  { repo: 'bettercallzaal/zaostock', hermesTarget: 'zaostock' },
+  { repo: 'ZAODEVZ/ZAOcowork', hermesTarget: 'zaocowork' },
+  { repo: 'bettercallzaal/zao-website', hermesTarget: null },
+  { repo: 'ZAODEVZ/zabalgames', hermesTarget: null },
+  { repo: 'bettercallzaal/wwtracker', hermesTarget: null },
+];
+
+export type ImprovementStatus =
+  | 'proposed' // scout wrote it, awaiting ZOE's review
+  | 'rejected' // ZOE reviewed and declined (logged, learned)
+  | 'fixing' // ZOE approved, fix pipeline running
+  | 'fixed' // PR open
+  | 'escalated'; // approved but no target / pipeline could not fix
+
+/** A single audit finding, validated from the scout model's JSON output. */
+export const FindingSchema = z.object({
+  area: z.string().min(1).max(120),
+  problem: z.string().min(1).max(800),
+  proposed_fix: z.string().min(1).max(800),
+  files: z.array(z.string()).max(20).default([]),
+  risk: z.enum(['low', 'medium', 'high']),
+  confidence: z.enum(['low', 'medium', 'high']),
+});
+export type Finding = z.infer<typeof FindingSchema>;
+
+/** ZOE's own verdict on a proposed finding (its yes/no + why - logged to learn). */
+export const VerdictSchema = z.object({
+  approve: z.boolean(),
+  reasoning: z.string().min(1).max(800),
+});
+export type Verdict = z.infer<typeof VerdictSchema>;
+
+export interface ImprovementRow extends Finding {
+  id: string;
+  repo: string;
+  hermes_target: string | null;
+  status: ImprovementStatus;
+  model: string | null;
+  zoe_reasoning: string | null;
+  pr_url: string | null;
+  run_id: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Round-robin: next repo index after lastIndex (-1 => start at 0). */
+export function nextRepoIndex(total: number, lastIndex: number): number {
+  if (total <= 0) return 0;
+  return ((lastIndex < 0 ? -1 : lastIndex) + 1) % total;
+}
+
+/** A repo's Hermes fix target, or null if not auto-fixable yet. */
+export function repoToHermesTarget(repo: string): HermesRepoTarget | null {
+  return SCOUT_REPOS.find((r) => r.repo === repo)?.hermesTarget ?? null;
+}
+
+function extractJson(rawText: string): unknown | null {
+  if (!rawText) return null;
+  const fenced = rawText.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : rawText;
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+  try {
+    return JSON.parse(candidate.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the finding JSON from a scout response. Returns null if absent or if
+ * the model signalled {"none":true} - the scout then skips rather than invent.
+ */
+export function parseFinding(rawText: string): Finding | null {
+  const obj = extractJson(rawText);
+  if (!obj || typeof obj !== 'object') return null;
+  if ((obj as Record<string, unknown>).none === true) return null;
+  const parsed = FindingSchema.safeParse(obj);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Parse ZOE's verdict JSON. Defaults to a conservative reject on malformed output. */
+export function parseVerdict(rawText: string): Verdict {
+  const obj = extractJson(rawText);
+  const parsed = VerdictSchema.safeParse(obj);
+  if (parsed.success) return parsed.data;
+  return { approve: false, reasoning: 'unparseable verdict - defaulting to reject (safe)' };
+}
+
+export function buildAuditSystemPrompt(): string {
+  return [
+    'You are a senior engineer auditing a repository for ONE high-value, LOW-RISK, concrete improvement.',
+    'Prefer: a real correctness bug with a clear fix, a missing input guard/error handler, a missing test on important code, or a broken reference.',
+    'Do NOT propose broad refactors, style-only changes, dependency bumps, or anything touching secrets, env, or database migrations.',
+    'Respond with ONLY a JSON object, no prose, matching:',
+    '{"area":"<short area>","problem":"<what is wrong>","proposed_fix":"<the smallest safe change>","files":["path"],"risk":"low|medium|high","confidence":"low|medium|high"}',
+    'If there is NO genuinely valuable, safe improvement, respond exactly {"none":true}. Never invent one.',
+  ].join('\n');
+}
+
+export function buildAuditUserPrompt(repo: string, context: string): string {
+  return `Repository: ${repo}\n\nContext (README, structure, key files):\n${context.slice(0, 12000)}\n\nFind ONE improvement per the rules. JSON only.`;
+}
+
+/** ZOE's review prompt: judge whether to make the scout's proposed fix. */
+export function buildReviewSystemPrompt(): string {
+  return [
+    'You are ZOE, deciding whether to act on an improvement a scout proposed for one of your repos.',
+    'Approve ONLY if the fix is genuinely valuable, clearly safe, and concrete enough to implement without guessing.',
+    'Reject vague, speculative, style-only, risky, or low-value proposals - a rejection is logged so you learn what is worth acting on.',
+    'Respond with ONLY JSON: {"approve": true|false, "reasoning": "<one or two sentences>"}.',
+  ].join('\n');
+}
+
+export function buildReviewUserPrompt(f: Finding, repo: string): string {
+  return `Repo: ${repo}\nArea: ${f.area}\nProblem: ${f.problem}\nProposed fix: ${f.proposed_fix}\nFiles: ${f.files.join(', ') || '(none listed)'}\nRisk: ${f.risk} | Confidence: ${f.confidence}\n\nShould you make this fix? JSON only.`;
+}
+
+/** One-line log/status summary of a decision (for the group + the learning log). */
+export function findingToLog(row: ImprovementRow, decision: 'approved' | 'rejected'): string {
+  return `[repo-improver] ${row.repo} - ${row.area}: ${decision}${row.zoe_reasoning ? ` (${row.zoe_reasoning})` : ''}`;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration (injected deps -> testable)
+// ---------------------------------------------------------------------------
+
+export interface ScoutDeps {
+  pickNextRepo: () => Promise<ScoutRepo>;
+  gatherContext: (repo: string) => Promise<string>;
+  /** Cheap audit: raw model text + the model name used. */
+  audit: (systemPrompt: string, userPrompt: string) => Promise<{ text: string; model: string }>;
+  saveProposed: (row: Omit<ImprovementRow, 'id' | 'status' | 'zoe_reasoning'>) => Promise<void>;
+}
+
+/** One scout cycle: audit the next repo and save a proposed finding (or skip). */
+export async function runRepoImproverScout(deps: ScoutDeps): Promise<string> {
+  const target = await deps.pickNextRepo();
+  let context: string;
+  try {
+    context = await deps.gatherContext(target.repo);
+  } catch (err) {
+    return `context failed for ${target.repo}: ${(err as Error)?.message ?? err}`;
+  }
+  const { text, model } = await deps.audit(
+    buildAuditSystemPrompt(),
+    buildAuditUserPrompt(target.repo, context),
+  );
+  const finding = parseFinding(text);
+  if (!finding) return `no finding for ${target.repo}`;
+  await deps.saveProposed({
+    ...finding,
+    repo: target.repo,
+    hermes_target: target.hermesTarget,
+    model,
+    pr_url: null,
+    run_id: null,
+  });
+  return `proposed: ${target.repo} - ${finding.area}`;
+}
+
+export interface ReviewDeps {
+  fetchProposed: () => Promise<ImprovementRow[]>;
+  /** ZOE's own judgment on a finding (its yes/no + reasoning). */
+  judge: (systemPrompt: string, userPrompt: string) => Promise<string>;
+  markStatus: (
+    id: string,
+    status: ImprovementStatus,
+    extra?: { zoe_reasoning?: string; pr_url?: string | null; run_id?: string | null },
+  ) => Promise<void>;
+  dispatchFix: (input: {
+    issueText: string;
+    targetRepo: HermesRepoTarget;
+  }) => Promise<{ kind: 'ready' | 'failed' | 'escalated'; prUrl: string | null; runId: string; reason?: string }>;
+  /** Status log to the group (not a question) + the durable learning log. */
+  log: (message: string) => Promise<void>;
+}
+
+/**
+ * ZOE reviews every proposed finding with its own judgment, LOGS the decision,
+ * and on approve routes the fix. This is the self-gate + learning loop.
+ */
+export async function reviewProposedImprovements(deps: ReviewDeps): Promise<string> {
+  const rows = await deps.fetchProposed();
+  if (rows.length === 0) return 'nothing to review';
+  let approved = 0;
+  let rejected = 0;
+
+  for (const row of rows) {
+    const verdict = parseVerdict(
+      await deps.judge(buildReviewSystemPrompt(), buildReviewUserPrompt(row, row.repo)),
+    );
+    const withReason: ImprovementRow = { ...row, zoe_reasoning: verdict.reasoning };
+
+    if (!verdict.approve) {
+      await deps.markStatus(row.id, 'rejected', { zoe_reasoning: verdict.reasoning });
+      await deps.log(findingToLog(withReason, 'rejected'));
+      rejected++;
+      continue;
+    }
+
+    const target = row.hermes_target as HermesRepoTarget | null;
+    if (!target) {
+      await deps.markStatus(row.id, 'escalated', { zoe_reasoning: verdict.reasoning });
+      await deps.log(`[repo-improver] ${row.repo} - ${row.area}: approved but no fix target (manual). (${verdict.reasoning})`);
+      continue;
+    }
+
+    await deps.markStatus(row.id, 'fixing', { zoe_reasoning: verdict.reasoning });
+    approved++;
+    const issueText = [
+      `Repo improvement approved by ZOE (repo-improver scout).`,
+      ``,
+      `Area: ${row.area}`,
+      `Problem: ${row.problem}`,
+      `Proposed fix: ${row.proposed_fix}`,
+      row.files.length ? `Suspect files: ${row.files.join(', ')}` : ``,
+      ``,
+      `Make the SMALLEST safe change to address this. Verify with typecheck/build before the PR. Do not touch secrets, env, or DB migrations.`,
+    ]
+      .filter((l) => l !== ``)
+      .join('\n');
+
+    let result: Awaited<ReturnType<ReviewDeps['dispatchFix']>>;
+    try {
+      result = await deps.dispatchFix({ issueText, targetRepo: target });
+    } catch (err) {
+      await deps.markStatus(row.id, 'escalated', { zoe_reasoning: verdict.reasoning });
+      await deps.log(`[repo-improver] ${row.repo} - fix pipeline errored: ${(err as Error)?.message ?? err}`);
+      continue;
+    }
+
+    if (result.kind === 'ready') {
+      await deps.markStatus(row.id, 'fixed', {
+        zoe_reasoning: verdict.reasoning,
+        pr_url: result.prUrl,
+        run_id: result.runId,
+      });
+      await deps.log(`[repo-improver] ${row.repo} - ${row.area}: fixed, PR ${result.prUrl ?? '(open)'} - ready for merge.`);
+    } else {
+      await deps.markStatus(row.id, 'escalated', { zoe_reasoning: verdict.reasoning, run_id: result.runId });
+      await deps.log(`[repo-improver] ${row.repo} - could not auto-fix (${result.kind}): ${result.reason ?? ''}`);
+    }
+  }
+
+  return `reviewed ${rows.length}: ${approved} approved, ${rejected} rejected`;
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -33,6 +33,7 @@ import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { runErrorRemediationTick, defaultRemediationDeps } from './error-remediation';
+import { runRepoImproverTick } from './repo-improver-io';
 import { shouldFireAlert, shouldPauseAutonomousWork, formatSpendStatus } from './cost-governance';
 import { surfaceNewHandoffs } from './handoffs-surface';
 import { surfaceZaostockApprovals } from './zaostock-approvals-surface';
@@ -640,6 +641,25 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         } catch (err) {
           console.error('[zoe/scheduler] error-remediation tick failed:', (err as Error).message);
         }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Repo-improver scout - every 3h, audit the next ZAO repo with a CHEAP
+  // OpenRouter model (off the Claude cap), then ZOE reviews each proposed
+  // finding with its own judgment, logs the decision (learning trail), and
+  // routes approved fixes through the Hermes pipeline. Human gate stays only at
+  // PR merge. Gated on the OpenRouter key + the group + the cost hard-stop.
+  tasks.push(
+    cron.schedule(
+      '30 */3 * * *',
+      async () => {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        if (!gid) return; // not configured
+        if (!process.env.OPENROUTER_API_KEY?.trim()) return; // scout needs the cheap model
+        if (shouldPauseAutonomousWork()) return; // cost hard-stop
+        await runRepoImproverTick((text: string) => opts.bot.api.sendMessage(gid, text).then(() => {}));
       },
       { timezone: 'UTC' },
     ),

--- a/scripts/2034-repo-improvements-scout.sql
+++ b/scripts/2034-repo-improvements-scout.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- repo_improvements: findings + decisions for the ZOE repo-improver scout
+-- ============================================================================
+-- A cheap OpenRouter scout audits ZAO repos and proposes improvements here.
+-- ZOE reviews each with its OWN judgment (its yes/no), logs the reasoning, and
+-- on approve routes the fix through the Hermes pipeline. This table is also the
+-- LEARNING LOG - every {finding, decision, reasoning, outcome} accumulates so
+-- ZOE can learn what is worth acting on. See bot/src/zoe/repo-improver.ts.
+--
+-- SAFE: CREATE TABLE IF NOT EXISTS only. Service-role RLS (scout + ZOE).
+-- APPLY ONLY VIA SUPABASE. DO NOT apply to production until Zaal approves.
+-- Reviewed-by: Zaal (gated before apply)
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS repo_improvements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  repo TEXT NOT NULL,
+  hermes_target TEXT,           -- null => no auto-fix target (manual follow-up)
+
+  -- The scout's proposed finding.
+  area TEXT NOT NULL,
+  problem TEXT NOT NULL,
+  proposed_fix TEXT NOT NULL,
+  files TEXT[] NOT NULL DEFAULT '{}',
+  risk TEXT NOT NULL CHECK (risk = ANY (ARRAY['low','medium','high'])),
+  confidence TEXT NOT NULL CHECK (confidence = ANY (ARRAY['low','medium','high'])),
+  model TEXT,                   -- the cheap model that produced the finding
+
+  -- ZOE's self-gate decision + the learning trail.
+  status TEXT NOT NULL DEFAULT 'proposed'
+    CHECK (status = ANY (ARRAY['proposed','rejected','fixing','fixed','escalated'])),
+  zoe_reasoning TEXT,           -- ZOE's own yes/no reasoning (learn from this)
+  pr_url TEXT,
+  run_id UUID,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ZOE's review scan: proposed findings first.
+CREATE INDEX IF NOT EXISTS repo_improvements_status_idx ON repo_improvements (status, created_at);
+-- Learning queries: "what did ZOE decide for this repo/area over time".
+CREATE INDEX IF NOT EXISTS repo_improvements_repo_idx ON repo_improvements (repo, created_at DESC);
+
+ALTER TABLE repo_improvements ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename='repo_improvements' AND policyname='repo_improvements_service_role'
+  ) THEN
+    CREATE POLICY repo_improvements_service_role ON repo_improvements
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+COMMIT;
+
+-- Rotation marker (which repo the scout audits next) lives in ~/.zao/zoe/
+-- as a small file, not the DB - no table needed for it.


### PR DESCRIPTION
## Summary
The repo-improver scout: a cheap-AI audit loop that ZOE self-gates and learns from. Zaal's idea, built on the cost ladder.

- A scout rotates through the ZAO repos (one per cycle - "find a new one each loop"), audits each with a CHEAP OpenRouter model (callCapFallback - OpenRouter/grok/gpt, NEVER the Claude cap), and proposes ONE high-value, safe improvement.
- ZOE then reviews each finding with its OWN judgment (its yes/no - not Zaal's), LOGS the decision + reasoning (the learning trail so ZOE learns what is worth acting on), and on approve routes the fix through the Hermes coder pipeline. The human gate stays ONLY at PR merge.

Twin of the error-remediation rail: trigger is a cheap-scout finding, gate is ZOE's own judgment. Scouting is cheap; the grounded fix spends the Claude cap only after ZOE confirms.

## What ships (code)
- `bot/src/zoe/repo-improver.ts` - pure helpers (rotation, parseFinding, parseVerdict which SAFE-REJECTS on malformed output, prompts) + injected orchestration (runRepoImproverScout, reviewProposedImprovements).
- `bot/src/zoe/repo-improver-io.ts` - default deps (cheap-model call, git-clone context gathering, Supabase persistence, dispatchHermesRun) + runRepoImproverTick.
- `bot/src/zoe/scheduler.ts` - every-3h tick, gated on OPENROUTER_API_KEY + group + cost hard-stop. Additive only.

## Gated (NOT applied)
- `scripts/2034-repo-improvements-scout.sql` - the repo_improvements table (findings + ZOE's decision/reasoning = the learning log). Apply-only-via-Supabase, Zaal-gated.

## Verification
- 21 tests: rotation/wrap, finding parse (fenced/none/malformed), verdict parse (safe-reject on garbage - never dispatches on unparseable output), approve->dispatch->fixed, reject->logged (never dispatches), no-target->escalate, dispatch-throw->escalate, empty no-op.
- My files typecheck-clean; scheduler diff additive-only (the one pre-existing curator typecheck error on main is untouched).
- Bot vitest ran locally (21/21).

## Design notes
- ZOE's review defaults to REJECT on any malformed verdict - it never acts on a fix it could not clearly evaluate.
- Repos without a Hermes fix target (zao-website, zabalgames, wwtracker) surface as escalated-for-manual on approve, rather than silently dropping.