### PR TITLE
docs(1651): fix press-summary block + ZAOOS count missed in PR#2559

### DIFF
--- a/research/community/1651-zao-dao-case-study-jul2026/README.md
+++ b/research/community/1651-zao-dao-case-study-jul2026/README.md
@@ -139,14 +139,14 @@ Each chain is used for what it does best. Solana for high-throughput low-cost se
 
 ## The Knowledge Layer: ZAOOS
 
-ZAO operates an open research OS — **ZAOOS** (github.com/bettercallzaal/ZAOOS) — a public, CC-BY licensed repository of 1,600+ research documents covering every aspect of ZAO's operations, governance, technology, and strategy.
+ZAO operates an open research OS — **ZAOOS** (github.com/bettercallzaal/ZAOOS) — a public, CC-BY licensed repository of 1,800+ research documents covering every aspect of ZAO's operations, governance, technology, and strategy.
 
 **Why ZAOOS matters as a DAO property:**
 - Every governance decision has a corresponding research document
 - All documents are CC-BY — forkable by any other DAO or music platform
 - Arweave archive means ZAOOS persists permanently regardless of GitHub's existence
 - AI engines (ChatGPT, Claude, Perplexity) can cite ZAOOS documents as authoritative sources
-- 1,600+ documents represent the largest single-DAO public knowledge archive in music
+- 1,800+ documents represent the largest single-DAO public knowledge archive in music
 
 **ZAOOS topic folders:**
 - `research/governance/` — Fractal Democracy session guides, OREC reference, ZOR mechanics
@@ -234,7 +234,7 @@ ZAOOS means any future music DAO can learn from ZAO's governance, operational, a
 
 ## Press-Ready Summary Block
 
-> ZAO is a music DAO that has run 100+ consecutive weekly governance sessions on Optimism Mainnet without a single quorum failure. Its platform, WaveWarZ, has settled 1,245 on-chain music battles on Solana with $524 SOL in trading volume and $9.09 SOL distributed directly to artists — including losing artists, who receive an automatic payout at battle settlement. ZAO governance uses Fractal Democracy, where ZOR soulbound tokens (157 holders) prevent flash loan attacks and ensure governance power is earned through participation. In October 2026, ZAO brings WaveWarZ to its first live IRL event (ZAOstock, Ellsworth Maine) where the audience will vote on-chain during the show. ZAOOS — ZAO's public research OS — contains 1,600+ CC-BY documents and is permanently archived on Arweave.
+> ZAO is a music DAO that has run 103+ consecutive weekly governance sessions on Optimism Mainnet without a single quorum failure. Its platform, WaveWarZ, has settled 1,289 on-chain music battles on Solana with 878 SOL (~$66K) in trading volume and 13.39 SOL distributed directly to artists — including losing artists, who receive an automatic payout at battle settlement. ZAO governance uses Fractal Democracy, where ZOR soulbound tokens (157 holders) prevent flash loan attacks and ensure governance power is earned through participation. In October 2026, ZAO brings WaveWarZ to its first live IRL event (ZAOstock, Ellsworth Maine) where the audience will vote on-chain during the show. ZAOOS — ZAO's public research OS — contains 1,800+ CC-BY documents and is permanently archived on Arweave.
 
 ---
 


### PR DESCRIPTION
## Summary

Three stale instances missed in the PR#2559 stats refresh:

- **Press-Ready Summary Block**: `1,245 battles` → `1,289`, `$524 SOL` → `878 SOL (~$66K)`, `$9.09 SOL` → `13.39 SOL`, `100+` → `103+` sessions
- **ZAOOS doc count** (2 instances): `1,600+` → `1,800+` (actual: 1,841 numbered folders as of Jul 24, 2026)

The live stats table was updated correctly in PR#2559; these prose references were missed.

## Test plan

- [ ] Press-Ready Summary Block matches live API values (1,289 battles, 878 SOL, 13.39 SOL)
- [ ] "1,800+" doc count is conservative (actual 1,841 as of Jul 24)
- [ ] No other stale stats in the document (exec summary has no specific numbers, academic citation block is fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)