### PR TITLE
feat(eyes): the Eyes organ - pure perception + organism roadmap

### DIFF
--- a/research/agents/2062-eyes-organ-and-organism-roadmap/README.md
+++ b/research/agents/2062-eyes-organ-and-organism-roadmap/README.md
@@ -1,0 +1,138 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-07-23
+related-docs: 2027, 2030
+original-query: "evolve the organism deeper - build the Eyes organ (pure observation), then a roadmap for the remaining organs (Ears, Hands, Nose, Skin, Immune, Memory, Nervous System)"
+tier: DEEP
+---
+
+# 2062 - Eyes organ + the ZAO organism roadmap
+
+> **Goal:** Evolve ZAO from a set of services into a modular digital organism where every organ has a single responsibility and clean interfaces, cooperating through the Spine. This doc designs the Eyes organ (shipped as `src/lib/eyes/`) and roadmaps the remaining organs.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **Build deeper, not wider.** Complete the organism one biological system at a time instead of adding more features. | The foundation (Brain/Spine/Heart/Mouth) is strong; the value now is clean separation of responsibility, not more surface. |
+| 2 | **Eyes = observe only. No thinking, deciding, or executing.** Enforced in code: a Sensor's only output is `Observation[]`; there is no action/write/decide surface in the interfaces. | A perception organ that could act would collapse the separation the organism depends on. The boundary must be structural, not a comment. |
+| 3 | **Standardized `Observation` object** with source, timestamps, confidence, provenance, content hash, evidence, and health metadata. | One contract lets the Brain, Spine, and Memory consume any sensor's output uniformly, and lets multiple Eyes be reconciled later. |
+| 4 | **Multiple Eyes can observe the same subject independently; the Eyes never decide what is true.** `subjectKey` + `contentHash` cluster matching reports for downstream consensus. | Truth is a reasoning concern (Brain/Spine), not a perception concern. Eyes report; consumers reconcile. |
+| 5 | **ZAO's own vocabulary. No external protocol/branding coupling.** | Clean interfaces and separation of responsibility are the goal, not shared branding. |
+
+## The Eyes organ (shipped)
+
+Code: `src/lib/eyes/` - `types.ts`, `observation.ts`, `registry.ts`, `sensors/filesystem-sensor.ts`, `index.ts`, `__tests__/eyes.test.ts`.
+
+- **Purpose:** perceive the outside world and emit structured Observations.
+- **Responsibilities:** GitHub, browser, OCR, vision, filesystem, search, blockchain, market feeds, logs, telemetry, and API observation - each as a hot-swappable sensor.
+- **Boundaries:** read-only. It does NOT think, decide, or execute. It never reconciles or asserts truth.
+- **Inputs:** an `ObserveContext` (observerId, a read-only cursor, read-only config, a deterministic `now`). Read-only.
+- **Outputs:** `Observation` objects (schemaVersion `zao.observation.v1`): `{ observationId, sensor, observerId, kind, subjectKey, observedAt, capturedAt, confidence, provenance{method,endpoint,query}, contentHash, payload, evidence[], health }`.
+- **Interfaces:** `Sensor { manifest; observe(ctx): Promise<ObserveResult>; health() }`, `SensorRegistry` (register/replace/unregister/list/runOnce/runAll/healthOf), the `createObservation` factory, and `clusterForConsensus` (clusters, never picks a winner).
+- **Internal components:** the Observation factory (canonical hashing), the sensor registry (validation + hot-swap + cursors), per-sensor manifests, a rolling health model, and the sensors themselves.
+- **Health model:** per-sensor rolling window of ok/fail -> status `healthy | degraded (>=2 consecutive fails) | failing (>=5) | stopped`, plus latency, errorRate, lastOkAt, consecutiveFailures, totals. Each Observation embeds a health snapshot at capture time.
+- **Failure modes:** a sensor throws, times out, returns malformed data, or a source rate-limits. Each is isolated: `runOnce`/`runAll` catch per-sensor, record the failure, and never take down the registry or sibling sensors.
+- **Recovery strategy:** failures are per-sensor and self-healing (consecutive-failure counter resets on the next success); cursors make polling incremental and replayable; a bad sensor can be hot-swapped (`replace`) without restarting the organ. Observations are content-hashed so a replay is deduplicable.
+- **Test strategy:** pure factory + registry + one reference sensor with an injectable filesystem, covering hash stability across independent Eyes, tamper detection, consensus clustering, hot-swap, failure isolation, status escalation, and cursor-diffed change detection. (Runs on CI; local `src/lib` vitest is blocked by a rolldown native-binding issue on this Mac.)
+- **Future evolution:** add sensors per manifest (github, browser via Playwright, OCR/vision, chain via RPC, market feeds, log/telemetry tails); add subscribe-strategy sensors (webhooks/streams) alongside poll; persist Observations to Memory; add an observation cache + replay log; add cross-Eye reconciliation as a Brain capability (never inside Eyes).
+
+## Roadmap - the remaining organs
+
+Each is a modular organ with one responsibility, clean interfaces, and independent evolution, cooperating through the Spine.
+
+### Ears - event listeners and subscriptions
+- **Purpose:** receive pushed events (the passive/subscribe complement to Eyes' active polling).
+- **Responsibilities:** webhooks, Telegram/Discord/Farcaster streams, chain event subscriptions, message queues, SSE/websockets.
+- **Boundaries:** receive + normalize only. Does not poll (that is Eyes), does not act, does not decide.
+- **Inputs:** inbound events from subscribed sources. **Outputs:** the same `Observation` contract (kind `*.event`), so Ears and Eyes are interchangeable to consumers.
+- **Interfaces:** `Listener { manifest; onEvent(raw): Observation[]; subscribe()/unsubscribe() }`, a listener registry mirroring the sensor registry.
+- **Internal components:** subscription manager, dedup (by contentHash), backpressure buffer, replay log.
+- **Health model:** per-listener connected/lagging/dropped + lag + reconnect count. **Failure modes:** dropped connection, event storm, duplicate delivery, malformed payload. **Recovery:** auto-reconnect with backoff, replay from last acked offset, dedup on contentHash. **Test:** fake event injectors, dedup + backpressure + reconnect cases. **Future:** exactly-once via the transactional outbox, per-source priority.
+
+### Hands - skills, tools, external actions
+- **Purpose:** the ONLY organ that acts on the outside world.
+- **Responsibilities:** skills, MCP tools, external API writes, on-chain transactions, posting, PR creation.
+- **Boundaries:** acts ONLY on an explicit, authorized instruction FROM THE SPINE. Never self-initiates; never decides what to do (that is the Brain). Every action carries an approval class and emits a receipt.
+- **Inputs:** an authorized action envelope from the Spine. **Outputs:** an outcome + a receipt (dreamnet.receipt.v1-shaped, already shipped) with evidence.
+- **Interfaces:** `Tool { manifest{riskTier, requiredApproval}; execute(action, approval): Result }`, a tool registry with capability + risk declarations.
+- **Internal components:** tool registry, approval gate, budget/rate limiter, receipt emitter, idempotency keys.
+- **Health model:** per-tool success rate, latency, spend vs budget. **Failure modes:** partial execution, unauthorized attempt, budget breach, external error. **Recovery:** idempotency + compensating actions (saga), hard budget stop, rollback. **Test:** dry-run mode, approval-gate enforcement, idempotency, budget caps. **Future:** the compensating-action layer (the discovered gap from doc 2027), per-tool canary.
+
+### Nose - anomaly and opportunity detection
+- **Purpose:** smell what is off or promising in the stream of Observations.
+- **Responsibilities:** anomaly detection (errors spiking, metrics drifting), opportunity detection (a mention, a market move, a new contributor).
+- **Boundaries:** flags signals; does NOT decide or act. Emits scented signals to the Brain/Nervous System.
+- **Inputs:** Observations (from Eyes/Ears) + Memory baselines. **Outputs:** `Signal { kind, severity, subjectKey, confidence, evidence[] }`.
+- **Interfaces:** `Detector { manifest; scan(observations, baseline): Signal[] }`, a detector registry.
+- **Internal components:** rolling baselines, threshold/statistical detectors, dedup, a signal ranker.
+- **Health model:** detector precision/recall proxy (how often its signals were acted on / were real), false-positive rate. **Failure modes:** alert fatigue (too noisy), missed signal (too quiet), stale baseline. **Recovery:** self-tune thresholds from the advisory-sandbox-style ground-truth loop, decay stale baselines. **Test:** replay known incidents, assert detect/no-detect. **Future:** learned detectors trained on the receipt + outcome history.
+
+### Skin - identity, authentication, trust surface
+- **Purpose:** the boundary between inside and outside - who is who, and what they are allowed to touch.
+- **Responsibilities:** identity (Farcaster/wallet/session), authentication, authorization, the trust surface for every inbound request and outbound action.
+- **Boundaries:** decides identity + permission ONLY; does not decide business logic or act. Advisory to Hands (Hands must check Skin before acting).
+- **Inputs:** credentials, tokens, signatures. **Outputs:** a verified `Principal { id, roles, trustTier }` or a rejection, with provenance.
+- **Interfaces:** `verify(credential): Principal`, `authorize(principal, action): allow|deny`, a policy source.
+- **Internal components:** verifiers (Farcaster Quick Auth, wallet sig, session), role/trust registry, a constant-time comparison layer, audit log.
+- **Health model:** auth success/failure rates, anomalous-attempt rate. **Failure modes:** token expiry (today's real incident), key compromise, replay, privilege drift. **Recovery:** fail-closed, short-lived tokens, key rotation, re-auth prompts. **Test:** expired/forged/replayed tokens, role escalation attempts. **Future:** ZAO Respect + on-chain reputation as trust tiers.
+
+### Immune System - policy, safety, rollback, threat detection
+- **Purpose:** protect the organism from harmful actions and states.
+- **Responsibilities:** policy enforcement, safety gates, rollback, threat detection, quarantine.
+- **Boundaries:** can BLOCK and ROLL BACK, but does not create business actions. It is the veto + the antibody, not the actor.
+- **Inputs:** proposed actions (from Spine/Hands), Observations, Signals. **Outputs:** allow/block/quarantine verdicts + rollback commands.
+- **Interfaces:** `check(action): allow|block+reason`, `rollback(runId)`, `quarantine(target)`.
+- **Internal components:** policy engine, the secret/PII scanners (already exist as rules), the advisory sandbox (already shipped), circuit breakers, the quarantine store.
+- **Health model:** blocks issued, false-block rate, incidents caught vs missed, mean-time-to-rollback. **Failure modes:** over-blocking (organism paralyzed), under-blocking (harm slips through), slow rollback. **Recovery:** tunable policy tiers, tested rollback paths (the recovery suite, doc 2027), kill switch. **Test:** red-team injected harmful actions, assert block + rollback. **Future:** learned threat detection from the receipt corpus.
+
+### Memory - episodic, semantic, receipts, knowledge
+- **Purpose:** remember - so the organism has continuity, context, and proof.
+- **Responsibilities:** episodic (what happened), semantic (what is known), receipts (what was done + proof), knowledge graph (Bonfire).
+- **Boundaries:** stores + retrieves; does not decide or act. Read/write of records only.
+- **Inputs:** Observations, Signals, receipts, decisions. **Outputs:** retrieval results, baselines, context packs for the Brain.
+- **Interfaces:** `store(record)`, `recall(query): records[]`, `baseline(kind)`.
+- **Internal components:** episodic store (agent_runs/receipts, shipped), semantic store, the Bonfire graph, an embedding/index layer, retention + compaction (the context-hygiene work, doc 2036).
+- **Health model:** write success, recall latency/relevance, storage growth, staleness. **Failure modes:** unbounded growth (real - see doc 2036), stale recall, lost writes (the silent-db-failure incident this session). **Recovery:** compaction, the config preflight (shipped) so a dead store is loud not silent, receipt content-hash dedup. **Test:** round-trip store/recall, retention, dedup. **Future:** portable receipt envelopes (shipped, doc 2030), cross-agent shared memory.
+
+### Nervous System - signals, interrupts, priorities, reflexes
+- **Purpose:** route urgency - carry signals to the right organ at the right priority, and fire reflexes.
+- **Responsibilities:** signal routing, interrupts, prioritization, reflex arcs (fast pre-Brain responses to critical Signals).
+- **Boundaries:** routes + prioritizes; does not decide strategy (Brain) or act (Hands). A reflex may trigger a pre-authorized Hands action for critical, pre-approved cases only.
+- **Inputs:** Signals (Nose), Observations (Eyes/Ears), health from every organ. **Outputs:** prioritized dispatches to the Spine, interrupts, reflex triggers.
+- **Interfaces:** `route(signal)`, `interrupt(priority)`, `reflex(signal): preAuthorizedAction | none`.
+- **Internal components:** priority queue, interrupt controller, reflex table (pre-approved signal->action pairs), backpressure.
+- **Health model:** dispatch latency, queue depth, dropped-signal rate, reflex-misfire rate. **Failure modes:** priority inversion, signal storm, reflex misfire. **Recovery:** backpressure, bounded reflex table with the Immune System as override, replay. **Test:** priority ordering, storm handling, reflex-authorization enforcement. **Future:** learned prioritization from outcome history.
+
+## The whole organism (target)
+
+```
+Eyes (observe, poll) ─┐
+Ears (observe, subscribe) ─┤─> Nose (detect signals) ─> Nervous System (prioritize/route)
+                          │                                        │
+                       Memory (remember) <──────────────────────> Brain (reason/decide)
+                          │                                        │
+Skin (identity/trust) ── gate ──> Spine (sole executor) ── authorize ──> Hands (act) ─> receipts -> Memory
+                                        │
+                                Immune System (policy, block, rollback) wraps the Spine/Hands path
+Heart (heartbeat, leases, recovery) + Mouth (communication) run throughout.
+```
+
+Every organ: one responsibility, a manifest, a health model, failure isolation, and a clean interface. Each evolves independently; they cooperate only through the Spine.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Merge the Eyes organ PR (contracts + registry + reference sensor + tests) | Zaal | PR | 2026-07-30 |
+| Add a real GitHub sensor (the first non-reference Eye) | Zaal | PR | 2026-08-06 |
+| Build Ears next (subscribe-strategy listeners), reusing the Observation contract | Zaal | build | 2026-08-13 |
+| Wire Eyes Observations into Memory + a Nose baseline | Zaal | build | when Eyes has 2+ live sensors |
+
+## Sources
+
+- [FULL] The shipped Eyes code in this PR (`src/lib/eyes/`).
+- [FULL] Brandon's organism directive (relayed 2026-07-23) + [[project_brandon_organism_directives]].
+- [FULL] Doc 2027 (Heart recovery suite), Doc 2030 (DreamNet receipt envelope), Doc 2036 (context hygiene) - prior organism work this design builds on.

--- a/research/agents/README.md
+++ b/research/agents/README.md
@@ -240,3 +240,4 @@
 | 90 | [AI-Run Community: Self-Improving Agent OS for ZAO](90-*) |
 | 2030 | [DreamNet Public Core is the receipt contract our organism should speak](./2030-dreamnet-public-core-organism-contract/) | STANDALONE | Assess Brandon's DreamNet repo constellation (Whale League + Public Core contracts) grounded in the actual code, and decide the single highest-leverage collab move for ZAO's organism. |
 | 2040 | [Suchbot Evaluation for ZOE](./2040-suchbot-evaluation-for-zoe/) | STANDALONE | Research doc 2040. |
+| 2062 | [Eyes organ + the ZAO organism roadmap](./2062-eyes-organ-and-organism-roadmap/) | STANDALONE | Evolve ZAO from a set of services into a modular digital organism where every organ has a single responsibility and clean interfaces, cooperating through the Spine. This doc designs the Eyes organ (shipped as `src/lib/eyes/`) and roadmaps the remaining organs. |

--- a/src/lib/eyes/__tests__/eyes.test.ts
+++ b/src/lib/eyes/__tests__/eyes.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createObservation,
+  observationContentHash,
+  verifyObservation,
+  clusterForConsensus,
+  SensorRegistry,
+  validateManifest,
+  createFilesystemSensor,
+  type Observation,
+  type Sensor,
+  type SensorHealthSnapshot,
+  type DirEntry,
+} from '../index';
+
+const HEALTH: SensorHealthSnapshot = { status: 'healthy', latencyMs: 3, errorRate: 0, lastOkAt: null, consecutiveFailures: 0 };
+const CTX = { observerId: 'eye-1', now: '2026-07-24T00:00:00.000Z' };
+
+function mkObs(over: Partial<Parameters<typeof createObservation>[0]> = {}) {
+  return createObservation(
+    { sensor: 's', kind: 'github.pr', subjectKey: 'pr:42', payload: { title: 'x' }, confidence: 0.9, provenance: { method: 'api' }, health: HEALTH, ...over },
+    CTX,
+  );
+}
+
+describe('createObservation + content hash', () => {
+  it('stamps all required fields', () => {
+    const o = mkObs();
+    expect(o.schemaVersion).toBe('zao.observation.v1');
+    expect(o.observationId).toMatch(/[0-9a-f-]{36}/);
+    expect(o.sensor).toBe('s');
+    expect(o.observerId).toBe('eye-1');
+    expect(o.capturedAt).toBe(CTX.now);
+    expect(o.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(o.evidence).toEqual([]);
+  });
+
+  it('clamps confidence to [0,1] - it is a self-report, not a truth claim', () => {
+    expect(mkObs({ confidence: 5 }).confidence).toBe(1);
+    expect(mkObs({ confidence: -2 }).confidence).toBe(0);
+  });
+
+  it('content hash is over WHAT was seen, not capture metadata - two Eyes hash identically', () => {
+    const eye1 = createObservation({ sensor: 's', kind: 'github.pr', subjectKey: 'pr:42', payload: { title: 'x' }, confidence: 0.9, provenance: { method: 'api' }, health: HEALTH }, { observerId: 'eye-1', now: '2026-07-24T00:00:00.000Z' });
+    const eye2 = createObservation({ sensor: 's', kind: 'github.pr', subjectKey: 'pr:42', payload: { title: 'x' }, confidence: 0.4, provenance: { method: 'scrape' }, health: HEALTH }, { observerId: 'eye-2', now: '2026-07-24T09:59:00.000Z' });
+    expect(eye1.contentHash).toBe(eye2.contentHash); // same subject+payload -> same hash despite different observer/time/confidence
+    expect(eye1.observationId).not.toBe(eye2.observationId);
+  });
+
+  it('different payload -> different hash', () => {
+    expect(mkObs({ payload: { title: 'a' } }).contentHash).not.toBe(mkObs({ payload: { title: 'b' } }).contentHash);
+  });
+
+  it('verifyObservation catches tampering', () => {
+    const o = mkObs();
+    expect(verifyObservation(o)).toBe(true);
+    expect(verifyObservation({ ...o, payload: { title: 'tampered' } })).toBe(false);
+  });
+});
+
+describe('clusterForConsensus - clusters, never decides', () => {
+  it('groups matching reports of the same subject and counts distinct Eyes', () => {
+    const obs: Observation[] = [
+      mkObs({ payload: { title: 'x' } }), // eye-1
+      createObservation({ sensor: 's', kind: 'github.pr', subjectKey: 'pr:42', payload: { title: 'x' }, confidence: 0.5, provenance: { method: 'api' }, health: HEALTH }, { observerId: 'eye-2', now: CTX.now }),
+      createObservation({ sensor: 's', kind: 'github.pr', subjectKey: 'pr:42', payload: { title: 'DIFFERENT' }, confidence: 0.5, provenance: { method: 'api' }, health: HEALTH }, { observerId: 'eye-3', now: CTX.now }),
+    ];
+    const c = clusterForConsensus(obs);
+    expect(c['pr:42']).toHaveLength(2); // two distinct content hashes
+    expect(c['pr:42'][0].count).toBe(2); // the agreed one, most-reported first
+    expect(c['pr:42'][0].observerIds.sort()).toEqual(['eye-1', 'eye-2']);
+    // clusterForConsensus does NOT pick a winner - it just reports the clusters.
+  });
+});
+
+describe('SensorRegistry', () => {
+  function fakeSensor(id: string, obsKind = 'test.kind'): Sensor {
+    return {
+      manifest: { sensorId: id, version: '1.0.0', description: 'fake', strategy: 'on_demand', produces: [obsKind], requiredConfig: [], riskTier: 'passive' },
+      async observe(ctx) {
+        return { observations: [createObservation({ sensor: id, kind: obsKind, subjectKey: 'k', payload: { v: 1 }, confidence: 1, provenance: { method: 'api' }, health: HEALTH }, { observerId: ctx.observerId, now: ctx.now })], cursor: 'c1' };
+      },
+      health() { return { sensorId: id, status: 'healthy', latencyMs: 0, errorRate: 0, lastOkAt: null, consecutiveFailures: 0, totalObservations: 0, totalErrors: 0 }; },
+    };
+  }
+
+  it('rejects a non-passive manifest - Eyes must be read-only', () => {
+    expect(() => validateManifest({ sensorId: 'x', version: '1', description: '', strategy: 'poll', pollIntervalMs: 1000, produces: ['k'], requiredConfig: [], riskTier: 'active' as never })).toThrow(/passive/);
+  });
+
+  it('rejects poll strategy without an interval', () => {
+    expect(() => validateManifest({ sensorId: 'x', version: '1', description: '', strategy: 'poll', produces: ['k'], requiredConfig: [], riskTier: 'passive' })).toThrow(/pollIntervalMs/);
+  });
+
+  it('registers, lists, and refuses duplicate registration', () => {
+    const r = new SensorRegistry();
+    r.register(fakeSensor('a'));
+    expect(r.list().map((m) => m.sensorId)).toEqual(['a']);
+    expect(() => r.register(fakeSensor('a'))).toThrow(/already registered/);
+  });
+
+  it('hot-swaps a live sensor via replace', () => {
+    const r = new SensorRegistry();
+    r.register(fakeSensor('a', 'old.kind'));
+    r.replace(fakeSensor('a', 'new.kind'));
+    expect(r.get('a')?.manifest.produces).toEqual(['new.kind']);
+  });
+
+  it('unregister removes it', () => {
+    const r = new SensorRegistry();
+    r.register(fakeSensor('a'));
+    expect(r.unregister('a')).toBe(true);
+    expect(r.list()).toHaveLength(0);
+  });
+
+  it('runOnce runs a sensor, records health, and threads the cursor', async () => {
+    const r = new SensorRegistry();
+    r.register(fakeSensor('a'));
+    const res = await r.runOnce('a', { observerId: 'eye-1', now: CTX.now });
+    expect(res.ok).toBe(true);
+    expect(res.observations).toHaveLength(1);
+    expect(res.cursor).toBe('c1');
+    expect(r.healthOf('a')?.totalObservations).toBe(1);
+    expect(r.healthOf('a')?.status).toBe('healthy');
+  });
+
+  it('isolates a failing sensor - it goes degraded/failing but never throws or stops others', async () => {
+    const r = new SensorRegistry();
+    const boom: Sensor = {
+      manifest: { sensorId: 'boom', version: '1', description: '', strategy: 'on_demand', produces: ['k'], requiredConfig: [], riskTier: 'passive' },
+      async observe() { throw new Error('sensor exploded'); },
+      health() { return { sensorId: 'boom', status: 'failing', latencyMs: 0, errorRate: 1, lastOkAt: null, consecutiveFailures: 9, totalObservations: 0, totalErrors: 9 }; },
+    };
+    r.register(boom);
+    r.register(fakeSensor('good'));
+    const results = await r.runAll({ observerId: 'eye-1', now: CTX.now });
+    const boomRes = results.find((x) => x.sensorId === 'boom')!;
+    const goodRes = results.find((x) => x.sensorId === 'good')!;
+    expect(boomRes.ok).toBe(false);
+    expect(boomRes.error).toContain('exploded');
+    expect(goodRes.ok).toBe(true); // the good sensor still ran
+  });
+
+  it('escalates status to failing after repeated failures', async () => {
+    const r = new SensorRegistry();
+    const boom: Sensor = {
+      manifest: { sensorId: 'boom', version: '1', description: '', strategy: 'on_demand', produces: ['k'], requiredConfig: [], riskTier: 'passive' },
+      async observe() { throw new Error('x'); },
+      health() { return { sensorId: 'boom', status: 'failing', latencyMs: 0, errorRate: 1, lastOkAt: null, consecutiveFailures: 0, totalObservations: 0, totalErrors: 0 }; },
+    };
+    r.register(boom);
+    for (let i = 0; i < 5; i++) await r.runOnce('boom', { observerId: 'e', now: CTX.now });
+    expect(r.healthOf('boom')?.status).toBe('failing');
+    expect(r.healthOf('boom')?.errorRate).toBeGreaterThan(0);
+  });
+});
+
+describe('filesystem sensor (reference Eye) - observe-only, cursor-diffed', () => {
+  const files: DirEntry[] = [
+    { path: '/w/a.txt', size: 10, mtimeMs: 1000 },
+    { path: '/w/b.txt', size: 20, mtimeMs: 2000 },
+  ];
+  function sensorOver(entries: DirEntry[]) {
+    return createFilesystemSensor({ watchPath: '/w', readDir: async () => entries });
+  }
+
+  it('emits an fs.change observation per file on first cycle (all new)', async () => {
+    const s = sensorOver(files);
+    const r = await s.observe({ observerId: 'eye-1', config: {}, now: CTX.now });
+    expect(r.observations).toHaveLength(2);
+    expect(r.observations[0].kind).toBe('fs.change');
+    expect(r.observations[0].payload).toMatchObject({ change: 'added' });
+    expect(r.cursor).toBeTruthy();
+  });
+
+  it('emits nothing when nothing changed (cursor diff)', async () => {
+    const s = sensorOver(files);
+    const first = await s.observe({ observerId: 'eye-1', config: {}, now: CTX.now });
+    const second = await s.observe({ observerId: 'eye-1', config: {}, now: CTX.now, cursor: first.cursor });
+    expect(second.observations).toHaveLength(0);
+  });
+
+  it('emits a modified observation when a file changes', async () => {
+    const s = sensorOver(files);
+    const first = await s.observe({ observerId: 'eye-1', config: {}, now: CTX.now });
+    const changed = [{ path: '/w/a.txt', size: 99, mtimeMs: 5000 }, files[1]];
+    const s2 = createFilesystemSensor({ watchPath: '/w', readDir: async () => changed });
+    const second = await s2.observe({ observerId: 'eye-1', config: {}, now: CTX.now, cursor: first.cursor });
+    expect(second.observations).toHaveLength(1);
+    expect(second.observations[0].payload).toMatchObject({ change: 'modified', path: '/w/a.txt' });
+  });
+
+  it('its observations verify + are passive by manifest', async () => {
+    const s = sensorOver(files);
+    expect(s.manifest.riskTier).toBe('passive');
+    const r = await s.observe({ observerId: 'eye-1', config: {}, now: CTX.now });
+    expect(verifyObservation(r.observations[0])).toBe(true);
+  });
+});

--- a/src/lib/eyes/index.ts
+++ b/src/lib/eyes/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Eyes - the perception organ. Public API.
+ *
+ * One responsibility: observe. Sensors perceive the outside world and emit
+ * standardized Observation objects; the registry plugs sensors in/out and runs
+ * perception cycles with health + failure isolation. Nothing here thinks,
+ * decides, or acts - Observations flow outward to the Brain, Spine, and Memory,
+ * which are the organs that reason and reconcile.
+ */
+
+export type {
+  Observation,
+  EvidenceRef,
+  SensorStatus,
+  SensorHealth,
+  SensorHealthSnapshot,
+  SensorManifest,
+  Sensor,
+  ObserveContext,
+  ObserveResult,
+} from './types';
+
+export {
+  createObservation,
+  observationContentHash,
+  verifyObservation,
+  clusterForConsensus,
+  canonicalize,
+  sha256Hex,
+} from './observation';
+
+export { SensorRegistry, validateManifest, ManifestError } from './registry';
+export type { RunCycleResult } from './registry';
+
+export { createFilesystemSensor } from './sensors/filesystem-sensor';
+export type { DirEntry, FilesystemSensorOptions } from './sensors/filesystem-sensor';

--- a/src/lib/eyes/observation.ts
+++ b/src/lib/eyes/observation.ts
@@ -1,0 +1,131 @@
+/**
+ * Observation factory - the one canonical way to mint an Observation.
+ *
+ * Pure. Stamps the content hash over a canonical serialization so two Eyes that
+ * saw the same thing produce the same contentHash (enabling downstream
+ * consensus), and so any later tampering is detectable. No I/O.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import type {
+  Observation,
+  EvidenceRef,
+  SensorHealthSnapshot,
+  ObserveContext,
+} from './types';
+
+/** Deterministic canonical JSON: keys sorted recursively, arrays in order. */
+export function canonicalize(value: unknown): string {
+  const sortDeep = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(sortDeep);
+    if (v && typeof v === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+        out[k] = sortDeep((v as Record<string, unknown>)[k]);
+      }
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(sortDeep(value));
+}
+
+/** sha256 hex of a string. */
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+/**
+ * The content hash groups observations of the same subject for consensus, so it
+ * is computed over WHAT was seen (kind + subjectKey + payload), NOT over the
+ * capture metadata (observationId, capturedAt, observerId, health). Two Eyes
+ * seeing the same PR at slightly different times therefore hash identically.
+ */
+export function observationContentHash(input: {
+  kind: string;
+  subjectKey: string;
+  payload: unknown;
+}): string {
+  return sha256Hex(
+    canonicalize({ kind: input.kind, subjectKey: input.subjectKey, payload: input.payload }),
+  );
+}
+
+export interface CreateObservationInput {
+  sensor: string;
+  kind: string;
+  subjectKey: string;
+  payload: unknown;
+  confidence: number;
+  provenance: Observation['provenance'];
+  evidence?: EvidenceRef[];
+  observedAt?: string | null;
+  health: SensorHealthSnapshot;
+}
+
+/**
+ * Mint an Observation from a sensor. `ctx` supplies observerId + a deterministic
+ * `now`. Clamps confidence to [0,1]. The Eyes never assert truth - confidence is
+ * the sensor's own self-report, nothing more.
+ */
+export function createObservation(
+  input: CreateObservationInput,
+  ctx: Pick<ObserveContext, 'observerId' | 'now'>,
+): Observation {
+  const capturedAt = ctx.now ?? new Date().toISOString();
+  const confidence = Math.max(0, Math.min(1, input.confidence));
+  return {
+    schemaVersion: 'zao.observation.v1',
+    observationId: randomUUID(),
+    sensor: input.sensor,
+    observerId: ctx.observerId,
+    kind: input.kind,
+    subjectKey: input.subjectKey,
+    observedAt: input.observedAt ?? null,
+    capturedAt,
+    confidence,
+    provenance: input.provenance,
+    contentHash: observationContentHash(input),
+    payload: input.payload,
+    evidence: input.evidence ?? [],
+    health: input.health,
+  };
+}
+
+/**
+ * Verify an observation's content hash - lets a consumer confirm the payload was
+ * not altered since capture. (capturedAt/observerId/health are intentionally
+ * outside the hash, per observationContentHash.)
+ */
+export function verifyObservation(obs: Observation): boolean {
+  return (
+    obs.contentHash ===
+    observationContentHash({ kind: obs.kind, subjectKey: obs.subjectKey, payload: obs.payload })
+  );
+}
+
+/**
+ * Group observations of the SAME subject by contentHash - the raw material for
+ * downstream consensus. This does NOT decide what is true; it only clusters
+ * matching reports so a Brain/Spine consumer can reconcile them. Returns, per
+ * subjectKey, the set of distinct contentHashes and how many Eyes reported each.
+ */
+export function clusterForConsensus(
+  observations: Observation[],
+): Record<string, Array<{ contentHash: string; count: number; observerIds: string[] }>> {
+  const bySubject: Record<string, Map<string, { count: number; observerIds: Set<string> }>> = {};
+  for (const o of observations) {
+    const m = (bySubject[o.subjectKey] ??= new Map());
+    const e = m.get(o.contentHash) ?? { count: 0, observerIds: new Set<string>() };
+    e.count++;
+    e.observerIds.add(o.observerId);
+    m.set(o.contentHash, e);
+  }
+  const out: Record<string, Array<{ contentHash: string; count: number; observerIds: string[] }>> = {};
+  for (const [subject, m] of Object.entries(bySubject)) {
+    out[subject] = [...m.entries()]
+      .map(([contentHash, e]) => ({ contentHash, count: e.count, observerIds: [...e.observerIds] }))
+      .sort((a, b) => b.count - a.count);
+  }
+  return out;
+}

--- a/src/lib/eyes/registry.ts
+++ b/src/lib/eyes/registry.ts
@@ -1,0 +1,181 @@
+/**
+ * SensorRegistry - the modular organ's plug board.
+ *
+ * Sensors are hot-swappable: register, unregister, or replace one at runtime
+ * without restarting the organ. The registry validates each sensor's manifest,
+ * tracks health, and runs observe cycles - but it never interprets what a
+ * sensor saw. It moves Observations outward; it does not decide.
+ *
+ * Pure orchestration + in-memory state. The registry itself does no perceiving;
+ * the sensors do. No I/O here beyond calling a sensor's own observe().
+ */
+
+import type {
+  Sensor,
+  SensorManifest,
+  SensorHealth,
+  SensorStatus,
+  Observation,
+  ObserveContext,
+} from './types';
+
+/** A validation problem with a manifest. */
+export class ManifestError extends Error {}
+
+/** Validate a manifest before a sensor is allowed onto the plug board. */
+export function validateManifest(m: SensorManifest): void {
+  if (!m.sensorId || !m.sensorId.trim()) throw new ManifestError('sensorId required');
+  if (!m.version) throw new ManifestError(`${m.sensorId}: version required`);
+  if (m.riskTier !== 'passive') throw new ManifestError(`${m.sensorId}: Eyes sensors must be riskTier 'passive'`);
+  if (!['poll', 'subscribe', 'on_demand'].includes(m.strategy)) throw new ManifestError(`${m.sensorId}: bad strategy`);
+  if (m.strategy === 'poll' && !(m.pollIntervalMs && m.pollIntervalMs > 0)) throw new ManifestError(`${m.sensorId}: poll strategy needs pollIntervalMs > 0`);
+  if (!Array.isArray(m.produces) || m.produces.length === 0) throw new ManifestError(`${m.sensorId}: produces[] required`);
+}
+
+/** Rolling health tracker for one sensor. */
+interface HealthState {
+  totalObservations: number;
+  totalErrors: number;
+  consecutiveFailures: number;
+  lastOkAt: string | null;
+  lastLatencyMs: number;
+  recent: boolean[]; // last N ok/fail for error-rate
+}
+
+const WINDOW = 20;
+
+function statusFrom(h: HealthState): SensorStatus {
+  if (h.consecutiveFailures >= 5) return 'failing';
+  if (h.consecutiveFailures >= 2) return 'degraded';
+  return 'healthy';
+}
+
+function errorRate(h: HealthState): number {
+  if (h.recent.length === 0) return 0;
+  const fails = h.recent.filter((ok) => !ok).length;
+  return Number((fails / h.recent.length).toFixed(3));
+}
+
+export interface RunCycleResult {
+  sensorId: string;
+  observations: Observation[];
+  ok: boolean;
+  error?: string;
+  cursor?: string;
+}
+
+export class SensorRegistry {
+  private sensors = new Map<string, Sensor>();
+  private health = new Map<string, HealthState>();
+  private cursors = new Map<string, string>();
+
+  private freshHealth(): HealthState {
+    return { totalObservations: 0, totalErrors: 0, consecutiveFailures: 0, lastOkAt: null, lastLatencyMs: 0, recent: [] };
+  }
+
+  /** Register a sensor. Throws on a bad manifest or a duplicate id. */
+  register(sensor: Sensor): void {
+    validateManifest(sensor.manifest);
+    if (this.sensors.has(sensor.manifest.sensorId)) {
+      throw new ManifestError(`${sensor.manifest.sensorId}: already registered (use replace to hot-swap)`);
+    }
+    this.sensors.set(sensor.manifest.sensorId, sensor);
+    this.health.set(sensor.manifest.sensorId, this.freshHealth());
+  }
+
+  /** Hot-swap: replace a live sensor (or add it if absent). Health resets for the new implementation. */
+  replace(sensor: Sensor): void {
+    validateManifest(sensor.manifest);
+    this.sensors.set(sensor.manifest.sensorId, sensor);
+    this.health.set(sensor.manifest.sensorId, this.freshHealth());
+  }
+
+  unregister(sensorId: string): boolean {
+    this.health.delete(sensorId);
+    this.cursors.delete(sensorId);
+    return this.sensors.delete(sensorId);
+  }
+
+  get(sensorId: string): Sensor | undefined {
+    return this.sensors.get(sensorId);
+  }
+
+  list(): SensorManifest[] {
+    return [...this.sensors.values()].map((s) => s.manifest);
+  }
+
+  /** Live health snapshot for one sensor (or null if unknown). */
+  healthOf(sensorId: string): SensorHealth | null {
+    const h = this.health.get(sensorId);
+    if (!h) return null;
+    return {
+      sensorId,
+      status: statusFrom(h),
+      latencyMs: h.lastLatencyMs,
+      errorRate: errorRate(h),
+      lastOkAt: h.lastOkAt,
+      consecutiveFailures: h.consecutiveFailures,
+      totalObservations: h.totalObservations,
+      totalErrors: h.totalErrors,
+    };
+  }
+
+  /** Health of every registered sensor. */
+  allHealth(): SensorHealth[] {
+    return [...this.sensors.keys()].map((id) => this.healthOf(id)!).filter(Boolean);
+  }
+
+  private record(sensorId: string, ok: boolean, latencyMs: number, count: number, nowIso: string): void {
+    const h = this.health.get(sensorId);
+    if (!h) return;
+    h.lastLatencyMs = latencyMs;
+    h.recent.push(ok);
+    if (h.recent.length > WINDOW) h.recent.shift();
+    if (ok) {
+      h.consecutiveFailures = 0;
+      h.lastOkAt = nowIso;
+      h.totalObservations += count;
+    } else {
+      h.consecutiveFailures += 1;
+      h.totalErrors += 1;
+    }
+  }
+
+  /**
+   * Run one sensor's observe cycle. Isolates failure: a throwing sensor is
+   * recorded as unhealthy and returns ok:false, but never takes down the
+   * registry or other sensors. Threads the sensor's cursor across cycles.
+   */
+  async runOnce(sensorId: string, ctx: Omit<ObserveContext, 'cursor' | 'config'> & { config?: ObserveContext['config'] }): Promise<RunCycleResult> {
+    const sensor = this.sensors.get(sensorId);
+    if (!sensor) return { sensorId, observations: [], ok: false, error: 'not registered' };
+    const startMs = ctx.now ? new Date(ctx.now).getTime() : Date.now();
+    const fullCtx: ObserveContext = {
+      observerId: ctx.observerId,
+      cursor: this.cursors.get(sensorId),
+      config: ctx.config ?? {},
+      now: ctx.now,
+    };
+    try {
+      const result = await sensor.observe(fullCtx);
+      const latency = (ctx.now ? new Date(ctx.now).getTime() : Date.now()) - startMs;
+      if (result.cursor !== undefined) this.cursors.set(sensorId, result.cursor);
+      this.record(sensorId, true, Math.max(0, latency), result.observations.length, ctx.now ?? new Date().toISOString());
+      return { sensorId, observations: result.observations, ok: true, cursor: result.cursor };
+    } catch (err) {
+      const latency = Date.now() - startMs;
+      this.record(sensorId, false, Math.max(0, latency), 0, ctx.now ?? new Date().toISOString());
+      return { sensorId, observations: [], ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Run every registered sensor once, in isolation. Returns each result; a
+   * failing sensor does not stop the others. This is how an Eye takes a full
+   * perception pass.
+   */
+  async runAll(ctx: Omit<ObserveContext, 'cursor' | 'config'> & { config?: ObserveContext['config'] }): Promise<RunCycleResult[]> {
+    const ids = [...this.sensors.keys()];
+    return Promise.all(ids.map((id) => this.runOnce(id, ctx)));
+  }
+}

--- a/src/lib/eyes/sensors/filesystem-sensor.ts
+++ b/src/lib/eyes/sensors/filesystem-sensor.ts
@@ -1,0 +1,150 @@
+/**
+ * Filesystem sensor - a reference Eye.
+ *
+ * Watches a directory and emits an Observation for each file that is new or
+ * changed since the last cycle (diffed against the sensor's cursor). It is a
+ * pure perceiver: it reads the directory, reports what changed, and stops. It
+ * never writes, deletes, or acts on anything it sees.
+ *
+ * The directory read is injectable (readDir) so the sensor is fully testable
+ * with a fake filesystem; the default reads the real fs via node:fs/promises.
+ */
+
+import { stat, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createObservation } from '../observation';
+import { sha256Hex } from '../observation';
+import type {
+  Sensor,
+  SensorManifest,
+  SensorHealth,
+  SensorHealthSnapshot,
+  ObserveContext,
+  ObserveResult,
+} from '../types';
+
+export interface DirEntry {
+  path: string;
+  size: number;
+  mtimeMs: number;
+}
+
+export interface FilesystemSensorOptions {
+  /** Directory to watch. */
+  watchPath: string;
+  /** Injectable read for tests; defaults to a real recursive-ish listing. */
+  readDir?: (watchPath: string) => Promise<DirEntry[]>;
+  /** Max files to report per cycle (bounded blast radius). */
+  maxPerCycle?: number;
+}
+
+async function defaultReadDir(watchPath: string): Promise<DirEntry[]> {
+  const names = await readdir(watchPath);
+  const out: DirEntry[] = [];
+  for (const name of names) {
+    try {
+      const p = join(watchPath, name);
+      const s = await stat(p);
+      if (s.isFile()) out.push({ path: p, size: s.size, mtimeMs: s.mtimeMs });
+    } catch {
+      // a file vanished mid-listing - skip, do not fail the whole cycle
+    }
+  }
+  return out;
+}
+
+function entryHash(e: DirEntry): string {
+  return sha256Hex(`${e.size}:${e.mtimeMs}`);
+}
+
+export function createFilesystemSensor(opts: FilesystemSensorOptions): Sensor {
+  const readDir = opts.readDir ?? defaultReadDir;
+  const maxPerCycle = opts.maxPerCycle ?? 200;
+
+  const manifest: SensorManifest = {
+    sensorId: `filesystem:${opts.watchPath}`,
+    version: '1.0.0',
+    description: `Observes new/changed files in ${opts.watchPath}`,
+    strategy: 'poll',
+    pollIntervalMs: 30_000,
+    produces: ['fs.change'],
+    requiredConfig: [],
+    riskTier: 'passive',
+  };
+
+  // Self-reported health (the registry keeps the authoritative organ view).
+  let totalObservations = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+  let lastOkAt: string | null = null;
+  let lastLatencyMs = 0;
+
+  function snapshot(): SensorHealthSnapshot {
+    return {
+      status: consecutiveFailures >= 5 ? 'failing' : consecutiveFailures >= 2 ? 'degraded' : 'healthy',
+      latencyMs: lastLatencyMs,
+      errorRate: 0,
+      lastOkAt,
+      consecutiveFailures,
+    };
+  }
+
+  return {
+    manifest,
+    async observe(ctx: ObserveContext): Promise<ObserveResult> {
+      const start = ctx.now ? new Date(ctx.now).getTime() : Date.now();
+      let prev: Record<string, string> = {};
+      if (ctx.cursor) {
+        try {
+          prev = JSON.parse(ctx.cursor);
+        } catch {
+          prev = {};
+        }
+      }
+      let entries: DirEntry[];
+      try {
+        entries = await readDir(opts.watchPath);
+      } catch (err) {
+        totalErrors++;
+        consecutiveFailures++;
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+
+      const next: Record<string, string> = {};
+      const observations = [];
+      for (const e of entries) {
+        const h = entryHash(e);
+        next[e.path] = h;
+        const before = prev[e.path];
+        if (before === h) continue; // unchanged
+        if (observations.length >= maxPerCycle) continue; // bounded; unchanged files still tracked in cursor
+        observations.push(
+          createObservation(
+            {
+              sensor: manifest.sensorId,
+              kind: 'fs.change',
+              subjectKey: e.path,
+              payload: { path: e.path, size: e.size, mtimeMs: e.mtimeMs, change: before ? 'modified' : 'added' },
+              confidence: 1,
+              provenance: { method: 'filesystem', endpoint: opts.watchPath },
+              evidence: [{ kind: 'snapshot', uri: e.path }],
+              observedAt: new Date(e.mtimeMs).toISOString(),
+              health: snapshot(),
+            },
+            { observerId: ctx.observerId, now: ctx.now },
+          ),
+        );
+      }
+
+      lastLatencyMs = Math.max(0, (ctx.now ? new Date(ctx.now).getTime() : Date.now()) - start);
+      lastOkAt = ctx.now ?? new Date().toISOString();
+      consecutiveFailures = 0;
+      totalObservations += observations.length;
+      return { observations, cursor: JSON.stringify(next) };
+    },
+    health(): SensorHealth {
+      const snap = snapshot();
+      return { sensorId: manifest.sensorId, ...snap, totalObservations, totalErrors };
+    },
+  };
+}

--- a/src/lib/eyes/types.ts
+++ b/src/lib/eyes/types.ts
@@ -1,0 +1,147 @@
+/**
+ * Eyes - the perception organ. Types + contracts.
+ *
+ * The Eyes have exactly ONE responsibility: observe. They perceive the outside
+ * world and emit structured Observations. They do NOT think, do NOT decide, and
+ * do NOT execute. That boundary is enforced by construction here: a Sensor's
+ * only output is an Observation[]; there is no action, write, or decision
+ * surface anywhere in these interfaces. If a future change gives a Sensor a way
+ * to act, the organ boundary is broken.
+ *
+ * Observations are consumed downstream by the Brain (reasoning), the Spine
+ * (coordination), and Memory - but the Eyes never tell them what is TRUE. They
+ * report what was seen, with enough provenance and evidence that consumers can
+ * reconcile multiple independent observations of the same subject later.
+ *
+ * ZAO's own vocabulary. No external protocol/branding coupling.
+ */
+
+/** A pointer to a supporting artifact (raw response, screenshot, OCR image, log slice). */
+export interface EvidenceRef {
+  /** What the artifact is. */
+  kind: 'raw' | 'screenshot' | 'image' | 'document' | 'log' | 'snapshot' | 'link';
+  /** Where it lives (file path, url, storage key). */
+  uri: string;
+  /** Content hash of the artifact, when available. */
+  sha256?: string;
+  mediaType?: string;
+  description?: string;
+}
+
+export type SensorStatus = 'healthy' | 'degraded' | 'failing' | 'stopped';
+
+/** A snapshot of a sensor's health at the moment it captured an observation. */
+export interface SensorHealthSnapshot {
+  status: SensorStatus;
+  /** Time the observe() call took, ms. */
+  latencyMs: number;
+  /** Rolling error rate 0..1 over the sensor's recent window. */
+  errorRate: number;
+  /** ISO time of the sensor's last successful observe. */
+  lastOkAt: string | null;
+  /** Consecutive failures before this capture. */
+  consecutiveFailures: number;
+}
+
+/**
+ * A single structured observation. Every field Brandon required is here:
+ * source (sensor), timestamp (capturedAt/observedAt), confidence, provenance,
+ * hashes (contentHash + evidence sha256s), evidence, supporting artifacts, and
+ * health metadata. Plus subjectKey so multiple Eyes observing the SAME thing
+ * can be grouped for later consensus - without any Eye deciding what is true.
+ */
+export interface Observation {
+  schemaVersion: 'zao.observation.v1';
+  /** Unique id for THIS observation. */
+  observationId: string;
+  /** The sensor that produced it (the source). */
+  sensor: string;
+  /** The Eye instance/process that ran the sensor (for multi-eye reconciliation). */
+  observerId: string;
+  /** What kind of thing was seen, e.g. 'github.pr', 'fs.change', 'chain.tx', 'market.price', 'log.error'. */
+  kind: string;
+  /**
+   * A STABLE key for the observed subject/event. Two Eyes seeing the same PR
+   * emit the same subjectKey with (likely) the same contentHash - which is what
+   * lets a downstream consumer reconcile them. The Eyes do not reconcile.
+   */
+  subjectKey: string;
+  /** When the observed event actually happened, if known. */
+  observedAt: string | null;
+  /** When the sensor captured it (always set). */
+  capturedAt: string;
+  /** How sure the sensor is about the observation, 0..1. Not a truth claim - a self-report. */
+  confidence: number;
+  /** How it was obtained. */
+  provenance: {
+    method: 'poll' | 'subscribe' | 'scrape' | 'api' | 'ocr' | 'vision' | 'filesystem' | 'search';
+    endpoint?: string;
+    query?: string;
+  };
+  /** sha256 of the canonical payload - dedup, tamper-evidence, and consensus grouping. */
+  contentHash: string;
+  /** The structured observation data. Consumer-defined shape per kind. */
+  payload: unknown;
+  /** Supporting artifacts backing the observation. */
+  evidence: EvidenceRef[];
+  /** The sensor's health at capture time. */
+  health: SensorHealthSnapshot;
+}
+
+/** Declarative description of a sensor - the manifest the registry reads. */
+export interface SensorManifest {
+  sensorId: string;
+  version: string;
+  /** Human description of what it observes. */
+  description: string;
+  /** How it acquires observations. */
+  strategy: 'poll' | 'subscribe' | 'on_demand';
+  /** For poll strategy, how often. */
+  pollIntervalMs?: number;
+  /** The observation kinds it can emit. */
+  produces: string[];
+  /** Env/config keys it needs to function. */
+  requiredConfig: string[];
+  /**
+   * Eyes are ALWAYS passive. This is fixed at the type level as a reminder that
+   * a sensor may only read. There is no other risk tier for an Eye.
+   */
+  riskTier: 'passive';
+}
+
+/** Live health of a sensor (richer than the per-observation snapshot). */
+export interface SensorHealth extends SensorHealthSnapshot {
+  sensorId: string;
+  totalObservations: number;
+  totalErrors: number;
+}
+
+/** Context handed to a sensor for one observe cycle. Read-only inputs only. */
+export interface ObserveContext {
+  observerId: string;
+  /** Opaque cursor from the sensor's previous run (for incremental polling). */
+  cursor?: string;
+  /** Read-only config values the sensor declared it needs. */
+  config: Readonly<Record<string, string | undefined>>;
+  /** ISO 'now' for deterministic testing. */
+  now?: string;
+}
+
+export interface ObserveResult {
+  observations: Observation[];
+  /** New cursor to hand back next cycle. */
+  cursor?: string;
+}
+
+/**
+ * A Sensor is text/read-in, Observation-out. Note there is NO method that acts,
+ * writes, or decides - observe() returns observations and health() reports
+ * state. That is the entire surface. This is the organ boundary in code.
+ */
+export interface Sensor {
+  readonly manifest: SensorManifest;
+  /** Perceive. Read-only. Returns structured observations + a cursor. */
+  observe(ctx: ObserveContext): Promise<ObserveResult>;
+  /** Report health. Does not perceive or act. */
+  health(): SensorHealth;
+}


### PR DESCRIPTION
## Summary
The next organ: Eyes. Evolve the organism deeper by completing it one biological system at a time. Eyes is pure perception - it observes the outside world and emits standardized Observation objects. It does NOT think, decide, or execute.

The observe-only boundary is STRUCTURAL, not a comment: a Sensor's only output is Observation[]; there is no action, write, or decision surface anywhere in the interfaces. If a future change gives a sensor a way to act, the organ boundary is broken.

## What ships (code, src/lib/eyes/)
- The Observation contract (zao.observation.v1): source, timestamps, confidence, provenance, contentHash, evidence, health metadata.
- Content-hashing so multiple Eyes observing the same subject hash identically (hash over WHAT was seen, not capture metadata) -> enables downstream consensus without any Eye deciding truth. clusterForConsensus groups matching reports; it never picks a winner.
- Hot-swappable SensorRegistry: manifest validation (riskTier must be 'passive'), rolling per-sensor health (healthy/degraded/failing), cursor threading, and per-sensor failure isolation.
- A reference filesystem sensor (injectable fs, cursor-diffed change detection).

## What ships (design, doc 2062)
Full Eyes spec + a roadmap for the remaining organs - Ears, Hands, Nose, Skin, Immune System, Memory, Nervous System - each with purpose, responsibilities, boundaries, inputs, outputs, interfaces, internal components, health model, failure modes, recovery strategy, test strategy, and future evolution. Plus the whole-organism diagram.

## Verification
- Typecheck clean on all eyes files.
- Comprehensive tests (hash stability across independent Eyes, tamper detection, consensus clustering, registry hot-swap, failure isolation, status escalation, cursor-diffed sensor). Run on CI - local src/lib vitest is blocked by a rolldown native-binding issue on this Mac (same as the Heart recovery suite).

ZAO's own vocabulary; no external protocol/branding coupling.