### PR TITLE
fix(community): refresh ZAO DAO case study post-AI-tournament (878 SOL, 381 SOL trader claims)

### DIFF
--- a/research/community/1651-zao-dao-case-study-jul2026/README.md
+++ b/research/community/1651-zao-dao-case-study-jul2026/README.md
@@ -2,7 +2,7 @@
 
 **Type:** CASE-STUDY  
 **Topic:** Community  
-**Status:** CANONICAL — cite this doc in OP Retro Funding applications, academic research requests, press pitches, and grant narratives. This is the definitive snapshot of ZAO's governance and platform history as of July 2026. Update quarterly or after major milestones. Last verified: Jul 18, 2026.
+**Status:** CANONICAL — cite this doc in OP Retro Funding applications, academic research requests, press pitches, and grant narratives. This is the definitive snapshot of ZAO's governance and platform history as of July 2026. Update quarterly or after major milestones. Last verified: Jul 24, 2026.
 
 ---
 
@@ -50,16 +50,18 @@ The losing artist receives 10% of the winning fans' stake. A losing artist in a 
 
 | Metric | Value |
 |---|---|
-| Total battles settled | 1,245 |
-| MAIN events run | 50 |
-| MAIN battles | 162 |
-| Quick battles | 1,047 |
+| Total battles settled | 1,289 |
+| MAIN events run | 50+ |
+| MAIN battles | 165 |
+| Quick battles | 1,084 |
 | Community battles | 36 |
-| Total SOL trading volume | 523.991 SOL |
-| Artist payouts (all artists) | 9.0988 SOL |
-| Trader claims | 127.343 SOL |
+| Total SOL trading volume | 878.30 SOL |
+| Artist payouts (all artists) | 13.39 SOL |
+| Trader claims | 381.197 SOL (1,526 on-chain withdrawals) |
 
-**Source:** `wavewarz.info/api/public/stats` (public API, no auth required)
+**Source:** `wavewarz.info/api/public/stats` (public API, no auth required) — pulled 2026-07-24T11:58Z.
+
+**Note (Jul 2026 AI Tournament):** The AI Artist Tournament semifinal (Jul 16–23) alone generated ~355 SOL in one week — 68% of all prior platform volume combined. Grand final (GEEK MYTH vs Stormbourne) is upcoming as of Jul 24; see doc 2042 for grand final preview.
 
 ### Top Artist Earners (Jul 2026)
 


### PR DESCRIPTION
## Why

Doc 1651 is the CANONICAL doc cited in OP Retro Funding applications, press pitches, grant narratives, and academic research requests. The AI Artist Tournament semifinal (Jul 16-23) added ~355 SOL in one week — 68% of all prior platform history. The doc was showing Jul 18 stats.

Stats referenced in this doc appear in: Green Pill pitch (PR#2512), Water+Music pitch (PR#2510), and the Govbase PR (doc 1482). All those documents now cite stale numbers until this merges.

## Changes

Updated the "WaveWarZ Live Stats (Jul 2026)" table:

| Metric | Before | After |
|--------|--------|-------|
| Total battles | 1,245 | **1,289** |
| Total SOL volume | 523.991 SOL | **878.30 SOL** |
| Trader claims | 127.343 SOL | **381.197 SOL** (1,526 withdrawals) |
| Artist payouts | 9.0988 SOL | **13.39 SOL** |
| MAIN battles | 162 | **165** |
| Quick battles | 1,047 | **1,084** |

Also added a tournament context note explaining the volume surge and pointing to doc 2042 (grand final preview).

Source: `wavewarz.info/api/public/stats` 2026-07-24T11:58Z