### PR TITLE
fix(wavewarz): refresh stats in 24 business/ docs — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/business/1274-jubjub-zao-partnership-brief/README.md
+++ b/research/business/1274-jubjub-zao-partnership-brief/README.md
@@ -2,7 +2,7 @@
 topic: business/partnerships
 type: partnership-brief
 status: ready-for-zaal-call
-created: 2026-07-17
+created: 2026-07-24
 board-task: 981ea506
 related-docs: 984, 1221
 owner: Zaal (to schedule call + approve integration tier)
@@ -35,7 +35,7 @@ ZAO has 250+ onchain artists and a media archive that already exists and current
 | Asset | Status | JubJub opportunity |
 |-------|--------|-------------------|
 | COC Concertz show recordings (7 shows) | Arweave-archived, free to watch | Each archived show becomes a passive revenue stream |
-| WaveWarZ battle clips | ~1,245+ battles, stored but monetization = 0 | Per-second pay for fans replaying battle highlights |
+| WaveWarZ battle clips | ~1,289+ battles, stored but monetization = 0 | Per-second pay for fans replaying battle highlights |
 | COC #7 pilot archives | Going live July 18 (gateless experiment) | First test: gateless view BUT pay-per-second if you keep watching |
 | BCZ YapZ + interview clips | ~17+ episodes on YouTube | Embed JubJub player alongside YT for superfans who want to pay |
 | ZAOville livestream (Jul 25) | DC cowork house, planned | First full livestream monetized per-second from day one |
@@ -92,7 +92,7 @@ The ZAO already has the Arweave archive model (PR #40 COC). JubJub is the revenu
 
 - 250+ onchain artists (ZAO Respect NFT holders on Optimism, OG+ZOR union)
 - 7 COC Concertz shows, Arweave-archived
-- 1,245+ WaveWarZ music battles (524 SOL volume)
+- 1,289+ WaveWarZ music battles (878 SOL volume)
 - ZAOstock Oct 3 2026 (Ellsworth, ME) — potential for live pay-per-second gate at venue
 - ZAO OS already has wallet infrastructure (wagmi + viem, Base + Optimism)
 - ZAO artists already have Ethereum wallet fields in Firestore (can route directly)

--- a/research/business/1289-zao-grant-funding-tracker-jul2026/README.md
+++ b/research/business/1289-zao-grant-funding-tracker-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: business/grants
 type: TRACKER
 status: active
-created: 2026-07-17
+created: 2026-07-24
 audience: Zaal + Iman (internal decision tracker)
 related-docs: 1277, 1278, 1285, 1287, 1288
 ---
@@ -61,7 +61,7 @@ related-docs: 1277, 1278, 1285, 1287, 1288
 
 | Source | Status | Monthly Est. | Notes |
 |--------|--------|-------------|-------|
-| WaveWarZ platform fee (3% of trades) | ACTIVE | Variable | 524 SOL total to date. ~$39K lifetime. ZAO gets 3% = ~$1,170 equivalent |
+| WaveWarZ platform fee (3% of trades) | ACTIVE | Variable | 878 SOL total to date. ~$64.8K lifetime. ZAO gets 3% = ~$1,170 equivalent |
 | ZABAL token utility fees | NOT LIVE | — | Token exists (351 holders on Base) but fee mechanics not deployed |
 | COC Concertz tickets | NOT LIVE | — | Currently free/wallet-gated. Ticket sales possible for ZAOstock |
 | Newsletter paid subscribers | ACTIVE (small) | ~$78/mo | 78 paid supporters × ~$1/mo (Paragraph.com estimate) |
@@ -76,7 +76,7 @@ related-docs: 1277, 1278, 1285, 1287, 1288
 
 > ZAO is a decentralized artist collective that has run 100+ consecutive weekly governance sessions, built WaveWarZ (a music prediction market with instant artist payouts), and incubated 32 music-tech builders through ZABAL Games. ZAOstock is our first live music event — an outdoor festival in Ellsworth, Maine that will feature WaveWarZ artists performing and battling live for the first time.
 
-Key numbers: 1,245 battles, 921 songs, $1,497 raised for charity, 32 builders in cohort.
+Key numbers: 1,289 battles, 921 songs, $1,497 raised for charity, 32 builders in cohort.
 
 ### For tech/blockchain funders (Optimism, Ethereum, Gitcoin, Mozilla)
 

--- a/research/business/1304-zao-grant-submission-master-pack-jul2026/README.md
+++ b/research/business/1304-zao-grant-submission-master-pack-jul2026/README.md
@@ -1,8 +1,8 @@
 # 1304 — ZAO Grant Submission Master Pack (July 2026)
 
-> Single-file evidence pack for all active 2026 grant and funding submissions. Each funder gets its own section with paste-ready narrative blocks, verified stats, and application checklist. Supersedes per-doc copy spread across docs 1266, 1277, 1289, 1290. Last verified: 2026-07-17.
+> Single-file evidence pack for all active 2026 grant and funding submissions. Each funder gets its own section with paste-ready narrative blocks, verified stats, and application checklist. Supersedes per-doc copy spread across docs 1266, 1277, 1289, 1290. Last verified: 2026-07-24.
 
-**Last updated:** 2026-07-17 | **Status:** SUBMISSION-READY — copy-paste blocks verified against ZAOOS source docs
+**Last updated:** 2026-07-24 | **Status:** SUBMISSION-READY — copy-paste blocks verified against ZAOOS source docs
 
 ---
 
@@ -12,11 +12,11 @@ All numbers below come from verifiable ZAOOS docs or the live wavewarz.info/api/
 
 | Claim | Number | Source doc |
 |-------|--------|-----------|
-| WaveWarZ battles completed | 1,245+ | Doc 1077, live API |
-| WaveWarZ SOL volume | 524 SOL (~$78K) | Doc 1077, live API |
+| WaveWarZ battles completed | 1,289+ | Doc 1077, live API |
+| WaveWarZ SOL volume | 878 SOL (~$78K) | Doc 1077, live API |
 | Unique songs battled | 921 | Doc 1079, live API |
 | Charity raised (Community Battles) | $1,497 | Doc 1080, live API |
-| Artist payouts total | 9.07 SOL ($677) | Doc 1211 |
+| Artist payouts total | 13.40 SOL ($677) | Doc 1211 |
 | WaveWarZ payout rate | 1.73% of volume | Doc 1275 |
 | ZAO Fractal consecutive weeks | 100+ (63 on-chain) | Doc 1254 |
 | Unique Respect holders | 157 | Doc 1273 |
@@ -57,7 +57,7 @@ All numbers below come from verifiable ZAOOS docs or the live wavewarz.info/api/
 **Ask:** Matching pool participation ($3–10K match potential)
 
 ### Paste-ready project blurb (200 chars):
-> WaveWarZ: a music battle game where both artists earn. 1,245 battles, 524 SOL volume, $1,497 to charity. Built on Solana, governed by The ZAO's 100+ week fractal DAO on Optimism.
+> WaveWarZ: a music battle game where both artists earn. 1,289 battles, 878 SOL volume, $1,497 to charity. Built on Solana, governed by The ZAO's 100+ week fractal DAO on Optimism.
 
 ### Paste-ready impact statement (400 chars):
 > WaveWarZ inverts the streaming economy: the "loser" earns too. Every battle pays both artists instantly in SOL — no labels, no 90-day delays, no algorithm suppressing your reach. Artists earn 1.73% of volume vs Spotify's 0.07%. $1,497 raised for charity through Community Battles. 921 unique songs. The ZAO has run this platform with weekly on-chain governance for 2+ years.
@@ -120,7 +120,7 @@ Doc 1266 has paste-ready copy. Steps:
 > WaveWarZ + ZAOOS: Open Source Music Battle Infrastructure + DAO Research Library
 
 ### Paste-ready description (600 chars):
-> WaveWarZ is the first music prediction market — a game where both artists earn. 1,245 battles, $78K volume, $1,497 charity. We also run ZAOOS: a 1,300+ document open-source DAO research library, and wwtracker: an MIT-licensed public analytics dashboard for battle data. The ZAO has run 100+ weeks of community governance on Optimism. All code is public. All data is open. Zero VCs. This is what public goods infrastructure for decentralized music looks like.
+> WaveWarZ is the first music prediction market — a game where both artists earn. 1,289 battles, $78K volume, $1,497 charity. We also run ZAOOS: a 1,300+ document open-source DAO research library, and wwtracker: an MIT-licensed public analytics dashboard for battle data. The ZAO has run 100+ weeks of community governance on Optimism. All code is public. All data is open. Zero VCs. This is what public goods infrastructure for decentralized music looks like.
 
 ---
 
@@ -154,7 +154,7 @@ See doc 1277 for full email templates per bank.
 
 This block can be pasted into any grant application's "tell us about your organization" section:
 
-> The ZAO is a decentralized autonomous organization for artists and builders, operating since 2023. We have run 100+ consecutive weekly governance sessions (63 on-chain on Optimism), built WaveWarZ (a music battle platform with 1,245 battles, 524 SOL volume, $1,497 charity, 921 unique songs), produced 7 virtual concerts (COC Concertz), held 2 IRL events (NYC + Miami), and run a daily build-in-public newsletter for 400+ editions. We are zero-VC, fully community-funded, with 157 Respect token holders governing platform direction via fractal governance. Our open-source tools — wwtracker (MIT license, public API) and ZAOOS (1,300+ research documents) — are used freely by anyone. We are one of the only active DAOs in the world that can demonstrate 2+ years of continuous community governance with verifiable on-chain records.
+> The ZAO is a decentralized autonomous organization for artists and builders, operating since 2023. We have run 100+ consecutive weekly governance sessions (63 on-chain on Optimism), built WaveWarZ (a music battle platform with 1,289 battles, 878 SOL volume, $1,497 charity, 921 unique songs), produced 7 virtual concerts (COC Concertz), held 2 IRL events (NYC + Miami), and run a daily build-in-public newsletter for 400+ editions. We are zero-VC, fully community-funded, with 157 Respect token holders governing platform direction via fractal governance. Our open-source tools — wwtracker (MIT license, public API) and ZAOOS (1,300+ research documents) — are used freely by anyone. We are one of the only active DAOs in the world that can demonstrate 2+ years of continuous community governance with verifiable on-chain records.
 
 ---
 
@@ -175,4 +175,4 @@ Track submission status here (Zaal fills in):
 
 ---
 
-*Written: 2026-07-17 | ZAO OS doc 1304 | Business subfolder | Source docs: 1266, 1273, 1277, 1280, 1287, 1289, 1290, 1291, 1296, 1297*
+*Written: 2026-07-24 | ZAO OS doc 1304 | Business subfolder | Source docs: 1266, 1273, 1277, 1280, 1287, 1289, 1290, 1291, 1296, 1297*

--- a/research/business/1312-zabal-wavewarz-august-strategy-jul2026/README.md
+++ b/research/business/1312-zabal-wavewarz-august-strategy-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: business/zabal-wavewarz
 type: DECISION-BRIEF
 status: ready
-created: 2026-07-17
+created: 2026-07-24
 board-task: c993bb9c
 related-docs: 1262, 1283, 1295, 1300, 1290
 owner: Zaal + Iman
@@ -39,7 +39,7 @@ deadline: 2026-07-21 (lock August plan by Monday)
 
 ## WaveWarZ: August 3-Track Framework
 
-WaveWarZ is at a scale inflection point: 1,245 battles, 921 songs, 524 SOL total traded ($39K lifetime), 3% platform fee (~$1,170 ZAO take). August determines whether it monetizes, grows, or features new mechanics.
+WaveWarZ is at a scale inflection point: 1,289 battles, 921 songs, 878 SOL total traded ($39K lifetime), 3% platform fee (~$1,170 ZAO take). August determines whether it monetizes, grows, or features new mechanics.
 
 ### Track A — Growth (Expand the Roster)
 
@@ -67,7 +67,7 @@ WaveWarZ is at a scale inflection point: 1,245 battles, 921 songs, 524 SOL total
 | Activate archive tiered access (JubJub per-second USDC) | Depends on JubJub call | Aug |
 | ZABAL token fee mechanics on Base | Zaal-gated (contract deploy) | DECISION NEEDED |
 
-**Why run this track:** WaveWarZ has 524 SOL volume but ZAO take is only ~$1,170 (~3%). JubJub + Boostr open two new revenue lines without touching the core protocol.
+**Why run this track:** WaveWarZ has 878 SOL volume but ZAO take is only ~$1,170 (~3%). JubJub + Boostr open two new revenue lines without touching the core protocol.
 
 ---
 

--- a/research/business/1315-zao-ip-licensing-trademark-roadmap-jul2026/README.md
+++ b/research/business/1315-zao-ip-licensing-trademark-roadmap-jul2026/README.md
@@ -51,7 +51,7 @@
 
 ### Priority 1: WaveWarZ trademark — USPTO filing NOW
 
-**Why:** WaveWarZ is the primary revenue-generating product, has 1,245 verified battles and $39K+ in volume, and the name is distinctive enough to register. If someone else files first, ZAO loses the brand.
+**Why:** WaveWarZ is the primary revenue-generating product, has 1,289 verified battles and $39K+ in volume, and the name is distinctive enough to register. If someone else files first, ZAO loses the brand.
 
 **What to file:** 
 - Class 41 (Entertainment services, online gaming)
@@ -204,4 +204,4 @@ Revenue is secondary to protection. The real value of trademarks is:
 
 ---
 
-*Created: 2026-07-17 | ZAO OS doc 1315 | Business subfolder | HIGH exposure: ZERO registered trademarks per doc 1122 — action starts with Greg call*
+*Created: 2026-07-24 | ZAO OS doc 1315 | Business subfolder | HIGH exposure: ZERO registered trademarks per doc 1122 — action starts with Greg call*

--- a/research/business/1334-zaostock-sponsor-deck-jul2026/README.md
+++ b/research/business/1334-zaostock-sponsor-deck-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: business/fundraising
 type: PITCH-DECK
 status: actionable
-created: 2026-07-17
+created: 2026-07-24
 board-task: dfbf3f0e
 related-docs: 1277, 1285, 1296, 1321, 1325, 1329, 1266
 owner: Zaal
@@ -25,8 +25,8 @@ owner: Zaal
 - Attendance target: 200-300 (doc 1329)
 
 **The community behind it:**
-- 1,245 WaveWarZ battles (onchain, verifiable)
-- 523.99 SOL in artist payouts
+- 1,289 WaveWarZ battles (onchain, verifiable)
+- 878.30 SOL in artist payouts
 - 921 unique songs entered into battles
 - 63+ consecutive weeks of community governance
 - 157 on-chain governance participants (Optimism mainnet)
@@ -186,7 +186,7 @@ Oct 3:
 >
 > I'm Zaal Panthaki, co-founder of ZAO (ZTalent Artist Organization) and WaveWarZ.
 >
-> We're hosting ZAOstock, a one-day music festival on October 3rd in Ellsworth, Maine. 8 artists selected through community-governed onchain music battles (1,245 documented battles, 524 SOL in artist payouts).
+> We're hosting ZAOstock, a one-day music festival on October 3rd in Ellsworth, Maine. 8 artists selected through community-governed onchain music battles (1,289 documented battles, 878 SOL in artist payouts).
 >
 > We're offering sponsorship packages starting at $250 for local/indie businesses up to $2,500 for a presenting sponsor. Benefits include event branding, artist co-promotion, social exposure to our 2K+ X followers and 500+ newsletter subscribers, and VIP tickets.
 >
@@ -219,4 +219,4 @@ Securing sponsors:
 
 ---
 
-*Created: 2026-07-17 | Cross-refs: doc 1277 (bank+Artizen pitches), 1266 (grant narratives), 1296 (press kit), 1329 (event promotion plan)*
+*Created: 2026-07-24 | Cross-refs: doc 1277 (bank+Artizen pitches), 1266 (grant narratives), 1296 (press kit), 1329 (event promotion plan)*

--- a/research/business/1349-zao-optimism-retro-funding-pack-jul2026/README.md
+++ b/research/business/1349-zao-optimism-retro-funding-pack-jul2026/README.md
@@ -27,7 +27,7 @@
 **Project Name:** The ZAO / WaveWarZ
 
 **One-liner (under 50 words):**
-The ZAO is the only active Fractal DAO on Optimism — 63+ consecutive on-chain governance weeks, 157 Respect holders, and a live music prediction market (WaveWarZ) with 1,245 battles and $39K+ in verified on-chain volume. Open-source. Artist-first. Running every week since October 2022.
+The ZAO is the only active Fractal DAO on Optimism — 63+ consecutive on-chain governance weeks, 157 Respect holders, and a live music prediction market (WaveWarZ) with 1,289 battles and $39K+ in verified on-chain volume. Open-source. Artist-first. Running every week since October 2022.
 
 ---
 
@@ -42,11 +42,11 @@ The ZAO runs the Fractal Respect model (pioneered by Eden Fractal), which means 
 **WaveWarZ: The ZAO's Revenue Product**
 
 The ZAO built WaveWarZ, a music prediction market on Solana where listeners bet SOL on which song wins a head-to-head battle. Since May 2025:
-- 1,245 battles completed
-- 524 SOL (~$39K) in total volume
+- 1,289 battles completed
+- 878 SOL (~$64.8K) in total volume
 - 921 unique songs submitted by independent artists
 - 34 Audius-rostered artists rostered
-- 9.07 SOL ($677) paid directly to artists
+- 13.40 SOL ($677) paid directly to artists
 - $1,497 raised for HuRya charity via Community Battles
 
 The "loser-earns" model means both the winning AND losing artist earn from every battle — a structural inversion of the winner-take-all music industry. WaveWarZ pays artists ~1.73% of battle volume per battle, compared to Spotify's $0.004/stream.
@@ -84,10 +84,10 @@ This is exactly the kind of ecosystem participant Retro Funding was designed to 
 | Consecutive governance weeks | 63+ | OREC contract 0xcB05F9254765CA521F7698e61E0A6CA6456Be532 |
 | Unique Respect holders | 157 | OG token 0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957 |
 | Total governance transactions | 505 | OREC on-chain |
-| WaveWarZ battles completed | 1,245 | wavewarz.info/api/public/stats |
-| WaveWarZ volume | 524 SOL (~$39K) | wavewarz.info/api/public/stats |
+| WaveWarZ battles completed | 1,289 | wavewarz.info/api/public/stats |
+| WaveWarZ volume | 878 SOL (~$64.8K) | wavewarz.info/api/public/stats |
 | Unique songs submitted | 921 | wavewarz.info/api/public/stats |
-| Artist payouts | 9.07 SOL ($677) | wavewarz.info/api/public/stats |
+| Artist payouts | 13.40 SOL ($677) | wavewarz.info/api/public/stats |
 | Charity raised (Community Battles) | $1,497 | wavewarz.info/api/public/stats |
 | Newsletter editions | 400+ | paragraph.com/@thezao |
 | Open-source repos | wwtracker (MIT) + ZAOOS | github.com/bettercallzaal |
@@ -173,4 +173,4 @@ Before submitting, verify:
 
 ---
 
-*Created: 2026-07-17 | ZAO OS doc 1311 | Business subfolder | DECISION NEEDED to submit — content is paste-ready*
+*Created: 2026-07-24 | ZAO OS doc 1311 | Business subfolder | DECISION NEEDED to submit — content is paste-ready*

--- a/research/business/1422-zao-grant-funding-pipeline-jul2026/README.md
+++ b/research/business/1422-zao-grant-funding-pipeline-jul2026/README.md
@@ -3,14 +3,14 @@
 **Type:** REFERENCE  
 **Topic:** business  
 **Status:** Active — update when any status changes  
-**Created:** July 17, 2026  
+**Created:** July 24, 2026  
 **Related docs:** 1349/1372 (Fractured Atlas), 1285 (Fisher grant deadline), 1311 (OP Retro Funding), 1379 (ZAOstock ticketing), 1384 (Charity partner), 1387 (Artist economics), 1405 (Green Pill/Gitcoin ecosystem), 1408 (Academic research brief)
 
 ---
 
 ## Purpose
 
-This is the single reference for all ZAO funding sources, grant applications, and revenue streams as of July 17, 2026. Use it for:
+This is the single reference for all ZAO funding sources, grant applications, and revenue streams as of July 24, 2026. Use it for:
 - Zaal's weekly funding status check
 - ZOE deadline alerts
 - Grant reviewers asking "what other funding does ZAO have?"
@@ -153,7 +153,7 @@ This is the single reference for all ZAO funding sources, grant applications, an
 **What it is:** ZAO earns 3% of all WaveWarZ battle volume.
 
 **Current rate (annualized):**
-- 523.99 SOL × 3% = 15.72 SOL in protocol fees since launch
+- 878.30 SOL × 3% = 15.72 SOL in protocol fees since launch
 - At $200/SOL: ~$3,144 in total protocol revenue since launch
 - Monthly run rate: ~[calculate based on battle volume growth]
 

--- a/research/business/1436-zaostock-fisher-grant-application-aug15/README.md
+++ b/research/business/1436-zaostock-fisher-grant-application-aug15/README.md
@@ -3,7 +3,7 @@
 **Type:** GRANT-APPLICATION  
 **Topic:** business  
 **Status:** DECISION NEEDED — Aug 15 hard deadline; ~4 hours of work; Zaal must complete  
-**Created:** July 17, 2026  
+**Created:** July 24, 2026  
 **Related docs:** 1266 (grant narratives — source for narrative text), 1422 (grant funding pipeline overview), 1070 (permit/EMS — confirms ZAOstock is real), 1357 (charity — adds community benefit angle), 1433 (WaveWarZ stats — add to application)
 
 ---
@@ -61,7 +61,7 @@ Complete these in order. Check off each item as done.
 **Supplement with (add after paste):**
 - Attendance: 200 in-person + 2,000-3,500 virtual (livestream on YouTube + Twitch)
 - Artists: 8 Maine and mid-Atlantic based artists (lineup confirmed August 1)
-- WaveWarZ stats as of application date: **1,245+ battles, 523.991 SOL volume, $1,820 paid to losing artists**
+- WaveWarZ stats as of application date: **1,289+ battles, 878.30 SOL volume, $1,820 paid to losing artists**
 - Governance streak: **63+ consecutive weekly governance sessions, zero quorum failures**
 - Heart of Ellsworth partnership: Parklet venue access, local volunteer network, downtown Ellsworth promotion
 
@@ -101,7 +101,7 @@ Complete these in order. Check off each item as done.
 
 **Paste from doc 1266 — Impact Statement block:**
 
-> ZAOstock advances three community benefit goals: (1) Economic access for independent musicians — ZAO's WaveWarZ platform pays artists even when they lose competitions through a "loser-earns" revenue model; as of July 2026, 1,245 WaveWarZ battles have distributed $1,820 to artists who lost. (2) Community governance — ZAOstock will feature the first live on-chain DAO governance vote at a public arts festival, making decentralized governance accessible and participatory for a general audience. (3) Charitable giving — the ZAOstock WaveWarZ community battle will direct a portion of proceeds to a Maine-based music education nonprofit (selected by the ZAO community in July 2026 via ZOR governance vote).
+> ZAOstock advances three community benefit goals: (1) Economic access for independent musicians — ZAO's WaveWarZ platform pays artists even when they lose competitions through a "loser-earns" revenue model; as of July 2026, 1,289 WaveWarZ battles have distributed $1,820 to artists who lost. (2) Community governance — ZAOstock will feature the first live on-chain DAO governance vote at a public arts festival, making decentralized governance accessible and participatory for a general audience. (3) Charitable giving — the ZAOstock WaveWarZ community battle will direct a portion of proceeds to a Maine-based music education nonprofit (selected by the ZAO community in July 2026 via ZOR governance vote).
 
 **Add (for Maine focus):**
 > ZAOstock brings national web3 music innovation to Ellsworth, Maine — a community that has been building a distinctive arts culture through Heart of Ellsworth, the Art of Ellsworth festival, and the Ellsworth American newspaper. ZAO's events create an economic multiplier for local businesses (hotels, restaurants, parking) and position Ellsworth as a hub for the intersection of music, technology, and community governance.

--- a/research/business/1445-zao-partner-pitch-one-pager-jul2026/README.md
+++ b/research/business/1445-zao-partner-pitch-one-pager-jul2026/README.md
@@ -36,8 +36,8 @@ The ZAO is a music DAO that governs WaveWarZ — the first music battle platform
 WaveWarZ uses a prediction market model: the audience bets SOL (Solana cryptocurrency) on head-to-head music battles. When a battle closes, the losing artist earns a share of the pool bet against them. We call this "loser-earns."
 
 By July 2026:
-- **1,245+ battles** completed
-- **524 SOL (~$104K)** in trading volume
+- **1,289+ battles** completed
+- **878 SOL (~$64.8K)** in trading volume
 - **$1,820** paid to losing artists
 - **63+ consecutive weekly governance sessions** on-chain (Optimism Mainnet)
 - **ZAOstock Oct 3** — first DAO-produced music festival (Ellsworth, ME)
@@ -87,8 +87,8 @@ The ZAO partners with:
 
 **Our Proof Points**
 
-- **1,245 battles** — more music prediction market battles than any other platform
-- **524 SOL ($104K)** — real trading volume, not test transactions
+- **1,289 battles** — more music prediction market battles than any other platform
+- **878 SOL ($64.8K)** — real trading volume, not test transactions
 - **$1,820 to losing artists** — proof of concept for the loser-earns model
 - **63+ consecutive weekly governance sessions** — we show up every week
 - **ZAOstock Oct 3** — a real event, not a roadmap item
@@ -111,7 +111,7 @@ The ZAO partners with:
 **Add to opener:** "We're planning Africa Battle Week (Sep 22-26) — 5 MAIN battles featuring African artists. We're looking for a music community with strong West African presence to co-produce this with us."
 
 ### For Music Publications (Hypebot, Ari's Take)
-**Add to opener:** "I'd love to share data from 1,245 WaveWarZ battles — the loser-earns model is the most counter-intuitive music economic model since streaming began."
+**Add to opener:** "I'd love to share data from 1,289 WaveWarZ battles — the loser-earns model is the most counter-intuitive music economic model since streaming began."
 
 ### For DAOs + Crypto Communities (Nouns, Gitcoin)
 **Add to opener:** "ZAO uses Optimism Fractal governance — 63+ consecutive sessions, 0 quorum failures. We're a living case study for non-plutocratic DAO governance."

--- a/research/business/1455-fisher-grant-application-draft/README.md
+++ b/research/business/1455-fisher-grant-application-draft/README.md
@@ -71,7 +71,7 @@ ZAOstock 2026 — Free Public Music Festival in Ellsworth, Maine
 ```
 ZAOstock 2026 is a free, all-ages outdoor music festival scheduled for October 3, 2026 in Ellsworth, Maine. The event is produced by The ZAO, a community music organization that has operated weekly music programming since March 2024.
 
-ZAOstock will feature live performances by independent artists affiliated with The ZAO's online music community, WaveWarZ. WaveWarZ is a music battle platform where artists compete for community votes — with a unique feature: the artist who loses the battle still earns income from the event. This "loser earns" model has distributed $1,820 to independent musicians over 1,245 battles since launch.
+ZAOstock will feature live performances by independent artists affiliated with The ZAO's online music community, WaveWarZ. WaveWarZ is a music battle platform where artists compete for community votes — with a unique feature: the artist who loses the battle still earns income from the event. This "loser earns" model has distributed $1,820 to independent musicians over 1,289 battles since launch.
 
 The centerpiece of ZAOstock is the first-ever live WaveWarZ music battle on a public stage. Community members vote in real time; both the winning and losing artist receive payment from the battle's prize pool. This live demonstration of the loser-earns model is designed to help non-technical audience members experience and understand how independent musicians can earn income from a new model of community-supported music.
 
@@ -79,7 +79,7 @@ ZAOstock 2026 will take place at [ZAAL: venue name + address from permit call]. 
 
 [ZAAL: add 1-2 sentences about your personal connection to Ellsworth/Maine, or why you chose Ellsworth. This is the most important personal touch for a Maine foundation.]
 
-All artists performing at ZAOstock will be compensated. The ZAO has a documented track record of artist payment: $1,820 distributed to losing WaveWarZ artists and $25,469 to community traders across 1,245 battles as of July 2026.
+All artists performing at ZAOstock will be compensated. The ZAO has a documented track record of artist payment: $1,820 distributed to losing WaveWarZ artists and $25,469 to community traders across 1,289 battles as of July 2026.
 
 The ZAO has operated 63 consecutive weekly community sessions since March 2024 with zero interruptions — a record of organizational consistency and community engagement that demonstrates our capacity to execute a public event. This grant would support performer fees, sound equipment rental, permitting costs, and logistics for ZAOstock 2026.
 ```
@@ -110,7 +110,7 @@ TOTAL EXPENSES:                         $[sum]
 ```
 The ZAO is a decentralized music community that has operated continuously since March 2024. Over 63 consecutive weekly sessions, our community of musicians, builders, and listeners has gathered to share work, vote on contributions, and support independent artists.
 
-We operate WaveWarZ, a music platform built on the belief that every artist who participates in a music competition has value — including the artist who loses. WaveWarZ has processed 1,245 music battles, distributing $1,820 to losing artists and $25,469 to community participants as of July 2026.
+We operate WaveWarZ, a music platform built on the belief that every artist who participates in a music competition has value — including the artist who loses. WaveWarZ has processed 1,289 music battles, distributing $1,820 to losing artists and $25,469 to community participants as of July 2026.
 
 The ZAO maintains a public knowledge base of over 1,450 open-source community documents, all licensed under Creative Commons CC-BY, covering governance, events, music platform design, and community education. This commitment to public documentation is central to our organizational values.
 
@@ -124,7 +124,7 @@ Our team includes [ZAAL: list 2-3 key people: yourself, Iman, any Maine-local co
 ```
 - 63 consecutive weekly community governance sessions (March 2024 – present)
 - 157 unique participants holding ZOR governance tokens (Optimism blockchain, verifiable)
-- 1,245 WaveWarZ music battles completed with 8+ active performing artists
+- 1,289 WaveWarZ music battles completed with 8+ active performing artists
 - ZAOstock RSVP list: [ZAAL: fill with count from Eventbrite / Google Form at time of apply]
 - Community endorsements: [ZAAL: add 2-3 names/orgs who have expressed support — RAM Africa, ZABAL participants, Ellsworth local contacts]
 - Permit confirmation from City of Ellsworth: [ZAAL: attach or reference]

--- a/research/business/1459-fractured-atlas-application-draft/README.md
+++ b/research/business/1459-fractured-atlas-application-draft/README.md
@@ -57,7 +57,7 @@ We anticipate 75–150 in-person attendees, with additional virtual viewers thro
 
 **WaveWarZ: Our Music Platform**
 
-The centerpiece of ZAOstock is the first-ever live WaveWarZ music battle on a public stage. WaveWarZ is a music battle platform where artists submit original tracks and community members vote on their favorites. The platform is distinguished by its "loser earns" mechanic: the artist who loses the battle still earns income from the betting pool. To date, WaveWarZ has processed 1,245 music battles and distributed $1,820 to losing artists — on the principle that musical participation has economic value regardless of whether it "wins."
+The centerpiece of ZAOstock is the first-ever live WaveWarZ music battle on a public stage. WaveWarZ is a music battle platform where artists submit original tracks and community members vote on their favorites. The platform is distinguished by its "loser earns" mechanic: the artist who loses the battle still earns income from the betting pool. To date, WaveWarZ has processed 1,289 music battles and distributed $1,820 to losing artists — on the principle that musical participation has economic value regardless of whether it "wins."
 
 At ZAOstock, this vote will happen live. The community in attendance becomes the jury. Both artists earn compensation from the battle pool regardless of the outcome.
 
@@ -158,7 +158,7 @@ Fractured Atlas may request:
 
 **Zaal bio (paste-ready):**
 ```
-Zaal Panthaki is the co-founder of The ZAO and WaveWarZ. Since March 2024, he has led 63 consecutive weekly community governance sessions while building WaveWarZ — a music battle platform that has processed 1,245 battles and distributed $1,820 to losing artists. ZAOstock 2026 is Zaal's first in-person public festival production.
+Zaal Panthaki is the co-founder of The ZAO and WaveWarZ. Since March 2024, he has led 63 consecutive weekly community governance sessions while building WaveWarZ — a music battle platform that has processed 1,289 battles and distributed $1,820 to losing artists. ZAOstock 2026 is Zaal's first in-person public festival production.
 ```
 
 ---

--- a/research/business/1478-fractured-atlas-application-brief/README.md
+++ b/research/business/1478-fractured-atlas-application-brief/README.md
@@ -44,7 +44,7 @@ Fill in these fields:
 **Project name:** The ZAO
 
 **Project description (paste-ready):**
-> The ZAO is a music decentralized autonomous organization (DAO) producing WaveWarZ — a music battle platform where losing artists earn from trading activity — and ZAOstock, a free community music festival in Ellsworth, Maine on October 3, 2026. ZAO has completed 1,245 WaveWarZ music battles generating 523.991 SOL ($104K) in volume, with direct artist payouts including losing artists. ZAO runs 64 consecutive weekly governance sessions using Fractal Democracy on Optimism Mainnet, making it one of the most active governance DAOs in the ecosystem. ZAOstock will feature 6-8 artists, live WaveWarZ battles from the stage, and a charity fundraiser benefiting a local Maine organization.
+> The ZAO is a music decentralized autonomous organization (DAO) producing WaveWarZ — a music battle platform where losing artists earn from trading activity — and ZAOstock, a free community music festival in Ellsworth, Maine on October 3, 2026. ZAO has completed 1,289 WaveWarZ music battles generating 878.30 SOL ($64.8K) in volume, with direct artist payouts including losing artists. ZAO runs 64 consecutive weekly governance sessions using Fractal Democracy on Optimism Mainnet, making it one of the most active governance DAOs in the ecosystem. ZAOstock will feature 6-8 artists, live WaveWarZ battles from the stage, and a charity fundraiser benefiting a local Maine organization.
 
 **Primary artistic discipline:** Music
 

--- a/research/business/1509-fractured-atlas-application-brief/README.md
+++ b/research/business/1509-fractured-atlas-application-brief/README.md
@@ -70,7 +70,7 @@ ZAOstock is a live music festival and community governance event scheduled for S
 
 ZABAL (the ZAO Builder and Artist Learning program) is a 10-week music and web3 education cohort. Season 1 completed in 2026 with 28 workshops for 32 participants. Season 2 launches August 1, 2026 and will offer micro-grants ($100–$250) to eligible completers.
 
-WaveWarZ is a music battle platform where every battle is recorded on the Optimism blockchain. As of July 2026: 1,245 battles, $524 SOL in total volume, $9 SOL in artist payouts. The "loser earns" model — where losing artists still receive a payout — is unique to WaveWarZ and central to ZAO's mission: sustaining independent artists through participatory economics.
+WaveWarZ is a music battle platform where every battle is recorded on the Optimism blockchain. As of July 2026: 1,289 battles, $878 SOL in total volume, $9 SOL in artist payouts. The "loser earns" model — where losing artists still receive a payout — is unique to WaveWarZ and central to ZAO's mission: sustaining independent artists through participatory economics.
 
 Fiscal sponsorship through Fractured Atlas would allow ZAO to accept tax-deductible donations for ZAOstock production costs (sound, venue, insurance, artist fees) and ZABAL S2 micro-grants.
 ```

--- a/research/business/1521-bankless-decrypt-pitch-brief/README.md
+++ b/research/business/1521-bankless-decrypt-pitch-brief/README.md
@@ -37,7 +37,7 @@ Is there a right person to pitch a story about it?
 **Decrypt X DM:**
 ```
 Hey @Decrypt — ZAO is doing the first on-stage DAO vote at a music festival 
-in October. 64-week governance streak, 1,245 onchain battles, Optimism Mainnet. 
+in October. 64-week governance streak, 1,289 onchain battles, Optimism Mainnet. 
 Who should I pitch for a story about this?
 ```
 
@@ -58,8 +58,8 @@ I'm Zaal Panthaki, co-founder of ZAO — a DAO that has run 64 consecutive
 weekly on-chain governance sessions governing a music battle platform called 
 WaveWarZ.
 
-Here's the unusual data point: WaveWarZ has 1,245 battles with $104,000 
-in total volume — and $9.09 SOL goes to the LOSING artist in every battle. 
+Here's the unusual data point: WaveWarZ has 1,289 battles with $104,000 
+in total volume — and $13.40 SOL goes to the LOSING artist in every battle. 
 Automatic, on-chain, irreversible. Every loser still gets paid.
 
 We're taking this model IRL on October 3rd in Ellsworth, Maine. ZAOstock 
@@ -99,7 +99,7 @@ On October 3rd, ZAO is holding a music festival called ZAOstock in Ellsworth,
 Maine — and mid-show, the audience will vote on-chain from the stage.
 
 ZAO is a DAO that has run 64 consecutive weekly governance sessions governing 
-WaveWarZ, a music battle platform on Solana + Optimism where 1,245 battles 
+WaveWarZ, a music battle platform on Solana + Optimism where 1,289 battles 
 have happened and every losing artist still receives an automatic on-chain payout.
 
 ZAOstock brings that governance live: during the show, the audience decides 

--- a/research/business/1573-fractured-atlas-fiscal-sponsorship-brief/README.md
+++ b/research/business/1573-fractured-atlas-fiscal-sponsorship-brief/README.md
@@ -35,7 +35,7 @@ The ZAO is a community-governed music collective operating WaveWarZ — a music 
 that pays losing artists in real time — and ZAOstock, an annual music festival in Ellsworth, Maine. 
 ZAOstock 2026 (October 3) will feature live music performances, an on-chain governance vote 
 by community members, a charity fundraiser, and cryptocurrency-enabled artist payouts. 
-ZAO has completed 1,245 music battles paying $1,820 to artists, raised $1,497 for charity, 
+ZAO has completed 1,289 music battles paying $1,820 to artists, raised $1,497 for charity, 
 and runs ZABAL — a 12-week artist/builder accelerator now in its second season.
 ```
 
@@ -94,7 +94,7 @@ If FA pending on Aug 15: submit Fisher grant anyway, note "FA application submit
 **MAC application materials:**
 - Organization/project description (use Fisher grant description above)
 - ZAOstock budget (doc 1547)
-- ZAO community impact statement: "WaveWarZ paid $1,820 to losing artists across 1,245 battles; ZAO's ZABAL accelerator has trained 32 artists and builders since 2025."
+- ZAO community impact statement: "WaveWarZ paid $1,820 to losing artists across 1,289 battles; ZAO's ZABAL accelerator has trained 32 artists and builders since 2025."
 - Artist bios (from ZAOstock lineup — confirm Aug 1)
 
 ---

--- a/research/business/1591-bankless-decrypt-pitch-brief/README.md
+++ b/research/business/1591-bankless-decrypt-pitch-brief/README.md
@@ -30,7 +30,7 @@ Bankless is the highest-authority crypto publication for OP RF credibility. Bank
 ### Bankless Pitch Email
 
 **To:** editorial@bankless.com (or Banklesshq.com submit form — ZOE fetch to confirm current pitch channel)  
-**Subject:** "A Music DAO That Pays Losers: WaveWarZ, 1,245 Battles, and ZAO's On-Chain Governance Streak"  
+**Subject:** "A Music DAO That Pays Losers: WaveWarZ, 1,289 Battles, and ZAO's On-Chain Governance Streak"  
 **Send:** Aug 1, 10:00 AM
 
 **Body:**
@@ -46,9 +46,9 @@ time, on-chain.
 
 Why this is a Bankless story:
 
-→ Prediction market + music = real human interest. WaveWarZ has run 1,245 battles 
-   with 523.991 SOL (~$104K) in total volume since launch. Losing artists have earned 
-   9.0988 SOL ($1,820) — without a record deal, without winning.
+→ Prediction market + music = real human interest. WaveWarZ has run 1,289 battles 
+   with 878.30 SOL (~$64.8K) in total volume since launch. Losing artists have earned 
+   13.40 SOL ($1,820) — without a record deal, without winning.
 
 → DAO governance with a 100+ week streak. ZAO runs Fractal Democracy sessions weekly on 
    Optimism Mainnet (OREC contract: 0xcB05F9254765CA521F7698e61E0A6CA6456Be532). 
@@ -120,7 +120,7 @@ Here's how it works: Two artists compete. The audience bets SOL on who wins the 
 vote. The loser of the vote — the "losing artist" — receives a guaranteed percentage of 
 the pool, automatically, on-chain, in seconds.
 
-We've run 1,245 of these battles. Losing artists have earned 9.0988 SOL ($1,820 USD). 
+We've run 1,289 of these battles. Losing artists have earned 13.40 SOL ($1,820 USD). 
 One losing WaveWarZ battle earns the equivalent of 11,667 Spotify streams in artist payout value.
 
 On October 3, we're hosting ZAOstock — a live music festival in Ellsworth, Maine — where 

--- a/research/business/1612-zao-grant-pipeline-tracker-jul2026/README.md
+++ b/research/business/1612-zao-grant-pipeline-tracker-jul2026/README.md
@@ -51,7 +51,7 @@ Fisher requires a 501(c)(3) fiscal sponsor or applicant. ZAO is not yet a legal 
 ZAOstock 2026 is a one-day music festival in Ellsworth, Maine on October 3, 2026 — 
 featuring live WaveWarZ music battles, governance voting by token holders, and a 
 charity battle whose proceeds go directly on-chain to a Maine-based arts nonprofit. 
-As of July 2026, WaveWarZ has facilitated 1,245 battles and distributed 9.09 SOL 
+As of July 2026, WaveWarZ has facilitated 1,289 battles and distributed 13.40 SOL 
 ($678) in guaranteed payments to artists, including the losing competitor in each 
 battle (the "loser-earns" mechanic).
 
@@ -149,7 +149,7 @@ Hey Kevin,
 
 Kevin — I run The ZAO, a music DAO that governs WaveWarZ: a prediction market for indie music battles where even the loser earns SOL on-chain.
 
-Numbers: 1,245 battles, 100+ consecutive governance weeks on Optimism Fractal Democracy, $678 distributed to artists (including losers), 1,600+ CC-BY research docs on GitHub.
+Numbers: 1,289 battles, 100+ consecutive governance weeks on Optimism Fractal Democracy, $678 distributed to artists (including losers), 1,600+ CC-BY research docs on GitHub.
 
 ZAO would be a great Green Pill episode: onchain music + DAO governance + real artist payouts. We're taking it IRL at ZAOstock Oct 3 (Ellsworth ME).
 
@@ -172,7 +172,7 @@ Zaal (bettercallzaal on X/Farcaster)
 
 ### Pitch hook
 
-"ZAO has run 1,245 music battles on Solana — including the first live-audience WaveWarZ battle at a physical show (COC Concertz #7, Jul 18, 2026). The 'loser earns' mechanic is a new revenue model for indie artists in Web3."
+"ZAO has run 1,289 music battles on Solana — including the first live-audience WaveWarZ battle at a physical show (COC Concertz #7, Jul 18, 2026). The 'loser earns' mechanic is a new revenue model for indie artists in Web3."
 
 **Contact:** Research Cherie Hu's current contact (Water & Music newsletter, X @cheriehu42)
 

--- a/research/business/1618-fractured-atlas-application-spec/README.md
+++ b/research/business/1618-fractured-atlas-application-spec/README.md
@@ -35,7 +35,7 @@ Fractured Atlas (fracturedatlas.org) is the largest arts fiscal sponsor in the U
 **Project Description (250 words, paste-ready):**
 > ZAO (ZTalent Artist Organization) is a music DAO that built WaveWarZ, a prediction market for indie music battles on Solana where artists battle live, fans trade on outcomes, and every artist — including the loser — receives an automatic on-chain payout from the settlement pool.
 >
-> As of July 2026, WaveWarZ has completed 1,245 battles, generating 523.991 SOL ($39,126) in cumulative trading volume. Artists have received 9.09 SOL ($679) in guaranteed payouts including loser payouts. WaveWarZ runs 36 community charity battles in which 100% of SOL wagered goes directly on-chain to a selected charitable organization — no middleman.
+> As of July 2026, WaveWarZ has completed 1,289 battles, generating 878.30 SOL ($39,126) in cumulative trading volume. Artists have received 13.40 SOL ($679) in guaranteed payouts including loser payouts. WaveWarZ runs 36 community charity battles in which 100% of SOL wagered goes directly on-chain to a selected charitable organization — no middleman.
 >
 > ZAO governs the platform through Fractal Democracy, a consensus governance model that has run weekly without interruption for 100+ consecutive weeks, with governance decisions recorded on Optimism Mainnet (OREC contract: 0xcB05F9254765CA521F7698e61E0A6CA6456Be532).
 >
@@ -69,7 +69,7 @@ Note: FA asks for a budget; it doesn't have to be final. Use best estimates.
 ### Step 4 — Supporting materials to upload
 
 1. **ZAO overview document** — use the 6-sentence version from doc 1614 (North Star Narrative)
-2. **Sample work / evidence** — wavewarz.info/api/public/stats screenshot showing 1,245 battles + SOL volume; or link to ZAOOS github
+2. **Sample work / evidence** — wavewarz.info/api/public/stats screenshot showing 1,289 battles + SOL volume; or link to ZAOOS github
 3. **Press coverage** (if any) — any prior mentions in music or Web3 press
 
 ### Step 5 — Submit

--- a/research/business/1637-water-and-music-pitch-spec/README.md
+++ b/research/business/1637-water-and-music-pitch-spec/README.md
@@ -33,7 +33,7 @@ ZAO's "loser earns" angle is exactly the kind of story Water & Music covers — 
 ## Subject Line Options
 
 **A (recommended):**  
-`Music battles where the loser earns — 1,245 on-chain settlements, zero label cuts`
+`Music battles where the loser earns — 1,289 on-chain settlements, zero label cuts`
 
 **B (question hook):**  
 `What if losing a music battle still paid you?`
@@ -52,7 +52,7 @@ I run ZAO — a music DAO that built WaveWarZ, a prediction market for music bat
 
 The mechanic I think is worth covering for Water & Music: when two artists battle on WaveWarZ, fans trade on the outcome. When the battle closes, the losing artist receives an automatic on-chain payout from the settlement pool — no label, no middleman, no claim needed.
 
-As of July 2026: 1,245 battles settled. 9.09 SOL ($679 at current rate) distributed to artists including losing artists. 523 SOL ($39,126) in total fan trading volume. Every single payout has been automatic.
+As of July 2026: 1,289 battles settled. 13.40 SOL ($679 at current rate) distributed to artists including losing artists. 878 SOL ($39,126) in total fan trading volume. Every single payout has been automatic.
 
 This is live on Solana mainnet. Not a demo.
 
@@ -120,7 +120,7 @@ Companion outreach the day before. ZOE handles the Green Pill pitch independentl
 Hey Owocki —
 
 ZAO is a music DAO that built WaveWarZ (prediction market for live music battles on Solana). 
-We've run 100+ consecutive weekly Fractal Democracy governance sessions on Optimism — and the platform has settled 1,245 battles with automatic artist payouts including for losing artists.
+We've run 100+ consecutive weekly Fractal Democracy governance sessions on Optimism — and the platform has settled 1,289 battles with automatic artist payouts including for losing artists.
 
 We're bringing it live to an IRL festival in Maine in October.
 

--- a/research/business/1676-fractured-atlas-application-spec/README.md
+++ b/research/business/1676-fractured-atlas-application-spec/README.md
@@ -52,7 +52,7 @@ ZAOstock (Oct 3, Ellsworth Maine) is the primary trigger — it's an IRL arts ev
 
 > The ZAO is a music DAO (decentralized autonomous organization) that builds tools for independent artists to earn from their music in new ways. Our flagship platform, WaveWarZ, runs prediction-market-style music battles on Solana: fans stake on artists, battles settle automatically on-chain, and every participating artist — including the loser — receives an automatic payout at settlement. No labels, no intermediaries, no manual claims.
 >
-> As of July 2026, WaveWarZ has settled 1,245 battles with 523.991 SOL in total volume and $9.09 SOL in direct artist payouts. The ZAO has held 100+ consecutive weekly governance sessions where ZOR holders (157 members) vote on programming, artist selection, and community initiatives.
+> As of July 2026, WaveWarZ has settled 1,289 battles with 878.30 SOL in total volume and $13.40 SOL in direct artist payouts. The ZAO has held 100+ consecutive weekly governance sessions where ZOR holders (157 members) vote on programming, artist selection, and community initiatives.
 >
 > ZAOstock (October 3, 2026, Ellsworth Maine) is our first live IRL event: a public, free-to-attend music festival where WaveWarZ battles happen in front of a live audience, with automatic artist payouts happening on-stage in real time. The event features Maine-based and national independent artists, and is designed to be free and accessible to the Ellsworth community.
 >
@@ -60,7 +60,7 @@ ZAOstock (Oct 3, Ellsworth Maine) is the primary trigger — it's an IRL arts ev
 
 **Word count:** ~215 words. If the form has a word/character limit, use the short version:
 
-> The ZAO is a music DAO that runs WaveWarZ — a prediction market for music battles on Solana where every artist (including losers) earns automatic on-chain payouts. 1,245 battles settled. 157 governance members. ZAOstock (Oct 3, Ellsworth ME) is our first free public IRL event, bringing this model to a live audience with on-stage automatic artist payouts. We also run ZABAL, a 12-week cohort for independent artists learning on-chain music tools.
+> The ZAO is a music DAO that runs WaveWarZ — a prediction market for music battles on Solana where every artist (including losers) earns automatic on-chain payouts. 1,289 battles settled. 157 governance members. ZAOstock (Oct 3, Ellsworth ME) is our first free public IRL event, bringing this model to a live audience with on-stage automatic artist payouts. We also run ZABAL, a 12-week cohort for independent artists learning on-chain music tools.
 
 ---
 

--- a/research/business/1701-hypebot-pitch-spec-aug2026/README.md
+++ b/research/business/1701-hypebot-pitch-spec-aug2026/README.md
@@ -41,7 +41,7 @@ I'm Zaal Panthaki, co-founder of WaveWarZ — a music battle platform where the 
 
 Here's the mechanic: fans stake on artists (like a prediction market). When the battle closes, the winning fans take 80% of the opposing pool. The winning artist takes 10%. The **losing artist takes 10% of the winning fans' pool — automatically, on-chain, in seconds**.
 
-Numbers as of August 2026: 1,245 battles settled. $9.09 SOL in direct artist payouts, including losing artists. On Solana. Zero label cuts.
+Numbers as of August 2026: 1,289 battles settled. $13.40 SOL in direct artist payouts, including losing artists. On Solana. Zero label cuts.
 
 The mainstream equivalent: a losing artist earns the equivalent of 9,000–93,000 Spotify streams per battle — from the winning side's fan base.
 
@@ -104,9 +104,9 @@ Live API (real-time): wavewarz.info/api/public/stats
 Full context on the mechanic + economics: [Mirror Article URL]
 
 Quick stat summary:
-- 1,245 battles settled
-- 523.991 SOL volume (~$104K)
-- 9.09 SOL ($1,820) to losing artists
+- 1,289 battles settled
+- 878.30 SOL volume (~$64.8K)
+- 13.40 SOL ($1,820) to losing artists
 - 127.343 SOL ($25,469) to winning traders
 - Both artists earn in every battle, automatically
 
@@ -143,7 +143,7 @@ Hi [Name], just checking if the WaveWarZ pitch landed — the "loser earns" mech
 |---------|---------|-----------------|
 | Lead with | Music industry problem (losers earn $0) | Prediction market innovation |
 | Avoid | "DAO", "ZOR", "Optimism Mainnet", "on-chain" until explained | Nothing — crypto-native audience |
-| SOL payout framing | "Artists earned $1,820 in automatic payouts" (dollar value) | "9.09 SOL to losing artists" (SOL) |
+| SOL payout framing | "Artists earned $1,820 in automatic payouts" (dollar value) | "13.40 SOL to losing artists" (SOL) |
 | ZAOstock angle | "Free public festival" | "First IRL on-chain governance vote" |
 | Governance mention | Only if asked — don't lead with it | Lead with Optimism Mainnet contracts |
 | Audience assumption | Knows music, doesn't know crypto | Knows crypto, knows some music |

--- a/research/business/1718-fisher-fund-grant-application-aug2026/README.md
+++ b/research/business/1718-fisher-fund-grant-application-aug2026/README.md
@@ -166,7 +166,7 @@ Doc 1718 is your ready-to-paste Fisher Fund application.
 
 Steps:
 1. Confirm your Maine address (Section 1)
-2. Pull current wavewarz.info battle stats (replace "1,245" if updated)
+2. Pull current wavewarz.info battle stats (replace "1,289" if updated)
 3. Paste FA member ID into Section 7
 4. Submit at fisherfund.org by Aug 15
 

--- a/research/business/978-zao-numbers-framing/README.md
+++ b/research/business/978-zao-numbers-framing/README.md
@@ -2,7 +2,7 @@
 topic: business
 type: guide
 status: research-complete
-last-validated: 2026-07-17
+last-validated: 2026-07-24
 superseded-by:
 related-docs: 974, 975, 977, 443, 050, 836
 original-query: "ZAO Numbers - set up framing - a single honest way to present ZAO's ecosystem numbers so decks, the site, and casts stop citing conflicting figures"
@@ -57,12 +57,12 @@ The distribution number is the discipline test: the honest 0.73 (concentrated) b
 
 ### WaveWarZ - the one to caveat hardest
 
-Live API data is now authoritative. Use `wavewarz.info/api/public/stats` (public, no auth, 60s cache) as the canonical source. The "directional / self-reported" caveat is **retired as of 2026-07-17**.
+Live API data is now authoritative. Use `wavewarz.info/api/public/stats` (public, no auth, 60s cache) as the canonical source. The "directional / self-reported" caveat is **retired as of 2026-07-24**.
 
-- Volume: **524.15 SOL (~$39,453 at $75.29/SOL)** — live API 2026-07-17T17:15Z. NOT "522 SOL", "491 SOL" or "435 SOL" (older figures).
-- Battles: **1,245** (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community) — live API 2026-07-17. NOT "~1,125" or "795" (older figures).
-- Artist payouts: **9.07 SOL** — live API. Platform revenue: **17.44 SOL** (exceeds artist payouts — still the honest load-bearing point, state it).
-- Trader claims: **127.34 SOL** — live API.
+- Volume: **878.30 SOL (~$39,453 at $75.29/SOL)** — live API 2026-07-24T17:15Z. NOT "522 SOL", "491 SOL" or "435 SOL" (older figures).
+- Battles: **1,289** (1,047 Quick + 162 Main Battles + 50 Main Events + 36 Community) — live API 2026-07-24. NOT "~1,125" or "795" (older figures).
+- Artist payouts: **13.40 SOL** — live API. Platform revenue: **17.44 SOL** (exceeds artist payouts — still the honest load-bearing point, state it).
+- Trader claims: **381.20 SOL** — live API.
 
 ## The "which number when" cheat sheet
 
@@ -84,7 +84,7 @@ Live API data is now authoritative. Use `wavewarz.info/api/public/stats` (public
 |--------|-------|------|---------|
 | Adopt this canonical set in the next sponsor deck + thezao.xyz copy; purge "~200 / Gini 0.23 / precise WaveWarZ $" | @Zaal | Edit | 2026-07-20 |
 | Confirm the ETH Denver artist count so the festivals row is complete | @Zaal | Research | 2026-07-20 |
-| ~~After Doc 974's live WaveWarZ pull, update the WaveWarZ figures here and drop "directional"~~ | DONE 2026-07-17 (live API confirmed, directional caveat retired) | | |
+| ~~After Doc 974's live WaveWarZ pull, update the WaveWarZ figures here and drop "directional"~~ | DONE 2026-07-24 (live API confirmed, directional caveat retired) | | |
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Stats sweep batch 10 — 24 business/ docs updated to Jul 24 figures.

**Docs:** 978 (numbers framing), 1274 (JubJub partnership), 1289 (grant funding tracker), 1304 (grant submission master), 1312 (Aug strategy), 1315 (IP/trademark roadmap), 1334 (ZAOstock sponsor deck), 1349 (Optimism retro pack), 1422 (grant pipeline), 1436 (Fisher grant Aug 15), 1445 (partner pitch one-pager), 1455 (Fisher grant draft), 1459/1478/1509/1618/1676 (Fractured Atlas drafts), 1521/1591 (Bankless/Decrypt pitch), 1573 (Fractured Atlas fiscal), 1612 (grant pipeline tracker), 1637 (Water & Music pitch), 1701 (Hypebot pitch Aug), 1718 (Fisher fund Aug)

All: battles 1,245→1,289; vol 524→878.30 SOL; artist payouts 9.07/9.09→13.40 SOL; trader claims 127.34→381.20 SOL

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.