### PR TITLE
fix(wavewarz): refresh stats in docs 1632, 1427, 987, 1310, 1441 — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/community/1310-zao-media-podcast-outreach-playbook-jul2026/README.md
+++ b/research/community/1310-zao-media-podcast-outreach-playbook-jul2026/README.md
@@ -31,7 +31,7 @@ The fix is outreach, not quality. The ZAO has more citable facts than 95% of mus
 **Hook:** "WaveWarZ pays losing artists 1.73% of battle volume — instantly, on-chain, in SOL. Spotify pays $0.004/stream. That's a 600× gap."
 **Why it works:** Concrete numbers, emotional hook (artists being paid fairly), familiar context (Spotify bad → web3 good)
 **Target shows:** Music business, creator economy, crypto podcasts
-**Supporting facts:** 9.07 SOL total payouts, $677 at current prices, 921 unique songs, 34 artists rostered
+**Supporting facts:** 13.40 SOL total payouts ($988 at $73.73/SOL), 921 unique songs, 34 artists rostered
 
 ### Angle 2: The DAO That Actually Shows Up (CRYPTO/DAO ANGLE)
 **Hook:** "63 consecutive on-chain governance weeks. 157 Respect holders. The only active Fractal DAO on Optimism. ZAO doesn't vote for show — it votes every single week."

--- a/research/community/1441-zao-lapsed-member-reengagement-jul2026/README.md
+++ b/research/community/1441-zao-lapsed-member-reengagement-jul2026/README.md
@@ -98,7 +98,7 @@ Hey [name] — haven't seen you at Fractal lately. We've been on a 100+ week str
 ```
 Hey [name] — I was looking at the ZAO governance record and found your name on session [#]. We've now hit 100+ consecutive weeks on-chain, and I wanted to reach out personally.
 
-We're launching ZABAL Season 2 in September — [1-line description of S2]. WaveWarZ just crossed 1,245 battles. COC Concertz #7 was today.
+We're launching ZABAL Season 2 in September — [1-line description of S2]. WaveWarZ just crossed 1,289 battles. COC Concertz #7 was today.
 
 No ask — just wanted you to know what became of the thing you were part of. If you want to rejoin or know someone who'd be interested, I'd love to reconnect.
 
@@ -117,7 +117,7 @@ No ask — just wanted you to know what became of the thing you were part of. If
 
 **Template (ZOE generates, Zaal sends):**
 ```
-Hey [artist name] — you submitted [TRACK] to WaveWarZ back in [MONTH]. We've crossed 1,245 battles since then. Things have grown.
+Hey [artist name] — you submitted [TRACK] to WaveWarZ back in [MONTH]. We've crossed 1,289 battles since then. Things have grown.
 
 COC Concertz #7 is tonight — our live concert series where WaveWarZ battles are featured live. We're building toward #8. If you have new music or want to get back in, submissions are open.
 

--- a/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
+++ b/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
@@ -35,7 +35,7 @@ tier: STANDARD
 - **zaalcaster** - open-sourced his own Farcaster client, vibe-coded with an AI agent. github.com/bettercallzaal/zaalcaster
 - **ZLANK** - no-code Farcaster snap builder, won FarHack 2026 Snaps track. zlank.online
 - **The ZAO** - 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism. 157 unique Respect holders (doc 1200). thezao.xyz
-- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 524.15 SOL lifetime volume (~$39K, 1,245 battles, 2026-07-17).
+- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 878.30 SOL lifetime volume (~$64.8K, 1,289 battles, 2026-07-24).
 - **ZABAL Gamez** - 3-month build-a-thon. zabalgamez.com
 - Build-in-public / vibe-coding lessons; artists owning their tools; onchain music.
 

--- a/research/security/1632-zao-smart-contract-security-posture/README.md
+++ b/research/security/1632-zao-smart-contract-security-posture/README.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-ZAO's on-chain components have operated without a security incident through 1,245 WaveWarZ battles and 100+ Fractal Democracy governance sessions (Jul 2026). No formal third-party audit has been completed as of Jul 2026. The design philosophy minimizes blast radius: governance contracts are optimistic (72h veto window), artist payouts are automatic (no manual intervention), and no user funds are custodied by ZAO.
+ZAO's on-chain components have operated without a security incident through 1,289 WaveWarZ battles and 100+ Fractal Democracy governance sessions (Jul 2026). No formal third-party audit has been completed as of Jul 2026. The design philosophy minimizes blast radius: governance contracts are optimistic (72h veto window), artist payouts are automatic (no manual intervention), and no user funds are custodied by ZAO.
 
 **Key security property:** ZAO never holds user funds. Fan prediction tokens are custodied by the WaveWarZ smart contract; artist payouts fire automatically at settlement; charity payouts fire automatically at settlement. There is no ZAO treasury wallet that could be compromised to drain user funds.
 
@@ -140,7 +140,7 @@ Before commissioning an audit, ZAO should:
 ## What ZAO Can Cite Today (Press/Grants)
 
 **Honest framing:**
-> "ZAO's smart contracts have operated through 1,245 WaveWarZ battles and 100+ governance sessions without a security incident. Key security properties: ZAO never custodies user funds (all held in smart contracts), governance uses a 72-hour optimistic veto window, and ZOR's soulbound design prevents flash loan governance attacks. A formal third-party audit is planned as part of ZAO's 2026 growth roadmap."
+> "ZAO's smart contracts have operated through 1,289 WaveWarZ battles and 100+ governance sessions without a security incident. Key security properties: ZAO never custodies user funds (all held in smart contracts), governance uses a 72-hour optimistic veto window, and ZOR's soulbound design prevents flash loan governance attacks. A formal third-party audit is planned as part of ZAO's 2026 growth roadmap."
 
 **What NOT to claim:**
 - "Audited" (not yet true)

--- a/research/technology/1427-wavewarz-zao-public-api-docs/README.md
+++ b/research/technology/1427-wavewarz-zao-public-api-docs/README.md
@@ -101,7 +101,7 @@ curl "https://wavewarz.info/api/public/battles?status=active&limit=10"
       "closes_at": "2026-07-18T20:00:00Z"
     }
   ],
-  "total": 1245,
+  "total": 1289,
   "page": 1
 }
 ```


### PR DESCRIPTION
## Summary

Stats sweep batch 4 — five outreach/security/API docs with stale Jul 17 stats updated to Jul 24 post-AI-Tournament figures.

- **1632** (smart contract security posture): 1,245 → 1,289 battles (2 instances in executive summary + citation block)
- **1427** (public API docs): pagination total example 1,245 → 1,289
- **987** (LinkedIn personal brand playbook): profile facts updated — 524.15 SOL / ~\$39K / 1,245 battles / 2026-07-17 → 878.30 SOL / ~\$64.8K / 1,289 battles / 2026-07-24
- **1310** (podcast outreach playbook): Angle 1 supporting facts — 9.07 SOL/\$677 → 13.40 SOL/\$988 at \$73.73/SOL
- **1441** (lapsed member reengagement): message templates — 1,245 → 1,289 battles (2 instances)

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.

Part of the S13 stats sweep series (batch 4 of 4): PRs #2573, #2574, #2576 (batches 1–3).