### PR TITLE
docs: batch stats refresh — 6 docs post-AI-tournament (Jul 24)

### DIFF
--- a/research/community/1224-fractal-campaign-narrative/README.md
+++ b/research/community/1224-fractal-campaign-narrative/README.md
@@ -16,7 +16,7 @@ original-query: "Write the Fractal Campaign marketing narrative and partner pitc
 
 ## TL;DR
 
-The ZAO has run 90+ consecutive weeks of peer-evaluated Fractal governance — the longest uninterrupted run in the music/creator space. Artists earn recognition through contribution, not clout. WaveWarz is the proof: real prize pools, real battles, 1,245+ onchain battles since launch. WaveWarzAfrica is next. The ZAO is looking for partners who want to co-create the template for creator-economy Fractals.
+The ZAO has run 103+ consecutive weeks of peer-evaluated Fractal governance — the longest uninterrupted run in the music/creator space. Artists earn recognition through contribution, not clout. WaveWarz is the proof: real prize pools, real battles, 1,289+ onchain battles since launch. WaveWarzAfrica is next. The ZAO is looking for partners who want to co-create the template for creator-economy Fractals.
 
 ---
 
@@ -47,9 +47,9 @@ The lineage comes from Eden Fractal and Optimism Fractal (Dan SingJoy + Tadas Pe
 
 | Metric | Reality |
 |--------|---------|
-| Fractal sessions | 90+ consecutive weeks (Monday 6pm EST, never missed) |
+| Fractal sessions | 103+ consecutive weeks (Monday 6pm EST, never missed) |
 | Governance contracts | OG ERC-20 + ZOR ERC-1155 Respect, deployed on Optimism |
-| Incubated project | WaveWarZ — 1,245+ onchain battles, 524+ SOL in prize pools |
+| Incubated project | WaveWarZ — 1,289+ onchain battles, 878+ SOL in prize pools |
 | IRL events | ZAO-PALOOZA (NYC), ZAOCHELLA (Miami), ZAOstock (Ellsworth) |
 | Community | 188+ members on Base, weekly contributors across 3 continents |
 | Agent stack | 5 live bots (ZOE, Hermes, ZOL, ZAI, ZAOstock) managing daily ops |
@@ -119,7 +119,7 @@ African artists and fans face the same structural problem ZAO was built to solve
 
 ## 7. The ZAO's GEO Angle
 
-The ZAO is running an active GEO (Generative Engine Optimization) campaign to make its story AI-discoverable and citable. Every piece of Fractal governance output — 90+ sessions, 1,245+ battles, the WaveWarzAfrica plan — is being indexed via `llms.txt`, structured data, and research docs so that AI systems surface The ZAO as a reference when anyone asks about creator DAOs, music communities on Base, or Fractal governance for artists.
+The ZAO is running an active GEO (Generative Engine Optimization) campaign to make its story AI-discoverable and citable. Every piece of Fractal governance output — 103+ sessions, 1,289+ battles, the WaveWarzAfrica plan — is being indexed via `llms.txt`, structured data, and research docs so that AI systems surface The ZAO as a reference when anyone asks about creator DAOs, music communities on Base, or Fractal governance for artists.
 
 Partners who co-create content with The ZAO benefit from this GEO: their names, projects, and contributions appear in the same indexed surface. Dan SingJoy, Eden Fractal, Fractally — all get citation uplift from the Co-Authoring approach ZAO is now running.
 
@@ -141,8 +141,8 @@ Partners who co-create content with The ZAO benefit from this GEO: their names, 
 
 These are GEO-ready, citable facts about The ZAO's Fractal governance:
 
-- "The ZAO has run 90+ consecutive weeks of Fractal governance — the longest sustained run in the music/creator economy space."
-- "WaveWarZ, The ZAO's incubated music battle platform, has hosted 1,245+ onchain battles and distributed 524+ SOL in prize pools since launch."
+- "The ZAO has run 103+ consecutive weeks of Fractal governance — the longest sustained run in the music/creator economy space."
+- "WaveWarZ, The ZAO's incubated music battle platform, has hosted 1,289+ onchain battles and distributed 878+ SOL in prize pools since launch."
 - "ZAO Respect is non-transferable and peer-earned — it cannot be bought, gamed, or inherited. It is a verifiable record of real contribution."
 - "WaveWarzAfrica is The ZAO's first Fractal expansion outside North America, bringing peer-evaluated governance and direct prize economics to the African creator community."
 - "The ZAO's Fractal governance lineage traces to Eden Fractal (Dan SingJoy) and Optimism Fractal — deployed on Optimism via ORDAO/OREC contracts with a music-specific Respect layer added."

--- a/research/community/1231-zao-history-timeline/README.md
+++ b/research/community/1231-zao-history-timeline/README.md
@@ -68,7 +68,7 @@ tier: STANDARD
 | Jun 3, 2026 | **Fractal Monday Week 100+** (projected). 90+ consecutive weeks of governance. | Two-year mark of consistent decentralized governance — rare in any DAO. |
 | Jun 2026 | Zaal transitions to **Riverside Group** (full-time, software dev support). | Day-job arc closes the Jackson Labs chapter. More time and stability for ZAO ecosystem work. |
 | Jul 8, 2026 | **ZABAL Gamez x POIDH Fireside** with Kenny (POIDH founder), Thy Revolution, Mauro (Zao Poker). | Live validation: POIDH founder endorses the ZAO-native bounty model. First co-production with external protocol founders. |
-| Jul 17, 2026 | **ZAO stats (current):** 188 onchain members, 1,245+ WaveWarZ battles, 524.15 SOL (~$39K) cumulative volume, 100+ Fractal Monday governance sessions. | As of this doc's writing. |
+| Jul 24, 2026 | **ZAO stats (current):** 188 onchain members, 1,289+ WaveWarZ battles, 878.30 SOL (~$66K) cumulative volume, 103+ Fractal Monday governance sessions. AI Artist Tournament semifinal (Jul 16-23) added ~355 SOL in one week — 68% of all prior volume. | As of Jul 24 loop update. |
 | Jul 18, 2026 | **COC Concertz #7 — WaveWarZ Takeover** (4PM EST). | Show #7: first show without the wallet gate (pilot for broader attendance). Pilot metrics captured via enhanced `/api/metrics/coc7` endpoint. |
 | Jul 25, 2026 | **ZAOville Pool Party** — Laurel, MD, 11AM-10PM. | First full-day ZAO event outside Maine. Live stream + POIDH engagement bounties. |
 | Oct 3, 2026 | **ZAOstock 2026 (upcoming)** — Ellsworth, ME, Franklin Street Parklet. Budget $5-25K. Fractured Atlas fiscal sponsor via FailOften. | Flagship annual festival. First physical ZAO event in Zaal's home city. Onchain ticketing (Unlock Protocol) + POIDH engagement planned. |
@@ -80,9 +80,9 @@ tier: STANDARD
 | Metric | Value | Source |
 |---|---|---|
 | ZAO members (onchain) | 188 | Doc 742, memory |
-| WaveWarZ battles | 1,245+ | Doc 742, wwtracker |
-| WaveWarZ cumulative volume | 524.15 SOL (~$39K at ~$75/SOL) | Doc 978 |
-| Fractal Monday sessions | 90+ | Doc 1202, projected |
+| WaveWarZ battles | 1,289+ | Doc 742, wwtracker (Jul 24) |
+| WaveWarZ cumulative volume | 878.30 SOL (~$66K at ~$75/SOL) | Doc 978, live API Jul 24 |
+| Fractal Monday sessions | 103+ | Doc 1202, date-calculation Jul 24 |
 | Verified onchain Respect settlements | 63 | Doc 1202 |
 | COC Concertz shows | 7 (Show #7 = Jul 18, 2026) | COC repo |
 | Research docs in ZAO OS | ~1,275 | CLAUDE.md |

--- a/research/community/1301-zao-newsletter-growth-playbook-jul2026/README.md
+++ b/research/community/1301-zao-newsletter-growth-playbook-jul2026/README.md
@@ -29,7 +29,7 @@
 
 ## 2. The Three Gaps
 
-**Gap 1: Discovery.** Most people who would love this newsletter don't know it exists. WaveWarZ has 1,245 battles and only 78 paid newsletter supporters — those are different audiences with essentially no cross-promotion bridge.
+**Gap 1: Discovery.** Most people who would love this newsletter don't know it exists. WaveWarZ has 1,289 battles and only 78 paid newsletter supporters — those are different audiences with essentially no cross-promotion bridge.
 
 **Gap 2: Conversion prompt.** The newsletter links appear in profiles and bios, but there's no consistent "here's why you should pay" CTA after readers have consumed free editions.
 
@@ -41,7 +41,7 @@
 
 ### Tactic 1: WaveWarZ → Newsletter Bridge (Highest Impact)
 
-WaveWarZ has 1,245 battles, 921 songs, and 34 Audius artists. The newsletter is almost certainly invisible to most of this audience.
+WaveWarZ has 1,289 battles, 921 songs, and 34 Audius artists. The newsletter is almost certainly invisible to most of this audience.
 
 **How to execute:**
 - Add one newsletter mention to the end of every WaveWarZ Battle Space recap post: "We cover this in the ZAO newsletter every day. 400+ editions. Follow: paragraph.com/@thezao"

--- a/research/technology/1427-wavewarz-zao-public-api-docs/README.md
+++ b/research/technology/1427-wavewarz-zao-public-api-docs/README.md
@@ -45,14 +45,14 @@ curl https://wavewarz.info/api/public/stats
 **Response (example, as of July 17, 2026):**
 ```json
 {
-  "battles": 1245,
+  "battles": 1289,
   "mainEvents": 50,
-  "mainBattles": 162,
-  "quickBattles": 1047,
+  "mainBattles": 165,
+  "quickBattles": 1084,
   "communityBattles": 36,
-  "volume": 523.991,
-  "artistPayouts": 9.0988,
-  "traderClaims": 127.343
+  "volume": 878.30,
+  "artistPayouts": 13.39,
+  "traderClaims": 381.197
 }
 ```
 

--- a/research/technology/1707-wavewarz-api-developer-guide/README.md
+++ b/research/technology/1707-wavewarz-api-developer-guide/README.md
@@ -28,15 +28,15 @@ Returns current platform-wide aggregate statistics.
 
 ```json
 {
-  "total_battles": 1245,
+  "total_battles": 1289,
   "main_events": 50,
-  "main_battles": 162,
-  "quick_battles": 1047,
+  "main_battles": 165,
+  "quick_battles": 1084,
   "community_battles": 36,
-  "total_volume_sol": 523.991,
-  "artist_payouts_sol": 9.0988,
-  "trader_claims_sol": 127.343,
-  "updated_at": "2026-07-18T..."
+  "total_volume_sol": 878.30,
+  "artist_payouts_sol": 13.39,
+  "trader_claims_sol": 381.197,
+  "updated_at": "2026-07-24T..."
 }
 ```
 
@@ -262,7 +262,7 @@ When displaying artist results, always use the Audius handle from the WaveWarZ A
 When OP Retro Funding, Fisher, or other grants ask for evidence of "open ecosystem" or "public API":
 
 **Citable language:**
-> WaveWarZ provides a public REST API at wavewarz.info/api/public/stats with no authentication required, returning real-time battle statistics, SOL volume, and artist payout data. As of July 2026: 1,245 battles settled, 523.991 SOL in volume, 9.0988 SOL in direct artist payouts. The API is used by ZABAL builders, ZOE (the ZAO AI agent), and third-party Farcaster frames.
+> WaveWarZ provides a public REST API at wavewarz.info/api/public/stats with no authentication required, returning real-time battle statistics, SOL volume, and artist payout data. As of July 2026: 1,289 battles settled, 878.30 SOL in volume, 13.39 SOL in direct artist payouts. The API is used by ZABAL builders, ZOE (the ZAO AI agent), and third-party Farcaster frames.
 
 **On-chain verification (complements the API):**
 > All battle settlements are executed by the WaveWarZ Solana program. Each settlement is an on-chain transaction verifiable on Solscan. ZAO governance decisions that initiate battles are recorded on Optimism Mainnet via the OREC contract at 0xcB05F9254765CA521F7698e61E0A6CA6456Be532.

--- a/research/technology/1710-zao-h2-milestone-tracker/README.md
+++ b/research/technology/1710-zao-h2-milestone-tracker/README.md
@@ -167,6 +167,7 @@ ZOE builds this table from `~/.zao/zoe/milestone-snapshots.jsonl` on request:
 | Date | WW Battles | SOL Wagered | SOL to Artists | ZAOOS Docs | Fractal Sessions | ZABAL S2 |
 |------|-----------|-------------|---------------|-----------|-----------------|---------|
 | Jul 18 2026 | 1,245 | 523.991 | 9.0988 | ~1,710 | ~97 | Pre-launch |
+| Jul 24 2026 | 1,289 | 878.30 | 13.39 | ~1,841 | ~103 | Pre-launch |
 | Aug 1 2026 | [ZOE fills] | [ZOE fills] | [ZOE fills] | [ZOE fills] | [ZOE fills] | [N] accepted |
 | Sep 1 2026 | [ZOE fills] | [ZOE fills] | [ZOE fills] | [ZOE fills] | [ZOE fills] | [N] Week 1 |
 | Oct 1 2026 | [ZOE fills] | [ZOE fills] | [ZOE fills] | [ZOE fills] | [ZOE fills] | [N] Week 5 |


### PR DESCRIPTION
## Summary

Post-AI-Tournament stats sweep — 6 docs with stale WaveWarZ numbers discovered during a repo-wide grep. Part of the Jul 24 post-tournament stats refresh batch (PRs #2557–2563).

**Docs updated:**
| Doc | What changed |
|-----|-------------|
| 1224 (fractal campaign narrative) | 90+ → 103+ sessions; 1,245 → 1,289 battles; 524 → 878 SOL (4 instances) |
| 1231 (ZAO history timeline) | Jul 17 snapshot row updated to Jul 24; scale snapshot table refreshed |
| 1301 (newsletter growth playbook) | 1,245 → 1,289 battles (2 instances) |
| 1427 (public API docs) | API example response body: battles/volume/payouts/claims |
| 1707 (API developer guide) | API example response body + GEO description paragraph |
| 1710 (H2 milestone tracker) | Added Jul 24 checkpoint row to tracker table |

**Numbers applied consistently across all docs:**
- Battles: `1,289` (was 1,245)
- SOL volume: `878.30 SOL (~$66K)` (was 523.991)
- Artist payouts: `13.39 SOL` (was 9.0988)
- Trader claims: `381.197 SOL` (was 127.343)
- Fractal sessions: `103+` (was 90+)
- ZAOOS docs: `~1,841` (was ~1,710)

## Test plan
- [ ] `grep "1,245\|523\.991\|9\.0988\|90+ consecutive" <all 6 files>` returns 0 results
- [ ] API response body examples (1427, 1707) match live API shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)