### PR TITLE
doc 2070: work efficiency / flow finish lines (STANDARD tier)

### DIFF
--- a/research/business/2070-work-efficiency-flow-finish-lines/README.md
+++ b/research/business/2070-work-efficiency-flow-finish-lines/README.md
@@ -1,0 +1,79 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-07-24
+superseded-by:
+related-docs: 928, 2064
+original-query: "/zao-research the FlowState.com newsletter by Rian Doris on 'work efficiency' - the work finish line, Tetris container, and finish line sting method (Kauai vs Zurich workday)."
+tier: STANDARD
+---
+
+# 2070 - Work Efficiency: Flow Finish Lines (Method + Science Caveats + ZAO Application)
+
+> **Goal:** Capture Rian Doris's "work efficiency" method (a hard daily finish line that forces flow), flag which of its science is solid vs popularized, and turn it into a concrete setup for how Zaal works and how ZAO's autonomous loops are governed.
+
+## Key Decisions (recommendations first)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **USE the work-finish-line method - Zaal already half-lives it.** Formalize the 4:30am-wake / 4-7pm-build pattern into a hard, calendared finish line. | The method's core claim (a finite window forces intensity + discernment) is behaviorally sound and matches Zaal's existing compressed-block habit. This makes the habit deliberate + protected instead of accidental. |
+| 2 | **Treat the METHOD as sound but do NOT repeat its SCIENCE as fact.** | Fact-check verdict is MIXED: the flow cycle + sleep efficiency are well-grounded, but the "central governor" model is actively contested (some call it pseudoscience), the "4% flow trigger" is an unvalidated heuristic, and "work efficiency" is the author's own coinage - not a peer-reviewed metric. The advice works; the mechanism claims are marketing-grade. |
+| 3 | **Map it to ZAO's agent loops: a human finish line = an agent budget cap.** | Doc 928 rule 5 already caps every autonomous loop (daily item cap, budget cap, one-instance lock). The finish line is the same discernment-forcing device for the human. Both make "what actually matters" legible by removing the option to add more hours/tokens. |
+
+## The method (3 steps, verbatim structure)
+
+**Step 1 - Set a work finish line.** A non-negotiable daily point after which the laptop closes and work stops. Setup: add up your real weekly work hours, cut by at least 25%, spread across workdays -> that's your daily finish line. Put a recurring start-line + finish-line event on the calendar (decided once, in advance) and a phone alarm at the finish line. Pull any standing calls that fall outside the window back inside it.
+
+**Step 2 - Turn the workday into a Tetris container.** Once the window can't grow, the only way to do more is more-per-hour, which forces speed, discernment, delegation, and strategy - "levers everyone reaches for last, because there are still hours to throw at the problem."
+
+**Step 3 - Embrace the finish-line sting.** The pain of hitting the line with work unfinished is what forces tomorrow's upgrade. Close the laptop mid-sentence; by morning the half-written thing usually turns out not to have needed the grind. Expect the first week to go sideways (missed deadlines) - that's the sting doing its job. Then keep pulling the line earlier so the sprint tightens.
+
+The illustrative contrast: a 5-hour Kauai workday at ~98% "work efficiency" (4h54m of real work) beat a 14.5-hour Zurich workday at ~41% (~6h of real work in 14.5h). "5 hours at 15mph = 75 miles; 12 hours at 3mph = 36 miles - the longer day covers less distance." The finish line is also the gate into the recovery phase of the flow cycle (struggle -> release -> flow -> recovery).
+
+## Science honesty (what to trust, what to flag)
+
+| Claim in the essay | Verdict | Note |
+|--------------------|---------|------|
+| Sleep efficiency (asleep / time-in-bed) is a real metric, ~80-90%+ healthy | **VERIFIED** | Standard in sleep medicine |
+| Flow cycle: struggle -> release -> flow -> recovery | **VERIFIED** | Kotler / Flow Research Collective framework |
+| Rian Doris is Co-Founder/CEO of Flow Research Collective (with Steven Kotler, 2019); neuroscience creds | **VERIFIED** | Solid credentials |
+| Central governor model (Noakes, 1996) - brain holds an effort buffer, releases at the "endspurt" | **CONTESTED** | Real proposed model but heavily disputed in exercise physiology; one critique classes it as pseudoscience. Do NOT cite as settled. |
+| Flow needs challenge ~4% above skill | **HEURISTIC** | A Kotler/FRC popularization; no peer-reviewed source for the specific 4%. A rule of thumb, not data. |
+| "Work efficiency" = % of workday spent actually working | **AUTHOR'S COINAGE** | Not an established productivity metric; the analogy to sleep efficiency is the author's framing. |
+
+Bottom line from the fact-check: the ADVICE is credible and useful; the SCIENCE is selectively cited. Use the method; don't parrot the mechanism claims.
+
+## ZAO / Zaal application
+
+- **Zaal already runs the pattern.** Per the operating memory: 4:30am wake, a compressed build block (4-7pm). The Kauai story is literally Zaal's default day. The gap is that the finish line is habit, not enforced - the essay's contribution is making it a hard, calendared, alarmed line so evenings actually close.
+- **Concrete setup (fill in your real numbers - not fabricated here):**
+  1. Sum your actual weekly work hours (be honest, count the grey-zone half-work).
+  2. Cut by >=25%. That capped number, spread across your workdays, is the daily finish line.
+  3. Two recurring calendar events per workday: a start line and a finish line. Phone alarm at the finish line.
+  4. Pull any standing call/meeting outside the window back inside it.
+  5. First week will sting - hold the line, then pull it 10-15 min earlier once it holds.
+- **The agent-loop parallel (why this doc lives in the lab).** ZAO's autonomous loops already have finish lines: Doc 928 rule 5 mandates a hard cap on every loop (daily item cap, budget cap), and empty-queue = zero spend. Brandon's organism ships a literal "governor" (atomic spend + rate velocity). The human finish line and the agent budget cap are the same device - remove the option to add more, and discernment appears. When designing ZAO loops, the finish line is the model: cap first, let the cap force the prioritization.
+
+## Also See
+
+- [Doc 928](../../agents/928-agent-loop-best-practices/) - loop cost/iteration ceilings (rule 5), the agent-side finish line
+- [Doc 2064](../../agents/2064-organism-runtime-memory-governance/) - the organism governor / Heart, budget as a first-class control
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Sum real weekly work hours, cut 25%, create the two recurring calendar events (start + finish line) + phone alarm | @Zaal | Calendar | 2026-07-31 |
+| Hold the finish line for two weeks, then pull it 10-15 min earlier; note whether the build block stays <=3h | @Zaal | Habit trial | 2026-08-14 |
+| When designing the next ZAO autonomous loop, set the budget/iteration cap FIRST (finish-line-as-code) per Doc 928 rule 5 | @Zaal | Design rule | wontfix (standing) |
+
+## Sources
+
+- FlowState.com newsletter by Rian Doris, "work efficiency / work finish line" (Kauai vs Zurich) `[FULL]` - full essay provided verbatim by Zaal
+- [Rian Doris (Flow Research Collective) - LinkedIn](https://www.linkedin.com/in/riandoris/) `[FULL]`
+- [Central governor model - Wikipedia](https://en.wikipedia.org/wiki/Central_governor) `[FULL]` - documents the dispute
+- ["Is it Time to Retire the Central Governor?" (Springer)](https://link.springer.com/article/10.2165/11315130-000000000-00000) `[PARTIAL - abstract]`
+- [The 4% flow rule (Vishen Lakhiani / Kotler, Medium)](https://medium.com/@Vishen/the-4-rule-to-get-in-flow-84258ededec2) `[FULL]` - shows it as a heuristic, unsourced
+- [Sleep efficiency - DiMe core measures](https://dimesociety.org/core-measures-sleep/) `[FULL]`
+- [Steven Kotler on flow cycles - Big Think](https://bigthink.com/videos/hack-your-flow-understanding-flow-cycles-with-steven-kotler/) `[FULL]`

--- a/research/business/README.md
+++ b/research/business/README.md
@@ -225,3 +225,4 @@
 | 2038 | [ZABAL Gamez QV Submission Pipeline: Architecture & Build Plan](./2038-zabal-gamez-qv-submission-pipeline/) | STANDALONE | Research doc 2038. |
 | 2050 | [JubJub Developer Platform - ZAO Relevance Assessment](./2050-jubjub-developer-platform-eval/) | STANDALONE | Research doc 2050. |
 | 2058 | [Sparkz UX/OSS Teardown: High-Traffic Creator & Crypto Apps](./2058-sparkz-ux-oss-teardown/) | STANDALONE | Research doc 2058. |
+| 2070 | [Work Efficiency: Flow Finish Lines (Method + Science Caveats + ZAO Application)](./2070-work-efficiency-flow-finish-lines/) | STANDALONE | Capture Rian Doris's "work efficiency" method (a hard daily finish line that forces flow), flag which of its science is solid vs popularized, and turn it into a concrete setup for how Zaal works and how ZAO's autonomous loops are governed. |


### PR DESCRIPTION
## Summary
Captures Rian Doris's (Flow Research Collective) "work efficiency" method - a hard daily work finish line that forces flow via a Tetris-container workday + the finish-line sting. Flags the science honestly: the flow cycle + sleep efficiency are solid, but the central-governor model is contested, the 4% flow trigger is an unvalidated heuristic, and "work efficiency" is the author's own coinage. Maps it to Zaal's existing 4:30am compressed-block habit (formalize it) and to ZAO's agent-loop budget caps (a human finish line = an agent budget cap, Doc 928 rule 5).

## Tier
STANDARD

## Sources
7 unique: the full essay (FULL) + fact-check sources (LinkedIn creds, central-governor dispute, 4%-rule heuristic, sleep-efficiency metric, flow-cycle).

## Next Actions
Actionable setup included: sum real hours, cut 25%, two recurring calendar events + alarm. See the doc's Next Actions table.