### PR TITLE
feat(zoe/tg): persistent tap-first button bar + / command menu (cockpit 1/N)

### DIFF
--- a/bot/src/zoe/__tests__/button-bar.test.ts
+++ b/bot/src/zoe/__tests__/button-bar.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { BUTTON_BAR, ZOE_COMMANDS, BAR_LABELS, isBarLabel } from '../button-bar';
+
+describe('button-bar', () => {
+  it('is a persistent, resized reply keyboard with the five labels', () => {
+    const kb = BUTTON_BAR.build();
+    const flat = kb.flat().map((b) => (b as { text: string }).text);
+    expect(flat).toEqual(['Agenda', 'Focus', 'Budget', 'Note', 'Board']);
+    // grammy Keyboard options
+    expect((BUTTON_BAR as unknown as { is_persistent?: boolean }).is_persistent).toBe(true);
+    expect((BUTTON_BAR as unknown as { resize_keyboard?: boolean }).resize_keyboard).toBe(true);
+  });
+
+  it('isBarLabel matches only the exact labels', () => {
+    for (const l of BAR_LABELS) expect(isBarLabel(l)).toBe(true);
+    expect(isBarLabel('agenda')).toBe(false); // case-sensitive
+    expect(isBarLabel('Agenda ')).toBe(false);
+    expect(isBarLabel('note: hi')).toBe(false);
+  });
+
+  it('registers only real, described commands for the / menu', () => {
+    expect(ZOE_COMMANDS.length).toBeGreaterThan(0);
+    for (const c of ZOE_COMMANDS) {
+      expect(c.command).toMatch(/^[a-z]+$/);
+      expect(c.description.length).toBeGreaterThan(3);
+    }
+    expect(ZOE_COMMANDS.map((c) => c.command)).toContain('focus');
+    expect(ZOE_COMMANDS.map((c) => c.command)).toContain('menu');
+  });
+});

--- a/bot/src/zoe/button-bar.ts
+++ b/bot/src/zoe/button-bar.ts
@@ -1,0 +1,49 @@
+/**
+ * button-bar - a persistent Telegram reply keyboard (the tap-first cockpit bar)
+ * + the `/` command menu registration.
+ *
+ * ZOE used inline buttons + reactions but had NO persistent reply keyboard, so
+ * every quick action meant typing or scrolling back to an old message. This
+ * pins a always-visible bar at the bottom of the DM: one thumb, no typing. The
+ * labels are plain words (no emoji, per house style); index.ts intercepts them
+ * at the top of the message:text handler and routes each to the existing action
+ * (Agenda -> sendAgenda, Budget -> formatSpendStatus, Focus -> focus toggle,
+ * Note -> capture prompt, Board -> the board link).
+ *
+ * Boundary: this module only DEFINES the keyboard + command list. The routing
+ * lives in index.ts where the action functions are in scope.
+ */
+
+import { Keyboard } from 'grammy';
+
+/** The five bar labels. index.ts checks membership before treating text as chat. */
+export const BAR_LABELS = ['Agenda', 'Focus', 'Budget', 'Note', 'Board'] as const;
+export type BarLabel = (typeof BAR_LABELS)[number];
+
+export function isBarLabel(text: string): text is BarLabel {
+  return (BAR_LABELS as readonly string[]).includes(text);
+}
+
+/** The persistent, auto-resized reply keyboard. Two rows. */
+export const BUTTON_BAR = new Keyboard()
+  .text('Agenda')
+  .text('Focus')
+  .text('Budget')
+  .row()
+  .text('Note')
+  .text('Board')
+  .resized()
+  .persistent();
+
+/**
+ * The `/` command menu (setMyCommands). Only the commands Zaal actually uses -
+ * the ones the usage audit flagged as high-leverage-but-invisible.
+ */
+export const ZOE_COMMANDS = [
+  { command: 'menu', description: 'Show the tap-first cockpit bar' },
+  { command: 'focus', description: 'Toggle hyperfocus (queue non-urgent pings)' },
+  { command: 'agenda', description: 'Show the board - all open items' },
+  { command: 'budget', description: "Today's spend + headroom" },
+  { command: 'checkpoint', description: 'Save a breadcrumb note' },
+  { command: 'audit', description: 'Scan for fallen tasks / captures' },
+];

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -17,7 +17,8 @@
 import { config as loadEnv } from 'dotenv';
 loadEnv();
 
-import { Bot, Context } from 'grammy';
+import { Bot, Context, InlineKeyboard } from 'grammy';
+import { BUTTON_BAR, ZOE_COMMANDS, isBarLabel } from './button-bar';
 import type { Client } from 'discord.js';
 import { bootDiscordClient } from './discord';
 import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, type TaskStatus } from '../lib/cowork';
@@ -384,7 +385,14 @@ bot.command('start', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   await ctx.reply(
     'ZOE online. Hermes runtime, Sonnet/Opus brain via Max plan. Memory blocks loaded (persona/human/working/tasks). Send anything.',
+    { reply_markup: BUTTON_BAR },
   );
+});
+
+// /menu - (re)show the persistent tap-first cockpit bar at the bottom of the DM.
+bot.command('menu', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  await ctx.reply('Cockpit bar ready - tap below.', { reply_markup: BUTTON_BAR });
 });
 
 // /chatid - report this chat's id + (in a forum topic) its topic thread id, so
@@ -1103,6 +1111,36 @@ bot.on('message:new_chat_members', async (ctx) => {
 bot.on('message:text', async (ctx) => {
   const text = ctx.message.text;
   if (text.startsWith('/')) return; // commands handled above
+
+  // Cockpit button-bar taps arrive as plain text (a reply keyboard sends the
+  // label). Intercept them BEFORE the concierge treats them as conversation,
+  // and route each to its existing action. Zaal-only + private chat.
+  if (isFromZaal(ctx) && ctx.chat.type === 'private' && isBarLabel(text)) {
+    try {
+      if (text === 'Agenda') {
+        await sendAgenda(ctx);
+      } else if (text === 'Budget') {
+        await ctx.reply(formatSpendStatus(false));
+      } else if (text === 'Focus') {
+        if (await isFocusMode()) {
+          const released = await endFocus();
+          await ctx.reply(`Focus OFF. ${released.length} queued ping${released.length === 1 ? '' : 's'} released.`);
+        } else {
+          await startFocus();
+          await ctx.reply('Focus ON. Non-urgent pings queue until you tap Focus again.');
+        }
+      } else if (text === 'Note') {
+        await ctx.reply('Send it as: note: <your thought>');
+      } else if (text === 'Board') {
+        const boardUrl = process.env.BOARD_MINI_URL || 'https://thezao.xyz/board';
+        await ctx.reply('ZAO board:', { reply_markup: new InlineKeyboard().url('Open board', boardUrl) });
+      }
+    } catch (e) {
+      console.error('[zoe/index] button-bar action failed:', e);
+      await ctx.reply(`That action hit a snag: ${sanitizeErrorForUser(e)}`);
+    }
+    return;
+  }
 
   const chatType = ctx.chat.type;
   const chatId = ctx.chat.id;
@@ -2691,6 +2729,11 @@ async function main(): Promise<void> {
   } catch (err) {
     console.error('[zoe/index] getMe failed:', (err as Error).message);
   }
+
+  // Register the `/` command menu so the underused commands are discoverable.
+  await bot.api.setMyCommands(ZOE_COMMANDS).catch((err: unknown) => {
+    console.error('[zoe/index] setMyCommands failed:', (err as Error).message);
+  });
 
   startScheduler({ bot, zaalTgId: zaalId, repoDir, devzChatId, routingDeps });
 


### PR DESCRIPTION
## Telegram cockpit (1/N): persistent button bar + / command menu

ZOE used inline buttons + reactions but had **no persistent reply keyboard**, so every quick action meant typing or scrolling to an old message.

- **`bot/src/zoe/button-bar.ts`** - a persistent, resized reply keyboard pinned at the bottom of the DM: **Agenda / Focus / Budget / Note / Board** (plain-word labels, no emoji). Plus `ZOE_COMMANDS` for the `/` menu.
- **index.ts** - intercepts the bar labels at the top of the `message:text` handler (before the concierge treats them as chat) and routes each to its existing action: Agenda->`sendAgenda`, Budget->`formatSpendStatus`, Focus->toggle, Note->capture prompt, Board->board link. Zaal-only, private chat.
- **`/menu`** (re)shows the bar; `/start` shows it too.
- **`setMyCommands`** at boot registers the `/` menu so the underused commands (focus/agenda/budget/checkpoint/audit) are discoverable.

### Verification
- button-bar tests 3/3; esbuild bundles clean; tsc adds zero new errors (46 baseline).

Next in the set: topic routing (Research topic -> zao-research on VPS -> PR -> DM), then feed hygiene (auto-delete stale messages), evening check-in, polls.