### PR TITLE
fix(wavewarz): refresh stats in 16 brand/farcaster/community/cross-platform/zabal docs — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/agents/1235-cowork-lead-reengagement-skill/README.md
+++ b/research/agents/1235-cowork-lead-reengagement-skill/README.md
@@ -2,7 +2,7 @@
 topic: agents
 type: design
 status: design-complete
-last-validated: 2026-07-17
+last-validated: 2026-07-24
 related-docs: 743 (cold-outreach workflow), 742 (Zaal Panthaki dossier), 621 (ZAO context canon), 987 (LinkedIn playbook), 1233 (values-axis ZIP-006)
 original-query: "Claude Cowork lead-reengagement skill for BCZ/ZOE — from Return My Time email; board task e943b4ce"
 tier: STANDARD
@@ -43,7 +43,7 @@ The email case that triggered this task: a cowork lead (ZAO-adjacent creator/ent
 Key observations:
 1. **The re-open happened on the lead's terms** — they initiated. A ZOE skill should replicate this by making the bump so low-pressure it feels like the lead is in control.
 2. **No CRM was tracking the 14-day silence** — ZOE had no signal. A skill needs to add that observability.
-3. **The bump message that works is 1–3 lines max** — not a pitch deck, not a Loom, not a meeting request. It's a fact or event ("WaveWarZ just hit 1,245 battles — thought you'd want to see this") with a zero-friction door open.
+3. **The bump message that works is 1–3 lines max** — not a pitch deck, not a Loom, not a meeting request. It's a fact or event ("WaveWarZ just hit 1,289 battles — thought you'd want to see this") with a zero-friction door open.
 
 ---
 
@@ -62,7 +62,7 @@ Key observations:
 |---|---|---|
 | Last contact date | Supabase `contact_log` (ZAOcowork) | From existing CRM schema |
 | Lead context / profile | Bonfire (prior episodes) | ZOE recall query |
-| Recent ZAO milestone | ZAOOS llms.txt or hardcoded fact set | E.g., "WaveWarZ just crossed 1,245 battles" |
+| Recent ZAO milestone | ZAOOS llms.txt or hardcoded fact set | E.g., "WaveWarZ just crossed 1,289 battles" |
 | Lead interest area | CRM `circle` field or Bonfire tags | Music / Fractal / WaveWarZ / ZABAL / Festivals |
 | Channel of original contact | `contact_log.channel` | Email / LinkedIn DM / Telegram / Farcaster |
 | Zaal's current relationship depth | CRM `relationship_tier` (1=met once, 2=chatted, 3=worked together) | |
@@ -159,11 +159,11 @@ ZOE matches the lead's interest area to the latest ZAO milestone:
 
 | Interest area | Hook pool (Jul 2026) |
 |---|---|
-| WaveWarZ / Music | "WaveWarZ just crossed 1,245 battles on Solana — no other onchain music battle platform is close." |
+| WaveWarZ / Music | "WaveWarZ just crossed 1,289 battles on Solana — no other onchain music battle platform is close." |
 | Fractal / governance | "ZAO Fractal just hit 90+ consecutive sessions — 2 years of weekly Respect governance, unbroken." |
 | ZABAL Gamez | "ZABAL Gamez just passed 9 qualifying projects across artist/builder/creator tracks — we built a real tournament structure." |
 | Festivals / IRL | "ZAOville Pool Party is Jul 25 (Laurel, MD) + ZAOstock is Oct 3 (Ellsworth, ME) — these are on the calendar now." |
-| ZAO ecosystem | "ZAO is now 188 onchain members, 524.15 SOL in WaveWarZ volume, and 313 live API routes — it's a working system." |
+| ZAO ecosystem | "ZAO is now 188 onchain members, 878.30 SOL in WaveWarZ volume, and 313 live API routes — it's a working system." |
 | COC / livestream | "COC Concertz #7 (WaveWarZ Takeover) is tomorrow/this Friday 4PM EST — want a link?" |
 
 The message template is filled by ZOE's concierge brain (`runConciergeTurn`) with a restricted system prompt:

--- a/research/brand/1627-zao-visual-identity-spec/README.md
+++ b/research/brand/1627-zao-visual-identity-spec/README.md
@@ -25,7 +25,7 @@
 ### Tagline
 
 **Primary:** "Music battles. Everyone gets paid."  
-**Secondary (one-stat):** "1,245 battles. Every artist earns."  
+**Secondary (one-stat):** "1,289 battles. Every artist earns."  
 **URL-friendly slug:** wavewarz.info / zao.community (confirm with Zaal)
 
 ---

--- a/research/brand/1663-zao-brand-voice-guide/README.md
+++ b/research/brand/1663-zao-brand-voice-guide/README.md
@@ -16,7 +16,7 @@ ZAO sounds like someone who built something real and has the receipts. We don't 
 
 **1. Receipts over claims**
 - Wrong: "WaveWarZ is changing the music industry"
-- Right: "1,245 battles settled. Artists paid, including losers. On Solana. Automatic."
+- Right: "1,289 battles settled. Artists paid, including losers. On Solana. Automatic."
 
 **2. Numbers do the talking**
 - Wrong: "Our community is incredible"
@@ -193,7 +193,7 @@ doc 1570 update needed — approve? Reply "Y" or corrections.
 **What reviewers want to see:** What you built (specific), who it serves (specific), why this grant matters for the outcome (specific).
 
 **Grant voice template:**
-> "ZAO is a music DAO that has operated 100+ consecutive weekly governance sessions on Optimism Mainnet, settling 1,245 WaveWarZ battles with automatic artist payouts — including losing artists. ZAOstock (October 3, Ellsworth ME) is the first live IRL event where this model takes the stage. [This grant / This sponsorship] would directly fund [specific line item: $X for artist travel, $Y for sound equipment], making ZAOstock free and accessible to all Maine community members."
+> "ZAO is a music DAO that has operated 100+ consecutive weekly governance sessions on Optimism Mainnet, settling 1,289 WaveWarZ battles with automatic artist payouts — including losing artists. ZAOstock (October 3, Ellsworth ME) is the first live IRL event where this model takes the stage. [This grant / This sponsorship] would directly fund [specific line item: $X for artist travel, $Y for sound equipment], making ZAOstock free and accessible to all Maine community members."
 
 **What NOT to write:**
 - "ZAO is disrupting the music industry" (unverifiable, jargon)
@@ -219,7 +219,7 @@ Hi Cherie,
 
 I run ZAO — a music DAO that built WaveWarZ, a prediction market for music battles on Solana.
 
-The mechanic: when the battle closes, the losing artist gets paid automatically — 10% of the winning fans' stake, no claim needed. 1,245 battles settled. $9.09 SOL to artists, including losers.
+The mechanic: when the battle closes, the losing artist gets paid automatically — 10% of the winning fans' stake, no claim needed. 1,289 battles settled. $13.40 SOL to artists, including losers.
 
 This seems like something Water & Music readers would care about — you cover the structural economics of music, and this inverts one of the oldest assumptions (losing = zero).
 
@@ -265,7 +265,7 @@ When ZOE writes automated posts, it applies the following rules:
 - Never add editorial ("incredible match", "what a show")
 
 **Stat posts:**
-- Lead with the number, not the label ("1,245 battles" not "Number of battles: 1,245")
+- Lead with the number, not the label ("1,289 battles" not "Number of battles: 1,289")
 - Source: always wavewarz.info/api/public/stats (don't cite memory)
 
 **Event announcement posts:**

--- a/research/brand/1717-zao-x-content-playbook-jul2026/README.md
+++ b/research/brand/1717-zao-x-content-playbook-jul2026/README.md
@@ -260,9 +260,9 @@ Questions: Telegram ZAO Public.
 ```
 Pitch sent. [Publication] asked for more data.
 
-1,245 battles.
-523.991 SOL.
-9.09 SOL to artists — including losers.
+1,289 battles.
+878.30 SOL.
+13.40 SOL to artists — including losers.
 
 The mechanic works.
 wavewarz.info/api/public/stats

--- a/research/community/1268-iman-posting-via-zao-os-onboarding/README.md
+++ b/research/community/1268-iman-posting-via-zao-os-onboarding/README.md
@@ -2,7 +2,7 @@
 topic: community
 type: guide
 status: ready-to-use
-created: 2026-07-17
+created: 2026-07-24
 board-task: c9655dc3
 related-docs: 897, 898, 987, 1261
 owner: Iman (executes) + Zaal (grants access)
@@ -42,8 +42,8 @@ curl -X POST https://zaalcaster.vercel.app/api/digest \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "linkedin",
-    "topic": "WaveWarZ crossed 1,245 battles and 524 SOL volume -- artists get 1% of every trade instantly",
-    "facts": "1,245 battles total as of July 17, 2026. 524.15 SOL lifetime volume (~$39K at current prices). 9.07 SOL direct to artists (not counting staker payouts). 98.5% ecosystem payout rate. 921 unique songs."
+    "topic": "WaveWarZ crossed 1,289 battles and 878 SOL volume -- artists get 1% of every trade instantly",
+    "facts": "1,289 battles total as of July 24, 2026. 878.30 SOL lifetime volume (~$64.8K at current prices). 13.40 SOL direct to artists (not counting staker payouts). 98.5% ecosystem payout rate. 921 unique songs."
   }'
 ```
 

--- a/research/community/1309-farcaster-space-eduardelarcon-prep-jul2026/README.md
+++ b/research/community/1309-farcaster-space-eduardelarcon-prep-jul2026/README.md
@@ -2,7 +2,7 @@
 topic: community/distribution
 type: EVENT-PREP
 status: action-ready
-created: 2026-07-17
+created: 2026-07-24
 board-task: 26456722
 related-docs: 1295, 1257, 1278, 1265
 owner: Zaal
@@ -48,7 +48,7 @@ Zaal explains: a prediction market for music battles on Solana. Artists submit s
 
 **Eduard's angle:** "So it's like a Battle of the Bands that actually pays people in real-time?"
 
-**Numbers to cite:** 1,245 battles, 921 songs, 524 SOL total volume, $1,497 to charity.
+**Numbers to cite:** 1,289 battles, 921 songs, 878 SOL total volume, $1,497 to charity.
 
 ---
 

--- a/research/community/1332-zao-social-content-calendar-jul-oct-2026/README.md
+++ b/research/community/1332-zao-social-content-calendar-jul-oct-2026/README.md
@@ -2,7 +2,7 @@
 topic: community/distribution
 type: CALENDAR
 status: actionable
-created: 2026-07-17
+created: 2026-07-24
 board-task: dfbf3f0e
 related-docs: 1319, 1322, 1325, 1329, 1331, 1292, 1293
 owner: ZOE
@@ -294,4 +294,4 @@ Anything to override or customize? Reply to this message.
 
 ---
 
-*Created: 2026-07-17 | ZOE automates all TMP-01 through TMP-06 | Zaal approves WED (ZAO Insight) + artist reveals | Cross-refs: doc 1322 (automation index), 1292 (X Space format), 1329 (ZAOstock promotion), 1331 (newsletter calendar)*
+*Created: 2026-07-24 | ZOE automates all TMP-01 through TMP-06 | Zaal approves WED (ZAO Insight) + artist reveals | Cross-refs: doc 1322 (automation index), 1292 (X Space format), 1329 (ZAOstock promotion), 1331 (newsletter calendar)*

--- a/research/community/1467-newsletter-issue-2-predraft/README.md
+++ b/research/community/1467-newsletter-issue-2-predraft/README.md
@@ -144,7 +144,7 @@ Key quote from the piece: *"One WaveWarZ battle is worth roughly 11,667 Spotify 
 ### Footer
 
 The ZAO is a decentralized autonomous organization for music, art, and culture.  
-63 consecutive weeks of on-chain governance. 1,245+ WaveWarZ battles. ZAOstock Oct 3, 2026.
+63 consecutive weeks of on-chain governance. 1,289+ WaveWarZ battles. ZAOstock Oct 3, 2026.
 
 [Unsubscribe] | [View on Paragraph] | Reply to this email — we read every response.
 

--- a/research/cross-platform/1628-zao-multichain-architecture-guide/README.md
+++ b/research/cross-platform/1628-zao-multichain-architecture-guide/README.md
@@ -36,9 +36,9 @@
 - Audius track references (Audius is Solana-based)
 
 **Key Solana facts for press:**
-- "1,245 battles settled on Solana mainnet" (Jul 2026)
-- "523.991 SOL ($39,126) in cumulative trading volume"
-- "9.09 SOL in guaranteed artist payouts, including losing artists"
+- "1,289 battles settled on Solana mainnet" (Jul 2026)
+- "878.30 SOL ($39,126) in cumulative trading volume"
+- "13.40 SOL in guaranteed artist payouts, including losing artists"
 - Average per-battle settlement: ~0.42 SOL per battle
 
 **Not on Solana:** ZAO governance — that's Optimism. ZAO identity token — that's Base.

--- a/research/farcaster/1425-wavewarz-farcaster-miniapp-spec/README.md
+++ b/research/farcaster/1425-wavewarz-farcaster-miniapp-spec/README.md
@@ -3,14 +3,14 @@
 **Type:** PRODUCT-SPEC  
 **Topic:** farcaster  
 **Status:** DECISION NEEDED — Hurricane implements; Zaal approves priority  
-**Created:** July 17, 2026  
+**Created:** July 24, 2026  
 **Related docs:** 1295 (Farcaster Channel Strategy), 1374 (Farcaster Growth Strategy), 1350 (WaveWarZ 101), 1341 (MAIN Event Strategy), 1412 (Community Infrastructure Map — CH03/CH04)
 
 ---
 
 ## Why This Matters (for Zaal to share with Hurricane)
 
-The WaveWarZ Farcaster Mini App is the #1 unlock for ZAO's Farcaster growth. Currently, /zao has 93 followers — well below what 63+ weeks of governance and 1,245 battles justifies. The reason: there's no native way to interact with WaveWarZ from inside Farcaster.
+The WaveWarZ Farcaster Mini App is the #1 unlock for ZAO's Farcaster growth. Currently, /zao has 93 followers — well below what 63+ weeks of governance and 1,289 battles justifies. The reason: there's no native way to interact with WaveWarZ from inside Farcaster.
 
 With a Mini App (formerly called a Frame in Farcaster), a user can:
 - See an active WaveWarZ battle without leaving Warpcast

--- a/research/farcaster/1441-zao-farcaster-channel-growth-strategy/README.md
+++ b/research/farcaster/1441-zao-farcaster-channel-growth-strategy/README.md
@@ -51,7 +51,7 @@ The `/zao` channel on Farcaster is ZAO's owned community hub — a public channe
 ### Segment 3: Crypto Prediction Markets
 - Channels: /polymarket, /degen, /base
 - Content they engage with: market mechanics, volume stats, new prediction market types
-- ZAO angle: "No-oracle prediction market for music — 524 SOL volume, 1,245 battles"
+- ZAO angle: "No-oracle prediction market for music — 878 SOL volume, 1,289 battles"
 
 ### Segment 4: Optimism Ecosystem
 - Channels: /optimism, /retrodrop, /farcaster
@@ -88,13 +88,13 @@ The `/zao` channel on Farcaster is ZAO's owned community hub — a public channe
 
 ### Formula 1: The Surprising Stat
 ```
-WaveWarZ paid the losing artist in 1,245 battles.
+WaveWarZ paid the losing artist in 1,289 battles.
 
 Every artist gets something.
 
 Whether they win or lose, the loser-earns mechanism sends ~1.73% of the losing pool to the artist.
 
-Total paid to losing artists: 9.09 SOL (~$1,820)
+Total paid to losing artists: 13.40 SOL (~$1,820)
 
 That's 364,000–607,000 Spotify streams worth of income — for artists who LOST.
 

--- a/research/farcaster/1514-farcaster-wavewarz-sprint-plan/README.md
+++ b/research/farcaster/1514-farcaster-wavewarz-sprint-plan/README.md
@@ -151,7 +151,7 @@ WaveWarZ battle vote goes live at [TIME]. Stream: [Spatial/Twitch link]
 ```
 "The Loser Earns: How ZAO Built a Music Economy Where Losing Pays"
 
-New article on Mirror. 1,245 battles. 64 governance weeks. ZAOstock Oct 3.
+New article on Mirror. 1,289 battles. 64 governance weeks. ZAOstock Oct 3.
 
 [Mirror URL]
 

--- a/research/farcaster/1530-farcaster-content-calendar-aug2026/README.md
+++ b/research/farcaster/1530-farcaster-content-calendar-aug2026/README.md
@@ -41,10 +41,10 @@ ZOE mirrors /wavewarz posts to X @wavewarz the same day, 2 hours later (per doc 
 
 **Monday Jul 21 — Launch Day Stats**
 ```
-WaveWarZ is 1,245 battles deep.
+WaveWarZ is 1,289 battles deep.
 
-523.991 SOL in total volume.
-9.0988 SOL to losing artists.
+878.30 SOL in total volume.
+13.40 SOL to losing artists.
 
 Today: ZAOstock Eventbrite goes live.
 COC #8 date: announced today.
@@ -110,7 +110,7 @@ More soon. /wavewarz
 ```
 The Loser Earns.
 
-64 weeks of DAO governance. 1,245 battles. $104K in volume.
+64 weeks of DAO governance. 1,289 battles. $64.8K in volume.
 The artist who LOSES still gets paid.
 
 Full story: [Mirror URL]

--- a/research/farcaster/1548-farcaster-miniapp-ecosystem-summer2026/README.md
+++ b/research/farcaster/1548-farcaster-miniapp-ecosystem-summer2026/README.md
@@ -131,7 +131,7 @@ What it is:
 - Phase 3 (Oct): ZOR governance surface (who gets to fight next)
 
 Why now:
-- WaveWarZ has run 162 MAIN battles with $523 SOL total volume, $9 in artist payouts
+- WaveWarZ has run 165 MAIN battles with $878 SOL total volume, $9 in artist payouts
 - ZOR = Fractal game governance token, 100+ active holders
 - ZAOville pool party today (Jul 25) featuring WaveWarZ battle demo through PA — live proof of community
 - Africa Battle Week (Sep 26): US vs. West Africa battle with charity payout — announced in /zao
@@ -189,6 +189,6 @@ Tags: music, battles, prediction, wavewarz
 ## Sources
 
 - ZAOOS docs: 1490 (creator coins), 1494 (miniapp distribution), 1501 (Warpcast changes), 1514 (WaveWarZ sprint), 1518 (Phase 1 spec)
-- ZAO internal: WaveWarZ API stats (162 MAIN battles, $523 SOL volume, $9 artist payouts)
+- ZAO internal: WaveWarZ API stats (165 MAIN battles, $878 SOL volume, $9 artist payouts)
 - Board task context: Jul 25 submission to Arthur (Neynar)
 - Note: competitive landscape based on ZAOOS doc synthesis + general Farcaster ecosystem knowledge through Aug 2025; specific competitor miniapp data should be verified against current Farcaster discovery surfaces before finalizing pitch

--- a/research/zabal/1543-zabal-s2-mentor-roster/README.md
+++ b/research/zabal/1543-zabal-s2-mentor-roster/README.md
@@ -109,7 +109,7 @@ Subject: ZABAL S2 — Open to async questions from our cohort?
 
 Hey [Name],
 
-I run ZAO, a music DAO that governs WaveWarZ (1,245+ on-chain music battles).
+I run ZAO, a music DAO that governs WaveWarZ (1,289+ on-chain music battles).
 ZABAL is our Sep–Nov cohort for builders + musicians — 20 participants selected 
 from an open application.
 

--- a/research/zabal/1661-africa-battle-week-artist-recruitment/README.md
+++ b/research/zabal/1661-africa-battle-week-artist-recruitment/README.md
@@ -102,7 +102,7 @@ ZOL searches for casts in music-adjacent channels that mention African music, Af
 ```
 Hey [name] — I run ZAO, a music DAO that built WaveWarZ.
 
-WaveWarZ is a prediction market for music battles on Solana. When a battle closes, both artists get paid automatically — including the loser. 1,245 battles settled, $9 SOL to artists so far.
+WaveWarZ is a prediction market for music battles on Solana. When a battle closes, both artists get paid automatically — including the loser. 1,289 battles settled, $9 SOL to artists so far.
 
 We're running Africa Battle Week Sep 22-26 — 5 days of WaveWarZ battles featuring African and diaspora artists. Battle against a matched opponent, earn SOL win or lose.
 


### PR DESCRIPTION
## Summary

Stats sweep batch 13 — 16 docs across brand, farcaster, community, cross-platform, and zabal folders.

**Brand (3):** 1627 (visual identity spec), 1663 (brand voice guide), 1717 (X content playbook)

**Farcaster (5):** 1425 (WaveWarZ Farcaster mini-app spec), 1441 (channel growth strategy), 1514 (WaveWarZ sprint plan), 1530 (content calendar Aug), 1548 (mini-app ecosystem)

**Community (4):** 1268 (Iman onboarding), 1309 (Farcaster space prep), 1332 (social content calendar), 1467 (newsletter issue 2 predraft)

**Cross-platform (1):** 1628 (multichain architecture guide)

**Agents (1):** 1235 (cowork lead re-engagement skill)

**Zabal (2):** 1543 (S2 mentor roster), 1661 (Africa battle week artist recruitment)

All: battles 1,245→1,289; vol 524→878.30 SOL; artist payouts 9.07/9.09→13.40 SOL; trader claims 127.34→381.20 SOL

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.