### PR TITLE
feat(zoe): scout decisions emit portable receipts

### DIFF
--- a/bot/src/zoe/repo-improver-io.ts
+++ b/bot/src/zoe/repo-improver-io.ts
@@ -16,6 +16,10 @@ import { db } from '../supabase';
 import { ZOE_PATHS } from './memory';
 import { callCapFallback } from './models/router';
 import { dispatchHermesRun } from '../hermes/runner';
+import { emitReceipt } from './receipts';
+
+// Scout decisions that are worth a durable, portable receipt (ZOE acted).
+const RECEIPTED_STATUSES = new Set(['fixed', 'rejected', 'escalated']);
 import type { HermesRepoTarget } from '../hermes/types';
 import {
   SCOUT_REPOS,
@@ -141,6 +145,19 @@ function defaultReviewDeps(log: (m: string) => Promise<void>): ReviewDeps {
           updated_at: new Date().toISOString(),
         })
         .eq('id', id);
+      // Every ZOE decision the scout makes leaves a portable receipt (best-effort).
+      if (RECEIPTED_STATUSES.has(status)) {
+        await emitReceipt({
+          runId: extra?.run_id ?? null,
+          agentIdentity: 'zoe',
+          capability: 'repo_improve',
+          tool: 'repo-improver-scout',
+          action: `scout_${status}`,
+          resultType: 'success',
+          approvalClass: 'auto',
+          evidenceUrl: extra?.pr_url ?? null,
+        });
+      }
     },
     dispatchFix: async ({ issueText, targetRepo }) => {
       const res = await dispatchHermesRun({


### PR DESCRIPTION
Loop iteration 1 (autonomous, while Zaal drives). Every ZOE scout decision (fixed/rejected/escalated) now emits a dreamnet.receipt.v1 receipt, so the learning log is an auditable portable proof trail. Best-effort, never throws. Typecheck clean, 21 scout tests green.