### PR TITLE
docs: stats refresh batch 2 — 6 docs post-AI-tournament (Jul 24)

### DIFF
--- a/research/community/1295-zao-farcaster-strategy-jul2026/README.md
+++ b/research/community/1295-zao-farcaster-strategy-jul2026/README.md
@@ -68,7 +68,7 @@ From doc 1265 (distribution network) and doc 1201 (canonical facts):
 | Battle hot take | "Song A just beat Song B on WaveWarZ. Nobody saw this coming. Here's why." | 2x/week |
 | Build-in-public | "Shipped [thing]. Here's what I learned." | 2x/week |
 | Governance update | "ZAO Fractal #[N] done. This week's top contributor: [name]. [Respect distribution link]." | 1x/week |
-| Number drop | "WaveWarZ just crossed 1,250 battles. 524 SOL in volume. Artist payout rate: 1.73%." | As milestones hit |
+| Number drop | "WaveWarZ just crossed 1,300 battles. 878 SOL in volume. Artist payout rate: 1.52%." | As milestones hit |
 
 ### @wavewarz
 
@@ -81,7 +81,7 @@ From doc 1265 (distribution network) and doc 1201 (canonical facts):
 |------|--------|-----------|
 | Battle result | "[Artist A] defeats [Artist B] on @WaveWarZ. [Volume] SOL traded. wavewarz.info" | After big battles |
 | Leaderboard update | "This week's leaderboard: 1. GodclouD (71% win rate) 2. [Artist B] 3. [Artist C]. Track your stats: wavewarz.info" | Weekly |
-| Platform milestone | "1,245 battles. 524 SOL. $1,497 for charity. This is what WaveWarZ looks like." | Monthly |
+| Platform milestone | "1,289 battles. 878 SOL. $1,497 for charity. This is what WaveWarZ looks like." | Monthly |
 | Artist payout | "[Artist name] just received [X] SOL in payouts from WaveWarZ battles. Automatically. No middleman." | When notable payouts happen |
 
 ---
@@ -139,7 +139,7 @@ See doc 1294 (community calendar) for the event schedule. Map to Farcaster:
 
 Based on ZAO's onchain-native audience, these formats consistently drive follows and engagement on Warpcast:
 
-1. **Number posts** — "1,245 battles. 524 SOL. 921 songs. WaveWarZ." Short, verifiable stats drive recast.
+1. **Number posts** — "1,289 battles. 878 SOL. 921 songs. WaveWarZ." Short, verifiable stats drive recast.
 2. **Milestone celebrations** — "100 weeks of ZAO Fractal governance. No missed weeks. Onchain." Milestone posts get shared.
 3. **Artist spotlights** — tag the artist: "@[audius-handle-if-on-farcaster] just crossed 10 battles on WaveWarZ. Total SOL: [X]."
 4. **Frame embeds** — when WW Mini App is live, embed the battle frame directly in the cast

--- a/research/community/1328-zao-podcast-pitch-kit-jul2026/README.md
+++ b/research/community/1328-zao-podcast-pitch-kit-jul2026/README.md
@@ -40,7 +40,7 @@ owner: Zaal
 | **BASS DROP** (Sound.xyz) | Sound's native pod; cross-promotion opportunity even as competitor. | @soundxyz_io DM |
 | **The Art of the Hustle** | Music business meets blockchain. | contact@artofthehustlepodcast.com |
 
-**Pitch hook:** *"We built a music battle platform where the loser still earns. 1,245 battles, 524 SOL in artist payouts, community-governed. Here's why prediction markets are the future of music discovery."*
+**Pitch hook:** *"We built a music battle platform where the loser still earns. 1,289 battles, 878 SOL in volume, community-governed. Here's why prediction markets are the future of music discovery."*
 
 ---
 
@@ -87,7 +87,7 @@ owner: Zaal
 >
 > Hi [Host name],
 >
-> Quick pitch: ZAO built WaveWarZ — a music battle platform where fans stake SOL predicting which artist wins. 1,245 battles, 524 SOL in payouts, and here's the twist: the loser still earns.
+> Quick pitch: ZAO built WaveWarZ — a music battle platform where fans stake SOL predicting which artist wins. 1,289 battles, 878 SOL in volume, and here's the twist: the loser still earns.
 >
 > The numbers (all verifiable at wavewarz.info):
 > - 1.73% of every SOL bet goes directly to artists, instantly, onchain

--- a/research/community/1617-zao-newsletter-issue-1-spec/README.md
+++ b/research/community/1617-zao-newsletter-issue-1-spec/README.md
@@ -25,7 +25,7 @@ A single, well-structured newsletter hitting all three — with clear CTAs and t
 `ZAOstock tickets are live. ZABAL applications open. COC #8 announced.`
 
 **B (stats-forward):**  
-`1,245 battles. Now: ZAOstock. ZABAL S2. COC #8.`
+`1,289 battles. Now: ZAOstock. ZABAL S2. COC #8.`
 
 **Preview text (both):**  
 `Three things you can do today to be part of ZAO's biggest month.`
@@ -47,7 +47,7 @@ July 21, 2026
 
 > WaveWarZ is the music battle platform where fans trade on outcomes and every artist — including the loser — earns automatically, on-chain.
 > 
-> As of today: 1,245 battles. 523 SOL in trading volume. 9.09 SOL to artists including losers.
+> As of today: 1,289 battles. 878 SOL in trading volume. 13.39 SOL to artists including losers.
 > 
 > Today we're launching three things at once. Here's what they are and how to act.
 
@@ -168,7 +168,7 @@ ZOE posts this as a thread after newsletter send:
 `3/ COC #8 date announced: [date]. Next live WaveWarZ battle series show.`
 
 **Tweet 5:**
-`ZAO: 1,245 battles. Every artist earns. wavewarz.info`
+`ZAO: 1,289 battles. Every artist earns. wavewarz.info`
 
 ---
 

--- a/research/community/1693-zao-community-onboarding-guide/README.md
+++ b/research/community/1693-zao-community-onboarding-guide/README.md
@@ -194,7 +194,7 @@ ZAO never holds your funds. When you stake on WaveWarZ, your SOL goes into smart
 **"Where can I verify ZAO's track record?"**
 - WaveWarZ stats: wavewarz.info/api/public/stats
 - Governance sessions: OREC contract on Optimistic Etherscan (`0xcB05F9254765CA521F7698e61E0A6CA6456Be532`)
-- ZAOOS knowledge base: github.com/bettercallzaal/ZAOOS (1,600+ CC-BY docs)
+- ZAOOS knowledge base: github.com/bettercallzaal/ZAOOS (1,800+ CC-BY docs)
 
 ---
 

--- a/research/technology/1499-zoe-daily-ops-report-spec/README.md
+++ b/research/technology/1499-zoe-daily-ops-report-spec/README.md
@@ -170,13 +170,13 @@ const stats = await fetch('https://wavewarz.info/api/public/stats')
   .then(r => r.json())
 
 const report = {
-  totalBattles: stats.totalBattles,     // 1245
-  totalVolume: stats.totalVolume,       // 523.991 SOL
-  artistPayouts: stats.artistPayouts,   // 9.0988 SOL
-  traderClaims: stats.traderClaims,     // 127.343 SOL
+  totalBattles: stats.totalBattles,     // 1289
+  totalVolume: stats.totalVolume,       // 878.30 SOL
+  artistPayouts: stats.artistPayouts,   // 13.39 SOL
+  traderClaims: stats.traderClaims,     // 381.197 SOL
   mainEvents: stats.mainEvents,         // 50
-  mainBattles: stats.mainBattles,       // 162
-  quickBattles: stats.quickBattles,     // 1047
+  mainBattles: stats.mainBattles,       // 165
+  quickBattles: stats.quickBattles,     // 1084
   communityBattles: stats.communityBattles // 36
 }
 ```

--- a/research/technology/1526-hurricane-aug1-dev-handoff/README.md
+++ b/research/technology/1526-hurricane-aug1-dev-handoff/README.md
@@ -31,11 +31,11 @@ a music battle platform on Solana where losing artists automatically receive
 an onchain payout. Founded 2024.
 
 ### Key Facts
-- 64+ consecutive weekly governance sessions (Fractal Democracy on Optimism Mainnet)
-- 1,245 battles completed (as of Jul 2026)
-- 523.991 SOL volume (~$104,000 USD)
-- 9.0988 SOL distributed to LOSING artists (loser-earns mechanism)
-- 127.343 SOL distributed to winning traders
+- 103+ consecutive weekly governance sessions (Fractal Democracy on Optimism Mainnet)
+- 1,289 battles completed (as of Jul 24, 2026)
+- 878.30 SOL volume (~$66K USD)
+- 13.39 SOL distributed to artists (loser-earns mechanism)
+- 381.197 SOL distributed to winning traders (1,526 on-chain withdrawals)
 - 36 community battles with charity payouts voted by ZOR holders
 
 ### Governance Contracts (Optimism Mainnet)


### PR DESCRIPTION
## Summary

Second batch of stale-stats fixes discovered during repo-wide grep. Completes the post-AI-Tournament stats sweep (part of Jul 24 batch PRs #2557–2565).

**Docs updated:**
| Doc | What changed |
|-----|-------------|
| 1295 (Farcaster strategy) | 3 content template examples: 1,245→1,289 battles, 524→878 SOL |
| 1328 (podcast pitch kit) | Pitch hook + email template: 1,245→1,289, 524→878 SOL |
| 1499 (ZOE daily ops report spec) | Code comment values updated to current API response |
| 1526 (Hurricane dev handoff) | Key facts block: battles, volume, payouts, trader claims, fractal sessions |
| 1617 (newsletter issue 1 spec) | Subject line + lede + tweet template |
| 1693 (community onboarding guide) | ZAOOS doc count: 1,600+ → 1,800+ |

**Numbers consistently applied:**
- Battles: `1,289` (was 1,245)
- SOL volume: `878.30 SOL` (was 523-524 SOL)
- Artist payouts: `13.39 SOL` (was 9.09 SOL)
- Trader claims: `381.197 SOL` (was 127.343 SOL)
- Fractal sessions: `103+` (was 64+)
- ZAOOS docs: `1,800+` (was 1,600+)

## Test plan
- [ ] `grep "1,245\|523\|9\.0988\|1,600+" <all 6 files>` returns 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)