### PR TITLE
feat(control-plane): operational nervous system - organ registry + discovery

### DIFF
--- a/src/lib/control-plane/__tests__/control-plane.test.ts
+++ b/src/lib/control-plane/__tests__/control-plane.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { ControlPlane, ControlPlaneError } from '../control-plane';
+import type { OrganRegistration, HealthReport } from '../types';
+
+const T0 = '2026-07-24T00:00:00.000Z';
+function at(offsetMs: number): string {
+  return new Date(new Date(T0).getTime() + offsetMs).toISOString();
+}
+function health(status: HealthReport['status'], m: Record<string, number> = {}): HealthReport {
+  return { status, metrics: m, reportedAt: T0 };
+}
+function organ(over: Partial<OrganRegistration> = {}): OrganRegistration {
+  return {
+    organId: 'eyes',
+    name: 'Eyes',
+    version: '1.0.0',
+    layer: 'core',
+    capabilities: [{ name: 'perceive.github', version: '1.0.0', maxConcurrency: 4 }],
+    dependencies: [],
+    endpoints: [{ name: 'observe', address: 'internal:eyes', protocol: 'internal' }],
+    secrets: [{ key: 'GITHUB_TOKEN', source: 'env' }],
+    health: health('healthy'),
+    ...over,
+  };
+}
+
+describe('ControlPlane registration', () => {
+  it('registers an organ and lists it with effective status', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ());
+    const list = cp.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].effectiveStatus).toBe('healthy');
+  });
+
+  it('rejects a bad layer', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    expect(() => cp.register(organ({ layer: 'nowhere' as never }))).toThrow(/layer/);
+  });
+
+  it('REJECTS a secret that is not a reference - the plane never holds values', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    expect(() => cp.register(organ({ secrets: [{ key: 'GITHUB_TOKEN', source: 'inline' as never }] }))).toThrow(/reference/);
+  });
+
+  it('only exposes secret REFERENCES, never values', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ());
+    const refs = cp.secretRefs('eyes');
+    expect(refs[0]).toEqual({ key: 'GITHUB_TOKEN', source: 'env' });
+    expect(JSON.stringify(refs)).not.toMatch(/value/i); // structurally impossible to carry a value
+  });
+});
+
+describe('heartbeat + staleness (liveness)', () => {
+  it('a heartbeat refreshes health', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ());
+    expect(cp.heartbeat('eyes', health('degraded', { errorRate: 0.3 }))).toBe(true);
+    expect(cp.get('eyes')?.health.status).toBe('degraded');
+  });
+
+  it('heartbeat on an unknown organ returns false', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    expect(cp.heartbeat('ghost', health('healthy'))).toBe(false);
+  });
+
+  it('an organ that stops heartbeating goes UNKNOWN after the TTL', () => {
+    let now = T0;
+    const cp = new ControlPlane({ livenessTtlMs: 90_000, now: () => now });
+    cp.register(organ());
+    now = at(120_000); // 2 min later, no heartbeat
+    expect(cp.list()[0].effectiveStatus).toBe('unknown');
+    const wentStale = cp.reapStale();
+    expect(wentStale).toEqual(['eyes']);
+  });
+});
+
+describe('capability registry + discovery', () => {
+  it('lists capabilities and their providers', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ({ organId: 'eyes', capabilities: [{ name: 'perceive.github', version: '1.0.0' }] }));
+    cp.register(organ({ organId: 'ears', name: 'Ears', capabilities: [{ name: 'perceive.github', version: '2.0.0' }], endpoints: [], secrets: [] }));
+    const caps = cp.capabilities();
+    const gh = caps.find((c) => c.name === 'perceive.github')!;
+    expect(gh.providers.map((p) => p.organId).sort()).toEqual(['ears', 'eyes']);
+  });
+
+  it('discover returns usable providers, healthy first, excludes failing/unknown', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ({ organId: 'eyes', health: health('degraded') }));
+    cp.register(organ({ organId: 'ears', name: 'Ears', health: health('healthy'), capabilities: [{ name: 'perceive.github', version: '1' }], endpoints: [], secrets: [] }));
+    cp.register(organ({ organId: 'dead', name: 'Dead', health: health('failing'), capabilities: [{ name: 'perceive.github', version: '1' }], endpoints: [], secrets: [] }));
+    const providers = cp.discover('perceive.github');
+    expect(providers.map((p) => p.organId)).toEqual(['ears', 'eyes']); // healthy before degraded; failing excluded
+  });
+});
+
+describe('dependencies + snapshot', () => {
+  it('reports unmet dependencies (missing or unusable)', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ({ organId: 'brain', name: 'Brain', dependencies: ['spine', 'memory'], capabilities: [] }));
+    cp.register(organ({ organId: 'spine', name: 'Spine', health: health('healthy'), capabilities: [], endpoints: [], secrets: [] }));
+    // memory not registered; spine healthy -> only memory is unmet
+    expect(cp.unmetDependencies('brain')).toEqual(['memory']);
+  });
+
+  it('version registry maps organId -> version', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ({ organId: 'eyes', version: '1.2.3' }));
+    expect(cp.versions().eyes).toBe('1.2.3');
+  });
+
+  it('snapshot answers what exists / healthy / degraded / capabilities', () => {
+    const cp = new ControlPlane({ now: () => T0 });
+    cp.register(organ({ organId: 'eyes', health: health('healthy') }));
+    cp.register(organ({ organId: 'ears', name: 'Ears', health: health('failing'), capabilities: [], endpoints: [], secrets: [] }));
+    const s = cp.snapshot();
+    expect(s.total).toBe(2);
+    expect(s.healthy).toBe(1);
+    expect(s.degraded).toBe(1);
+  });
+});

--- a/src/lib/control-plane/control-plane.ts
+++ b/src/lib/control-plane/control-plane.ts
@@ -1,0 +1,179 @@
+/**
+ * ControlPlane - the registry + discovery engine.
+ *
+ * Organs register, then heartbeat to keep their record fresh. The plane answers
+ * the organism's standing questions: what organs exist, which are healthy vs
+ * degraded, what capabilities are available and who provides them, and what
+ * each organ depends on. It is discovery + health rollup, not execution - it
+ * never runs a workload (that is the Spine) and never holds a secret value
+ * (only references).
+ *
+ * Pure in-memory state + injectable clock, so it is fully testable.
+ */
+
+import type {
+  OrganRegistration,
+  OrganRecord,
+  OrganStatus,
+  Capability,
+  CapabilityListing,
+  SecretRef,
+  HealthReport,
+} from './types';
+
+export class ControlPlaneError extends Error {}
+
+function validate(reg: OrganRegistration): void {
+  if (!reg.organId?.trim()) throw new ControlPlaneError('organId required');
+  if (!reg.version) throw new ControlPlaneError(`${reg.organId}: version required`);
+  if (!['edge', 'core', 'data', 'observability'].includes(reg.layer)) throw new ControlPlaneError(`${reg.organId}: bad layer`);
+  // Secrets must be references, never values - reject anything that looks like a value.
+  for (const s of reg.secrets ?? []) {
+    if (!s.key || !['env', 'vault', 'manager'].includes(s.source)) throw new ControlPlaneError(`${reg.organId}: secret must be a reference {key, source}`);
+  }
+}
+
+export interface ControlPlaneOptions {
+  /** How long without a heartbeat before an organ is marked stale (unknown). */
+  livenessTtlMs?: number;
+  now?: () => string;
+}
+
+export class ControlPlane {
+  private organs = new Map<string, OrganRecord>();
+  private readonly ttlMs: number;
+  private readonly now: () => string;
+
+  constructor(opts: ControlPlaneOptions = {}) {
+    this.ttlMs = opts.livenessTtlMs ?? 90_000;
+    this.now = opts.now ?? (() => new Date().toISOString());
+  }
+
+  /** Register (or re-register) an organ. Idempotent by organId. */
+  register(reg: OrganRegistration): OrganRecord {
+    validate(reg);
+    const t = this.now();
+    const record: OrganRecord = { ...reg, registeredAt: t, lastHeartbeatAt: t, stale: false };
+    this.organs.set(reg.organId, record);
+    return record;
+  }
+
+  deregister(organId: string): boolean {
+    return this.organs.delete(organId);
+  }
+
+  /**
+   * An organ heartbeats to publish fresh health/metrics/status (and optionally
+   * updated capabilities). Keeps its record live. Returns false if unknown.
+   */
+  heartbeat(organId: string, health: HealthReport, capabilities?: Capability[]): boolean {
+    const rec = this.organs.get(organId);
+    if (!rec) return false;
+    rec.health = health;
+    rec.lastHeartbeatAt = this.now();
+    rec.stale = false;
+    if (capabilities) rec.capabilities = capabilities;
+    return true;
+  }
+
+  private effectiveStatus(rec: OrganRecord, nowMs: number): OrganStatus {
+    if (nowMs - new Date(rec.lastHeartbeatAt).getTime() > this.ttlMs) return 'unknown';
+    return rec.health.status;
+  }
+
+  /** Refresh staleness against the clock; returns organs that just went stale. */
+  reapStale(): string[] {
+    const nowMs = new Date(this.now()).getTime();
+    const wentStale: string[] = [];
+    for (const rec of this.organs.values()) {
+      const stale = nowMs - new Date(rec.lastHeartbeatAt).getTime() > this.ttlMs;
+      if (stale && !rec.stale) wentStale.push(rec.organId);
+      rec.stale = stale;
+    }
+    return wentStale;
+  }
+
+  get(organId: string): OrganRecord | undefined {
+    return this.organs.get(organId);
+  }
+
+  /** Every organ + its effective status (heartbeat-aware). */
+  list(): Array<OrganRecord & { effectiveStatus: OrganStatus }> {
+    const nowMs = new Date(this.now()).getTime();
+    return [...this.organs.values()].map((r) => ({ ...r, effectiveStatus: this.effectiveStatus(r, nowMs) }));
+  }
+
+  /** Organs whose effective status is healthy. */
+  healthy(): OrganRecord[] {
+    return this.list().filter((r) => r.effectiveStatus === 'healthy');
+  }
+
+  /** Organs that need attention (degraded/failing/unknown). */
+  degraded(): Array<OrganRecord & { effectiveStatus: OrganStatus }> {
+    return this.list().filter((r) => ['degraded', 'failing', 'unknown'].includes(r.effectiveStatus));
+  }
+
+  /**
+   * The Capability Registry: who can do what, right now. Only providers whose
+   * effective status is healthy or degraded are listed as usable providers
+   * (a failing/unknown organ is not offered as a provider).
+   */
+  capabilities(): CapabilityListing[] {
+    const nowMs = new Date(this.now()).getTime();
+    const map = new Map<string, CapabilityListing>();
+    for (const rec of this.organs.values()) {
+      const status = this.effectiveStatus(rec, nowMs);
+      for (const cap of rec.capabilities) {
+        const listing = map.get(cap.name) ?? { name: cap.name, providers: [] };
+        listing.providers.push({ organId: rec.organId, version: cap.version, status, maxConcurrency: cap.maxConcurrency });
+        map.set(cap.name, listing);
+      }
+    }
+    return [...map.values()];
+  }
+
+  /** Discovery: usable providers of a capability (healthy first, failing/unknown excluded). */
+  discover(capabilityName: string): CapabilityListing['providers'] {
+    const listing = this.capabilities().find((c) => c.name === capabilityName);
+    if (!listing) return [];
+    const rank = (s: OrganStatus) => (s === 'healthy' ? 0 : s === 'degraded' ? 1 : 2);
+    return listing.providers.filter((p) => p.status === 'healthy' || p.status === 'degraded').sort((a, b) => rank(a.status) - rank(b.status));
+  }
+
+  /** Version registry: organId -> version. */
+  versions(): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const rec of this.organs.values()) out[rec.organId] = rec.version;
+    return out;
+  }
+
+  /** Dependency check: does every declared dependency exist + is it usable? */
+  unmetDependencies(organId: string): string[] {
+    const rec = this.organs.get(organId);
+    if (!rec) return [];
+    const nowMs = new Date(this.now()).getTime();
+    return rec.dependencies.filter((dep) => {
+      const d = this.organs.get(dep);
+      if (!d) return true;
+      const s = this.effectiveStatus(d, nowMs);
+      return s === 'failing' || s === 'unknown' || s === 'stopped';
+    });
+  }
+
+  /** The secret REFERENCES an organ declared (names only - never values). */
+  secretRefs(organId: string): SecretRef[] {
+    return this.organs.get(organId)?.secrets ?? [];
+  }
+
+  /** A one-shot organism snapshot for a dashboard. */
+  snapshot(): { total: number; healthy: number; degraded: number; capabilities: number; organs: Array<{ organId: string; layer: string; status: OrganStatus; version: string }> } {
+    const list = this.list();
+    return {
+      total: list.length,
+      healthy: list.filter((r) => r.effectiveStatus === 'healthy').length,
+      degraded: list.filter((r) => ['degraded', 'failing', 'unknown'].includes(r.effectiveStatus)).length,
+      capabilities: this.capabilities().length,
+      organs: list.map((r) => ({ organId: r.organId, layer: r.layer, status: r.effectiveStatus, version: r.version })),
+    };
+  }
+}

--- a/src/lib/control-plane/index.ts
+++ b/src/lib/control-plane/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Control Plane - the organism's operational nervous system. Public API.
+ *
+ * Organs register and continuously publish identity, version, capabilities,
+ * dependencies, health, metrics, status, and endpoints. The plane answers what
+ * organs exist, which are healthy vs degraded, what capabilities are available
+ * and who provides them - so organs discover each other through the plane rather
+ * than coupling directly. Registry + discovery only; it never executes a
+ * workload (Spine) and never holds a secret value (references only).
+ */
+
+export type {
+  OrganStatus,
+  Capability,
+  OrganEndpoint,
+  SecretRef,
+  HealthReport,
+  OrganRegistration,
+  OrganRecord,
+  CapabilityListing,
+} from './types';
+
+export { ControlPlane, ControlPlaneError } from './control-plane';
+export type { ControlPlaneOptions } from './control-plane';

--- a/src/lib/control-plane/types.ts
+++ b/src/lib/control-plane/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Control Plane - the organism's operational nervous system. Types + contracts.
+ *
+ * Rather than coupling organs to each other, every organ REGISTERS with the
+ * Control Plane and continuously publishes who it is, what it can do, and how
+ * healthy it is. The organism can then always answer: what organs exist, which
+ * are healthy vs degraded, what capabilities are available, and what workloads
+ * each organ can accept - without any organ hard-wiring to another.
+ *
+ * The Control Plane is a REGISTRY + DISCOVERY surface. It does not execute
+ * workloads (that is the Spine) and it never holds secret VALUES (only
+ * references to where a secret lives). Clean interfaces, ZAO's own vocabulary.
+ */
+
+export type OrganStatus = 'starting' | 'healthy' | 'degraded' | 'failing' | 'draining' | 'stopped' | 'unknown';
+
+/** A capability an organ offers, e.g. 'perceive.github', 'act.open_pr', 'remember.episodic'. */
+export interface Capability {
+  name: string;
+  version: string;
+  description?: string;
+  /** Max concurrent workloads of this capability the organ will accept (backpressure hint). */
+  maxConcurrency?: number;
+}
+
+/** A reachable endpoint an organ exposes (never a secret). */
+export interface OrganEndpoint {
+  name: string;
+  /** Logical address - an internal service name, a queue, a function ref. Not a credential. */
+  address: string;
+  protocol: 'http' | 'queue' | 'internal' | 'ws' | 'cron';
+}
+
+/** A reference to a secret - the NAME/location, never the value. */
+export interface SecretRef {
+  key: string;
+  /** Where it lives: env, a vault path, a manager id. The plane resolves references, not values. */
+  source: 'env' | 'vault' | 'manager';
+}
+
+export interface HealthReport {
+  status: OrganStatus;
+  /** Free-form health detail (latency, error rate, queue depth) - metrics, not decisions. */
+  metrics: Record<string, number>;
+  message?: string;
+  reportedAt: string;
+}
+
+/**
+ * What an organ publishes to the Control Plane. Identity + version +
+ * capabilities + dependencies + health + metrics + status + endpoints - exactly
+ * the fields Brandon specified. Secrets appear only as references.
+ */
+export interface OrganRegistration {
+  /** Stable organ identity, e.g. 'eyes', 'bloodstream', 'spine'. */
+  organId: string;
+  /** Human name / role. */
+  name: string;
+  version: string;
+  /** Layer this organ runs in (Edge/Core/Data/Observability). */
+  layer: 'edge' | 'core' | 'data' | 'observability';
+  capabilities: Capability[];
+  /** organIds this organ depends on (for discovery + startup ordering). */
+  dependencies: string[];
+  endpoints: OrganEndpoint[];
+  /** Secret references this organ needs (names only). */
+  secrets: SecretRef[];
+  /** Initial health at registration. */
+  health: HealthReport;
+  /** Free-form labels (region, instance, etc). */
+  labels?: Record<string, string>;
+}
+
+/** A live record the plane holds per organ. */
+export interface OrganRecord extends OrganRegistration {
+  registeredAt: string;
+  lastHeartbeatAt: string;
+  /** True once the plane has not heard a heartbeat within the liveness TTL. */
+  stale: boolean;
+}
+
+/** A capability offered by one or more organs, as the plane sees it. */
+export interface CapabilityListing {
+  name: string;
+  providers: Array<{ organId: string; version: string; status: OrganStatus; maxConcurrency?: number }>;
+}


### PR DESCRIPTION
Brandon's Control Plane. Rather than coupling organs to each other, every organ registers and continuously publishes identity, version, capabilities, dependencies, health, metrics, status, and endpoints. The organism can then always answer: what organs exist, which are healthy vs degraded, what capabilities are available and who provides them.

- OrganRegistration contract (all Brandon's fields) + Capability/Endpoint/SecretRef (references only, never values)/HealthReport.
- ControlPlane: register/heartbeat/deregister, liveness TTL (stale organs go 'unknown'), capability registry, discovery (usable providers healthy-first, failing/unknown excluded), version registry, unmet-dependency check, dashboard snapshot.
- Registry + discovery ONLY: never executes a workload (Spine) and never holds a secret value (a test asserts secrets are references only).

Tests cover registration, secret-reference enforcement, heartbeat/staleness->unknown, capability discovery ranking, unmet dependencies, and the snapshot. Typecheck clean; tests on CI (local src/lib rolldown binding). Companion architecture doc (runtime, layers, Memory interfaces, governance, roadmap) is next.