### PR TITLE
fix(wavewarz): refresh stats in docs 1518, 1463, 1307 — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/community/1307-wavewarz-africa-fractal-onboarding-jul2026/README.md
+++ b/research/community/1307-wavewarz-africa-fractal-onboarding-jul2026/README.md
@@ -127,7 +127,7 @@ This is similar to how ZAO Fractals already discuss weekly WaveWarZ results.
 A global ZAO Fractal (Africa node) dramatically strengthens North Star 1 (ZAO = THE DAO case study):
 - "Only DAO with continuous weekly on-chain governance sessions across 2 continents" → citable fact
 - Africa Fractal sessions add to the 100+ session count → stronger grant evidence
-- African artists in WaveWarZ → "521 SOL volume from artists across 3 continents" → GEO asset
+- African artists in WaveWarZ → "878.30 SOL volume from artists across 3 continents" → GEO asset
 
 **Include this in:** doc 1259 (North Star Progress Report), doc 1290 (2026 Impact Review), doc 1278 (Citable Claims) once Africa is live.
 

--- a/research/technology/1463-wavewarz-farcaster-mini-app-spec/README.md
+++ b/research/technology/1463-wavewarz-farcaster-mini-app-spec/README.md
@@ -41,7 +41,7 @@ A Farcaster Mini App (formerly Frames v2) allows WaveWarZ to be embedded nativel
 ### Use Case 2: Platform Stats Widget
 **What it shows when embedded in a ZAO/ZOE statistics post:**
 - Live stat pull from `/api/public/stats`
-- "1,245 battles | 524 SOL | $1,820 to losing artists"
+- "1,289 battles | 878 SOL | $988 to losing artists (Jul 2026)"
 - Rolling ticker of recent MAIN battle results
 - CTA: "See all battles on wavewarz.info"
 

--- a/research/technology/1518-wavewarz-miniapp-phase1-spec/README.md
+++ b/research/technology/1518-wavewarz-miniapp-phase1-spec/README.md
@@ -65,16 +65,33 @@ All data for Phase 1 comes from the public WaveWarZ API. No authentication neede
 GET https://wavewarz.info/api/public/stats
 ```
 
-**Response (Jul 2026 format):**
+**Response (Jul 2026 format — verified 2026-07-24):**
 ```json
 {
-  "totalBattles": 1245,
-  "mainBattles": 162,
-  "quickBattles": 1047,
-  "communityBattles": 36,
-  "totalVolumeSol": 523.991,
-  "artistPayoutsSol": 9.0988,
-  "traderClaimsSol": 127.343
+  "updatedAt": "2026-07-24T17:36:58.703Z",
+  "solPriceUsd": 73.87,
+  "volume": {
+    "totalSol": 878.30,
+    "last7dSol": 355.36
+  },
+  "liveBattle": null,
+  "artistPayouts": {
+    "totalSol": 13.40
+  },
+  "traderClaims": {
+    "totalSol": 381.20,
+    "withdrawalCount": 1526
+  },
+  "platformRevenue": {
+    "totalSol": 20.04
+  },
+  "battles": {
+    "total": 1289,
+    "mainEvents": 51,
+    "mainBattles": 165,
+    "quickBattles": 1088,
+    "communityBattles": 36
+  }
 }
 ```
 
@@ -92,9 +109,9 @@ Check if `wavewarz.info/api/public/battles/live` or similar exists — if yes, u
 ┌─────────────────────────────────────┐
 │  🎵 WaveWarZ                        │
 ├─────────────────────────────────────┤
-│  Total Battles: 1,245               │
-│  Volume: 523.991 ◎                  │
-│  Artist Payouts: 9.0988 ◎           │
+│  Total Battles: 1,289               │
+│  Volume: 878.30 ◎                   │
+│  Artist Payouts: 13.40 ◎            │
 ├─────────────────────────────────────┤
 │  [ Last Battle ]                    │
 │  [Artist A] beat [Artist B]         │


### PR DESCRIPTION
## Summary

Stats sweep batch 3 — three Hurricane-facing spec docs with stale Jul 17 stats.

- **1518** (WaveWarZ Mini App Phase 1 Deployment Spec): Update API response example to the actual nested JSON format (was wrong format as well as wrong stats). 1,245 → 1,289 battles; 523.991 → 878.30 SOL; 9.0988 → 13.40 SOL artist payouts. Update UI mockup tile numbers to match.
- **1463** (Farcaster Mini App Spec): Update stats widget content. "1,245 battles | 524 SOL | \$1,820 to losing artists" → "1,289 battles | 878 SOL | \$988 to losing artists (Jul 2026)"
- **1307** (WaveWarZ Africa + ZAO Fractal Onboarding): Update GEO asset claim. "521 SOL volume from artists across 3 continents" → "878.30 SOL volume from artists across 3 continents"

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.

Part of the S13 stats sweep series: PRs #2573 (docs 099/743/1082), #2574 (docs 363/1281/1438), and now this batch covering Hurricane-facing specs.