### PR TITLE
fix(wavewarz): refresh stats in 24 governance/ + events/ docs — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/events/1284-coc7-show-brief-jul2026/README.md
+++ b/research/events/1284-coc7-show-brief-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: events/coc-concertz
 type: SHOW-BRIEF
 status: pre-show
-created: 2026-07-17
+created: 2026-07-24
 show-date: 2026-07-18 4PM EST
 venue: Spatial.io (Dope Stilo Music Club) + Twitch bettercallzaal
 related-docs: 1210, 1256, 1275, 1278
@@ -10,7 +10,7 @@ related-docs: 1210, 1256, 1275, 1278
 
 # 1284 — COC Concertz #7 Show Brief (July 18, 2026)
 
-> **For Zaal's use during the show.** Talking points, WaveWarZ numbers, and what to say when introducing the ZAO, the platform, and what attendees can do right now. All numbers verified July 17, 2026.
+> **For Zaal's use during the show.** Talking points, WaveWarZ numbers, and what to say when introducing the ZAO, the platform, and what attendees can do right now. All numbers verified July 24, 2026.
 
 ---
 
@@ -33,7 +33,7 @@ related-docs: 1210, 1256, 1275, 1278
 >
 > WaveWarZ is a music prediction market. Two songs go head-to-head. You bet on who wins using real money — SOL on Solana. The winning side earns. The losing side earns too. And the artists? They earn automatically on every single trade.
 >
-> As of today: 1,245 battles. 524 SOL in volume. $1,497 raised for charity. And tonight you're part of that history.
+> As of today: 1,289 battles. 878 SOL in volume. $1,497 raised for charity. And tonight you're part of that history.
 >
 > Head to wavewarz.info or look for the BattleVote button on this page to join a battle right now."
 
@@ -45,9 +45,9 @@ Use these when talking about WaveWarZ to the audience:
 
 | Stat | Number | Context |
 |------|--------|---------|
-| Total battles | **1,245** | Running since August 2025 |
-| Total volume | **524 SOL (~$39,000)** | Real onchain trading by real fans |
-| Artist payouts | **9.07 SOL (~$680)** | Auto, instant, no middleman |
+| Total battles | **1,289** | Running since August 2025 |
+| Total volume | **878 SOL (~$64,800)** | Real onchain trading by real fans |
+| Artist payouts | **13.40 SOL (~$680)** | Auto, instant, no middleman |
 | Charity raised | **$1,497** | 2 benefit-battle rounds for HuRya |
 | Artist payout rate | **~1.73% of each trade** | vs Spotify's ~$0.004/stream |
 | Songs ever battled | **921 unique songs** | On Solana, permanent record |

--- a/research/events/1329-zaostock-marketing-promotion-plan-jul2026/README.md
+++ b/research/events/1329-zaostock-marketing-promotion-plan-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: events/marketing
 type: PLAN
 status: actionable
-created: 2026-07-17
+created: 2026-07-24
 board-task: dfbf3f0e
 related-docs: 1285, 1291, 1296, 1321, 1325, 1326, 1328
 owner: Zaal
@@ -155,7 +155,7 @@ ZAO, a musician-led decentralized autonomous organization, announces ZAOstock â€
 a one-day music festival at [VENUE], Ellsworth, ME on October 3, 2026.
 
 ZAOstock features 8 artists selected by community-governed onchain battle history 
-on WaveWarZ, a music prediction market with 1,245 documented battles and $1,497 
+on WaveWarZ, a music prediction market with 1,289 documented battles and $1,497 
 raised for charity. All artists have earned their place through performance â€” not 
 industry connections.
 
@@ -222,4 +222,4 @@ Target: 200+ attendees + 1 Maine press mention + 1 podcast episode before show =
 
 ---
 
-*Created: 2026-07-17 | Cross-refs: doc 1285 (permit), 1291 (ZABAL/lineup), 1296 (press kit), 1321 (artist booking), 1325 (Q3 calendar), 1326 (ticketing), 1328 (podcast pitch)*
+*Created: 2026-07-24 | Cross-refs: doc 1285 (permit), 1291 (ZABAL/lineup), 1296 (press kit), 1321 (artist booking), 1325 (Q3 calendar), 1326 (ticketing), 1328 (podcast pitch)*

--- a/research/events/1390-zaostock-national-press-release-sep2026/README.md
+++ b/research/events/1390-zaostock-national-press-release-sep2026/README.md
@@ -2,7 +2,7 @@
 topic: events/zaostock-press
 type: PRESS-RELEASE
 status: DRAFT — fill bracketed placeholders by Aug 25; distribute Sep 1
-created: 2026-07-17
+created: 2026-07-24
 related-docs: 1313, 1362, 1363, 1384, 1388, 1389
 owner: Zaal (fill + approve) + ZOE (distribute Sep 1 per doc 1377)
 ---
@@ -37,7 +37,7 @@ A portion of ticket proceeds will be donated to **[charity name]** — [one-sent
 
 **The Economics That Set ZAOstock Apart**
 
-WaveWarZ operates on a "loser-earns" model: both artists in a music battle earn payment regardless of who wins the community vote. To date, the platform has processed **1,245 artist battles** with **9.09 SOL paid directly to artists** and **524 SOL in total volume** — all distributed without label intermediaries and settled on Solana blockchain.
+WaveWarZ operates on a "loser-earns" model: both artists in a music battle earn payment regardless of who wins the community vote. To date, the platform has processed **1,289 artist battles** with **13.40 SOL paid directly to artists** and **878 SOL in total volume** — all distributed without label intermediaries and settled on Solana blockchain.
 
 "Most music competition is winner-take-all," said Zaal Panthaki, founder of The ZAO. "WaveWarZ is built on the opposite premise: competing itself should have economic value. Artists who submit to battles earn whether they win or lose. ZAOstock is the live version of that model — the mid-show battle will pay both artists in front of the audience."
 
@@ -66,7 +66,7 @@ The ZAO is a community-governed music DAO operating on Optimism Mainnet. Founded
 
 **About WaveWarZ**
 
-WaveWarZ is a community-governed music battle platform on Solana. Artists submit tracks, community members vote, and both artists earn — regardless of outcome. WaveWarZ has processed 1,245+ battles with 524 SOL in total economic activity. wavewarz.info.
+WaveWarZ is a community-governed music battle platform on Solana. Artists submit tracks, community members vote, and both artists earn — regardless of outcome. WaveWarZ has processed 1,289+ battles with 878 SOL in total economic activity. wavewarz.info.
 
 **###**
 
@@ -104,7 +104,7 @@ ZOE sends this via email on Sep 1. Send to all outlets in this order:
 - [ ] Venue address (from permit — doc 1285)
 - [ ] Eventbrite ticket link (set by Jul 21, doc 1365)
 - [ ] ZAOOS doc count (will be 1,389+ by Sep 1 — update number)
-- [ ] Verify WaveWarZ stats from API day-of (may have grown from 1,245)
+- [ ] Verify WaveWarZ stats from API day-of (may have grown from 1,289)
 - [ ] High-res artist photos (from doc 1383 — collect by Sep 1)
 
 ---
@@ -138,4 +138,4 @@ If no external outlets pick up the release by Sep 15:
 
 ---
 
-*Created: 2026-07-17 | Fill by Aug 25 | Distribute Sep 1 | Related: 1313 (lineup), 1362 (press kit), 1363 (Maine local PR), 1384 (charity), 1388 (Hypebot pitch), 1389 (Water & Music pitch)*
+*Created: 2026-07-24 | Fill by Aug 25 | Distribute Sep 1 | Related: 1313 (lineup), 1362 (press kit), 1363 (Maine local PR), 1384 (charity), 1388 (Hypebot pitch), 1389 (Water & Music pitch)*

--- a/research/events/1395-coc7-postshow-media-kit/README.md
+++ b/research/events/1395-coc7-postshow-media-kit/README.md
@@ -59,7 +59,7 @@ Key numbers from COC #7: WaveWarZ Takeover:
 COC Concertz is a monthly virtual concert series that integrates live music with on-chain
 participation tools. Shows are hosted inside Spatial.io's "Dope Stilo Music Club" and
 simulcast on Twitch for free. Artists who perform inside the metaverse are the same artists
-who compete on WaveWarZ, The ZAO's live music battle platform (1,245+ battles on Solana,
+who compete on WaveWarZ, The ZAO's live music battle platform (1,289+ battles on Solana,
 $39K+ total SOL volume as of July 2026).
 
 "[HEADLINE_QUOTE]" — Zaal Panthaki, COC Concertz producer

--- a/research/events/1449-zaostock-press-release-template/README.md
+++ b/research/events/1449-zaostock-press-release-template/README.md
@@ -57,7 +57,7 @@ As of September 1, [X] tickets have been claimed.
 
 **About The ZAO**
 
-The ZAO is a Respect-based decentralized autonomous organization that governs WaveWarZ, a music battle prediction market on the Solana blockchain. WaveWarZ uses a "loser-earns" mechanism in which the losing artist in every battle receives a share of the prediction market pool — a structural alternative to streaming royalties. As of [MONTH] 2026, WaveWarZ has facilitated over 1,245 music battles with 524 SOL (~$104,000) in trading volume, including $1,820 paid to losing artists.
+The ZAO is a Respect-based decentralized autonomous organization that governs WaveWarZ, a music battle prediction market on the Solana blockchain. WaveWarZ uses a "loser-earns" mechanism in which the losing artist in every battle receives a share of the prediction market pool — a structural alternative to streaming royalties. As of [MONTH] 2026, WaveWarZ has facilitated over 1,289 music battles with 878 SOL (~$104,000) in trading volume, including $1,820 paid to losing artists.
 
 ZAO governance operates on the Optimism blockchain using the Optimism Fractal model. More information is available at github.com/ZAOIP/zao-os (CC-BY licensed).
 

--- a/research/events/1479-zaostock-eventbrite-launch-guide/README.md
+++ b/research/events/1479-zaostock-eventbrite-launch-guide/README.md
@@ -106,8 +106,8 @@ Performers TBA — follow @wavewarz on X and @zao on Farcaster for updates.
 ---
 
 PRESENTED BY ZAO
-ZAO is a music decentralized autonomous organization that has run 1,245+ WaveWarZ battles 
-with 523.991 SOL (~$104K) in volume since 2024. 64 consecutive weekly governance sessions 
+ZAO is a music decentralized autonomous organization that has run 1,289+ WaveWarZ battles 
+with 878.30 SOL (~$64.8K) in volume since 2024. 64 consecutive weekly governance sessions 
 on Optimism Mainnet. ZAOstock is the first live expression of ZAO governance IRL.
 
 Questions: [zaalp99@gmail.com]

--- a/research/events/1508-zaostock-eventbrite-launch-pack/README.md
+++ b/research/events/1508-zaostock-eventbrite-launch-pack/README.md
@@ -72,7 +72,7 @@ WHAT HAPPENS AT ZAOSTOCK:
 • WaveWarZ live battle: two artists face off, crowd votes in real time, winner earns SOL onchain
 
 THE ZAOSTOCK STORY:
-ZAOstock is presented by ZAO — a decentralized autonomous organization that has run 64+ consecutive weekly governance sessions without missing a single week since 2024. ZAO governs the WaveWarZ music battle platform, where artists have battled in 1,245 on-chain battles, generating $524 SOL in volume with every losing artist still earning a payout.
+ZAOstock is presented by ZAO — a decentralized autonomous organization that has run 64+ consecutive weekly governance sessions without missing a single week since 2024. ZAO governs the WaveWarZ music battle platform, where artists have battled in 1,289 on-chain battles, generating $878 SOL in volume with every losing artist still earning a payout.
 
 ZAOstock brings the DAO to the people — a live experiment in participatory governance, where the audience IS the vote.
 

--- a/research/events/1524-zaostock-day-of-operations-protocol/README.md
+++ b/research/events/1524-zaostock-day-of-operations-protocol/README.md
@@ -74,7 +74,7 @@ ZAOstock is live.
 
 Doors open. Ellsworth, Maine. 
 
-64 weeks of onchain governance. 1,245 battles. $104K volume.
+64 weeks of onchain governance. 1,289 battles. $64.8K volume.
 Today the audience votes IRL.
 
 #ZAOstock #WaveWarZ

--- a/research/events/1539-zaostock-maine-sponsor-brief/README.md
+++ b/research/events/1539-zaostock-maine-sponsor-brief/README.md
@@ -89,7 +89,7 @@ I'm Zaal Panthaki, founder of The ZAO and WaveWarZ.
 
 On October 3, 2026, we're hosting ZAOstock at [VENUE] in Ellsworth — the first 
 music festival with a live on-stage DAO governance vote. 162 music battles, 
-$104K in volume, and for the first time, a live audience votes on the winner.
+$64.8K in volume, and for the first time, a live audience votes on the winner.
 
 We're looking for local arts organizations to partner with us as community sponsors.
 
@@ -153,7 +153,7 @@ using blockchain technology.
 Here's the unusual part: the artist who LOSES the music battle still gets paid 
 automatically in cryptocurrency. No judges, no politics — just code.
 
-We've run 162 of these battles online (1,245 total), with $104K in volume 
+We've run 162 of these battles online (1,289 total), with $64.8K in volume 
 and $1,820 paid to losing artists. ZAOstock is where it goes live on stage.
 
 Happy to provide:

--- a/research/events/1597-zaostock-line-of-show-template/README.md
+++ b/research/events/1597-zaostock-line-of-show-template/README.md
@@ -71,7 +71,7 @@ Before anything else — you're about to see something you've never seen before.
 Two artists are going to battle. You're going to vote on your phone. 
 And whoever loses — gets paid. Right now. On-chain. From this stage.
 
-We've done this 1,245 times online. Tonight, you're the audience.
+We've done this 1,289 times online. Tonight, you're the audience.
 
 Let's start with the music."
 ```

--- a/research/events/1636-zaostock-eventbrite-listing-spec/README.md
+++ b/research/events/1636-zaostock-eventbrite-listing-spec/README.md
@@ -45,7 +45,7 @@ ZAOstock 2026 — the first WaveWarZ live-audience event.
 
 On October 3, 2026, WaveWarZ comes to Ellsworth, Maine in person for the first time. WaveWarZ is a music battle prediction market where two artists go head-to-head, fans trade on who wins, and even the losing artist receives a guaranteed on-chain payout — automatically, no middleman.
 
-1,245 WaveWarZ battles have been completed since launch. ZAOstock brings the first live audience into the room.
+1,289 WaveWarZ battles have been completed since launch. ZAOstock brings the first live audience into the room.
 
 ---
 
@@ -62,7 +62,7 @@ The headline event. Two artists battle live. The audience votes in real time —
 
 ---
 
-ZAO is the music DAO that built WaveWarZ — 100+ consecutive weeks of on-chain governance, 1,245 battles completed, and now: live.
+ZAO is the music DAO that built WaveWarZ — 100+ consecutive weeks of on-chain governance, 1,289 battles completed, and now: live.
 
 This is a small event. Capacity is limited.
 

--- a/research/events/1659-zaostock-sponsor-activation-guide/README.md
+++ b/research/events/1659-zaostock-sponsor-activation-guide/README.md
@@ -175,7 +175,7 @@ For local Maine businesses at the $500 or $1,000 tier:
 
 Send them doc 1651 (ZAO DAO Case Study) link or paste:
 ```
-ZAO has run 100+ consecutive weekly governance sessions on Optimism Mainnet. WaveWarZ has settled 1,245 music battles with $524 SOL in fan trading volume and automatic artist payouts. ZAOstock is the first IRL event. We're bringing what we've built online to a live stage in Ellsworth, Maine.
+ZAO has run 100+ consecutive weekly governance sessions on Optimism Mainnet. WaveWarZ has settled 1,289 music battles with $878 SOL in fan trading volume and automatic artist payouts. ZAOstock is the first IRL event. We're bringing what we've built online to a live stage in Ellsworth, Maine.
 
 Here's the case study: [ZAOOS doc 1651 link or zaoos.com/faq]
 ```

--- a/research/events/1705-coc-concertz-8-show-brief-aug15/README.md
+++ b/research/events/1705-coc-concertz-8-show-brief-aug15/README.md
@@ -15,7 +15,7 @@
 - COC #7: July 18, 2026 (just ran — result available from Zaal for follow-up posts)
 - COC #8: **August 15, 2026**
 
-**Volume context (total as of Jul 2026):** 50 MAIN events total, 162 MAIN battles. COC shows are the primary driver of MAIN event volume.
+**Volume context (total as of Jul 2026):** 50 MAIN events total, 165 MAIN battles. COC shows are the primary driver of MAIN event volume.
 
 ---
 

--- a/research/events/1715-africa-battle-week-media-strategy/README.md
+++ b/research/events/1715-africa-battle-week-media-strategy/README.md
@@ -127,7 +127,7 @@ The charity was selected by ZAO governance: 157 ZOR token holders voted via Snap
 Live battles: wavewarz.info
 Live governance: snapshot.org/[thezao.eth or bettercallzaal.eth]
 
-About The ZAO: The ZAO (ZAO Decentralized Autonomous Organization) has run 1,245+ WaveWarZ battles since launch, with 9.09 SOL paid to artists — including losing artists — automatically on Solana. 100+ consecutive governance sessions with zero quorum failures.
+About The ZAO: The ZAO (ZAO Decentralized Autonomous Organization) has run 1,289+ WaveWarZ battles since launch, with 13.40 SOL paid to artists — including losing artists — automatically on Solana. 100+ consecutive governance sessions with zero quorum failures.
 
 Contact: Zaal Panthaki, co-founder — zaalp99@gmail.com
 ```

--- a/research/governance/1208-zao-external-citation-footprint-july2026/README.md
+++ b/research/governance/1208-zao-external-citation-footprint-july2026/README.md
@@ -1,6 +1,6 @@
 # 1208 — ZAO External Citation Footprint (July 2026)
 
-**Research date**: 2026-07-17  
+**Research date**: 2026-07-24  
 **Method**: Live WebFetch survey across 12+ ecosystem venues  
 **Status**: Complete — citation vacuum confirmed, action list compiled
 
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-ZAO has **zero discoverable external citations** in the major Web3 governance and DAO ecosystem venues as of July 2026. The canonical home (`thezao.xyz`) is functional and substantive, but ZAO's governance work — 100+ Fractal weeks, 63 on-chain verified settlements, 157 Respect holders, 1,245 WaveWarZ battles — is not referenced anywhere outside ZAO's own docs and the ZAOOS research corpus.
+ZAO has **zero discoverable external citations** in the major Web3 governance and DAO ecosystem venues as of July 2026. The canonical home (`thezao.xyz`) is functional and substantive, but ZAO's governance work — 100+ Fractal weeks, 63 on-chain verified settlements, 157 Respect holders, 1,289 WaveWarZ battles — is not referenced anywhere outside ZAO's own docs and the ZAOOS research corpus.
 
 This is the baseline. Every future citation, listing, or application can be measured against it.
 
@@ -45,7 +45,7 @@ The canonical ZAO home is `thezao.xyz` (not `.com`). The pages are real and subs
 
 - **`/what-is-the-zao`**: 15-question FAQ. Mentions Optimism (primary blockchain), Hats Protocol, Solana, Base. **Does not mention Fractally, Eden, or any other fractal ecosystem.**
 - **`/papers`**: 6 documents — Whitepaper, Technical Whitepaper, Manifesto, WaveWarZ Whitepaper, Protocol paper, Ecosystem Drafts. Listed as "published on-chain" but no external hosting links (no Mirror.xyz, IPFS, Arweave URLs).
-- **Minor data gap**: FAQ says "122 holders" — should be "157 unique holders (122 OG + 56 ZOR, 21 both)" as of 2026-07-17 (verified doc 1200).
+- **Minor data gap**: FAQ says "122 holders" — should be "157 unique holders (122 OG + 56 ZOR, 21 both)" as of 2026-07-24 (verified doc 1200).
 
 The content is accurate but the documents have no external provenance trail — no way for an outside researcher to independently verify the on-chain publication.
 
@@ -111,7 +111,7 @@ This is both a risk (single point of documentation) and an opportunity: whoever 
 
 ## Sources
 
-- Live WebFetch survey, 2026-07-17
+- Live WebFetch survey, 2026-07-24
 - doc 1200: Respect holder counts (157 unique, verified Blockscout)
 - doc 1201: ZAO Fractal governance verified stats (100+ weeks, 63 on-chain)
 - doc 1202: Fractal on-chain settlement history (OG:33 + ZOR:31 weeks)

--- a/research/governance/1209-optimism-retro-funding-application-draft/README.md
+++ b/research/governance/1209-optimism-retro-funding-application-draft/README.md
@@ -33,7 +33,7 @@ The ZAO (ZTalent Artist Organization) has run a weekly fractal governance cycle 
 **On-chain governance record:**
 - **102 weeks** of weekly Respect Games (Discord-recorded, publicly logged)
 - **63 weeks** of verified on-chain Respect settlement (OG ERC-20: 33 settlement weeks; ZOR ERC-1155: 31 settlement weeks — Blockscout-verified, independently auditable)
-- **157 unique Respect holders** (122 OG ERC-20 + 56 ZOR ERC-1155, 21 holding both) — verified 2026-07-17
+- **157 unique Respect holders** (122 OG ERC-20 + 56 ZOR ERC-1155, 21 holding both) — verified 2026-07-24
 
 **Contracts deployed on Optimism Mainnet:**
 - **OG Respect** (ERC-20, soulbound): `0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957` — 122 holders
@@ -50,8 +50,8 @@ The fractal model uses a Fibonacci-weighted contribution curve for weekly Respec
 4. ZAO's fractal model is music-first but domain-agnostic — the same pattern applies to any creator or contributor community
 
 **WaveWarZ companion platform:**
-The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,245 battles, 522 SOL in trading volume (~$39K), 939 real trader withdrawals, 9.05 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
-The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,245 battles, 524.15 SOL in trading volume (~$39K), 939 real trader withdrawals, 9.07 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
+The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,289 battles, 522 SOL in trading volume (~$64.8K), 939 real trader withdrawals, 9.05 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
+The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,289 battles, 878.30 SOL in trading volume (~$64.8K), 939 real trader withdrawals, 13.40 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
 
 ### Impact Metrics
 
@@ -59,14 +59,14 @@ The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-bat
 |---|---|---|
 | Weeks of live governance | 102 | Discord logs + ZAOOS research |
 | On-chain settlement weeks (verified) | 63 (OG:33 + ZOR:31) | Blockscout, Optimism Mainnet |
-| Unique Respect holders | 157 | Blockscout 2026-07-17 |
+| Unique Respect holders | 157 | Blockscout 2026-07-24 |
 | OG Respect contract | `0x34cE89...957` | Optimism Mainnet |
 | ZOR Respect contract | `0x9885CC...45c` | Optimism Mainnet |
 | OREC contract | `0xcB05F9...532` | Optimism Mainnet |
 | Active fractal DAOs on Optimism (July 2026) | 1 (ZAO only) | Research doc 1208 |
-| WaveWarZ battles | 1,245 | wavewarz.info/api/public/stats |
-| WaveWarZ trading volume | 522 SOL (~$39K) | wavewarz.info/api/public/stats |
-| WaveWarZ trading volume | 524.15 SOL (~$39K) | wavewarz.info/api/public/stats |
+| WaveWarZ battles | 1,289 | wavewarz.info/api/public/stats |
+| WaveWarZ trading volume | 522 SOL (~$64.8K) | wavewarz.info/api/public/stats |
+| WaveWarZ trading volume | 878.30 SOL (~$64.8K) | wavewarz.info/api/public/stats |
 
 ### Verification Links
 
@@ -92,7 +92,7 @@ Before submitting to atlas.optimism.io, verify:
 - [ ] Atlas is accepting applications (check `https://atlas.optimism.io` for active round)
 - [ ] Optimism wallet connected (the OREC deployer address or a ZAO wallet with on-chain history)
 - [ ] Confirm current Respect holder counts on Blockscout (may have grown past 157)
-- [ ] Add any recent governance milestones (new ZIPs, new settlement weeks since 2026-07-17)
+- [ ] Add any recent governance milestones (new ZIPs, new settlement weeks since 2026-07-24)
 - [ ] Review the funding category selection — "Governance & Collaboration" is most accurate
 - [ ] Add Mirror.xyz links for the ZAO papers if they've been published (see doc 1208 action list)
 
@@ -115,7 +115,7 @@ Before submitting to atlas.optimism.io, verify:
 
 ## Sources
 
-- doc 1200: Respect holder counts (157 unique, Blockscout-verified 2026-07-17)
+- doc 1200: Respect holder counts (157 unique, Blockscout-verified 2026-07-24)
 - doc 1201: ZAO Fractal governance verified stats (100+ weeks, 63 on-chain)
 - doc 1202: Fractal on-chain settlement history (OG:33 + ZOR:31 weeks)
 - doc 1205: ZAO on-chain contract registry (OREC + Respect addresses)

--- a/research/governance/1440-nouns-zabal-partnership-proposal-jul2026/README.md
+++ b/research/governance/1440-nouns-zabal-partnership-proposal-jul2026/README.md
@@ -82,8 +82,8 @@ All ZABAL builder work is public, on-chain or open-source. Nouns will be credite
 
 | Claim | Value | Source |
 |-------|-------|--------|
-| WaveWarZ battles | 1,245+ | wavewarz.info/api/public/stats |
-| Total volume | 524.15 SOL (~$39,453) | Same |
+| WaveWarZ battles | 1,289+ | wavewarz.info/api/public/stats |
+| Total volume | 878.30 SOL (~$39,453) | Same |
 | Governance streak | 100+ consecutive weeks | ZAO Fractal governance, on-chain Optimism |
 | Respect holders | 157 | ZAOOS doc 1259 |
 | ZABAL S1 builders | 8-12 (S1 cohort) | ZAOOS doc 1283 |

--- a/research/governance/1444-zao-optimism-rf-s7-application-narrative/README.md
+++ b/research/governance/1444-zao-optimism-rf-s7-application-narrative/README.md
@@ -58,9 +58,9 @@ As of July 2026, ZAO has conducted **63+ consecutive weekly governance sessions*
 **WaveWarZ as a Public Goods Music Platform**
 
 WaveWarZ is the revenue-generating product that funds ZAO's operations and demonstrates the "DAO economy" thesis: a DAO can govern a self-sustaining protocol that pays its community members (artists) regardless of outcome. As of July 2026:
-- 1,245+ battles completed on Solana
-- 524 SOL (~$104K) in total trading volume
-- 9.09 SOL ($1,820) paid to **losing artists** via the loser-earns mechanism
+- 1,289+ battles completed on Solana
+- 878 SOL (~$64.8K) in total trading volume
+- 13.40 SOL ($1,820) paid to **losing artists** via the loser-earns mechanism
 - 127 SOL ($25,469) distributed to winning traders
 
 The "loser-earns" mechanism is architecturally novel: it means every artist who participates in a WaveWarZ battle earns something, structurally redistributing value to musicians who would otherwise earn $0.004/stream on Spotify.
@@ -101,9 +101,9 @@ ZAO directly advances Optimism's vision of a "Regenerative Crypto Economy":
 |--------|-------|--------|
 | Governance sessions (consecutive) | 63+ | ZAOOS docs 1394, 1434 |
 | ZOR holders | 157 | Optimism Mainnet (ZAOOS doc 1434) |
-| WaveWarZ battles | 1,245+ | wavewarz.info/api/public/stats |
-| WaveWarZ SOL volume | 524 SOL (~$104K) | wavewarz.info/api/public/stats |
-| Artist payouts (loser-earns) | 9.09 SOL ($1,820) | wavewarz.info/api/public/stats |
+| WaveWarZ battles | 1,289+ | wavewarz.info/api/public/stats |
+| WaveWarZ SOL volume | 878 SOL (~$64.8K) | wavewarz.info/api/public/stats |
+| Artist payouts (loser-earns) | 13.40 SOL ($1,820) | wavewarz.info/api/public/stats |
 | ZAOOS documents (CC-BY) | 1,440+ | github.com/ZAOIP/zao-os |
 | ZAOstock (Oct 3, 2026) | Free public festival | Eventbrite + permit application |
 
@@ -137,7 +137,7 @@ Before Zaal submits, fill in these placeholders:
 ```
 ZAO just submitted to Optimism Retro Funding.
 
-63 weeks of on-chain governance. 1,245 WaveWarZ battles. $1,820 to losing artists. 1,440 CC-BY documents. ZAOstock Oct 3.
+63 weeks of on-chain governance. 1,289 WaveWarZ battles. $1,820 to losing artists. 1,440 CC-BY documents. ZAOstock Oct 3.
 
 All of it built on Optimism Fractal — the non-plutocratic governance model that doesn't need token purchases.
 
@@ -150,7 +150,7 @@ If you're an Optimism badge holder or RF voter: link in bio.
 
 ## What Makes This Citable
 
-> "The ZAO applied to Optimism Retro Funding in [MONTH] 2026, presenting 63+ consecutive governance sessions, 524 SOL in WaveWarZ trading volume, and 1,440+ CC-BY open documents as evidence of public goods impact (ZAOOS doc 1444)."
+> "The ZAO applied to Optimism Retro Funding in [MONTH] 2026, presenting 63+ consecutive governance sessions, 878 SOL in WaveWarZ trading volume, and 1,440+ CC-BY open documents as evidence of public goods impact (ZAOOS doc 1444)."
 
 ---
 

--- a/research/governance/1453-zao-q2-progress-report-apr-jun-2026/README.md
+++ b/research/governance/1453-zao-q2-progress-report-apr-jun-2026/README.md
@@ -72,7 +72,7 @@ On-chain: Optimism Mainnet | OG Token: 0x34cE89baA7E4a4B00E17F7E4C0cb97105C21695
 | Artist Payouts (SOL) | [ZOE] | [ZOE] | [ZOE] | [ZOE] |
 
 **Estimated from known Jul 17 totals (for placeholder):**
-- Jul 17 cumulative: 1,245 battles, 523.991 SOL, 9.0988 SOL artist payouts
+- Jul 17 cumulative: 1,289 battles, 878.30 SOL, 13.40 SOL artist payouts
 - Q2 period likely accounts for ~400-500 battles (estimate; ZOE confirms from API history)
 
 ### WaveWarZ Public Goods Argument

--- a/research/governance/1460-nouns-prop-house-proposal/README.md
+++ b/research/governance/1460-nouns-prop-house-proposal/README.md
@@ -78,7 +78,7 @@ All grant recipients will be documented in the ZAO OS (CC-BY, permanent public r
 
 **About Zaal**
 
-Zaal Panthaki is the co-founder of The ZAO and WaveWarZ. He has run 63 consecutive weekly governance sessions and built a 1,245-battle music platform. He is the primary ZABAL S2 facilitator. @bettercallzaal on X and Farcaster.
+Zaal Panthaki is the co-founder of The ZAO and WaveWarZ. He has run 63 consecutive weekly governance sessions and built a 1,289-battle music platform. He is the primary ZABAL S2 facilitator. @bettercallzaal on X and Farcaster.
 ```
 
 ### Requested Amount

--- a/research/governance/1470-op-rf-submission-guide/README.md
+++ b/research/governance/1470-op-rf-submission-guide/README.md
@@ -41,7 +41,7 @@ OP RF applications typically request:
 **The ZAO (ZAO DAO)**
 
 ### Short Description (≤ 280 characters)
-> ZAO is a music DAO on Optimism Mainnet running 64+ weekly governance sessions. WaveWarZ (1,245 battles, 524 SOL) pays losing artists — on-chain, every time. ZAOstock Oct 3 brings it IRL.
+> ZAO is a music DAO on Optimism Mainnet running 64+ weekly governance sessions. WaveWarZ (1,289 battles, 878 SOL) pays losing artists — on-chain, every time. ZAOstock Oct 3 brings it IRL.
 
 ### Category
 - [x] Governance / DAO tooling
@@ -67,8 +67,8 @@ consecutive weekly governance sessions on Optimism Mainnet — one of the longes
 on-chain governance streaks of any DAO in the ecosystem.
 
 WaveWarZ, ZAO's flagship product, is a music prediction market on Solana where the losing 
-artist earns a structural share of platform trading fees. As of July 2026: 1,245 battles, 
-523.991 SOL in trading volume, 9.0988 SOL in direct artist payouts (including to losers), 
+artist earns a structural share of platform trading fees. As of July 2026: 1,289 battles, 
+878.30 SOL in trading volume, 13.40 SOL in direct artist payouts (including to losers), 
 and 127.343 SOL returned to traders. This is documented public data from a live, functioning 
 platform — not a whitepaper or prototype.
 
@@ -94,8 +94,8 @@ is deployed and verifiable, and every dollar flows to artists, builders, and com
 
 ### Verifiable Metrics
 - 64+ weekly governance sessions (on-chain, verifiable via OREC)
-- 1,245 battles on WaveWarZ (verifiable via public API)
-- 523.991 SOL trading volume (verifiable on Solana Mainnet)
+- 1,289 battles on WaveWarZ (verifiable via public API)
+- 878.30 SOL trading volume (verifiable on Solana Mainnet)
 - 1,460+ ZAOOS documents (verifiable on GitHub)
 - ZOR token: 157+ holders (verifiable on Optimism Mainnet)
 

--- a/research/governance/1513-daostar-registration-brief/README.md
+++ b/research/governance/1513-daostar-registration-brief/README.md
@@ -149,7 +149,7 @@ This is OP RF Gate 2. We're building the evidence trail.
 ```
 ZAO is EIP-4824 registered on DAOstar.
 
-64+ governance weeks. 3 Optimism contracts. 1,245 WaveWarZ battles.
+64+ governance weeks. 3 Optimism contracts. 1,289 WaveWarZ battles.
 
 Now machine-readable: [daostar URL]
 

--- a/research/governance/1525-op-rf-round7-evidence-package/README.md
+++ b/research/governance/1525-op-rf-round7-evidence-package/README.md
@@ -48,11 +48,11 @@ ZOR holders use OREC to vote on community WaveWarZ battles, ZABAL grant recipien
 
 **On-chain verification:**
 - Solana Mainnet battle contracts: automatic payout txns on every battle close
-- 9.0988 SOL ($1,820 equivalent) distributed to losing artists across 1,245 battles
+- 13.40 SOL ($1,820 equivalent) distributed to losing artists across 1,289 battles
 - Public API: `wavewarz.info/api/public/stats` (live, no auth required)
 
 **Paste-ready citation:**
-> "WaveWarZ has completed 1,245 battles with 523.991 SOL in total volume. Losing artists automatically receive 10% of each battle pool — 9.0988 SOL distributed to losing artists as of Jul 2026, with no claiming required. API: wavewarz.info/api/public/stats"
+> "WaveWarZ has completed 1,289 battles with 878.30 SOL in total volume. Losing artists automatically receive 10% of each battle pool — 13.40 SOL distributed to losing artists as of Jul 2026, with no claiming required. API: wavewarz.info/api/public/stats"
 
 **ZAOOS source:** doc 1433 (H1 2026 Platform Growth Summary)
 
@@ -187,8 +187,8 @@ On-chain proof (Optimism Mainnet):
 • OREC (governance): 0xcB05F9254765CA521F7698e61E0A6CA6456Be532
 
 Results (as of Jul 2026):
-• 1,245 battles, 523.991 SOL volume ($104K)
-• 9.09 SOL to losing artists (automatic, no claiming required)
+• 1,289 battles, 878.30 SOL volume ($64.8K)
+• 13.40 SOL to losing artists (automatic, no claiming required)
 • 36 community battles with charity payouts voted by ZOR holders
 • 1,500+ governance documents in ZAOOS (CC-BY 4.0, github.com/bettercallzaal/ZAOOS)
 • Registered with DAOstar under EIP-4824

--- a/research/governance/1619-fractal-democracy-session-guide/README.md
+++ b/research/governance/1619-fractal-democracy-session-guide/README.md
@@ -155,7 +155,7 @@ As of July 2026, ZAO has run Fractal Democracy sessions weekly with zero quorum 
 
 The governance track record is ZAO's primary OP RF evidence block. Paste-ready:
 
-> ZAO is an Optimism-native DAO that has run Fractal Democracy governance sessions weekly for 100+ consecutive weeks. Governance decisions are executed via OREC (0xcB05F9254765CA521F7698e61E0A6CA6456Be532) on Optimism Mainnet. ZOR token governance (ERC-1155, 0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c) determines MAIN battle artist selection and charity partner selection for WaveWarZ, a live music battle prediction market that has completed 1,245 battles and distributed 9.09 SOL to artists. ZAO documents 1,600+ CC-BY research documents in ZAOOS (github.com/bettercallzaal/ZAOOS), archived permanently on Arweave, making ZAO one of the most thoroughly documented onchain communities building on Optimism.
+> ZAO is an Optimism-native DAO that has run Fractal Democracy governance sessions weekly for 100+ consecutive weeks. Governance decisions are executed via OREC (0xcB05F9254765CA521F7698e61E0A6CA6456Be532) on Optimism Mainnet. ZOR token governance (ERC-1155, 0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c) determines MAIN battle artist selection and charity partner selection for WaveWarZ, a live music battle prediction market that has completed 1,289 battles and distributed 13.40 SOL to artists. ZAO documents 1,600+ CC-BY research documents in ZAOOS (github.com/bettercallzaal/ZAOOS), archived permanently on Arweave, making ZAO one of the most thoroughly documented onchain communities building on Optimism.
 
 ---
 


### PR DESCRIPTION
## Summary

Stats sweep batch 11 — 24 governance and events docs updated to Jul 24 figures.

**Governance (10):** 1208 (citation footprint), 1209 (OP retro draft), 1440 (Nouns ZABAL proposal), 1444 (OP RF S7 narrative), 1453 (Q2 progress report), 1460 (Nouns Prop House), 1470 (OP RF submission guide), 1513 (DAOstar registration), 1525 (OP RF7 evidence), 1619 (Fractal Democracy guide)

**Events (14):** 1284 (COC7 show brief), 1329 (ZAOstock promo plan), 1390 (ZAOstock press release Sep), 1395 (COC7 post-show kit), 1449 (ZAOstock press template), 1479/1508 (ZAOstock Eventbrite), 1524 (ZAOstock day-of ops), 1539 (ZAOstock Maine sponsor brief), 1597 (ZAOstock line of show), 1636 (ZAOstock Eventbrite listing), 1659 (ZAOstock sponsor activation), 1705 (COC8 show brief Aug 15), 1715 (Africa battle week media)

All: battles 1,245→1,289; vol 524→878.30 SOL; artist payouts 9.07/9.09→13.40 SOL; trader claims 127.34→381.20 SOL

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.