### PR TITLE
fix(wavewarz): refresh stats in docs 363, 1281, 1438 — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/community/1281-zao-member-journey-jul2026/README.md
+++ b/research/community/1281-zao-member-journey-jul2026/README.md
@@ -165,7 +165,7 @@ Grant reviewers often ask: "How do we verify your community is real?" The ZAO ha
 
 2. **The newsletter is an externally auditable archive.** 400+ editions at paragraph.com/@thezao, with 78 paid subscribers. Each edition is timestamped and public.
 
-3. **WaveWarZ volume is onchain.** 524.15 SOL in trade volume is real economic activity by real participants — not artificially inflated.
+3. **WaveWarZ volume is onchain.** 878.30 SOL in trade volume is real economic activity by real participants — not artificially inflated.
 
 The combination of on-chain governance + on-chain economic activity + verifiable publication record makes The ZAO's community claims unusually hard to fake.
 

--- a/research/community/363-zao-stock-people-brands-2026/README.md
+++ b/research/community/363-zao-stock-people-brands-2026/README.md
@@ -16,7 +16,7 @@
 |----------|----------------|
 | **Profile gaps** | Tom Fellenz profile COMPLETE. Shawn, DFresh, Craig G need bios from them directly - no public web presence found. |
 | **Brand profiles** | WaveWarZ and COC Concertz have strong public data. FISHBOWLZ, Songjam, ZAOVille are internal/early-stage. |
-| **For pitch page** | USE WaveWarZ stats (1,245 battles, 524.15 SOL), COC Concertz (5 events), newsletter (400+ editions), fractals (100+ weeks) as credibility proof |
+| **For pitch page** | USE WaveWarZ stats (1,289 battles, 878.30 SOL), COC Concertz (5 events), newsletter (400+ editions), fractals (100+ weeks) as credibility proof |
 | **Missing data** | NEED photos/video from ZAO-CHELLA, Maine Craft Weekend attendance numbers, Fractured Atlas exact wording |
 
 ---
@@ -120,14 +120,14 @@
 |-------|--------|
 | **What** | Live-traded music battle platform on Solana |
 | **Website** | [wavewarz.com](https://www.wavewarz.com), [wavewarz.info](https://wavewarz.info) (analytics) |
-| **Total battles** | 1,245 (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community) |
-| **Total volume** | 524.15 SOL (~$39K at $75/SOL, 2026-07-17) |
-| **Total artist payouts** | 9.07 SOL |
+| **Total battles** | 1,289 (1,088 Quick + 165 Main Battles + 51 Main Events + 36 Community) |
+| **Total volume** | 878.30 SOL (~$64.8K at $73.73/SOL, 2026-07-24) |
+| **Total artist payouts** | 13.40 SOL |
 | **Artist economics** | 1% trading volume + 5-7% settlement bonus, instant onchain |
 | **Legal entity** | Delaware C-Corp |
 | **Founders** | Hurric4n3Ike + Candy |
 | **Smart contracts** | Base L2 (Candy's wavewarz-base, 8/8 tests, A+ audit) |
-| **Key stat for sponsors** | 1,245 battles, 524.15 SOL volume, real artists getting paid |
+| **Key stat for sponsors** | 1,289 battles, 878.30 SOL volume, real artists getting paid |
 
 ### ZAOstock
 
@@ -200,8 +200,8 @@
 |--------|--------|--------|
 | Weekly governance sessions | 100+ consecutive | ZAO Fractals (Mondays 6pm EST) |
 | Newsletter editions | 400+ | Year of the ZABAL on Paragraph |
-| WaveWarZ battles | 1,245 | wavewarz.info/api/public/stats (2026-07-17) |
-| WaveWarZ volume | 524.15 SOL (~$39K) | wavewarz.info/api/public/stats (2026-07-17) |
+| WaveWarZ battles | 1,289 | wavewarz.info/api/public/stats (2026-07-24) |
+| WaveWarZ volume | 878.30 SOL (~$64.8K) | wavewarz.info/api/public/stats (2026-07-24) |
 | COC Concertz events | 5 (monthly recurring) | cocconcertz.com |
 | Team members | 14 active + 4 advisors | Dashboard |
 | ZAO members | ~188 gated | ZAO OS |

--- a/research/technology/1438-zao-llmstxt-deploy-guide/README.md
+++ b/research/technology/1438-zao-llmstxt-deploy-guide/README.md
@@ -53,12 +53,12 @@ On-chain contracts (Optimism Mainnet):
 
 ## WaveWarZ (Product)
 
-WaveWarZ is a music battle prediction market. Stats as of July 2026:
-- 1,245+ battles completed
-- 50 MAIN events
-- 523.99 SOL total trading volume (~$104K USD)
-- 9.09 SOL paid to losing artists
-- 127.34 SOL claimed by winning traders
+WaveWarZ is a music battle prediction market. Stats as of July 2026 (post-AI-Tournament):
+- 1,289+ battles completed
+- 51 MAIN events
+- 878.30 SOL total trading volume (~$64.8K USD at $73.73/SOL)
+- 13.40 SOL paid to artists (instant, per-trade)
+- 381.20 SOL claimed by winning traders
 - 3 battle types: MAIN, Quick Battle, Community/Charity Battle
 
 The "loser-earns" mechanism: when a battle closes, the losing artist receives ~1.73% of the pool bet against them. This means every artist earns something regardless of outcome — structurally different from streaming royalties.


### PR DESCRIPTION
## Summary

Batch stats refresh across 3 living docs — post-AI-Tournament numbers (Jul 24):

| Doc | What changed |
|-----|-------------|
| 363 (ZAOstock pitch/brands) | 4 instances: decisions table, brand table, key stats, metrics table |
| 1281 (ZAO member journey) | Onchain proof section: `524.15 SOL` → `878.30 SOL` |
| 1438 (llms.txt deploy guide) | Battles, SOL volume, artist payouts, trader claims — also fixed USD calc (was wrongly ~$104K; correct at $73.73/SOL is ~$64.8K) |

**Stats source:** `wavewarz.info/api/public/stats` (Jul 24, 16:53 UTC)

## Test plan
- [ ] Doc 363 line 19: uses `1,289 battles, 878.30 SOL`
- [ ] Doc 363 brand table: `878.30 SOL (~$64.8K at $73.73/SOL, 2026-07-24)`
- [ ] Doc 1281 line 168: `878.30 SOL in trade volume`
- [ ] Doc 1438 stats block: `1,289+ battles`, `878.30 SOL (~$64.8K)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)