### PR TITLE
fix: refresh WaveWarZ stats in 3 external-facing docs (Jul 24)

### DIFF
--- a/research/community/050-the-zao-complete-guide/README.md
+++ b/research/community/050-the-zao-complete-guide/README.md
@@ -227,7 +227,7 @@ A music competition and discovery platform originally incubated within the ZAO e
 | **What** | Onchain music prediction market on Solana |
 | **Legal** | Delaware C-Corporation |
 | **Smart contract** | `9TUfEHvk5fN5vogtQyrefgNqzKy2Bqb4nWVhSFUg2fYo` (Solana Mainnet, Anchor/Rust) |
-| **Volume** | 524.15 SOL (~$39K USD, July 2026) across 1,245 total battles |
+| **Volume** | 878.30 SOL (~$66K USD, July 2026) across 1,289 total battles |
 | **Website** | [wavewarz.com](https://www.wavewarz.com/) |
 
 **How it works:** Artists battle in 3 consecutive 20-minute rounds. Fans trade using ephemeral bonding curve tokens that exist only during each round. Triple judging combines a human judge, X poll, and SOL trading activity. Artists earn 1% of all trading volume immediately. Losing traders get 50% partial recovery.

--- a/research/cross-platform/1261-linkedin-profile-copy-july2026/README.md
+++ b/research/cross-platform/1261-linkedin-profile-copy-july2026/README.md
@@ -34,7 +34,7 @@ Most music platforms keep the revenue, the data, and the relationship. The artis
 
 What this looks like in practice:
 
-WaveWarZ -- an onchain music battle platform on Solana. Artists earn 1% of every trade, paid instantly to their wallet. 1,245 battles have run. Lifetime volume: 524 SOL (~$39K). No streaming deal, no label cut, no waiting.
+WaveWarZ -- an onchain music battle platform on Solana. Artists earn 1% of every trade, paid instantly to their wallet. 1,289 battles have run. Lifetime volume: 878 SOL (~$66K). No streaming deal, no label cut, no waiting.
 
 The ZAO -- a music-tech DAO that has run 101+ consecutive weekly governance sessions. 63 of those weeks are settled on-chain (Optimism). 157 unique Respect holders. It is the most consistent onchain music community I know of.
 
@@ -77,7 +77,7 @@ LinkedIn Featured allows pinned links or posts. Pin in this order:
 ### Pin 3 -- WaveWarZ (best available link -- wwtracker or app)
 
 - **URL:** https://wavewarz.xyz (or wwtracker equivalent -- confirm live URL with Zaal)
-- **Headline:** "WaveWarZ -- 524 SOL volume, 1% instantly to artists"
+- **Headline:** "WaveWarZ -- 878 SOL volume, 1% instantly to artists"
 - **Why third:** The most concrete proof point. Real numbers, real payouts.
 
 **Note on Featured posts:** Once the LinkedIn posting cadence is running (3x/week per doc 987), replace Pin 3 with the highest-performing post (ranked by saves + comments). Best-performing posts move to Featured; evergreen links stay in Pins 1 and 2.
@@ -97,8 +97,8 @@ LinkedIn Featured allows pinned links or posts. Pin in this order:
 
 | Claim | Source |
 |-------|--------|
-| 1,245 WaveWarZ battles | Doc 1077 (July 17 audit), wwtracker |
-| 524 SOL lifetime volume | Doc 1077, 1219, 1237 |
+| 1,289 WaveWarZ battles | Live API Jul 24, wwtracker |
+| 878 SOL lifetime volume | Live API Jul 24 |
 | 1% instant artist payout | WaveWarZ smart contract, confirmed doc 1252 |
 | 101+ weekly Fractal sessions | Doc 1254 (ZAO Fractal 100-week record) |
 | 63 on-chain weeks (Optimism) | Doc 1254 |

--- a/research/identity/1437-zao-wavewarz-wikipedia-article-guide/README.md
+++ b/research/identity/1437-zao-wavewarz-wikipedia-article-guide/README.md
@@ -92,7 +92,7 @@ The ZAO's governance contracts operate on the Optimism blockchain, including an 
 
 WaveWarZ is a music battle platform developed by The ZAO that uses a prediction market model in which audience members bet cryptocurrency (SOL) on which of two competing artists will win a head-to-head competition. Unlike traditional music streaming, WaveWarZ's "loser-earns" mechanism distributes a share of the losing side's pool to the artist who lost, providing revenue for artists regardless of outcome.<ref>[CITE: Hypebot or Ari's Take article]</ref>
 
-As of July 2026, WaveWarZ had facilitated over 1,245 battles with cumulative trading volume exceeding 523 SOL.<ref>[CITE: wavewarz.info API / ZAOOS doc]</ref>
+As of July 2026, WaveWarZ had facilitated over 1,289 battles with cumulative trading volume exceeding 878 SOL.<ref>[CITE: wavewarz.info API / ZAOOS doc]</ref>
 
 === ZAOstock ===
 
@@ -118,7 +118,7 @@ WaveWarZ operates three battle formats: MAIN battles (curated multi-battle event
 
 === History ===
 
-WaveWarZ launched in 2024. As of July 2026, the platform had completed over 1,245 battles across 50 MAIN events, with cumulative trading volume of approximately 524 SOL (approximately $104,000 USD at July 2026 prices).<ref>[CITE: wavewarz.info public API / ZAOOS doc 1435]</ref>
+WaveWarZ launched in 2024. As of July 2026, the platform had completed over 1,289 battles across 51 MAIN events, with cumulative trading volume of approximately 878 SOL (approximately $66,000 USD at July 2026 prices).<ref>[CITE: wavewarz.info public API / ZAOOS doc 1435]</ref>
 
 === Criticism and analysis ===
 


### PR DESCRIPTION
## Summary

Stats sweep for external-facing / press-critical docs — these get picked up by journalists, Wikipedia editors, and AI crawlers, so accuracy matters most.

- **1261** (LinkedIn profile copy): 1,245→1,289 battles, 524→878 SOL (About section + Featured section + verification table)
- **1437** (Wikipedia article guide): 1,245→1,289, 523/524→878 SOL, 50→51 MAIN events, ~$104K→~$66K (both draft article instances)
- **050** (ZAO complete guide): 524.15→878.30 SOL, ~$39K→~$66K, 1,245→1,289 battles

All stats from live API Jul 24, 2026 (878.30 SOL, 1,289 battles).

Part of post-AI-Tournament stats sweep (PRs #2561–2566 preceded this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)