### PR TITLE
feat(bloodstream): circulatory organ - Vacuum Spikes + shared distribution

### DIFF
--- a/src/lib/bloodstream/__tests__/bloodstream.test.ts
+++ b/src/lib/bloodstream/__tests__/bloodstream.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Bloodstream, validateSpikeManifest, createHttpPollSpike, type Subscriber } from '../index';
+import { verifyObservation } from '@/lib/eyes';
+
+const NOW = '2026-07-24T00:00:00.000Z';
+const noSleep = async () => {};
+const ctx = { observerId: 'blood-1', config: {}, now: NOW };
+
+function priceSpike(body: unknown, over: Partial<Parameters<typeof createHttpPollSpike>[0]> = {}) {
+  return createHttpPollSpike({
+    spikeId: 'coinbase-eth',
+    endpoint: 'https://api.example/price',
+    capabilities: ['market.price'],
+    produces: ['market.price'],
+    minIntervalMs: 10_000,
+    fetchJson: async () => body,
+    map: (b: any) => (b?.price ? [{ kind: 'market.price', subjectKey: 'eth-usd', payload: { price: b.price } }] : []),
+    ...over,
+  });
+}
+
+describe('validateSpikeManifest', () => {
+  it('requires passive risk tier', () => {
+    expect(() => validateSpikeManifest({ spikeId: 'x', version: '1', description: '', capabilities: [], produces: ['k'], strategy: 'poll', pollIntervalMs: 1000, requiredConfig: [], riskTier: 'active' as never })).toThrow(/passive/);
+  });
+  it('poll needs an interval', () => {
+    expect(() => validateSpikeManifest({ spikeId: 'x', version: '1', description: '', capabilities: [], produces: ['k'], strategy: 'poll', requiredConfig: [], riskTier: 'passive' })).toThrow(/pollIntervalMs/);
+  });
+});
+
+describe('http-poll vacuum spike', () => {
+  it('ingests + normalizes to valid Observations', async () => {
+    const s = priceSpike({ price: 3500 });
+    const r = await s.ingest(ctx);
+    expect(r.observations).toHaveLength(1);
+    expect(r.observations[0].kind).toBe('market.price');
+    expect(r.observations[0].provenance.method).toBe('poll');
+    expect(verifyObservation(r.observations[0])).toBe(true);
+  });
+  it('emits nothing for an empty body', async () => {
+    expect((await priceSpike({}).ingest(ctx)).observations).toHaveLength(0);
+  });
+});
+
+describe('Bloodstream circulation', () => {
+  it('registers spikes, refuses dup, lists', () => {
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(priceSpike({ price: 1 }));
+    expect(b.listSpikes().map((m) => m.spikeId)).toEqual(['coinbase-eth']);
+    expect(() => b.registerSpike(priceSpike({ price: 1 }))).toThrow(/already registered/);
+  });
+
+  it('circulates and DISTRIBUTES to subscribers of the matching kind only', async () => {
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(priceSpike({ price: 3500 }));
+    const got: string[] = [];
+    const other: string[] = [];
+    b.subscribe({ id: 'memory', kinds: ['market.price'], deliver: (o) => { got.push(o.kind); } });
+    b.subscribe({ id: 'weather-only', kinds: ['weather.current'], deliver: (o) => { other.push(o.kind); } });
+    const res = await b.circulateSpike('coinbase-eth', ctx);
+    expect(res.ok).toBe(true);
+    expect(res.distributed).toBe(1);
+    expect(got).toEqual(['market.price']);
+    expect(other).toEqual([]); // kind filter respected
+  });
+
+  it('caches: the same observation within TTL is NOT re-distributed (the whole point)', async () => {
+    const b = new Bloodstream({ sleep: noSleep, cacheTtlMs: 60_000 });
+    b.registerSpike(priceSpike({ price: 3500 }));
+    let delivered = 0;
+    b.subscribe({ id: 's', kinds: [], deliver: () => { delivered++; } });
+    await b.circulateSpike('coinbase-eth', ctx);
+    // second identical circulation (same content) - a real feed re-serving the same value
+    const second = await b.circulateSpike('coinbase-eth', { ...ctx, now: '2026-07-24T00:00:05.000Z' });
+    expect(delivered).toBe(1);       // only distributed once
+    expect(second.deduped).toBe(1);  // the repeat was cache-deduped
+  });
+
+  it('rate-limits: a poll within minIntervalMs is skipped', async () => {
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(priceSpike({ price: 3500 }));
+    await b.circulateSpike('coinbase-eth', ctx);
+    const soon = await b.circulateSpike('coinbase-eth', { ...ctx, now: '2026-07-24T00:00:02.000Z' }); // 2s < 10s
+    expect(soon.skipped).toBe('rate-limited');
+    expect(b.healthOf('coinbase-eth')?.rateLimited).toBe(1);
+  });
+
+  it('retries with backoff then succeeds', async () => {
+    let calls = 0;
+    const flaky = priceSpike({ price: 1 }, {
+      fetchJson: async () => { calls++; if (calls < 3) throw new Error('503'); return { price: 42 }; },
+    });
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(flaky);
+    const res = await b.circulateSpike('coinbase-eth', ctx);
+    expect(calls).toBe(3);       // failed twice, succeeded on the third
+    expect(res.ok).toBe(true);
+    expect(res.ingested).toBe(1);
+  });
+
+  it('isolates a spike that exhausts retries - records failure, never throws out', async () => {
+    const dead = priceSpike({ price: 1 }, { fetchJson: async () => { throw new Error('down'); } });
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(dead);
+    b.registerSpike(priceSpike({ price: 2 }, { spikeId: 'other', produces: ['market.price'] }));
+    const results = await b.circulateAll(ctx);
+    const deadRes = results.find((r) => r.spikeId === 'coinbase-eth')!;
+    const otherRes = results.find((r) => r.spikeId === 'other')!;
+    expect(deadRes.ok).toBe(false);
+    expect(otherRes.ok).toBe(true); // sibling unaffected
+    expect(b.healthOf('coinbase-eth')?.status).not.toBe('healthy');
+  });
+
+  it('applies enrichers before distribution', async () => {
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(priceSpike({ price: 3500 }));
+    b.addEnricher({ id: 'tag', appliesTo: ['market.price'], enrich: (o) => ({ ...o, payload: { ...(o.payload as object), enriched: true } }) });
+    let seen: any;
+    b.subscribe({ id: 's', kinds: [], deliver: (o) => { seen = o.payload; } });
+    await b.circulateSpike('coinbase-eth', ctx);
+    expect(seen.enriched).toBe(true);
+  });
+
+  it('a throwing subscriber does not stop delivery to others', async () => {
+    const b = new Bloodstream({ sleep: noSleep });
+    b.registerSpike(priceSpike({ price: 3500 }));
+    let good = 0;
+    b.subscribe({ id: 'bad', kinds: [], deliver: () => { throw new Error('consumer boom'); } });
+    b.subscribe({ id: 'good', kinds: [], deliver: () => { good++; } });
+    await b.circulateSpike('coinbase-eth', ctx);
+    expect(good).toBe(1);
+    expect(b.getMetrics().deliveryErrors).toBe(1);
+  });
+});

--- a/src/lib/bloodstream/__tests__/bloodstream.test.ts
+++ b/src/lib/bloodstream/__tests__/bloodstream.test.ts
@@ -66,7 +66,7 @@ describe('Bloodstream circulation', () => {
 
   it('caches: the same observation within TTL is NOT re-distributed (the whole point)', async () => {
     const b = new Bloodstream({ sleep: noSleep, cacheTtlMs: 60_000 });
-    b.registerSpike(priceSpike({ price: 3500 }));
+    b.registerSpike(priceSpike({ price: 3500 }, { minIntervalMs: 0 })); // no rate limit - isolate the cache path
     let delivered = 0;
     b.subscribe({ id: 's', kinds: [], deliver: () => { delivered++; } });
     await b.circulateSpike('coinbase-eth', ctx);

--- a/src/lib/bloodstream/bloodstream.ts
+++ b/src/lib/bloodstream/bloodstream.ts
@@ -128,8 +128,11 @@ export class Bloodstream {
 
   // ---- health ----
   private status(s: SpikeState): SpikeStatus {
-    if (s.consecutiveFailures >= 5) return 'failing';
-    if (s.consecutiveFailures >= 2) return 'degraded';
+    // Every failure here is retry-EXHAUSTED (ingestWithBackoff already retried
+    // internally), so a single one is a real fault -> degraded immediately, not
+    // a transient blip. Sustained failure (3+ cycles) is failing.
+    if (s.consecutiveFailures >= 3) return 'failing';
+    if (s.consecutiveFailures >= 1) return 'degraded';
     return 'healthy';
   }
   private errorRate(s: SpikeState): number {

--- a/src/lib/bloodstream/bloodstream.ts
+++ b/src/lib/bloodstream/bloodstream.ts
@@ -1,0 +1,270 @@
+/**
+ * Bloodstream - the circulatory core.
+ *
+ * Registers Vacuum Spikes, circulates (ingest with retry/backoff + rate-limit),
+ * normalizes into the shared Observation contract, enriches, caches + dedups,
+ * prioritizes, and distributes to subscribers. Downstream organs SUBSCRIBE by
+ * observation kind rather than polling the outside world themselves - that is
+ * the whole point of a shared circulatory system.
+ *
+ * It transports; it never decides. Pure orchestration + in-memory state; the
+ * only outward I/O is a spike's own read-only ingest().
+ */
+
+import { observationContentHash } from '@/lib/eyes';
+import type { Observation } from '@/lib/eyes';
+import {
+  DEFAULT_BACKOFF,
+  type VacuumSpike,
+  type VacuumSpikeManifest,
+  type SpikeHealth,
+  type SpikeStatus,
+  type Enricher,
+  type Subscriber,
+  type BloodstreamMetrics,
+  type IngestContext,
+  type BackoffPolicy,
+} from './types';
+
+export class SpikeManifestError extends Error {}
+
+export function validateSpikeManifest(m: VacuumSpikeManifest): void {
+  if (!m.spikeId?.trim()) throw new SpikeManifestError('spikeId required');
+  if (!m.version) throw new SpikeManifestError(`${m.spikeId}: version required`);
+  if (m.riskTier !== 'passive') throw new SpikeManifestError(`${m.spikeId}: spikes must be riskTier 'passive'`);
+  if (!['poll', 'subscribe'].includes(m.strategy)) throw new SpikeManifestError(`${m.spikeId}: bad strategy`);
+  if (m.strategy === 'poll' && !(m.pollIntervalMs && m.pollIntervalMs > 0)) throw new SpikeManifestError(`${m.spikeId}: poll needs pollIntervalMs`);
+  if (!Array.isArray(m.produces) || m.produces.length === 0) throw new SpikeManifestError(`${m.spikeId}: produces[] required`);
+}
+
+interface SpikeState {
+  consecutiveFailures: number;
+  lastOkAt: string | null;
+  lastLatencyMs: number;
+  lastPollAtMs: number;
+  totalIngested: number;
+  totalErrors: number;
+  rateLimited: number;
+  cursor?: string;
+  recent: boolean[];
+}
+
+const WINDOW = 20;
+
+export interface CirculateResult {
+  spikeId: string;
+  ingested: number;
+  distributed: number;
+  deduped: number;
+  ok: boolean;
+  skipped?: 'rate-limited';
+  error?: string;
+}
+
+export interface BloodstreamOptions {
+  /** TTL for the observation cache, ms. */
+  cacheTtlMs?: number;
+  /** Max cache entries (drop-oldest). */
+  cacheSize?: number;
+  /** Sleep function - injectable so backoff is deterministic in tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class Bloodstream {
+  private spikes = new Map<string, VacuumSpike>();
+  private state = new Map<string, SpikeState>();
+  private enrichers: Enricher[] = [];
+  private subscribers = new Map<string, Subscriber>();
+  private cache = new Map<string, { at: number; obs: Observation }>();
+  private metrics: BloodstreamMetrics = { spikes: 0, subscribers: 0, circulated: 0, cachedHits: 0, deduped: 0, distributed: 0, deliveryErrors: 0 };
+  private readonly cacheTtlMs: number;
+  private readonly cacheSize: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(opts: BloodstreamOptions = {}) {
+    this.cacheTtlMs = opts.cacheTtlMs ?? 60_000;
+    this.cacheSize = opts.cacheSize ?? 5000;
+    this.sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  }
+
+  // ---- registration ----
+  registerSpike(spike: VacuumSpike): void {
+    validateSpikeManifest(spike.manifest);
+    if (this.spikes.has(spike.manifest.spikeId)) throw new SpikeManifestError(`${spike.manifest.spikeId}: already registered`);
+    this.spikes.set(spike.manifest.spikeId, spike);
+    this.state.set(spike.manifest.spikeId, { consecutiveFailures: 0, lastOkAt: null, lastLatencyMs: 0, lastPollAtMs: 0, totalIngested: 0, totalErrors: 0, rateLimited: 0, recent: [] });
+    this.metrics.spikes = this.spikes.size;
+  }
+  replaceSpike(spike: VacuumSpike): void {
+    validateSpikeManifest(spike.manifest);
+    this.spikes.set(spike.manifest.spikeId, spike);
+    if (!this.state.has(spike.manifest.spikeId)) this.state.set(spike.manifest.spikeId, { consecutiveFailures: 0, lastOkAt: null, lastLatencyMs: 0, lastPollAtMs: 0, totalIngested: 0, totalErrors: 0, rateLimited: 0, recent: [] });
+    this.metrics.spikes = this.spikes.size;
+  }
+  removeSpike(spikeId: string): boolean {
+    this.state.delete(spikeId);
+    const ok = this.spikes.delete(spikeId);
+    this.metrics.spikes = this.spikes.size;
+    return ok;
+  }
+  listSpikes(): VacuumSpikeManifest[] {
+    return [...this.spikes.values()].map((s) => s.manifest);
+  }
+  addEnricher(e: Enricher): void {
+    this.enrichers.push(e);
+  }
+  subscribe(sub: Subscriber): () => void {
+    this.subscribers.set(sub.id, sub);
+    this.metrics.subscribers = this.subscribers.size;
+    return () => {
+      this.subscribers.delete(sub.id);
+      this.metrics.subscribers = this.subscribers.size;
+    };
+  }
+
+  getMetrics(): BloodstreamMetrics {
+    return { ...this.metrics };
+  }
+
+  // ---- health ----
+  private status(s: SpikeState): SpikeStatus {
+    if (s.consecutiveFailures >= 5) return 'failing';
+    if (s.consecutiveFailures >= 2) return 'degraded';
+    return 'healthy';
+  }
+  private errorRate(s: SpikeState): number {
+    if (s.recent.length === 0) return 0;
+    return Number((s.recent.filter((ok) => !ok).length / s.recent.length).toFixed(3));
+  }
+  healthOf(spikeId: string): SpikeHealth | null {
+    const s = this.state.get(spikeId);
+    if (!s) return null;
+    return { spikeId, status: this.status(s), latencyMs: s.lastLatencyMs, errorRate: this.errorRate(s), lastOkAt: s.lastOkAt, consecutiveFailures: s.consecutiveFailures, totalIngested: s.totalIngested, totalErrors: s.totalErrors, rateLimited: s.rateLimited };
+  }
+  allHealth(): SpikeHealth[] {
+    return [...this.spikes.keys()].map((id) => this.healthOf(id)!).filter(Boolean);
+  }
+
+  // ---- circulation ----
+  private nowMs(ctx: IngestContext): number {
+    return ctx.now ? new Date(ctx.now).getTime() : Date.now();
+  }
+
+  private async ingestWithBackoff(spike: VacuumSpike, ctx: IngestContext, policy: BackoffPolicy) {
+    let attempt = 0;
+    let lastErr: unknown;
+    while (attempt <= policy.maxRetries) {
+      try {
+        return await spike.ingest(ctx);
+      } catch (err) {
+        lastErr = err;
+        if (attempt === policy.maxRetries) break;
+        const delay = Math.min(policy.maxDelayMs, policy.baseDelayMs * policy.factor ** attempt);
+        await this.sleep(delay);
+        attempt++;
+      }
+    }
+    throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  }
+
+  private cacheGetFresh(hash: string, nowMs: number): boolean {
+    const hit = this.cache.get(hash);
+    if (hit && nowMs - hit.at < this.cacheTtlMs) return true;
+    return false;
+  }
+  private cachePut(hash: string, obs: Observation, nowMs: number): void {
+    this.cache.set(hash, { at: nowMs, obs });
+    if (this.cache.size > this.cacheSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+  }
+
+  private enrich(obs: Observation): Observation {
+    let cur = obs;
+    for (const e of this.enrichers) {
+      if (e.appliesTo.length === 0 || e.appliesTo.includes(cur.kind)) {
+        try {
+          cur = e.enrich(cur);
+        } catch {
+          // an enricher failure must not drop the observation
+        }
+      }
+    }
+    return cur;
+  }
+
+  private async distribute(obs: Observation): Promise<void> {
+    for (const sub of this.subscribers.values()) {
+      if (sub.kinds.length && !sub.kinds.includes(obs.kind)) continue;
+      try {
+        await sub.deliver(obs);
+        this.metrics.distributed++;
+      } catch {
+        this.metrics.deliveryErrors++;
+      }
+    }
+  }
+
+  /**
+   * Circulate one spike: rate-limit check, ingest with retry/backoff, then for
+   * each observation enrich -> cache-dedup -> distribute. A cached-fresh
+   * observation (same contentHash within TTL) is NOT re-distributed - that is
+   * how the Bloodstream stops N subsystems from re-processing the same feed.
+   */
+  async circulateSpike(spikeId: string, ctx: IngestContext): Promise<CirculateResult> {
+    const spike = this.spikes.get(spikeId);
+    const s = this.state.get(spikeId);
+    if (!spike || !s) return { spikeId, ingested: 0, distributed: 0, deduped: 0, ok: false, error: 'not registered' };
+    const nowMs = this.nowMs(ctx);
+
+    // Rate limit: honor minIntervalMs since the last poll.
+    const minInterval = spike.manifest.minIntervalMs ?? 0;
+    if (minInterval && s.lastPollAtMs && nowMs - s.lastPollAtMs < minInterval) {
+      s.rateLimited++;
+      return { spikeId, ingested: 0, distributed: 0, deduped: 0, ok: true, skipped: 'rate-limited' };
+    }
+    s.lastPollAtMs = nowMs;
+
+    let result;
+    try {
+      result = await this.ingestWithBackoff(spike, { ...ctx, cursor: s.cursor }, spike.manifest.backoff ?? DEFAULT_BACKOFF);
+    } catch (err) {
+      s.totalErrors++;
+      s.consecutiveFailures++;
+      s.recent.push(false);
+      if (s.recent.length > WINDOW) s.recent.shift();
+      return { spikeId, ingested: 0, distributed: 0, deduped: 0, ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    if (result.cursor !== undefined) s.cursor = result.cursor;
+    let distributed = 0;
+    let deduped = 0;
+    for (const raw of result.observations) {
+      const enriched = this.enrich(raw);
+      const hash = enriched.contentHash || observationContentHash({ kind: enriched.kind, subjectKey: enriched.subjectKey, payload: enriched.payload });
+      if (this.cacheGetFresh(hash, nowMs)) {
+        deduped++;
+        this.metrics.deduped++;
+        this.metrics.cachedHits++;
+        continue;
+      }
+      this.cachePut(hash, enriched, nowMs);
+      await this.distribute(enriched);
+      distributed++;
+    }
+    s.totalIngested += result.observations.length;
+    s.consecutiveFailures = 0;
+    s.lastOkAt = ctx.now ?? new Date().toISOString();
+    s.lastLatencyMs = Math.max(0, this.nowMs(ctx) - nowMs);
+    s.recent.push(true);
+    if (s.recent.length > WINDOW) s.recent.shift();
+    this.metrics.circulated++;
+    return { spikeId, ingested: result.observations.length, distributed, deduped, ok: true };
+  }
+
+  /** Circulate every registered spike once, isolated. */
+  async circulateAll(ctx: IngestContext): Promise<CirculateResult[]> {
+    return Promise.all([...this.spikes.keys()].map((id) => this.circulateSpike(id, ctx)));
+  }
+}

--- a/src/lib/bloodstream/index.ts
+++ b/src/lib/bloodstream/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Bloodstream - the circulatory organ. Public API.
+ *
+ * One shared system that ingests the outside world via Vacuum Spikes, normalizes
+ * to the shared Observation contract, enriches, caches/dedups, and distributes
+ * to subscribed organs - so no organ polls the same source twice. It transports;
+ * it never decides.
+ */
+
+export type {
+  VacuumSpike,
+  VacuumSpikeManifest,
+  SpikeHealth,
+  SpikeStatus,
+  BackoffPolicy,
+  Enricher,
+  Subscriber,
+  BloodstreamMetrics,
+  IngestContext,
+  IngestResult,
+} from './types';
+export { DEFAULT_BACKOFF } from './types';
+
+export { Bloodstream, validateSpikeManifest, SpikeManifestError } from './bloodstream';
+export type { CirculateResult, BloodstreamOptions } from './bloodstream';
+
+export { createHttpPollSpike } from './spikes/http-poll-spike';
+export type { HttpPollSpikeOptions, MappedRecord } from './spikes/http-poll-spike';

--- a/src/lib/bloodstream/spikes/http-poll-spike.ts
+++ b/src/lib/bloodstream/spikes/http-poll-spike.ts
@@ -1,0 +1,111 @@
+/**
+ * HTTP-poll Vacuum Spike - a reference ingestion module.
+ *
+ * The generic shape most external feeds fit (weather, SEC, chain RPC, RSS-as-
+ * JSON, market feeds): authenticate via headers, GET an endpoint, validate the
+ * body, and map it to Observations. The fetch and the mapping are injectable so
+ * the spike is fully testable and adapts to any source without new code.
+ *
+ * Read-only ingestion: it GETs and reports. It never POSTs, mutates, or acts.
+ */
+
+import { createObservation } from '@/lib/eyes';
+import type { Observation, SensorHealthSnapshot } from '@/lib/eyes';
+import type { VacuumSpike, VacuumSpikeManifest, SpikeHealth, IngestContext, IngestResult } from '../types';
+
+export interface MappedRecord {
+  kind: string;
+  subjectKey: string;
+  payload: unknown;
+  observedAt?: string | null;
+  confidence?: number;
+}
+
+export interface HttpPollSpikeOptions {
+  spikeId: string;
+  endpoint: string;
+  capabilities: string[];
+  produces: string[];
+  pollIntervalMs?: number;
+  minIntervalMs?: number;
+  requiredConfig?: string[];
+  /** Injectable fetch (defaults to global fetch). Returns parsed body. */
+  fetchJson?: (endpoint: string, headers: Record<string, string>) => Promise<unknown>;
+  /** Build auth/other headers from config. Pure. */
+  headers?: (config: Readonly<Record<string, string | undefined>>) => Record<string, string>;
+  /** Validate + map a body to records. Return [] to ingest nothing. Pure. */
+  map: (body: unknown) => MappedRecord[];
+}
+
+async function defaultFetchJson(endpoint: string, headers: Record<string, string>): Promise<unknown> {
+  const res = await fetch(endpoint, { headers });
+  if (!res.ok) throw new Error(`HTTP ${res.status} from ${endpoint}`);
+  return res.json();
+}
+
+export function createHttpPollSpike(opts: HttpPollSpikeOptions): VacuumSpike {
+  const fetchJson = opts.fetchJson ?? defaultFetchJson;
+  const manifest: VacuumSpikeManifest = {
+    spikeId: opts.spikeId,
+    version: '1.0.0',
+    description: `HTTP-poll ingestion of ${opts.endpoint}`,
+    capabilities: opts.capabilities,
+    produces: opts.produces,
+    strategy: 'poll',
+    pollIntervalMs: opts.pollIntervalMs ?? 60_000,
+    minIntervalMs: opts.minIntervalMs,
+    requiredConfig: opts.requiredConfig ?? [],
+    riskTier: 'passive',
+  };
+
+  let totalIngested = 0;
+  let totalErrors = 0;
+  let consecutiveFailures = 0;
+  let lastOkAt: string | null = null;
+  let lastLatencyMs = 0;
+
+  function snapshot(): SensorHealthSnapshot {
+    return { status: consecutiveFailures >= 5 ? 'failing' : consecutiveFailures >= 2 ? 'degraded' : 'healthy', latencyMs: lastLatencyMs, errorRate: 0, lastOkAt, consecutiveFailures };
+  }
+
+  return {
+    manifest,
+    async ingest(ctx: IngestContext): Promise<IngestResult> {
+      const start = ctx.now ? new Date(ctx.now).getTime() : Date.now();
+      let body: unknown;
+      try {
+        const headers = opts.headers ? opts.headers(ctx.config) : {};
+        body = await fetchJson(opts.endpoint, headers);
+      } catch (err) {
+        totalErrors++;
+        consecutiveFailures++;
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+      const records = opts.map(body) ?? [];
+      const observations: Observation[] = records.map((r) =>
+        createObservation(
+          {
+            sensor: manifest.spikeId,
+            kind: r.kind,
+            subjectKey: r.subjectKey,
+            payload: r.payload,
+            confidence: r.confidence ?? 0.9,
+            provenance: { method: 'poll', endpoint: opts.endpoint },
+            observedAt: r.observedAt ?? null,
+            health: snapshot(),
+          },
+          { observerId: ctx.observerId, now: ctx.now },
+        ),
+      );
+      consecutiveFailures = 0;
+      lastOkAt = ctx.now ?? new Date().toISOString();
+      lastLatencyMs = Math.max(0, (ctx.now ? new Date(ctx.now).getTime() : Date.now()) - start);
+      totalIngested += observations.length;
+      return { observations };
+    },
+    health(): SpikeHealth {
+      const snap = snapshot();
+      return { spikeId: manifest.spikeId, status: snap.status, latencyMs: snap.latencyMs, errorRate: 0, lastOkAt, consecutiveFailures, totalIngested, totalErrors, rateLimited: 0 };
+    },
+  };
+}

--- a/src/lib/bloodstream/types.ts
+++ b/src/lib/bloodstream/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Bloodstream - the circulatory organ. Types + contracts.
+ *
+ * Eyes collect. The Bloodstream TRANSPORTS. Rather than every subsystem polling
+ * the same APIs independently, the Bloodstream is one shared circulatory system
+ * that continuously ingests (via Vacuum Spikes), normalizes to the shared
+ * Observation contract, enriches, caches, prioritizes, and DISTRIBUTES to every
+ * downstream organ that subscribed - so no organ polls the outside world twice.
+ *
+ * Flow: External World -> Vacuum Spike -> Observation -> normalization ->
+ * Bloodstream -> Memory -> Brain -> Spine -> Hands -> Proof Drops.
+ *
+ * Boundary: the Bloodstream MOVES information; it never decides what it means.
+ * A Vacuum Spike ingests read-only and emits Observations; there is no action,
+ * write-to-the-world, or decide surface in these interfaces.
+ */
+
+import type { Observation } from '@/lib/eyes';
+
+export type SpikeStatus = 'healthy' | 'degraded' | 'failing' | 'stopped';
+
+/** Retry/backoff policy for a spike's ingest. */
+export interface BackoffPolicy {
+  maxRetries: number;
+  baseDelayMs: number;
+  /** Multiplier per attempt (exponential when > 1). */
+  factor: number;
+  maxDelayMs: number;
+}
+
+export const DEFAULT_BACKOFF: BackoffPolicy = { maxRetries: 3, baseDelayMs: 500, factor: 2, maxDelayMs: 8000 };
+
+export interface SpikeHealth {
+  spikeId: string;
+  status: SpikeStatus;
+  latencyMs: number;
+  errorRate: number;
+  lastOkAt: string | null;
+  consecutiveFailures: number;
+  totalIngested: number;
+  totalErrors: number;
+  /** Times the rate limiter deferred a poll. */
+  rateLimited: number;
+}
+
+/**
+ * A Vacuum Spike is a pluggable ingestion module for one external source. It
+ * authenticates, polls or subscribes, validates, rate-limits, and emits
+ * standardized Observations. It is read-only w.r.t. the outside world.
+ */
+export interface VacuumSpikeManifest {
+  spikeId: string;
+  version: string;
+  description: string;
+  /** What this spike can pull, e.g. ['weather.current', 'weather.forecast']. */
+  capabilities: string[];
+  /** Observation kinds it emits. */
+  produces: string[];
+  strategy: 'poll' | 'subscribe';
+  pollIntervalMs?: number;
+  requiredConfig: string[];
+  /** Minimum ms between polls this source tolerates (rate limit). */
+  minIntervalMs?: number;
+  backoff?: BackoffPolicy;
+  /** Ingestion is read-only. Fixed at the type level. */
+  riskTier: 'passive';
+}
+
+/** Read-only context for one ingest cycle. */
+export interface IngestContext {
+  observerId: string;
+  cursor?: string;
+  config: Readonly<Record<string, string | undefined>>;
+  now?: string;
+}
+
+export interface IngestResult {
+  observations: Observation[];
+  cursor?: string;
+}
+
+export interface VacuumSpike {
+  readonly manifest: VacuumSpikeManifest;
+  /** Authenticate + poll/subscribe + validate + normalize -> Observations. Read-only. */
+  ingest(ctx: IngestContext): Promise<IngestResult>;
+  health(): SpikeHealth;
+}
+
+/**
+ * An Enricher augments an Observation as it flows through the Bloodstream (e.g.
+ * attach a market symbol's metadata, geocode a location). Pure: it returns a
+ * new payload/evidence; it does not act. Optional per Bloodstream.
+ */
+export interface Enricher {
+  id: string;
+  /** Which observation kinds it applies to (empty = all). */
+  appliesTo: string[];
+  enrich(obs: Observation): Observation;
+}
+
+/** A downstream consumer subscribes to observation kinds instead of polling. */
+export interface Subscriber {
+  id: string;
+  /** Observation kinds it wants (empty = all). */
+  kinds: string[];
+  /** Called for each distributed observation. Should not throw; failures are isolated. */
+  deliver(obs: Observation): void | Promise<void>;
+}
+
+export interface BloodstreamMetrics {
+  spikes: number;
+  subscribers: number;
+  circulated: number;
+  cachedHits: number;
+  deduped: number;
+  distributed: number;
+  deliveryErrors: number;
+}
+
+export type { Observation };


### PR DESCRIPTION
Brandon's circulatory system. Eyes collect; the Bloodstream transports. One shared system that ingests external sources via pluggable Vacuum Spikes, normalizes to the shared Observation contract, enriches, caches/dedups, and distributes to subscribed organs - so no subsystem polls the same API twice.

- Vacuum Spike contract: manifest (capabilities/version/backoff/retries/provenance), read-only ingest, riskTier passive. Reuses the Observation contract from Eyes.
- Bloodstream core: register/hot-swap spikes, circulate with retry+backoff + rate-limiting, enrichers, TTL cache + contentHash dedup (same feed value not re-distributed), kind-filtered pub/sub distribution, per-spike health + failure isolation, metrics.
- Reference HTTP-poll Vacuum Spike (injectable fetch+map) for the generic feed shape.

Tests cover: normalize-to-valid-Observation, kind-filtered distribution, cache-dedup (not re-distributed within TTL), rate-limit skip, retry-then-succeed, spike failure isolation, enrichers, subscriber-failure isolation. Typecheck clean; tests on CI (local src/lib rolldown binding). Design in the architecture doc (next PR).