### PR TITLE
feat(ears): the Ears organ - event listeners on the shared Observation contract

### DIFF
--- a/src/lib/ears/__tests__/ears.test.ts
+++ b/src/lib/ears/__tests__/ears.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ListenerRegistry,
+  validateListenerManifest,
+  createWebhookListener,
+  type Listener,
+  type EventEnvelope,
+} from '../index';
+import { verifyObservation, clusterForConsensus } from '@/lib/eyes';
+
+const NOW = '2026-07-24T00:00:00.000Z';
+const CTX = { observerId: 'ear-1', now: NOW };
+
+function ghWebhook(): Listener {
+  return createWebhookListener({
+    listenerId: 'github-webhook',
+    produces: ['github.pr.event'],
+    extract: (raw: any) => {
+      if (!raw?.pull_request) return [];
+      return [{ kind: 'github.pr.event', subjectKey: `pr:${raw.pull_request.number}`, payload: { action: raw.action, title: raw.pull_request.title }, confidence: 0.98 }];
+    },
+  });
+}
+function evt(raw: unknown, deliveryId?: string): EventEnvelope {
+  return { source: 'github', receivedAt: NOW, raw, deliveryId };
+}
+
+describe('validateListenerManifest', () => {
+  it('rejects a non-passive listener - Ears must be receive-only', () => {
+    expect(() => validateListenerManifest({ listenerId: 'x', version: '1', description: '', transport: 'webhook', produces: ['k'], requiredConfig: [], riskTier: 'active' as never })).toThrow(/passive/);
+  });
+  it('rejects a bad transport', () => {
+    expect(() => validateListenerManifest({ listenerId: 'x', version: '1', description: '', transport: 'carrier-pigeon' as never, produces: ['k'], requiredConfig: [], riskTier: 'passive' })).toThrow(/transport/);
+  });
+});
+
+describe('webhook listener normalizes to the shared Observation contract', () => {
+  it('turns a PR webhook into a valid Observation', () => {
+    const l = ghWebhook();
+    const obs = l.onEvent(evt({ action: 'opened', pull_request: { number: 42, title: 'Add eyes' } }), CTX);
+    expect(obs).toHaveLength(1);
+    expect(obs[0].kind).toBe('github.pr.event');
+    expect(obs[0].subjectKey).toBe('pr:42');
+    expect(obs[0].provenance.method).toBe('subscribe');
+    expect(verifyObservation(obs[0])).toBe(true); // it IS a real Observation - Eyes/Ears interchangeable
+  });
+  it('emits nothing for an irrelevant payload', () => {
+    expect(ghWebhook().onEvent(evt({ ping: true }), CTX)).toHaveLength(0);
+  });
+  it('is passive by manifest', () => {
+    expect(ghWebhook().manifest.riskTier).toBe('passive');
+  });
+});
+
+describe('ListenerRegistry - dedup, backpressure, isolation', () => {
+  it('registers, lists, refuses duplicate, hot-swaps', () => {
+    const r = new ListenerRegistry();
+    r.register(ghWebhook());
+    expect(r.list().map((m) => m.listenerId)).toEqual(['github-webhook']);
+    expect(() => r.register(ghWebhook())).toThrow(/already registered/);
+    r.replace(createWebhookListener({ listenerId: 'github-webhook', produces: ['github.issue.event'], extract: () => [] }));
+    expect(r.get('github-webhook')?.manifest.produces).toEqual(['github.issue.event']);
+  });
+
+  it('ingests an event and returns the fresh observation', () => {
+    const r = new ListenerRegistry();
+    r.register(ghWebhook());
+    const res = r.ingest('github-webhook', evt({ action: 'opened', pull_request: { number: 1, title: 't' } }), CTX);
+    expect(res.ok).toBe(true);
+    expect(res.observations).toHaveLength(1);
+    expect(r.healthOf('github-webhook')?.connection).toBe('connected');
+  });
+
+  it('DEDUPS at-least-once redelivery by delivery id', () => {
+    const r = new ListenerRegistry();
+    r.register(ghWebhook());
+    const e = evt({ action: 'opened', pull_request: { number: 5, title: 't' } }, 'delivery-abc');
+    const first = r.ingest('github-webhook', e, CTX);
+    const second = r.ingest('github-webhook', e, CTX); // same delivery id
+    expect(first.observations).toHaveLength(1);
+    expect(second.observations).toHaveLength(0);
+    expect(second.deduped).toBe(1);
+  });
+
+  it('DEDUPS redelivery with a NEW delivery id by contentHash', () => {
+    const r = new ListenerRegistry();
+    r.register(ghWebhook());
+    const raw = { action: 'opened', pull_request: { number: 9, title: 't' } };
+    const first = r.ingest('github-webhook', evt(raw, 'd1'), CTX);
+    const second = r.ingest('github-webhook', evt(raw, 'd2'), CTX); // different delivery, same content
+    expect(first.observations).toHaveLength(1);
+    expect(second.observations).toHaveLength(0); // caught by contentHash
+    expect(second.deduped).toBe(1);
+  });
+
+  it('backpressure: replay buffer is bounded (drop-oldest)', () => {
+    const r = new ListenerRegistry({ replayBufferSize: 3 });
+    r.register(ghWebhook());
+    for (let i = 0; i < 6; i++) r.ingest('github-webhook', evt({ action: 'opened', pull_request: { number: i, title: 't' } }), CTX);
+    expect(r.replayBuffer().length).toBe(3); // capped
+    expect(r.healthOf('github-webhook')?.lag).toBe(3);
+  });
+
+  it('isolates a throwing listener - records error, never throws out', () => {
+    const r = new ListenerRegistry();
+    const boom = createWebhookListener({ listenerId: 'boom', produces: ['k'], extract: () => { throw new Error('bad payload'); } });
+    r.register(boom);
+    r.register(ghWebhook());
+    const bad = r.ingest('boom', evt({}), CTX);
+    const good = r.ingest('github-webhook', evt({ action: 'opened', pull_request: { number: 1, title: 't' } }), CTX);
+    expect(bad.ok).toBe(false);
+    expect(bad.error).toContain('bad payload');
+    expect(good.ok).toBe(true); // sibling unaffected
+    expect(r.healthOf('boom')?.totalErrors).toBe(1);
+  });
+
+  it('tracks reconnects', () => {
+    const r = new ListenerRegistry();
+    r.register(ghWebhook());
+    r.markDropped('github-webhook');
+    expect(r.healthOf('github-webhook')?.connection).toBe('dropped');
+    r.markReconnect('github-webhook');
+    expect(r.healthOf('github-webhook')?.connection).toBe('connected');
+    expect(r.healthOf('github-webhook')?.reconnects).toBe(1);
+  });
+});
+
+describe('Ears + Eyes interoperate', () => {
+  it('an Ear observation clusters with an Eye observation of the same subject', () => {
+    // Ear hears a PR event; an Eye (elsewhere) saw the same PR with the same payload.
+    const l = ghWebhook();
+    const earObs = l.onEvent(evt({ action: 'opened', pull_request: { number: 7, title: 'same' } }), { observerId: 'ear-1', now: NOW });
+    // Build an equivalent Eye-style observation via the same kind/subject/payload:
+    const eyeObs = { ...earObs[0], observerId: 'eye-9', sensor: 'github-poller' };
+    const clusters = clusterForConsensus([earObs[0], eyeObs as any]);
+    // Same subject + payload -> one shared contentHash cluster with two observers.
+    expect(clusters['pr:7'][0].observerIds.sort()).toEqual(['ear-1', 'eye-9']);
+  });
+});

--- a/src/lib/ears/index.ts
+++ b/src/lib/ears/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Ears - the event-listening organ. Public API.
+ *
+ * One responsibility: receive pushed events and normalize them into the shared
+ * Observation contract (defined by Eyes, reused here so Ears and Eyes are
+ * interchangeable to any consumer). Ears do not poll, act, or decide. The
+ * registry handles push-specific concerns: dedup of at-least-once delivery,
+ * backpressure via a bounded replay buffer, and connection-state health.
+ */
+
+export type {
+  Listener,
+  ListenerManifest,
+  ListenerHealth,
+  ListenerConnState,
+  EventEnvelope,
+  EarContext,
+} from './types';
+
+export {
+  ListenerRegistry,
+  validateListenerManifest,
+  ListenerManifestError,
+} from './registry';
+export type { IngestResult, ListenerRegistryOptions } from './registry';
+
+export { createWebhookListener } from './listeners/webhook-listener';
+export type { WebhookListenerOptions, ExtractedEvent } from './listeners/webhook-listener';

--- a/src/lib/ears/listeners/webhook-listener.ts
+++ b/src/lib/ears/listeners/webhook-listener.ts
@@ -1,0 +1,105 @@
+/**
+ * Webhook listener - a reference Ear.
+ *
+ * Normalizes a generic inbound webhook payload into Observations. It is a pure
+ * normalizer: it reads the raw event and reports what arrived. It never acts on
+ * it. The field extraction is injectable (extract) so it adapts to any provider
+ * without new code, and stays fully testable.
+ */
+
+import { createObservation } from '@/lib/eyes';
+import type { Observation, SensorHealthSnapshot } from '@/lib/eyes';
+import type { Listener, ListenerManifest, ListenerHealth, EventEnvelope, EarContext } from '../types';
+
+/** What a provider-specific extractor pulls out of a raw webhook body. */
+export interface ExtractedEvent {
+  /** Observation kind, e.g. 'github.pr.event'. */
+  kind: string;
+  /** Stable key for the subject (so this event clusters with Eye observations of the same thing). */
+  subjectKey: string;
+  /** The normalized structured payload. */
+  payload: unknown;
+  /** When the event actually happened, if the payload carries it. */
+  observedAt?: string | null;
+  /** 0..1 self-report. Webhooks from a trusted provider are typically high. */
+  confidence?: number;
+}
+
+export interface WebhookListenerOptions {
+  listenerId: string;
+  /** Observation kinds this webhook can produce (for the manifest). */
+  produces: string[];
+  /**
+   * Turn one raw webhook body into zero or more normalized events. Return []
+   * for an irrelevant/ignored payload. Pure - no side effects.
+   */
+  extract: (raw: unknown) => ExtractedEvent[];
+  requiredConfig?: string[];
+}
+
+export function createWebhookListener(opts: WebhookListenerOptions): Listener {
+  const manifest: ListenerManifest = {
+    listenerId: opts.listenerId,
+    version: '1.0.0',
+    description: `Webhook listener for ${opts.produces.join(', ')}`,
+    transport: 'webhook',
+    produces: opts.produces,
+    requiredConfig: opts.requiredConfig ?? [],
+    riskTier: 'passive',
+  };
+
+  let totalReceived = 0;
+  let totalObservations = 0;
+  let totalErrors = 0;
+  let lastEventAt: string | null = null;
+
+  function snapshot(): SensorHealthSnapshot {
+    return { status: 'healthy', latencyMs: 0, errorRate: 0, lastOkAt: lastEventAt, consecutiveFailures: 0 };
+  }
+
+  return {
+    manifest,
+    onEvent(event: EventEnvelope, ctx: EarContext): Observation[] {
+      totalReceived += 1;
+      lastEventAt = event.receivedAt;
+      let extracted: ExtractedEvent[];
+      try {
+        extracted = opts.extract(event.raw) ?? [];
+      } catch (err) {
+        totalErrors += 1;
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+      const obs = extracted.map((e) =>
+        createObservation(
+          {
+            sensor: manifest.listenerId,
+            kind: e.kind,
+            subjectKey: e.subjectKey,
+            payload: e.payload,
+            confidence: e.confidence ?? 0.95,
+            provenance: { method: 'subscribe', endpoint: event.source },
+            evidence: event.deliveryId ? [{ kind: 'raw', uri: `delivery:${event.deliveryId}` }] : [],
+            observedAt: e.observedAt ?? event.receivedAt,
+            health: snapshot(),
+          },
+          { observerId: ctx.observerId, now: ctx.now },
+        ),
+      );
+      totalObservations += obs.length;
+      return obs;
+    },
+    health(): ListenerHealth {
+      return {
+        listenerId: manifest.listenerId,
+        connection: 'connected',
+        lag: 0,
+        reconnects: 0,
+        totalReceived,
+        totalDeduped: 0,
+        totalObservations,
+        totalErrors,
+        lastEventAt,
+      };
+    },
+  };
+}

--- a/src/lib/ears/registry.ts
+++ b/src/lib/ears/registry.ts
@@ -1,0 +1,208 @@
+/**
+ * ListenerRegistry - the Ears plug board.
+ *
+ * Mirrors the Eyes SensorRegistry but for PUSH: instead of running observe
+ * cycles, it ingests raw events pushed to it, hands them to the right listener
+ * for normalization, and handles the two problems push has that poll does not:
+ *   - at-least-once delivery -> DEDUP (by delivery id and Observation contentHash)
+ *   - event storms -> BACKPRESSURE (a bounded replay buffer, drop-oldest)
+ * plus connection-state health for reconnect tracking.
+ *
+ * It moves Observations outward; it never decides what they mean.
+ */
+
+import type { Observation } from '@/lib/eyes';
+import type {
+  Listener,
+  ListenerManifest,
+  ListenerHealth,
+  ListenerConnState,
+  EventEnvelope,
+  EarContext,
+} from './types';
+
+export class ListenerManifestError extends Error {}
+
+export function validateListenerManifest(m: ListenerManifest): void {
+  if (!m.listenerId || !m.listenerId.trim()) throw new ListenerManifestError('listenerId required');
+  if (!m.version) throw new ListenerManifestError(`${m.listenerId}: version required`);
+  if (m.riskTier !== 'passive') throw new ListenerManifestError(`${m.listenerId}: Ears listeners must be riskTier 'passive'`);
+  if (!['webhook', 'websocket', 'sse', 'queue', 'poll-bridge'].includes(m.transport)) throw new ListenerManifestError(`${m.listenerId}: bad transport`);
+  if (!Array.isArray(m.produces) || m.produces.length === 0) throw new ListenerManifestError(`${m.listenerId}: produces[] required`);
+}
+
+interface HealthState {
+  connection: ListenerConnState;
+  reconnects: number;
+  totalReceived: number;
+  totalDeduped: number;
+  totalObservations: number;
+  totalErrors: number;
+  lastEventAt: string | null;
+}
+
+export interface IngestResult {
+  listenerId: string;
+  /** Newly-seen observations (dedup already applied). */
+  observations: Observation[];
+  /** How many were dropped as duplicates. */
+  deduped: number;
+  ok: boolean;
+  error?: string;
+}
+
+export interface ListenerRegistryOptions {
+  /** Max recent contentHashes/deliveryIds kept for dedup. */
+  dedupWindow?: number;
+  /** Max observations kept in the replay buffer (backpressure bound). */
+  replayBufferSize?: number;
+}
+
+export class ListenerRegistry {
+  private listeners = new Map<string, Listener>();
+  private health = new Map<string, HealthState>();
+  private seen = new Set<string>(); // dedup keys (deliveryId or contentHash), insertion-ordered
+  private replay: Observation[] = [];
+  private readonly dedupWindow: number;
+  private readonly replayBufferSize: number;
+
+  constructor(opts: ListenerRegistryOptions = {}) {
+    this.dedupWindow = opts.dedupWindow ?? 5000;
+    this.replayBufferSize = opts.replayBufferSize ?? 1000;
+  }
+
+  private fresh(): HealthState {
+    return { connection: 'idle', reconnects: 0, totalReceived: 0, totalDeduped: 0, totalObservations: 0, totalErrors: 0, lastEventAt: null };
+  }
+
+  register(listener: Listener): void {
+    validateListenerManifest(listener.manifest);
+    if (this.listeners.has(listener.manifest.listenerId)) {
+      throw new ListenerManifestError(`${listener.manifest.listenerId}: already registered (use replace to hot-swap)`);
+    }
+    this.listeners.set(listener.manifest.listenerId, listener);
+    this.health.set(listener.manifest.listenerId, this.fresh());
+  }
+
+  /** Hot-swap a live listener (or add it). Connection health resets. */
+  replace(listener: Listener): void {
+    validateListenerManifest(listener.manifest);
+    this.listeners.set(listener.manifest.listenerId, listener);
+    this.health.set(listener.manifest.listenerId, this.fresh());
+  }
+
+  unregister(listenerId: string): boolean {
+    this.health.delete(listenerId);
+    return this.listeners.delete(listenerId);
+  }
+
+  get(listenerId: string): Listener | undefined {
+    return this.listeners.get(listenerId);
+  }
+
+  list(): ListenerManifest[] {
+    return [...this.listeners.values()].map((l) => l.manifest);
+  }
+
+  /** Record a transport reconnect (a listener calls this when it re-establishes). */
+  markReconnect(listenerId: string): void {
+    const h = this.health.get(listenerId);
+    if (h) {
+      h.reconnects += 1;
+      h.connection = 'connected';
+    }
+  }
+
+  /** Record a dropped transport connection. */
+  markDropped(listenerId: string): void {
+    const h = this.health.get(listenerId);
+    if (h) h.connection = 'dropped';
+  }
+
+  private remember(key: string): boolean {
+    // returns true if NEW, false if already seen
+    if (this.seen.has(key)) return false;
+    this.seen.add(key);
+    if (this.seen.size > this.dedupWindow) {
+      // drop oldest (insertion order)
+      const oldest = this.seen.values().next().value;
+      if (oldest !== undefined) this.seen.delete(oldest);
+    }
+    return true;
+  }
+
+  private buffer(obs: Observation): void {
+    this.replay.push(obs);
+    if (this.replay.length > this.replayBufferSize) this.replay.shift(); // backpressure: drop-oldest
+  }
+
+  /**
+   * Ingest one raw event: normalize via the listener, dedup (by deliveryId AND
+   * per-observation contentHash), buffer for replay, and return the newly-seen
+   * observations. Isolates failure - a throwing listener is recorded and returns
+   * ok:false, never taking down the registry.
+   */
+  ingest(listenerId: string, event: EventEnvelope, ctx: Omit<EarContext, 'config'> & { config?: EarContext['config'] }): IngestResult {
+    const listener = this.listeners.get(listenerId);
+    if (!listener) return { listenerId, observations: [], deduped: 0, ok: false, error: 'not registered' };
+    const h = this.health.get(listenerId)!;
+    h.totalReceived += 1;
+    h.lastEventAt = event.receivedAt;
+    h.connection = 'connected';
+
+    // Transport-level dedup by delivery id (before we even normalize).
+    if (event.deliveryId && !this.remember(`d:${listenerId}:${event.deliveryId}`)) {
+      h.totalDeduped += 1;
+      return { listenerId, observations: [], deduped: 1, ok: true };
+    }
+
+    let produced: Observation[];
+    try {
+      produced = listener.onEvent(event, { observerId: ctx.observerId, config: ctx.config ?? {}, now: ctx.now });
+    } catch (err) {
+      h.totalErrors += 1;
+      return { listenerId, observations: [], deduped: 0, ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    // Content-level dedup by contentHash (catches redelivery with a new delivery id).
+    const fresh: Observation[] = [];
+    let deduped = 0;
+    for (const o of produced) {
+      if (this.remember(`h:${o.contentHash}`)) {
+        fresh.push(o);
+        this.buffer(o);
+      } else {
+        deduped += 1;
+      }
+    }
+    h.totalObservations += fresh.length;
+    h.totalDeduped += deduped;
+    return { listenerId, observations: fresh, deduped, ok: true };
+  }
+
+  /** The replay buffer - recent observations, for a consumer that reconnected. */
+  replayBuffer(): readonly Observation[] {
+    return this.replay;
+  }
+
+  healthOf(listenerId: string): ListenerHealth | null {
+    const h = this.health.get(listenerId);
+    if (!h) return null;
+    // lag = how full the replay buffer is (a coarse backpressure signal).
+    return {
+      listenerId,
+      connection: h.connection,
+      lag: this.replay.length,
+      reconnects: h.reconnects,
+      totalReceived: h.totalReceived,
+      totalDeduped: h.totalDeduped,
+      totalObservations: h.totalObservations,
+      totalErrors: h.totalErrors,
+      lastEventAt: h.lastEventAt,
+    };
+  }
+
+  allHealth(): ListenerHealth[] {
+    return [...this.listeners.keys()].map((id) => this.healthOf(id)!).filter(Boolean);
+  }
+}

--- a/src/lib/ears/types.ts
+++ b/src/lib/ears/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Ears - the event-listening organ. Types + contracts.
+ *
+ * Ears are the push/subscribe twin of the Eyes. Where Eyes actively poll, Ears
+ * passively RECEIVE events that are pushed to them (webhooks, websockets, SSE,
+ * chain event subscriptions, chat streams, queues) and normalize each into the
+ * SAME Observation contract the Eyes produce - so any consumer (Brain, Spine,
+ * Memory) treats an Ear-heard event and an Eye-seen state identically.
+ *
+ * Boundary: Ears RECEIVE and NORMALIZE only. They do NOT poll (that is Eyes),
+ * do NOT act, and do NOT decide. A Listener's only output is Observation[].
+ * There is no action/write/decide surface in these interfaces - the organ
+ * boundary is structural, exactly as with Eyes.
+ */
+
+import type { Observation, SensorHealthSnapshot } from '@/lib/eyes';
+
+/** A raw inbound event as delivered by a transport, before normalization. */
+export interface EventEnvelope {
+  /** The source that pushed it (e.g. 'github-webhook', 'farcaster-stream'). */
+  source: string;
+  /** ISO time the transport received it. */
+  receivedAt: string;
+  /** The raw payload. Listener-defined shape per transport. */
+  raw: unknown;
+  /**
+   * The transport/provider's own delivery id, when present. Used for dedup of
+   * at-least-once delivery in addition to the Observation contentHash.
+   */
+  deliveryId?: string;
+}
+
+export type ListenerConnState = 'connected' | 'lagging' | 'dropped' | 'idle';
+
+/** Health of a listener - richer than the per-observation snapshot. */
+export interface ListenerHealth {
+  listenerId: string;
+  connection: ListenerConnState;
+  /** Buffered-but-undelivered depth (backpressure signal). */
+  lag: number;
+  reconnects: number;
+  totalReceived: number;
+  totalDeduped: number;
+  totalObservations: number;
+  totalErrors: number;
+  lastEventAt: string | null;
+}
+
+/** Declarative description of a listener - what the registry validates. */
+export interface ListenerManifest {
+  listenerId: string;
+  version: string;
+  description: string;
+  /** How events arrive. */
+  transport: 'webhook' | 'websocket' | 'sse' | 'queue' | 'poll-bridge';
+  /** Observation kinds it can emit (e.g. 'github.pr.event', 'chain.tx.event'). */
+  produces: string[];
+  requiredConfig: string[];
+  /** Ears are ALWAYS passive - receive-only, fixed at the type level. */
+  riskTier: 'passive';
+}
+
+/** Read-only context for normalizing one event. */
+export interface EarContext {
+  observerId: string;
+  config: Readonly<Record<string, string | undefined>>;
+  now?: string;
+}
+
+/**
+ * A Listener is raw-event-in, Observation-out. Note there is NO method that
+ * acts, writes, or decides - onEvent() normalizes and health() reports.
+ * subscribe/unsubscribe manage the transport connection only. That is the whole
+ * surface. This is the organ boundary in code.
+ */
+export interface Listener {
+  readonly manifest: ListenerManifest;
+  /** Normalize one raw inbound event into zero or more Observations. Read-only. */
+  onEvent(event: EventEnvelope, ctx: EarContext): Observation[];
+  /** Open the transport connection (no-op for pure webhook push). Optional. */
+  subscribe?(): Promise<void>;
+  /** Close the transport connection. Optional. */
+  unsubscribe?(): Promise<void>;
+  health(): ListenerHealth;
+}
+
+export type { Observation, SensorHealthSnapshot };


### PR DESCRIPTION
The second organ this cycle: Ears - the push/subscribe twin of Eyes. Where Eyes poll, Ears RECEIVE pushed events (webhooks, websockets, sse, queues, chain subscriptions, chat streams) and normalize each into the SAME Observation contract, so Ear-heard and Eye-seen are interchangeable to any consumer (Brain/Spine/Memory).

This proves the Observation contract generalizes beyond one organ - the whole point of doing Ears next.

- Structural observe-only boundary (Listener -> Observation[] only; no action surface).
- ListenerRegistry handles what push has and poll does not: DEDUP of at-least-once delivery (by delivery id AND contentHash) and BACKPRESSURE (bounded replay buffer), plus reconnect/connection health and per-listener failure isolation.
- Reference webhook listener with an injectable extractor.
- A test shows an Ear observation clusters for consensus with an Eye observation of the same subject - Eyes + Ears interoperate.

Design in doc 2062. Typecheck clean; tests on CI (local src/lib rolldown binding issue).