### PR TITLE
feat(zoe): error-remediation rail emits receipts

### DIFF
--- a/bot/src/zoe/error-remediation.ts
+++ b/bot/src/zoe/error-remediation.ts
@@ -22,6 +22,7 @@ import { createHash } from 'node:crypto';
 import type { HermesRepoTarget } from '../hermes/types';
 import { db } from '../supabase';
 import { dispatchHermesRun } from '../hermes/runner';
+import { emitReceipt } from './receipts';
 
 export interface AppError {
   id: string;
@@ -201,12 +202,33 @@ export function defaultRemediationDeps(
         .from('app_errors')
         .update({ status: 'fixed', pr_url: prUrl, run_id: runId, updated_at: new Date().toISOString() })
         .eq('id', id);
+      // Portable receipt for the autonomous fix (best-effort, never throws).
+      await emitReceipt({
+        runId,
+        agentIdentity: 'zoe',
+        capability: 'error_remediation',
+        tool: 'error-remediation-rail',
+        action: 'auto_fix_pr',
+        resultType: 'success',
+        approvalClass: 'auto',
+        evidenceUrl: prUrl,
+      });
     },
     markEscalated: async (id: string, notes: string) => {
       await db()
         .from('app_errors')
         .update({ status: 'escalated', notes, updated_at: new Date().toISOString() })
         .eq('id', id);
+      await emitReceipt({
+        runId: null,
+        agentIdentity: 'zoe',
+        capability: 'error_remediation',
+        tool: 'error-remediation-rail',
+        action: 'escalated',
+        resultType: 'error',
+        approvalClass: 'auto',
+        evidenceUrl: null,
+      });
     },
     dispatchFix: async ({ issueText, targetRepo }) => {
       const result = await dispatchHermesRun({


### PR DESCRIPTION
Small completion of today's receipts work: the error-remediation rail now emits a portable receipt on every auto-fix (with the PR link) and every escalation, exactly like the scout does. Both autonomous paths are now fully receipted. Best-effort, never throws. Typecheck clean, 15 rail tests still pass.