### PR TITLE
fix(fractals): member history source field uses scoring_era not notes strings

### DIFF
--- a/bot/src/zoe/meetings.ts
+++ b/bot/src/zoe/meetings.ts
@@ -71,9 +71,14 @@ function isRecentMeeting(dateStr: string, hoursBack: number = 48): boolean {
     // Parse: try ISO first, then common variants
     let date: Date | null = null;
 
-    // Try ISO date (2026-07-20)
+    // Try ISO date (2026-07-20) or with time (2026-07-20 8:03)
+    // "YYYY-MM-DD H:mm" is not valid ISO 8601 — normalize to "YYYY-MM-DDTHH:mm"
     if (dateStr.includes('-') && dateStr.match(/^\d{4}-\d{2}-\d{2}/)) {
-      date = new Date(dateStr);
+      const normalized = dateStr.trim().replace(
+        /^(\d{4}-\d{2}-\d{2})\s+(\d{1,2}):(\d{2})$/,
+        (_, d, h, m) => `${d}T${h.padStart(2, '0')}:${m}`,
+      );
+      date = new Date(normalized);
     }
 
     if (!date || isNaN(date.getTime())) return false;

--- a/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
+++ b/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
@@ -370,7 +370,7 @@ describe('GET /api/fractals/member/[wallet]', () => {
       expect(body.history[0].sessionName).toBe('Session B');
     });
 
-    it('detects ORDAO sessions from notes', async () => {
+    it('detects ORDAO sessions from scoring_era field', async () => {
       const member = {
         name: 'Henry',
         wallet_address: VALID_WALLET.toLowerCase(),
@@ -393,11 +393,11 @@ describe('GET /api/fractals/member/[wallet]', () => {
           member_name: member.name,
           fractal_sessions: {
             id: 's1',
-            name: 'ORDAO',
+            name: 'Fractal 80',
             session_date: '2024-03-10',
-            scoring_era: '3x',
+            scoring_era: '2x',
             participant_count: 12,
-            notes: 'ORDAO test',
+            notes: null,
           },
         },
         {
@@ -524,7 +524,7 @@ describe('GET /api/fractals/member/[wallet]', () => {
             id: 's1',
             name: 'Session 1',
             session_date: '2024-01-01',
-            scoring_era: '2x',
+            scoring_era: '1x',
             participant_count: 10,
             notes: 'og',
           },

--- a/src/app/api/fractals/member/[wallet]/route.ts
+++ b/src/app/api/fractals/member/[wallet]/route.ts
@@ -76,7 +76,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ wall
 
     const history = (scores ?? []).map((s) => {
       const sess = Array.isArray(s.fractal_sessions) ? s.fractal_sessions[0] : s.fractal_sessions;
-      const isOrdao = sess?.notes?.includes('ORDAO') || sess?.notes?.includes('on-chain');
+      const isOrdao = sess?.scoring_era === '2x';
       const txMatch = sess?.notes?.match(/Tx: (0x[a-fA-F0-9]+)/);
       return {
         sessionName: sess?.name ?? 'Unknown',


### PR DESCRIPTION
## Problem

`fractals/member/[wallet]/route.ts:79` was determining the ORDAO era from `session.notes` content:

```typescript
const isOrdao = sess?.notes?.includes('ORDAO') || sess?.notes?.includes('on-chain');
```

This is fragile — `notes` is a free-text field that can say anything. The canonical field is `scoring_era`, already selected in the DB query.

**Note:** The equivalent bug in `members/[username]/route.ts` was already fixed on main. This PR fixes the remaining instance.

## Fix

Use `scoring_era === '2x'` for the `isOrdao` check. Update test fixtures to match.

## Why a new PR instead of PR#2171?

PR#2171 has the same fix but CI stopped running on it after the Jul 22 meetings.test bug was introduced (which broke all ZAOOS CI). Since then new pushes to that branch don't trigger CI. Fresh branch → fresh CI run.

PR#2171 should be closed after this merges.

## Test plan
- [ ] `detects ORDAO sessions from scoring_era field` passes
- [ ] Stats test `ogSessions: 2 / ordaoSessions: 1` passes
- [ ] All fractals/member tests pass
- [ ] ZAOOS CI green (pending PR#2555 meetings fix first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)