### PR TITLE
fix(zoe/meetings): parse 'YYYY-MM-DD H:mm' dates correctly

### DIFF
--- a/bot/src/zoe/meetings.ts
+++ b/bot/src/zoe/meetings.ts
@@ -71,9 +71,14 @@ function isRecentMeeting(dateStr: string, hoursBack: number = 48): boolean {
     // Parse: try ISO first, then common variants
     let date: Date | null = null;
 
-    // Try ISO date (2026-07-20)
+    // Try ISO date (2026-07-20) or with time (2026-07-20 8:03)
+    // "YYYY-MM-DD H:mm" is not valid ISO 8601 — normalize to "YYYY-MM-DDTHH:mm"
     if (dateStr.includes('-') && dateStr.match(/^\d{4}-\d{2}-\d{2}/)) {
-      date = new Date(dateStr);
+      const normalized = dateStr.trim().replace(
+        /^(\d{4}-\d{2}-\d{2})\s+(\d{1,2}):(\d{2})$/,
+        (_, d, h, m) => `${d}T${h.padStart(2, '0')}:${m}`,
+      );
+      date = new Date(normalized);
     }
 
     if (!date || isNaN(date.getTime())) return false;


### PR DESCRIPTION
## Problem

`new Date('2026-07-24 8:03')` returns `Invalid Date` in Node.js — the space separator between date and time is not valid ISO 8601. The meetings index can contain entries like `| 2026-07-24 8:03 | ...` (added by the /meeting skill), and `isRecentMeeting` was silently returning `false` for all of them.

**Failing test:** `meetings > should handle dates with times` — `expected null not to be null`

This is causing the ZAOOS CI to fail on all recent PRs (1 failed test file, 122 passing).

## Fix

Normalize `"YYYY-MM-DD H:mm"` → `"YYYY-MM-DDTHH:mm"` before passing to `new Date()`. This makes `new Date("2026-07-24T08:03")` which is valid ISO 8601 and parses correctly.

## Test plan
- [ ] `meetings > should handle dates with times` passes
- [ ] All other meetings tests continue to pass
- [ ] ZAOOS CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)