### PR TITLE
feat(zoe): config preflight - fail loudly, not silently

### DIFF
--- a/bot/src/zoe/__tests__/preflight.test.ts
+++ b/bot/src/zoe/__tests__/preflight.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  checkCapabilities,
+  formatPreflightReport,
+  hasCriticalFailure,
+  runPreflight,
+  CAPABILITIES,
+  type Capability,
+} from '../preflight';
+
+const FULL_ENV: Record<string, string> = {
+  ZOE_BOT_TOKEN: 't',
+  ZAAL_TELEGRAM_ID: '1',
+  SUPABASE_URL: 'https://x.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: 'k',
+  OPENROUTER_API_KEY: 'o',
+  ZAAL_BOTZ_GROUP_ID: '-100',
+};
+
+describe('checkCapabilities', () => {
+  it('reports all ok when every var is present', () => {
+    const res = checkCapabilities(FULL_ENV);
+    expect(res.every((r) => r.ok)).toBe(true);
+    expect(res).toHaveLength(CAPABILITIES.length);
+  });
+
+  it('catches the real incident: missing Supabase creds disables the database capability', () => {
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ...noDb } = FULL_ENV;
+    const db = checkCapabilities(noDb).find((r) => r.name === 'database');
+    expect(db?.ok).toBe(false);
+    expect(db?.missing).toEqual(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']);
+    expect(db?.severity).toBe('critical');
+  });
+
+  it('treats empty and whitespace-only values as missing', () => {
+    const res = checkCapabilities({ ...FULL_ENV, OPENROUTER_API_KEY: '   ' });
+    expect(res.find((r) => r.name === 'cheap-ai')?.ok).toBe(false);
+  });
+
+  it('reports only the vars actually absent, not the whole group', () => {
+    const { SUPABASE_SERVICE_ROLE_KEY, ...partial } = FULL_ENV;
+    expect(checkCapabilities(partial).find((r) => r.name === 'database')?.missing).toEqual([
+      'SUPABASE_SERVICE_ROLE_KEY',
+    ]);
+  });
+
+  it('accepts a custom capability list', () => {
+    const caps: Capability[] = [{ name: 'x', requires: ['A'], impact: 'i', severity: 'degraded' }];
+    expect(checkCapabilities({}, caps)).toEqual([
+      { name: 'x', ok: false, missing: ['A'], impact: 'i', severity: 'degraded' },
+    ]);
+  });
+});
+
+describe('formatPreflightReport', () => {
+  it('returns null on a clean boot (stay silent when healthy)', () => {
+    expect(formatPreflightReport(checkCapabilities(FULL_ENV))).toBeNull();
+  });
+
+  it('names the missing vars and the impact so the fix is obvious', () => {
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ...noDb } = FULL_ENV;
+    const report = formatPreflightReport(checkCapabilities(noDb))!;
+    expect(report).toContain('CRITICAL');
+    expect(report).toContain('SUPABASE_URL');
+    expect(report).toContain('SUPABASE_SERVICE_ROLE_KEY');
+    expect(report).toContain('fail silently');
+  });
+
+  it('separates critical from degraded', () => {
+    const { OPENROUTER_API_KEY, ...noCheap } = FULL_ENV;
+    const report = formatPreflightReport(checkCapabilities(noCheap))!;
+    expect(report).toContain('DEGRADED');
+    expect(report).not.toContain('CRITICAL');
+  });
+});
+
+describe('hasCriticalFailure', () => {
+  it('is false when only a degraded capability is missing', () => {
+    const { ZAAL_BOTZ_GROUP_ID, ...noGroup } = FULL_ENV;
+    expect(hasCriticalFailure(checkCapabilities(noGroup))).toBe(false);
+  });
+  it('is true when a critical capability is missing', () => {
+    const { ZOE_BOT_TOKEN, ...noTg } = FULL_ENV;
+    expect(hasCriticalFailure(checkCapabilities(noTg))).toBe(true);
+  });
+});
+
+describe('runPreflight', () => {
+  it('alerts once when something is missing', async () => {
+    const alert = vi.fn(async (_report: string) => {});
+    const { SUPABASE_URL, ...broken } = FULL_ENV;
+    await runPreflight(alert, broken);
+    expect(alert).toHaveBeenCalledOnce();
+    expect(alert.mock.calls[0][0]).toContain('SUPABASE_URL');
+  });
+
+  it('stays silent on a healthy boot', async () => {
+    const alert = vi.fn(async (_report: string) => {});
+    await runPreflight(alert, FULL_ENV);
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it('never throws even if the alert channel fails', async () => {
+    const alert = vi.fn(async () => {
+      throw new Error('telegram down');
+    });
+    const { SUPABASE_URL, ...broken } = FULL_ENV;
+    await expect(runPreflight(alert, broken)).resolves.toBeDefined();
+  });
+
+  it('works with no alert channel wired', async () => {
+    const { SUPABASE_URL, ...broken } = FULL_ENV;
+    await expect(runPreflight(undefined, broken)).resolves.toBeDefined();
+  });
+});

--- a/bot/src/zoe/preflight.ts
+++ b/bot/src/zoe/preflight.ts
@@ -1,0 +1,129 @@
+/**
+ * ZOE Config Preflight: fail LOUDLY on missing config, never silently.
+ *
+ * Built 2026-07-23 after a real incident: the ZOE bot's .env had no Supabase
+ * credentials at all, so db() threw on every call. The error-remediation rail
+ * logged one line per tick and moved on, the receipts emitter swallowed it
+ * (best-effort by design), and the repo-improver scout half-worked - its
+ * OpenRouter audit succeeded and only the DB write failed. Net effect: an
+ * entire class of capability was dead for an unknown period and nothing ever
+ * said so.
+ *
+ * Silent degradation is the worst failure mode for an autonomous system: it
+ * looks alive while doing nothing. This module declares what each capability
+ * NEEDS, checks it at boot, and reports what is disabled and why - to the log
+ * and to Zaal - so "quietly broken" becomes "loudly reported".
+ *
+ * Pure (checkCapabilities/formatPreflightReport) so it is fully unit-tested;
+ * runPreflight does the logging + one-shot alert.
+ */
+
+/** A ZOE capability and the env vars it cannot run without. */
+export interface Capability {
+  name: string;
+  /** Env vars that MUST be present for this capability to function. */
+  requires: string[];
+  /** What stops working when it is missing - shown in the alert. */
+  impact: string;
+  /** critical = ZOE is broken; degraded = a feature is off but ZOE runs. */
+  severity: 'critical' | 'degraded';
+}
+
+export const CAPABILITIES: Capability[] = [
+  {
+    name: 'telegram-core',
+    requires: ['ZOE_BOT_TOKEN', 'ZAAL_TELEGRAM_ID'],
+    impact: 'ZOE cannot talk to Zaal at all',
+    severity: 'critical',
+  },
+  {
+    name: 'database',
+    requires: ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'],
+    impact: 'receipts, error-remediation rail, repo-improver findings, and CRM writes all fail silently',
+    severity: 'critical',
+  },
+  {
+    name: 'cheap-ai',
+    requires: ['OPENROUTER_API_KEY'],
+    impact: 'no cap-fallback and no repo-improver scout audits (Claude cap becomes a hard stop)',
+    severity: 'degraded',
+  },
+  {
+    name: 'group-status',
+    requires: ['ZAAL_BOTZ_GROUP_ID'],
+    impact: 'autonomous status reports (fixes, scout decisions) have nowhere to post',
+    severity: 'degraded',
+  },
+];
+
+export interface CapabilityResult {
+  name: string;
+  ok: boolean;
+  missing: string[];
+  impact: string;
+  severity: 'critical' | 'degraded';
+}
+
+/**
+ * Check every capability against an env map. Pure - pass process.env or a fake.
+ * A var counts as present only if it is a non-empty, non-whitespace string.
+ */
+export function checkCapabilities(
+  env: Record<string, string | undefined>,
+  caps: Capability[] = CAPABILITIES,
+): CapabilityResult[] {
+  return caps.map((c) => {
+    const missing = c.requires.filter((v) => !env[v] || String(env[v]).trim() === '');
+    return { name: c.name, ok: missing.length === 0, missing, impact: c.impact, severity: c.severity };
+  });
+}
+
+/**
+ * Human-readable report. Returns null when everything is healthy, so callers
+ * can stay silent on a clean boot and only speak up when something is wrong.
+ */
+export function formatPreflightReport(results: CapabilityResult[]): string | null {
+  const broken = results.filter((r) => !r.ok);
+  if (broken.length === 0) return null;
+  const critical = broken.filter((r) => r.severity === 'critical');
+  const degraded = broken.filter((r) => r.severity === 'degraded');
+  const lines: string[] = ['ZOE preflight: some capabilities are DISABLED (missing config).'];
+  for (const r of critical) {
+    lines.push('', `CRITICAL - ${r.name}: missing ${r.missing.join(', ')}`, `  -> ${r.impact}`);
+  }
+  for (const r of degraded) {
+    lines.push('', `DEGRADED - ${r.name}: missing ${r.missing.join(', ')}`, `  -> ${r.impact}`);
+  }
+  lines.push('', 'Add the missing vars to the bot .env and restart. Until then those paths fail silently.');
+  return lines.join('\n');
+}
+
+/** True if any critical capability is missing config. */
+export function hasCriticalFailure(results: CapabilityResult[]): boolean {
+  return results.some((r) => !r.ok && r.severity === 'critical');
+}
+
+/**
+ * Run the preflight at boot: log the report and (best-effort) alert Zaal once.
+ * Never throws - a broken preflight must not stop ZOE from starting.
+ */
+export async function runPreflight(
+  alert?: (message: string) => Promise<void>,
+  env: Record<string, string | undefined> = process.env,
+): Promise<CapabilityResult[]> {
+  const results = checkCapabilities(env);
+  const report = formatPreflightReport(results);
+  if (!report) {
+    console.log('[zoe/preflight] all capabilities configured');
+    return results;
+  }
+  console.error(`[zoe/preflight] ${report}`);
+  if (alert) {
+    try {
+      await alert(report);
+    } catch (err) {
+      console.error('[zoe/preflight] alert failed:', (err as Error)?.message ?? err);
+    }
+  }
+  return results;
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -34,6 +34,7 @@ import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { runErrorRemediationTick, defaultRemediationDeps } from './error-remediation';
 import { runRepoImproverTick } from './repo-improver-io';
+import { runPreflight } from './preflight';
 import { shouldFireAlert, shouldPauseAutonomousWork, formatSpendStatus } from './cost-governance';
 import { surfaceNewHandoffs } from './handoffs-surface';
 import { surfaceZaostockApprovals } from './zaostock-approvals-surface';
@@ -103,6 +104,16 @@ export interface SchedulerOptions {
 
 export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
   const tasks: ScheduledTask[] = [];
+
+  // Config preflight FIRST: report any capability that is missing its env, to
+  // the log and to Zaal. Silent degradation (a dead db() that every tick just
+  // logs past) is the failure mode this exists to kill. Fire-and-forget - a
+  // preflight problem must never stop the scheduler from starting.
+  void runPreflight(async (report: string) => {
+    const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    const target = gid || opts.zaalTgId;
+    if (target) await opts.bot.api.sendMessage(target, report).then(() => {});
+  });
 
   // Morning brief — 09:00 UTC = 05:00 EDT, 04:00 EST. We anchor to UTC; Zaal in EST/EDT.
   // Cron: '0 9 * * *' → 09:00 UTC daily.


### PR DESCRIPTION
Loop iteration 2. Makes ZOE report missing config at boot instead of degrading silently.

**Why:** today the bot .env had no Supabase creds, so db() threw on every call - the rail logged past it, receipts swallowed it, the scout half-worked. A whole capability class was dead and nothing said so.

**What:** declares each capability + required env (telegram-core, database, cheap-ai, group-status), checks at boot, reports what is disabled and the concrete impact to the log + ZAALBOTS. Silent when healthy. Never throws.

**Verified:** 14 tests including the exact incident; typecheck clean; ran against a simulated VPS env and it correctly emits CRITICAL - database: missing SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.