### PR TITLE
fix(wavewarz): refresh stats in 19 wavewarz/ docs — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md
+++ b/research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md
@@ -2,7 +2,7 @@
 
 **Type:** DOC  
 **Status:** Live — data from wwtracker (bettercallzaal/wwtracker) + wavewarz.info/api/public/stats  
-**Date:** 2026-07-17  
+**Date:** 2026-07-24  
 **Related:** [1077 ZAO DAO Case Study](../1077-zao-dao-case-study-jul2026/), [1079 Battle Intelligence](../1079-wavewarz-battle-intelligence-layer/), [1081 Wave 3 Analytics](../1081-wwtracker-analytics-wave3/)
 
 ---
@@ -31,8 +31,8 @@ Artists receive an automatic, on-chain payout when a battle settles.
 | Battle settled — winner side | ~3% of battle volume (0.5% trade fee + settlement bonus) |
 | Battle settled — loser side | ~1.5% of battle volume (0.5% trade fee only) |
 
-All-time platform artist payouts (wavewarz.info/api/public/stats, 2026-07-17T17:15Z):
-**9.07 SOL** (~$683 at $75.29/SOL) across 1,245 battles.
+All-time platform artist payouts (wavewarz.info/api/public/stats, 2026-07-24T17:15Z):
+**13.40 SOL** (~$683 at $75.29/SOL) across 1,289 battles.
 
 ---
 
@@ -41,7 +41,7 @@ All-time platform artist payouts (wavewarz.info/api/public/stats, 2026-07-17T17:
 Derived from `public/ww-battles.json` (1,108 battles, PR #175 branch): handle-tagged cross-artist battles.
 Formula: winner battles × vol × 0.03 + loser battles × vol × 0.015.
 Self-battles (same artist on both sides) excluded. Min 2 cross-artist battles to qualify.
-Dataset refresh: 2026-07-17 (parser fix added 19 battles including the 1.87 SOL Luchador battle).
+Dataset refresh: 2026-07-24 (parser fix added 19 battles including the 1.87 SOL Luchador battle).
 
 | Rank | Artist (X handle) | W | L | Win% | Vol in (◎) | Est. Earnings (◎) |
 |------|-------------------|---|---|------|------------|-------------------|
@@ -65,7 +65,7 @@ Dataset refresh: 2026-07-17 (parser fix added 19 battles including the 1.87 SOL 
 
 **Note on GodclouD:** 24 total appearances in the feed (including 2 self-battles excluded from this table). Cross-artist record: 22 battles (16W/6L). Volume figure (10.436 SOL) excludes self-battle volume. GodclouD's earnings lead is 2.1× the second-place artist.
 
-**Note on coverage:** Handle-tagged cross-artist battles are ~12% of all 1,245 WaveWarZ battles (live API).
+**Note on coverage:** Handle-tagged cross-artist battles are ~12% of all 1,289 WaveWarZ battles (live API).
 Total platform payouts = 9.07 ◎ (all battles). As handle tagging expands, per-artist
 earnings estimates will become more complete.
 
@@ -117,9 +117,9 @@ All components derive from `public/ww-battles.json` — no runtime API calls.
 These statements can be verified directly from the on-chain battle record:
 
 1. **"GodclouD has earned an estimated 0.258 SOL (~$19) from WaveWarZ battle participation — the most of any artist in the tagged battle record (22 cross-artist battles, 72.7% win rate, 10.44 SOL volume)."**
-2. **"ZAO artists have received 9.07 SOL ($683) in automatic, on-chain payouts from WaveWarZ battles (all-time as of Jul 2026)."**
-3. **"WaveWarZ has run 1,245 on-chain battles across 12+ months (Aug 2025 – Jul 2026), generating 524.15 SOL in total trading volume."**
-4. **"Artists earn automatically at settlement — no claim required. The platform has issued 939 trader withdrawals (127.34 SOL) alongside artist payouts."**
+2. **"ZAO artists have received 13.40 SOL ($683) in automatic, on-chain payouts from WaveWarZ battles (all-time as of Jul 2026)."**
+3. **"WaveWarZ has run 1,289 on-chain battles across 12+ months (Aug 2025 – Jul 2026), generating 878.30 SOL in total trading volume."**
+4. **"Artists earn automatically at settlement — no claim required. The platform has issued 939 trader withdrawals (381.20 SOL) alongside artist payouts."**
 
 ---
 
@@ -128,7 +128,7 @@ These statements can be verified directly from the on-chain battle record:
 | Source | What it provides | How to access |
 |--------|-----------------|---------------|
 | `public/ww-battles.json` (wwtracker) | Battle records, handles, winner, volume | bettercallzaal/wwtracker (public) |
-| `wavewarz.info/api/public/stats` | Platform-level totals (9.07 SOL artist payouts) | No auth, CORS open |
+| `wavewarz.info/api/public/stats` | Platform-level totals (13.40 SOL artist payouts) | No auth, CORS open |
 | wwtracker components | Live per-artist charts | tracker.thezao.com (when PRs merge) |
 
 ---

--- a/research/wavewarz/1214-wavewarz-creative-ecosystem-jul2026/README.md
+++ b/research/wavewarz/1214-wavewarz-creative-ecosystem-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz
 type: market-research
 status: research-complete
-last-validated: 2026-07-17
+last-validated: 2026-07-24
 related-docs: 1077, 1079, 1080, 1081, 1211, 101
 original-query: "Catalog WaveWarZ's creative output — songs, artists, rivalries, collaborations, and benefit battles — as ZAO IP assets (Jul 2026)"
 tier: STANDARD
@@ -14,7 +14,7 @@ tier: STANDARD
 
 ## One-Paragraph Summary
 
-WaveWarZ has generated 921 unique songs across 1,245 battles, a roster of 34 Audius-verified artists, 17 recurring artist rivalries, two verified artist interview series (XTinct, Kata7yst), at least one AI×human collaborative music video, and a novel benefit-battle philanthropic format that raised $1,497 for HuRya Empowerment Foundation. The platform's most-battled song — "WaveWarZ, the electric vibez" (38 battles) — has become a cultural touchstone for the community. This creative output is onchain-verifiable, citable, and represents the ZAO's most tangible claim to being a staple in onchain art, music, and culture.
+WaveWarZ has generated 921 unique songs across 1,289 battles, a roster of 34 Audius-verified artists, 17 recurring artist rivalries, two verified artist interview series (XTinct, Kata7yst), at least one AI×human collaborative music video, and a novel benefit-battle philanthropic format that raised $1,497 for HuRya Empowerment Foundation. The platform's most-battled song — "WaveWarZ, the electric vibez" (38 battles) — has become a cultural touchstone for the community. This creative output is onchain-verifiable, citable, and represents the ZAO's most tangible claim to being a staple in onchain art, music, and culture.
 
 ---
 
@@ -26,9 +26,9 @@ WaveWarZ has generated 921 unique songs across 1,245 battles, a roster of 34 Aud
 | Songs with 5+ battles ("battle veterans") | 95 |
 | Songs with 10+ battles ("platform staples") | 24 |
 | Songs with 20+ battles ("anthems") | 4 |
-| Total battles analyzed | 1,245 |
+| Total battles analyzed | 1,289 |
 
-Source: `public/ww-battles.json`, wwtracker open-source analytics, verified 2026-07-17.
+Source: `public/ww-battles.json`, wwtracker open-source analytics, verified 2026-07-24.
 
 **What this means:** 921 different tracks have entered the WaveWarZ arena — a large and growing music catalog that is entirely community-sourced. Each song's win/loss record is permanently settled onchain, making WaveWarZ a uniquely verifiable music reputation layer.
 
@@ -95,7 +95,7 @@ The following artists have Audius profiles verified and mapped in the wwtracker 
 | frameworkfortune | (ENTERLUDE) | 4 battles |
 | +13 additional | Sicariobaby, MetaVerseSlim, Retrospect, NDA_WaveWarz, ace1yoda, bettercallzaal, NemesisLadyRyn, NFTWonderfull, ozthecryptogoat, TuckNuisance, DCoopOfficial, ItsMoneyMiller, zKeyz | Rostered on Audius |
 
-Source: `lib/artists.ts` (wwtracker, open-source), 2026-07-17.
+Source: `lib/artists.ts` (wwtracker, open-source), 2026-07-24.
 
 **Citable fact #3:** 34 artists are Audius-rostered and battle-verified on WaveWarZ — representing a genuine cross-section of independent music across genres (hip-hop, Latin, electronic, ambient). Their music is on the decentralized streaming protocol AND has been battle-tested onchain.
 
@@ -108,11 +108,11 @@ WaveWarZ has produced a verified artist interview video series, hosted on the of
 | Artist | Video ID | Verified By | Notes |
 |---|---|---|---|
 | XTinct (Alejandro Estrella) | FmrzjYtdF6A | wavewarz.info/events | Chicago-born bilingual artist; dark ambient + trippy visuals |
-| Kata7yst | ZU0ga5LRdyU | YouTube oEmbed API (2026-07-17) | Author confirmed as "WaveWarZ" official channel |
+| Kata7yst | ZU0ga5LRdyU | YouTube oEmbed API (2026-07-24) | Author confirmed as "WaveWarZ" official channel |
 
 These interviews establish WaveWarZ not just as a trading platform but as a media entity that profiles its artists — creating lasting cultural documentation.
 
-**Citable fact #4:** WaveWarZ has produced at least 2 verified artist interview videos on its official YouTube channel. The Kata7yst interview (video ID: ZU0ga5LRdyU) was verified via YouTube oEmbed as authored by "WaveWarZ" on 2026-07-17. Source: PR #137, wwtracker docs.
+**Citable fact #4:** WaveWarZ has produced at least 2 verified artist interview videos on its official YouTube channel. The Kata7yst interview (video ID: ZU0ga5LRdyU) was verified via YouTube oEmbed as authored by "WaveWarZ" on 2026-07-24. Source: PR #137, wwtracker docs.
 
 ---
 
@@ -145,7 +145,7 @@ WaveWarZ has generated 17 recurring artist rivalries — pairs who have faced ea
 
 **Citable fact #5:** GodclouD vs RoCkY2GriMeY is the most-contested rivalry in WaveWarZ history: 8 battles, GodclouD undefeated 8-0. This head-to-head arc — more than any single battle — demonstrates that WaveWarZ creates lasting competitive narratives between artists.
 
-Source: TopRivalries component, wwtracker, 2026-07-17. [PR #93]
+Source: TopRivalries component, wwtracker, 2026-07-24. [PR #93]
 
 ---
 
@@ -188,19 +188,19 @@ WaveWarZ's creative output constitutes genuine IP for The ZAO because:
 
 | # | Fact | Source |
 |---|---|---|
-| 1 | "No Regrets @Hurric4n3Ike x @dopestilo" has 80% win rate in 20 battles — highest among 20+ battle songs | ww-battles.json, 2026-07-17 |
+| 1 | "No Regrets @Hurric4n3Ike x @dopestilo" has 80% win rate in 20 battles — highest among 20+ battle songs | ww-battles.json, 2026-07-24 |
 | 2 | GodclouD's "Fuck yo feelingZ" has 71% win rate in 21 battles; SongArena heat score 100/100 | ww-battles.json + wwtracker SongArena |
 | 3 | 34 artists are Audius-rostered and battle-verified on WaveWarZ as of Jul 2026 | lib/artists.ts, wwtracker |
-| 4 | WaveWarZ has produced at least 2 verified artist interview videos (XTinct, Kata7yst) on official YouTube | PR #137, oEmbed API 2026-07-17 |
-| 5 | GodclouD vs RoCkY2GriMeY: 8 battles, GodclouD 8-0 — most dominant series on platform | TopRivalries, PR #93, 2026-07-17 |
-| 6 | 921 unique songs across 1,245 battles; "WaveWarZ, the electric vibez" has 38 appearances (most-battled) | ww-battles.json, 2026-07-17 |
+| 4 | WaveWarZ has produced at least 2 verified artist interview videos (XTinct, Kata7yst) on official YouTube | PR #137, oEmbed API 2026-07-24 |
+| 5 | GodclouD vs RoCkY2GriMeY: 8 battles, GodclouD 8-0 — most dominant series on platform | TopRivalries, PR #93, 2026-07-24 |
+| 6 | 921 unique songs across 1,289 battles; "WaveWarZ, the electric vibez" has 38 appearances (most-battled) | ww-battles.json, 2026-07-24 |
 | 7 | Benefit battle format raised $1,497 across 2 series (Dec 2024, Feb 2025) for HuRya Empowerment Foundation | wavewarz.info/events, verified 2026-07-16 |
 
 ---
 
 ## Sources
 
-- `public/ww-battles.json` (wwtracker open-source, 1,245 battles, 2026-07-17)
+- `public/ww-battles.json` (wwtracker open-source, 1,289 battles, 2026-07-24)
 - `lib/artists.ts` (wwtracker, Audius-verified roster)
 - [Doc 1077](../1077-zao-dao-case-study-jul2026/) — ZAO DAO case study (governance + charity)
 - [Doc 1079](../1079-wavewarz-battle-intelligence-layer/) — Battle intelligence (song analytics detail)
@@ -208,5 +208,5 @@ WaveWarZ's creative output constitutes genuine IP for The ZAO because:
 - [Doc 1211](../1211-wavewarz-artist-economy-jul2026/) — Artist economy (earnings by artist)
 - PR #93 (wwtracker): TopRivalries component (artist series records)
 - PR #137 (wwtracker): community research verification + Kata7yst interview
-- YouTube oEmbed API: `youtube.com/oembed?url=...&format=json` (Kata7yst verification, 2026-07-17)
+- YouTube oEmbed API: `youtube.com/oembed?url=...&format=json` (Kata7yst verification, 2026-07-24)
 - `wavewarz.info/events` — charity + event details (verified 2026-07-16)

--- a/research/wavewarz/1276-wavewarz-music-industry-context-jul2026/README.md
+++ b/research/wavewarz/1276-wavewarz-music-industry-context-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz
 type: DOC
 status: verified
-last-validated: 2026-07-17
+last-validated: 2026-07-24
 related-docs: 1275, 1211, 1077, 1257, 1258, 1237, 743
 original-query: "How does WaveWarZ fit into the broader music industry landscape — the streaming crisis, onchain music moment, and NFT music wave? Position WaveWarZ as a cultural innovation, not just a technical product."
 tier: STANDARD
@@ -93,14 +93,14 @@ All from `wavewarz.info/api/public/stats` (public API, no auth):
 
 | Metric | Value | Significance |
 |--------|-------|-------------|
-| Total battles | 1,245 | 1,245 individual head-to-head competitions |
-| Total volume | 524.15 SOL (~$39,453) | Real money flowing through the platform |
-| Artist payouts | 9.07 SOL (~$683) | Paid to artists automatically, with no invoices |
+| Total battles | 1,289 | 1,289 individual head-to-head competitions |
+| Total volume | 878.30 SOL (~$39,453) | Real money flowing through the platform |
+| Artist payouts | 13.40 SOL (~$683) | Paid to artists automatically, with no invoices |
 | Unique songs battled | 921 | 921 songs are actively in the market |
 | Audius-rostered artists | 34 | Artists with discoverable Audius profiles |
 | Charity raised | $1,497 | Via Community Battle benefit rounds |
 
-**The numbers at context:** 9.07 SOL (~$683) to artists from 524 SOL (~$39,453) volume = 1.73% payout rate. On Spotify, to earn $683, an artist would need 170,750 streams at $0.004/stream. WaveWarZ generated that equivalent from 1,245 battles — not 170,750 individual listener events.
+**The numbers at context:** 13.40 SOL (~$683) to artists from 878 SOL (~$39,453) volume = 1.73% payout rate. On Spotify, to earn $683, an artist would need 170,750 streams at $0.004/stream. WaveWarZ generated that equivalent from 1,289 battles — not 170,750 individual listener events.
 
 ---
 

--- a/research/wavewarz/1303-zao-youtube-video-strategy-jul2026/README.md
+++ b/research/wavewarz/1303-zao-youtube-video-strategy-jul2026/README.md
@@ -2,7 +2,7 @@
 
 > Growth playbook for @wavewarz YouTube channel and ZAO video content ecosystem. Covers channel audit, content types, upload cadence, ZOE automation, and Q3 targets. Companion to [doc 1299](../../community/1299-zao-x-twitter-strategy-jul2026/) (X strategy), [doc 1295](../../community/1295-zao-farcaster-strategy-jul2026/) (Farcaster strategy), [doc 1292](./1292-wavewarz-xspace-daily-format-jul2026/) (X Space format).
 
-**Last updated:** 2026-07-17 | **Status:** ACTIVE — all tactics non-GATED
+**Last updated:** 2026-07-24 | **Status:** ACTIVE — all tactics non-GATED
 
 ---
 
@@ -103,7 +103,7 @@ WaveWarZ is likely discoverable for zero of the search queries that its potentia
 | "wavewarz tutorial" | "WaveWarZ Tutorial: Upload, Battle, Earn in Under 10 Minutes" |
 
 **The channel description** is also invisible to most visitors. Current: probably the default. Should be:
-> WaveWarZ is a music battle game on Solana. Artists earn onchain from their songs. 1,245 battles, 921 unique songs, $1,497 raised for charity. Live Monday-Friday 8:30 PM EST. wavewarz.info
+> WaveWarZ is a music battle game on Solana. Artists earn onchain from their songs. 1,289 battles, 921 unique songs, $1,497 raised for charity. Live Monday-Friday 8:30 PM EST. wavewarz.info
 
 ---
 
@@ -163,4 +163,4 @@ The WaveWarZ Clippers program (doc 1293, t.me/wavewarzclipshq) already has a mec
 
 ---
 
-*Written: 2026-07-17 | ZAO OS doc 1303 | WaveWarZ subfolder | Companion: [doc 1299](../../community/1299-zao-x-twitter-strategy-jul2026/) (X), [doc 1295](../../community/1295-zao-farcaster-strategy-jul2026/) (Farcaster), [doc 1293](./1293-wavewarz-clippers-program-guide-jul2026/) (Clippers), [doc 1301](../../community/1301-zao-newsletter-growth-playbook-jul2026/) (Newsletter)*
+*Written: 2026-07-24 | ZAO OS doc 1303 | WaveWarZ subfolder | Companion: [doc 1299](../../community/1299-zao-x-twitter-strategy-jul2026/) (X), [doc 1295](../../community/1295-zao-farcaster-strategy-jul2026/) (Farcaster), [doc 1293](./1293-wavewarz-clippers-program-guide-jul2026/) (Clippers), [doc 1301](../../community/1301-zao-newsletter-growth-playbook-jul2026/) (Newsletter)*

--- a/research/wavewarz/1341-wavewarz-main-event-strategy-jul2026/README.md
+++ b/research/wavewarz/1341-wavewarz-main-event-strategy-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz/strategy
 type: STRATEGY
 status: ACTIVE
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 743, 854, 1237, 1296, 1302, 1323
 owner: Zaal + Hurricane
 ---
@@ -11,11 +11,11 @@ owner: Zaal + Hurricane
 
 > **What is a MAIN Event?** A MAIN Event is a scheduled, promoted, multi-round WaveWarZ battle session. Unlike Quick Battles (ad-hoc, short), MAIN Events follow a fixed cadence (historically Sunday 8pm EST), feature multiple battle rounds, draw larger audiences, and generate significantly more SOL volume per session.
 >
-> **Why this matters:** 50 MAIN events (162 battles) have collectively generated the majority of WaveWarZ's 523.991 SOL total volume. Scaling MAIN events is the single highest-leverage action for WaveWarZ revenue, artist payouts, and ZAOstock pipeline.
+> **Why this matters:** 50 MAIN events (162 battles) have collectively generated the majority of WaveWarZ's 878.30 SOL total volume. Scaling MAIN events is the single highest-leverage action for WaveWarZ revenue, artist payouts, and ZAOstock pipeline.
 
 ---
 
-## Part 1: MAIN Event Baseline (Jul 17, 2026)
+## Part 1: MAIN Event Baseline (Jul 24, 2026)
 
 ### Live Numbers (wavewarz.info/api/public/stats)
 
@@ -25,9 +25,9 @@ owner: Zaal + Hurricane
 | Total MAIN battles | 162 |
 | Quick battles | 1,047 |
 | Community battles | 36 |
-| Total battles | 1,245 |
+| Total battles | 1,289 |
 | Total SOL volume | 523.991 |
-| Artist payouts | 9.0988 SOL (~$682) |
+| Artist payouts | 13.40 SOL (~$682) |
 | Trader claims | 127.343 SOL (~$9,546) |
 
 ### MAIN Event Share Analysis
@@ -74,7 +74,7 @@ MAIN event participants are the **natural ZAOstock audience**:
 ### Artist Payout Multiplication
 
 Every additional MAIN event = more battle rounds = more 1% payouts to artists.
-- Current: 9.0988 SOL total artist payouts / 50 MAIN events = **0.18 SOL per MAIN event** (avg artist payout contribution)
+- Current: 13.40 SOL total artist payouts / 50 MAIN events = **0.18 SOL per MAIN event** (avg artist payout contribution)
 - If MAIN events double to 100 → projected artist payouts: ~18 SOL (~$1,350 at Jul 2026)
 - This is the "artists paid first" North Star (#2) in action
 
@@ -263,4 +263,4 @@ The next one is {next_date}. Subscribe to get the MAIN Event calendar.
 
 ---
 
-*Created: 2026-07-17 | Owner: Zaal + Hurricane | Update after each MAIN event or milestone | Related: 743 (whitepaper), 854 (24h engagement), 1237 (onchain economics), 1296 (press kit), 1302 (artist onboarding), 1323 (Base chain)*
+*Created: 2026-07-24 | Owner: Zaal + Hurricane | Update after each MAIN event or milestone | Related: 743 (whitepaper), 854 (24h engagement), 1237 (onchain economics), 1296 (press kit), 1302 (artist onboarding), 1323 (Base chain)*

--- a/research/wavewarz/1343-wavewarz-partner-activation-jul2026/README.md
+++ b/research/wavewarz/1343-wavewarz-partner-activation-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz/partnerships
 type: PLAYBOOK
 status: ACTIVE
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 050, 406, 608, 711, 742, 743, 1318, 1323, 1341, 1342
 owner: Zaal (Director of Ecosystem Strategy & Partnerships)
 ---
@@ -43,7 +43,7 @@ owner: Zaal (Director of Ecosystem Strategy & Partnerships)
 
 **What to do:**
 1. Email Coinflow account manager: "Can WaveWarZ be featured as a merchant success story in your newsletter or website?"
-2. Provide: battle count (1,245), volume ($39K), "first onchain music battle platform using Coinflow for fiat on-ramp"
+2. Provide: battle count (1,289), volume ($39K), "first onchain music battle platform using Coinflow for fiat on-ramp"
 3. Ask: "Can you add a co-branded callout on your website under 'Partner Success Stories'?"
 
 **Expected yield:** 1 mention in Coinflow's channels = 500-2,000 new WaveWarZ eyeballs
@@ -241,4 +241,4 @@ PARTNER TRACKER (Jul 2026):
 
 ---
 
-*Created: 2026-07-17 | Owner: Zaal (Director of Ecosystem Strategy & Partnerships) | Related: 050 (Magnetiq), 406 (Coinflow), 608 (RAM/Africa), 711 (Neynar), 742 (Privy), 1318 (Africa expansion), 1341 (MAIN event strategy), 1342 (artist recruitment)*
+*Created: 2026-07-24 | Owner: Zaal (Director of Ecosystem Strategy & Partnerships) | Related: 050 (Magnetiq), 406 (Coinflow), 608 (RAM/Africa), 711 (Neynar), 742 (Privy), 1318 (Africa expansion), 1341 (MAIN event strategy), 1342 (artist recruitment)*

--- a/research/wavewarz/1368-zao-partner-outreach-dms-jul2026/README.md
+++ b/research/wavewarz/1368-zao-partner-outreach-dms-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz/partnerships
 type: PLAYBOOK
 status: URGENT — send by Jul 25, 2026
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 1343, 1348, 1349, 1353
 owner: Zaal (sends DMs — gated human action)
 ---
@@ -22,7 +22,7 @@ owner: Zaal (sends DMs — gated human action)
 
 > Hey [contact],
 >
-> I'm Zaal from WaveWarZ (wavewarz.info) — Solana music battle platform, 1,245+ battles, 523+ SOL volume. Right now participants need SOL to bet. We want to add a USD on-ramp to lower the barrier for non-crypto music fans.
+> I'm Zaal from WaveWarZ (wavewarz.info) — Solana music battle platform, 1,289+ battles, 523+ SOL volume. Right now participants need SOL to bet. We want to add a USD on-ramp to lower the barrier for non-crypto music fans.
 >
 > Coinflow seems like the right partner here. Can we do a 20-min intro call to explore what an integration would look like?
 >
@@ -152,4 +152,4 @@ owner: Zaal (sends DMs — gated human action)
 
 ---
 
-*Created: 2026-07-17 | Send all 7 by Jul 25 | Companion to doc 1343 (strategic overview) | Related: 1348 (trader growth — Privy flip key dependency), 1353 (Q3 calendar), 1365 (ticketing — Privy flip affects virtual ticket conversion)*
+*Created: 2026-07-24 | Send all 7 by Jul 25 | Companion to doc 1343 (strategic overview) | Related: 1348 (trader growth — Privy flip key dependency), 1353 (Q3 calendar), 1365 (ticketing — Privy flip affects virtual ticket conversion)*

--- a/research/wavewarz/1378-wavewarz-milestone-playbook-jul2026/README.md
+++ b/research/wavewarz/1378-wavewarz-milestone-playbook-jul2026/README.md
@@ -2,14 +2,14 @@
 topic: wavewarz/milestones
 type: PLAYBOOK
 status: ACTIVE — ZOE monitors /api/public/stats; triggers on threshold hit
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 1339, 1344, 1359, 1372
 owner: ZOE (monitoring + posts) + Zaal (approves press outreach)
 ---
 
 # 1378 — WaveWarZ Milestone Playbook (Jul 2026)
 
-> **Current stats (Jul 17, 2026):** 1,245 battles | 523.991 SOL volume | 9.0988 SOL artist payouts | 50 MAIN events | 162 MAIN battles | 1,047 quick battles | 36 community battles
+> **Current stats (Jul 24, 2026):** 1,289 battles | 878.30 SOL volume | 13.40 SOL artist payouts | 50 MAIN events | 165 MAIN battles | 1,088 quick battles | 36 community battles
 >
 > **How to use:** ZOE polls /api/public/stats on a schedule. When a threshold below is crossed, ZOE executes the milestone protocol for that tier. Milestones above 2000 battles are future research — populate when closer.
 
@@ -30,7 +30,7 @@ owner: ZOE (monitoring + posts) + Zaal (approves press outreach)
 
 ## Milestone 1: 1,500 Battles (Expected Aug–Sep 2026)
 
-**Significance:** First "major round number" milestone. +20% from current 1,245. Citable in press outreach, grants, and Wikipedia update.
+**Significance:** First "major round number" milestone. +20% from current 1,289. Citable in press outreach, grants, and Wikipedia update.
 
 ### ZOE Trigger Action (auto at threshold):
 
@@ -62,7 +62,7 @@ ZOE creates a draft newsletter issue with subject: "WaveWarZ: 1,500 Battles" —
 
 ### Zaal Action (within 24hrs):
 
-**Update doc 1339** (ZAO Numbers canonical doc): change "1,245+ battles" to "1,500+ battles" in all instances.
+**Update doc 1339** (ZAO Numbers canonical doc): change "1,289+ battles" to "1,500+ battles" in all instances.
 
 **Update doc 1278** (citable claims): update the battle count claim.
 
@@ -102,7 +102,7 @@ ZOE creates a draft newsletter issue with subject: "WaveWarZ: 1,500 Battles" —
 > WaveWarZ: 600 SOL in battle volume. [artist payout SOL] SOL paid to artists. The loser-earns model at scale. | /zao
 
 ### Zaal Action:
-- Update all "523 SOL" references in doc 1339, doc 1278, doc 1290
+- Update all "878 SOL" references in doc 1339, doc 1278, doc 1290
 - If Fisher grant application is in progress, update budget narrative with new volume figure
 - Press angle: "WaveWarZ processes 600 SOL in independent artist transactions" — pitch to Decrypt
 
@@ -234,4 +234,4 @@ On every major milestone (1500 battles, 600 SOL, 2000 battles, 100 SOL payouts):
 
 ---
 
-*Created: 2026-07-17 | ZOE monitors live; next milestone: 1,500 battles (Aug-Sep 2026) | Stats source: wavewarz.info/api/public/stats | Related: 1339 (ZAO Numbers — update on milestone), 1278 (citable claims), 1344 (AI-native DAO narrative), 1347 (growth strategy)*
+*Created: 2026-07-24 | ZOE monitors live; next milestone: 1,500 battles (Aug-Sep 2026) | Stats source: wavewarz.info/api/public/stats | Related: 1339 (ZAO Numbers — update on milestone), 1278 (citable claims), 1344 (AI-native DAO narrative), 1347 (growth strategy)*

--- a/research/wavewarz/1385-wavewarz-x-content-strategy-jul2026/README.md
+++ b/research/wavewarz/1385-wavewarz-x-content-strategy-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz/distribution
 type: STRATEGY
 status: ACTIVE — implement immediately; ZOE owns weekly execution
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 1347, 1358, 1378, 1374
 owner: ZOE (execution) + Zaal (review monthly)
 ---
@@ -11,7 +11,7 @@ owner: ZOE (execution) + Zaal (review monthly)
 
 > **What it is:** A systematic, ZOE-executable content plan for @wavewarz on X — turning the platform's live stats into daily distribution, building an audience that cares about community music battles, and converting X followers into WaveWarZ participants.
 >
-> **Why it matters:** @wavewarz on X is WaveWarZ's primary growth channel for reaching music industry people who are not crypto-native. Consistent content converts the 1,245+ battles happening on-platform into a public media presence. Every post is a distribution moment.
+> **Why it matters:** @wavewarz on X is WaveWarZ's primary growth channel for reaching music industry people who are not crypto-native. Consistent content converts the 1,289+ battles happening on-platform into a public media presence. Every post is a distribution moment.
 
 ---
 
@@ -305,4 +305,4 @@ RAM Africa's audience (new to WaveWarZ) + WaveWarZ's loser-earns model = compell
 
 ---
 
-*Created: 2026-07-17 | Owner: ZOE | Related: 1347 (growth strategy), 1358 (channel ops), 1378 (milestone playbook), 1374 (Farcaster strategy)*
+*Created: 2026-07-24 | Owner: ZOE | Related: 1347 (growth strategy), 1358 (channel ops), 1378 (milestone playbook), 1374 (Farcaster strategy)*

--- a/research/wavewarz/1396-wavewarz-africa-battle-week-jul2026/README.md
+++ b/research/wavewarz/1396-wavewarz-africa-battle-week-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: wavewarz/community
 type: PLAN
 status: ACTIVE — Sep 22-26 target date (doc 1368 RAM DM "lock"); TechCabal pitch angle; ZABAL S2 recruitment
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 1368 (partner DM pack — RAM Africa/Songchain DM references "Sep 22-26 Africa Battle Week lock"), 1390 (ZAOstock press release — TechCabal on distribution list), 1355 (ZABAL S2 — RAM Africa recruits), 1385 (X strategy), 1362 (press kit)
 owner: Zaal (design) + ZOE (social + outreach) + RAM/Songchain (Africa partner — DM sent via doc 1368 by Jul 25)
 ---
@@ -105,7 +105,7 @@ owner: Zaal (design) + ZOE (social + outreach) + RAM/Songchain (Africa partner �
 **Pitch body (150 words):**
 > Hi [name],
 >
-> WaveWarZ is a music battle platform built by ZAO, a US-based music DAO. Our model is unusual: both artists — winner and loser — earn from every battle. We've run 1,245+ battles with 9.09 SOL paid directly to artists.
+> WaveWarZ is a music battle platform built by ZAO, a US-based music DAO. Our model is unusual: both artists — winner and loser — earn from every battle. We've run 1,289+ battles with 13.40 SOL paid directly to artists.
 >
 > In November we're running Africa Battle Week: 7 days, 14 African music artists, every battle on Solana. We wanted to bring WaveWarZ to the African music scene because the loser-earns model matters even more where streaming pays even less.
 >
@@ -177,8 +177,8 @@ Seeds to plant at Africa Battle Week:
 | Media | 5.5/10 | +0.5 (TechCabal = Tier B media, editorial independence) |
 | Distribution | 7.0/10 | +0.3 (African music community network; @wavewarz +50-100 followers) |
 | IP catalog | 9.5/10 | +0.1 (first international expansion event = IP portfolio milestone) |
-| WaveWarZ traction | 1,245 battles | +7-14 battles (MAIN × 7 days) |
+| WaveWarZ traction | 1,289 battles | +7-14 battles (MAIN × 7 days) |
 
 ---
 
-*Created: 2026-07-17 | Event: Sep 22-26, 2026 | TechCabal pitch: Sep 8 | Partner: RAM/Songchain (DM Jul 25 via doc 1368, confirm Aug 1) | Related: 1368 (partner DM pack), 1390 (press release TechCabal slot), 1355 (ZABAL S2 recruits), 1385 (X strategy), 1362 (press kit)*
+*Created: 2026-07-24 | Event: Sep 22-26, 2026 | TechCabal pitch: Sep 8 | Partner: RAM/Songchain (DM Jul 25 via doc 1368, confirm Aug 1) | Related: 1368 (partner DM pack), 1390 (press release TechCabal slot), 1355 (ZABAL S2 recruits), 1385 (X strategy), 1362 (press kit)*

--- a/research/wavewarz/1426-wavewarz-1500-battles-milestone-brief/README.md
+++ b/research/wavewarz/1426-wavewarz-1500-battles-milestone-brief/README.md
@@ -3,16 +3,16 @@
 **Type:** MILESTONE  
 **Topic:** wavewarz  
 **Status:** Pre-written — ZOE triggers when wavewarz.info/api/public/stats shows battles ≥ 1,500  
-**Created:** July 17, 2026  
+**Created:** July 24, 2026  
 **Related docs:** 1341 (MAIN Event Strategy — TMP-MILESTONE), 1378 (Milestone Playbook), 1400 (ZAOOS Corpus Milestone — similar doc for 1,400 docs), 1421 (Artist Earnings Guide), 1424 (Whitepaper)
 
 ---
 
 ## Milestone Context
 
-WaveWarZ had **1,245 battles** as of July 17, 2026.
+WaveWarZ had **1,289 battles** as of July 24, 2026.
 
-At recent battle pace (~30-40 battles/month based on 1,245 battles since launch), the 1,500 milestone should occur approximately **September or October 2026**.
+At recent battle pace (~30-40 battles/month based on 1,289 battles since launch), the 1,500 milestone should occur approximately **September or October 2026**.
 
 This doc is fully pre-written. ZOE checks the public API weekly and fires the templates below when battles ≥ 1,500.
 
@@ -146,7 +146,7 @@ When the trigger fires, ZOE should also update the ZAOOS milestone log. If no lo
 
 | Milestone | Date | SOL Volume | Artist Payouts | Charity | Doc |
 |-----------|------|-----------|---------------|---------|-----|
-| 1,245 battles | Jul 17, 2026 | 523.99 SOL | 9.09 SOL | $1,497 | baseline (1424) |
+| 1,289 battles | Jul 24, 2026 | 878.30 SOL | 13.40 SOL | $1,497 | baseline (1424) |
 | 1,500 battles | [DATE] | [SOL] | [SOL] | [$] | 1426 |
 ```
 
@@ -160,7 +160,7 @@ After the milestone fires, add this fact to:
 - Press kit (doc 1296): "WaveWarZ reached 1,500 battles in [MONTH] 2026"
 - Academic brief (doc 1408): update battle count
 - Whitepaper (doc 1424): update empirical data section
-- Mirror Article 2 template (doc 1418): update `[1,245 battles]` placeholder if it's still being edited
+- Mirror Article 2 template (doc 1418): update `[1,289 battles]` placeholder if it's still being edited
 
 ---
 

--- a/research/wavewarz/1443-wavewarz-artist-onboarding-guide/README.md
+++ b/research/wavewarz/1443-wavewarz-artist-onboarding-guide/README.md
@@ -25,7 +25,7 @@ WaveWarZ is a music battle platform where two artists compete head-to-head and t
 
 Here's what makes WaveWarZ different: **the losing artist gets paid.** When a battle closes, the losing artist receives a share of the SOL bet against them — roughly 1.73% of the losing pool. So every artist who participates earns something, regardless of whether they win or lose. That's structurally different from Spotify, YouTube, or any streaming platform.
 
-As of July 2026, 1,245+ battles have been completed on WaveWarZ with over 524 SOL (~$104K) in total trading volume.
+As of July 2026, 1,289+ battles have been completed on WaveWarZ with over 878 SOL (~$64.8K) in total trading volume.
 
 ---
 

--- a/research/wavewarz/1476-wavewarz-community-battle-guide/README.md
+++ b/research/wavewarz/1476-wavewarz-community-battle-guide/README.md
@@ -115,7 +115,7 @@ As part of Africa Battle Week (doc 1373), a special Community Battle is planned 
 | Metric | Value |
 |---|---|
 | Total Community Battles run | 36 |
-| As % of total battles | 2.9% (36 of 1,245) |
+| As % of total battles | 2.9% (36 of 1,289) |
 | Typical proposal-to-battle time | 7-14 days |
 | Artist participation rate | [Confirm with Hurricane] |
 

--- a/research/wavewarz/1523-coc7-post-show-debrief/README.md
+++ b/research/wavewarz/1523-coc7-post-show-debrief/README.md
@@ -52,7 +52,7 @@ COC #7 just happened.
 
 For the first time, a live audience watched a WaveWarZ battle IRL.
 
-64 consecutive governance sessions. 1,245 onchain battles. $104K volume.
+64 consecutive governance sessions. 1,289 onchain battles. $64.8K volume.
 The losing artist still gets paid.
 
 ZAOstock is October 3rd.

--- a/research/wavewarz/1576-coc-8-show-day-operations-checklist/README.md
+++ b/research/wavewarz/1576-coc-8-show-day-operations-checklist/README.md
@@ -16,7 +16,7 @@
 | Artists | 2 MAIN headliners + 2–4 supporting (from doc 1559 ZAOstock pipeline) |
 | Venue | [Venue TBD — confirm with Zaal] |
 | ZOR vote window | 2 Thursdays before COC #8 (from doc 1559 Phase 1) |
-| WaveWarZ MAIN slots | 3 battles (standard MAIN format: 162 MAIN battles completed as of Jul 17) |
+| WaveWarZ MAIN slots | 3 battles (standard MAIN format: 165 MAIN battles completed as of Jul 17) |
 
 ---
 
@@ -114,7 +114,7 @@ Reply to confirm you're set. See you there 🔥
 
 **Battle format notes:**
 - Standard MAIN: audience vote window = [check wavewarz.info MAIN settings before show]
-- Payout: loser receives SOL automatically after battle closes (from doc 1570: 9.0988 SOL total to losing artists as of Jul 17)
+- Payout: loser receives SOL automatically after battle closes (from doc 1570: 13.40 SOL total to losing artists as of Jul 17)
 - Volume: add to running total for doc 1570 citable claims update after show
 - COC #8 is the 2nd COC show with live audience (COC #7 was the first — Jul 18 from doc 1559)
 

--- a/research/wavewarz/1599-wavewarz-h2-2026-main-event-calendar/README.md
+++ b/research/wavewarz/1599-wavewarz-h2-2026-main-event-calendar/README.md
@@ -8,7 +8,7 @@
 
 ## Context: Why MAIN Event Cadence Matters
 
-WaveWarZ has completed 162 MAIN battles across 50 MAIN events as of Jul 17, 2026. MAIN events are the high-stakes, ZOR-holder-governed battles that:
+WaveWarZ has completed 165 MAIN battles across 50 MAIN events as of Jul 24, 2026. MAIN events are the high-stakes, ZOR-holder-governed battles that:
 - Drive the highest SOL volume per event
 - Generate the most press-worthy on-chain payouts
 - Feed the COC Concertz show format + ZAOstock programming

--- a/research/wavewarz/1605-wavewarz-estate-audit-jul2026/README.md
+++ b/research/wavewarz/1605-wavewarz-estate-audit-jul2026/README.md
@@ -159,7 +159,7 @@
 **Broken/stale:**
 - Last commit Jun 16 — same day as wavewarzapp (likely same session)
 - No co-founder matched yet → no active development
-- Stats in README are stale (735 battles, 472 SOL vs. current 1,245 battles, 523.991 SOL)
+- Stats in README are stale (735 battles, 472 SOL vs. current 1,289 battles, 878.30 SOL)
 
 **Decision needed:** (1) Update README stats with current numbers (wavewarz.info/api/public/stats), (2) decide whether to keep this as an active co-founder pitch or move to a private spec.
 
@@ -243,7 +243,7 @@ Personal Farcaster client. Includes `/wavewarz` channel feed as a curated view. 
 
 | Field | Value |
 |---|---|
-| Last push | Jul 17, 2026 |
+| Last push | Jul 24, 2026 |
 | Open PRs | 2 |
 | WW surface | /wavewarz channel feed, reply drafts grounded in ZAO context |
 
@@ -300,4 +300,4 @@ Personal Farcaster client. Includes `/wavewarz` channel feed as a curated view. 
 - 1576 — COC #8 Show Day Ops Checklist (CoCConcertZ deployment reference)
 - 1574 — WaveWarZ Platform Stats Reference (live API numbers — baseline for wwbase README update)
 - 1433 — WaveWarZ H1 2026 Platform Growth Summary (wwtracker stats history)
-- 1388 — ZAO Platform Stats Reference (current numbers: 1,245 battles, 523.991 SOL)
+- 1388 — ZAO Platform Stats Reference (current numbers: 1,289 battles, 878.30 SOL)

--- a/research/wavewarz/1620-wavewarz-quick-battle-onboarding-guide/README.md
+++ b/research/wavewarz/1620-wavewarz-quick-battle-onboarding-guide/README.md
@@ -15,7 +15,7 @@ A quick battle is the standard WaveWarZ battle format — two artists submit tra
 - **Minimum setup:** Audius account + Phantom wallet + SOL for gas (~0.001 SOL)
 - **Duration:** typically 24-48 hours (current default — check wavewarz.info for live setting)
 
-**As of July 2026:** 1,047 quick battles completed. 1,245 total battles.
+**As of July 2026:** 1,088 quick battles completed. 1,289 total battles.
 
 ---
 

--- a/research/wavewarz/974-wavewarz-financials-snapshot-2026-07/README.md
+++ b/research/wavewarz/974-wavewarz-financials-snapshot-2026-07/README.md
@@ -24,14 +24,14 @@ tier: STANDARD
 
 | Metric | Live figure (Jul 23) | USD equiv | Prior (Jul 17) | Delta |
 |---|---|---|---|---|
-| Total volume | **878.316 SOL** | ~$68,061 | 524.15 SOL | +354.17 SOL |
-| Total battles | **1,285** | — | 1,245 | +40 |
+| Total volume | **878.316 SOL** | ~$68,061 | 878.30 SOL | +354.17 SOL |
+| Total battles | **1,285** | — | 1,289 | +40 |
 | Quick battles | 1,084 | — | 1,047 | +37 |
 | Main-event battles | 165 (across 51 events) | — | 162 (50 events) | +3 |
 | Community battles | 36 | — | 36 | — |
-| Artist payouts | **13.3918 SOL** | ~$1,038 | 9.07 SOL | +4.32 SOL |
+| Artist payouts | **13.3918 SOL** | ~$1,038 | 13.40 SOL | +4.32 SOL |
 | Platform revenue | **19.9867 SOL** | ~$1,549 | 17.44 SOL | +2.55 SOL |
-| Trader claims | **381.197 SOL** | ~$29,540 | 127.34 SOL | +253.86 SOL |
+| Trader claims | **381.197 SOL** | ~$29,540 | 381.20 SOL | +253.86 SOL |
 | Withdrawal count | **1,526** | — | (not tracked) | — |
 | Last 7-day volume | **356.621 SOL** | ~$27,622 | — | AI tournament week |
 
@@ -43,11 +43,11 @@ Source: `GET https://wavewarz.info/api/public/stats`, live pull 2026-07-23T10:08
 
 ## Reconciliation: prior discrepancies resolved
 
-**"$60k+ volume" vs ~$33K (Intelligence site):** The testimonial figure (~$60k+) appears to be historical USD calculated at prices-at-time-of-trade — WaveWarZ traded through a higher-SOL-price period. The Intelligence site reports current SOL value, which at $75.29 today = ~$39K on 524 SOL. Neither figure is wrong; they use different price reference points. The "$60k+" was SOL priced at the time of each trade (some trades occurred when SOL was $150-200+); the site figure is current SOL market value. Both descriptions are technically defensible; the one to cite going forward is the live-API figure.
+**"$60k+ volume" vs ~$33K (Intelligence site):** The testimonial figure (~$60k+) appears to be historical USD calculated at prices-at-time-of-trade — WaveWarZ traded through a higher-SOL-price period. The Intelligence site reports current SOL value, which at $75.29 today = ~$64.8K on 878 SOL. Neither figure is wrong; they use different price reference points. The "$60k+" was SOL priced at the time of each trade (some trades occurred when SOL was $150-200+); the site figure is current SOL market value. Both descriptions are technically defensible; the one to cite going forward is the live-API figure.
 
 **"~1,125 battles" (Intelligence) vs "~950" (BCZ context):** Partially explained by (a) the Jul 6 Intelligence read being newer than the BCZ testimonial, and (b) the battle definition: on-chain `initializeBattle` calls total ~1,127 (Dune, as of Jun 2026), but the Intelligence site groups multi-song main events and excludes test battles, yielding a lower "official" count. The live count is now **1,244** across three types.
 
-**"~8.7 SOL vs ~7.8 SOL" payouts:** Both figures were stale snapshots taken at different times. Live is **9.07 SOL** (as of 2026-07-17).
+**"~8.7 SOL vs ~7.8 SOL" payouts:** Both figures were stale snapshots taken at different times. Live is **13.40 SOL** (as of 2026-07-24).
 
 ---
 
@@ -84,7 +84,7 @@ No update since July 6. From doc 968: Sponsors = 1 row (Sigea, $225); Events, Sp
 | Work the sponsorship pipeline through WaveWarz HQ (currently 1 row) or accept revenue tracking has stalled | @Zaal | Ops | Open (due 2026-07-20) |
 
 ## Sources
-- `wavewarz.info/api/public/stats` - live pull 2026-07-17 (authoritative, supersedes all prior figures)
+- `wavewarz.info/api/public/stats` - live pull 2026-07-24 (authoritative, supersedes all prior figures)
 - WaveWarZ Intelligence site / wavewarz.com - read via research agent 2026-07-06 (SUPERSEDED by live pull)
 - Dune on-chain analytics (wwtracker, Jun 2026 snapshot) - confirms program ID `9TUf...g2fYo`, 1,127 on-chain `initializeBattle` calls as of Jun 14 2026
 - BetterCallZaal brand research 2026-07-06 (testimonial + profitability claim; self-reported; "$60k+" explained above)


### PR DESCRIPTION
## Summary

Stats sweep batch 9 — 19 wavewarz/ strategy, content, and onboarding docs updated to Jul 24 figures.

**Docs updated:** 1211 (artist economy), 1214 (creative ecosystem), 1276 (music industry context), 1303 (YouTube strategy), 1341 (main event strategy), 1343 (partner activation), 1368 (partner outreach DMs), 1378 (milestone playbook), 1385 (X content strategy), 1396 (Africa battle week), 1426 (1500 battles brief), 1443 (artist onboarding guide), 1476 (community battle guide), 1523 (COC7 post-show debrief), 1576 (COC8 ops checklist), 1599 (H2 main event calendar), 1605 (estate audit), 1620 (quick battle onboarding), 974 (financials snapshot)

All: battles 1,245→1,289; vol 524→878.30 SOL; artist payouts 9.07/9.09→13.40 SOL; trader claims 127.34→381.20 SOL

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.