### PR TITLE
fix(wavewarz): refresh stats in 18 analytics-wave + misc docs — 878 SOL / 1,289 battles (Jul 24)

### DIFF
--- a/research/dev-workflows/1263-zao-papers-program-roadmap-july2026/README.md
+++ b/research/dev-workflows/1263-zao-papers-program-roadmap-july2026/README.md
@@ -28,7 +28,7 @@ The ZAO Papers program publishes canonical research papers about The ZAO's ecosy
 
 | Title | Key Data | Status |
 |-------|----------|--------|
-| WaveWarZ | 1,108+ battles, 524 SOL, 9.07 SOL payouts | DONE (PR #5) |
+| WaveWarZ | 1,108+ battles, 878 SOL, 13.40 SOL payouts | DONE (PR #5) |
 | COC Concertz | 7 shows, Mar 2025-Jul 2026, Arweave archive | DONE (PR #6) |
 | ZABAL Games | 28 June workshops, July stalled, Aug Finals pending | NEXT |
 | ZAO Festivals (ZAOstock) | Oct 3 Ellsworth ME, Franklin St Parklet | QUEUE |

--- a/research/events/1414-coc7-show-day-social-kit-jul2026/README.md
+++ b/research/events/1414-coc7-show-day-social-kit-jul2026/README.md
@@ -36,7 +36,7 @@ COC Concertz #7 is tomorrow — Saturday July 18, 4PM EST.
 
 WaveWarZ Takeover. The crowd votes live on which song wins the battle.
 
-1,245 battles. 524 SOL in volume. Tonight you're in the room.
+1,289 battles. 878 SOL in volume. Tonight you're in the room.
 
 No wallet required. Join from any browser.
 

--- a/research/events/1416-coc7-show-night-quick-ref-jul2026/README.md
+++ b/research/events/1416-coc7-show-night-quick-ref-jul2026/README.md
@@ -85,9 +85,9 @@ Key fields:
 
 | Stat | Number |
 |------|--------|
-| Total battles | 1,245 |
-| Total volume | 524 SOL (~$39,000) |
-| Artist payouts | 9.07 SOL (~$680) |
+| Total battles | 1,289 |
+| Total volume | 878 SOL (~$64,800) |
+| Artist payouts | 13.40 SOL (~$680) |
 | Charity raised | $1,497 (2 HuRya rounds) |
 | Artist payout rate | ~1.73% of every trade |
 

--- a/research/events/443-zao-stock-sponsor-pitch-drafts/README.md
+++ b/research/events/443-zao-stock-sponsor-pitch-drafts/README.md
@@ -18,7 +18,7 @@
 |----------|--------|
 | **Tier structure** | Small (under $1K), Medium ($1-5K), Large ($5K+) |
 | **Tone** | Warm, community-first, music-forward. Lead with the event, not the tech. |
-| **Proof points** | Use credibility stats from Doc 363: 100+ governance sessions, 1,245 WaveWarZ battles (524.15 SOL volume), 400+ newsletter editions, ZAO-CHELLA/ZAO-PALOOZA track record |
+| **Proof points** | Use credibility stats from Doc 363: 100+ governance sessions, 1,289 WaveWarZ battles (878.30 SOL volume), 400+ newsletter editions, ZAO-CHELLA/ZAO-PALOOZA track record |
 | **Venue details** | Franklin Street Parklet, Ellsworth ME. Part of 9th Annual Art of Ellsworth / Maine Craft Weekend. 12pm-6pm. After-party at Black Moon Public House. |
 | **Customization notes** | Replace [BUSINESS NAME], [YOUR NAME], and specific benefit lines per prospect |
 
@@ -107,7 +107,7 @@ ZAOstock is a first-of-its-kind outdoor music festival launching October 3, 2026
 
 **The event:** 10 live artists, a WaveWarZ live music battle bracket (audience votes via QR code — real stakes, real payouts to artists on-chain), 5 short talks, and an after-party at Black Moon Public House. Six hours of programming at the Franklin Street Parklet during Maine Craft Weekend, one of the state's largest statewide arts weekends. Free admission. Fully livestreamed.
 
-**The organization behind it:** The ZAO (ZTalent Artist Organization) is a 188-member decentralized music community that has run 100+ consecutive weekly governance sessions, published 400+ daily newsletter editions, produced events at NFT NYC (12 artists), Art Basel Miami (10 artists, AR installations), and ETH Denver. Our WaveWarZ music battle platform has hosted 1,245 battles with 524.15 SOL (~$39K) in real trading volume and direct artist payouts. We have a 14-person organizing team with advisors from Whop ($1.6B creator platform), JPMorgan/Accenture alumni, and NEA/Warhol-funded artists.
+**The organization behind it:** The ZAO (ZTalent Artist Organization) is a 188-member decentralized music community that has run 100+ consecutive weekly governance sessions, published 400+ daily newsletter editions, produced events at NFT NYC (12 artists), Art Basel Miami (10 artists, AR installations), and ETH Denver. Our WaveWarZ music battle platform has hosted 1,289 battles with 878.30 SOL (~$64.8K) in real trading volume and direct artist payouts. We have a 14-person organizing team with advisors from Whop ($1.6B creator platform), JPMorgan/Accenture alumni, and NEA/Warhol-funded artists.
 
 **At the $5,000+ presenting sponsor level:**
 

--- a/research/events/945-devcon8-mumbai-buildcamp-sponsorship/README.md
+++ b/research/events/945-devcon8-mumbai-buildcamp-sponsorship/README.md
@@ -78,7 +78,7 @@ Lead with these; every one traces to a doc or live fetch:
 | ZAO members onchain (Base) | 188 | Doc 742 |
 | Broader ecosystem participants | 1,000+ | Doc 050/051 |
 | Consecutive weekly Respect Game governance | 100+ weeks | Doc 742/050 |
-| WaveWarZ live battles / volume | 1,245 battles, ~$39K, 524.15 SOL | Doc 742/051 (2026-07-17) |
+| WaveWarZ live battles / volume | 1,289 battles, ~$64.8K, 878.30 SOL | Doc 742/051 (2026-07-17) |
 | COC Concertz consecutive weekly shows | 150+ | Doc 050/352 |
 | IRL festivals produced | ZAO-PALOOZA (12 artists, NFT NYC), ZAO-CHELLA (10 artists, Art Basel), ZAO-PROS (ETH Denver), ZAOstock Oct 3 2026 | Doc 742/270 |
 | Newsletter editions / paid supporters | 400+ / 78 | Doc 742/051 |

--- a/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
+++ b/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
@@ -128,7 +128,7 @@ Hub currently links 8 portals. Sub-Agent B identified 25 more projects/people/br
 | SongJam (SANG token + $ZABAL leaderboard) | songjam.space | Live-now widget + top-5 Empire embed | 5 |
 | ZAO Stock (Oct 2026 festival, Ellsworth ME) | zaoos.com/stock | Hero card + countdown | 5 |
 | COC Concertz (150+ weekly VR shows) | cocconcertz.com | "Next show" badge | 4 |
-| WaveWarZ (1,245 battles, 524.15 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
+| WaveWarZ (1,289 battles, 878.30 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
 | Magnetiq Proof-of-Meet (IRL connection badges) | magnetiq.xyz | Portal card in ecosystem grid | 4 |
 | Ohnahji University ("Web3's first HBCU") | ohnahjiu.com | Portal card | 3 |
 | Hats Protocol (ZAO roles, tree 226 Optimism) | hatsprotocol.xyz | Roles section in About | 3 |

--- a/research/wavewarz/1075-wavewarz-growth/README.md
+++ b/research/wavewarz/1075-wavewarz-growth/README.md
@@ -24,13 +24,13 @@ tier: DEEP
 
 ## Executive Summary
 
-WaveWarZ is the ZAO's only working revenue product (98.5% of every dollar stays in the ecosystem, only 1.5% platform fee). At 524.15 SOL (~$39K USD at Jul 2026 SOL price) volume and 1,245 battles, it has product-market fit in the ZAO community (188 members). Growth now is about **breaking out beyond the ZAO** via three unlocked levers:
+WaveWarZ is the ZAO's only working revenue product (98.5% of every dollar stays in the ecosystem, only 1.5% platform fee). At 878.30 SOL (~$64.8K USD at Jul 2026 SOL price) volume and 1,289 battles, it has product-market fit in the ZAO community (188 members). Growth now is about **breaking out beyond the ZAO** via three unlocked levers:
 
 1. **Distribution via existing partnerships** - the 7 partners (Coinflow, Juke, Magnetiq, Empire Builder, Neynar, RAM, Privy) have no active co-marketing plan
 2. **Tournament engagement** - the weekly bracket + leaderboard is registered but not live/promoted
 3. **Artist supply chain** - onboarding friction (Solana wallet, claims flow) limits artist participation to 48 songs; competitors do 100+ artist events/month
 
-The financials show a healthy unit economics story: artists earned 9.07 SOL (~$683 USD) cumulatively, platform earned 17.44 SOL (~$1,313 USD), proving the revenue model works. The tension: **platform revenue (1.93x artist revenue) is driven by launch/queue fees**, not trading volume fees. As volume grows, trading fees (0.5% per trade) become the dominant line item, and this ratio should flip toward artists. The growth plays below address volume growth first, then unit economics optimization.
+The financials show a healthy unit economics story: artists earned 13.40 SOL (~$683 USD) cumulatively, platform earned 17.44 SOL (~$1,313 USD), proving the revenue model works. The tension: **platform revenue (1.93x artist revenue) is driven by launch/queue fees**, not trading volume fees. As volume grows, trading fees (0.5% per trade) become the dominant line item, and this ratio should flip toward artists. The growth plays below address volume growth first, then unit economics optimization.
 
 ## Current State (Deep Dive)
 
@@ -38,11 +38,11 @@ The financials show a healthy unit economics story: artists earned 9.07 SOL (~$6
 
 | Metric | Value | Benchmark | Status |
 |--------|-------|-----------|--------|
-| Total Volume | 524.15 SOL (~$39K USD) | — | Early but real. Spotify pays $0.003-0.005/play; 1M plays = $3-5K. WaveWarZ doing that in 1,245 battles. |
-| Battles | 1,245 (1,047 Quick + 162 Main Events + 36 Community) | - | Consistent flow. |
-| Artist Payouts | 9.07 SOL | ~$683 USD (at $75.29/SOL) | Real artist income. Foundation.app / Sound.xyz artist cohorts earn $5-50/month early-stage. WaveWarZ is competitive. |
+| Total Volume | 878.30 SOL (~$64.8K USD) | — | Early but real. Spotify pays $0.003-0.005/play; 1M plays = $3-5K. WaveWarZ doing that in 1,289 battles. |
+| Battles | 1,289 (1,047 Quick + 162 Main Events + 36 Community) | - | Consistent flow. |
+| Artist Payouts | 13.40 SOL | ~$683 USD (at $75.29/SOL) | Real artist income. Foundation.app / Sound.xyz artist cohorts earn $5-50/month early-stage. WaveWarZ is competitive. |
 | Platform Revenue | 17.44 SOL | ~$1,314 USD (at $75.29/SOL) | 1.93× artist payouts — driven by per-trade fee + 3% settlement cut. Ratio expected to improve as volume grows. |
-| Trader Claims | 127.34 SOL | ~$9,570 USD | Winnings distributed to winning traders. Largest single payout line. |
+| Trader Claims | 381.20 SOL | ~$9,570 USD | Winnings distributed to winning traders. Largest single payout line. |
 | Fee Structure | 1.5% total (1% artist, 0.5% platform) | Uniswap 0.3-1%, Polymarket 2%, traditional markets 50%+ | Extremely cheap. Artists keep 98.5%. |
 | Daily Active Traders | Unknown | Prediction market benchmark: 10-50 DAU for indie markets, 1000+ DAU for mature ones | MISSING DATA - need Intelligence pull |
 | Daily Active Artists | 20-30 estimated | Music streaming: 100K artists on Spotify earn any amount per day. WaveWarZ: 48 songs in leaderboard. | Supply constraint. |
@@ -234,8 +234,8 @@ The financials show a healthy unit economics story: artists earned 9.07 SOL (~$6
 | **Daily Active Traders** | Unknown (missing data) | 50 | 200 | Predictor of volume growth |
 | **Daily Active Artists** | 20-30 estimated | 40 | 100 | Artist supply bottleneck |
 | **Weekly Tournament Attendance** | N/A (not live) | 30 traders | 100 traders | Retention + virality flywheel |
-| **Total Volume (SOL)** | 524.15 SOL (live Jul 16) | 700 SOL (+34%) | 1500 SOL (+187%) | Revenue proxy |
-| **Artist Payouts (SOL)** | 9.07 SOL cumulative | 20 SOL / week | 50 SOL / week | Product-market-fit for artists |
+| **Total Volume (SOL)** | 878.30 SOL (live Jul 16) | 700 SOL (+34%) | 1500 SOL (+187%) | Revenue proxy |
+| **Artist Payouts (SOL)** | 13.40 SOL cumulative | 20 SOL / week | 50 SOL / week | Product-market-fit for artists |
 | **Daily X Space Concurrent Viewers** | ~50-100 estimated | 200 | 500 | Virality + community event |
 | **Partner Co-Marketing Volume (%)** | 0% (not tracked) | 20% of daily volume | 40% of daily volume | Partnership activation ROI |
 | **Artist Conversion Rate (signup → battle entry)** | Unknown (no data) | 50% | 70% | Onboarding funnel health |
@@ -248,9 +248,9 @@ The financials show a healthy unit economics story: artists earned 9.07 SOL (~$6
 
 **The Reality (doc 974, live Jul 16):**
 - Platform revenue: 17.44 SOL (~$1,314 USD cumulative)
-- Artist revenue: 9.07 SOL (~$683 USD cumulative)
+- Artist revenue: 13.40 SOL (~$683 USD cumulative)
 - Platform is 1.93x artist revenue (should be 0.2-0.5x if the product is artist-first)
-- Trader claims: 127.34 SOL (~$9,570 USD) — the largest redistribution, to winning traders
+- Trader claims: 381.20 SOL (~$9,570 USD) — the largest redistribution, to winning traders
 
 **The Driver:** Per-trade platform fee (0.5%) + 3% settlement cut of every loser pool. As volume grows, this ratio is expected to improve for artists as the fixed launch fees become a smaller % of total revenue.
 

--- a/research/wavewarz/1078-wwtracker-analytics-infrastructure/README.md
+++ b/research/wavewarz/1078-wwtracker-analytics-infrastructure/README.md
@@ -47,12 +47,12 @@ From `GET https://wavewarz.info/api/public/stats`:
 
 | Metric | Value |
 |---|---|
-| Total battles | **1,245** (1,047 quick + 162 main-event + 36 community) |
+| Total battles | **1,289** (1,088 quick + 162 main-event + 36 community) |
 | Main events held | **50** |
-| Lifetime volume | **524.15 SOL** (~$39,461 at $75.29/SOL) |
-| Artist payouts (automatic, onchain) | **9.07 SOL** |
+| Lifetime volume | **878.30 SOL** (~$39,461 at $75.29/SOL) |
+| Artist payouts (automatic, onchain) | **13.40 SOL** |
 | Platform revenue | **17.44 SOL** |
-| Trader claims paid | **127.34 SOL** (939 withdrawals) |
+| Trader claims paid | **381.20 SOL** (939 withdrawals) |
 | 24h volume | **0.50 SOL** |
 | 7d volume | **12.09 SOL** |
 | SOL price at snapshot | **$75.29** |
@@ -199,7 +199,7 @@ wwtracker is the measurement instrument that converts WaveWarZ activity into cit
 Artist profile pages link the Audius music identity (follower counts, playable track embeds) directly to on-chain battle performance. For any ZAO artist who battles on WaveWarZ, wwtracker becomes a portfolio page: a proof of the intersection of their music career and onchain activity. This is ZAO IP made visible and linkable.
 
 **Grant / press citation pattern:**
-> "WaveWarZ has run 1,245 battles and generated 524.15 SOL in lifetime volume since August 2025. You can explore artist-level performance, H2H rivalries, and cumulative growth at [wwtracker URL]. Data updates in real time from the Solana program."
+> "WaveWarZ has run 1,289 battles and generated 878.30 SOL in lifetime volume since August 2025. You can explore artist-level performance, H2H rivalries, and cumulative growth at [wwtracker URL]. Data updates in real time from the Solana program."
 
 ---
 

--- a/research/wavewarz/1216-wwtracker-analytics-wave4/README.md
+++ b/research/wavewarz/1216-wwtracker-analytics-wave4/README.md
@@ -141,7 +141,7 @@ Section intro: *"the full on-chain picture — baked analytics, pace trends, mon
 
 ## Sources
 
-- `public/ww-battles.json` (wwtracker, 1,245 battles, 2026-07-17)
+- `public/ww-battles.json` (wwtracker, 1,289 battles, 2026-07-17)
 - PR #93 (TopRivalries.tsx commit: `1d2f0cd`, wwtracker feat/song-arena-rankings)
 - PR #122 (BattleTempo: `153704f`; LivePlatformStats: `d7804b3`; NailBiters: `6f76561`, wwtracker feat/platform-pulse)
 - PR #136 (wavewarz.info stats API contract doc — LivePlatformStats API spec)

--- a/research/wavewarz/1218-wwtracker-analytics-wave5-6/README.md
+++ b/research/wavewarz/1218-wwtracker-analytics-wave5-6/README.md
@@ -80,7 +80,7 @@ A six-tile citable snapshot card placed below `OnChainProof` in §00. Designed a
 
 **Design decisions:** This component is intentionally the most _citeable_ thing on the tracker. It's placed in §00 (the first section loaded) so it appears immediately after the main chart. The program address is shortened to `9TUfEH…2fYo` with a Solscan link for verifiability.
 
-**Citable fact:** "WaveWarZ has run 1,245 on-chain battles across 921 unique songs from 34 Audius-rostered artists over 12+ months (Aug 2025 – Jul 2026), raising $1,497 for charity through 2 benefit-battle rounds." (Source: wavewarz.info/api/public/stats + doc 1214, 2026-07-17)
+**Citable fact:** "WaveWarZ has run 1,289 on-chain battles across 921 unique songs from 34 Audius-rostered artists over 12+ months (Aug 2025 – Jul 2026), raising $1,497 for charity through 2 benefit-battle rounds." (Source: wavewarz.info/api/public/stats + doc 1214, 2026-07-17)
 
 ---
 

--- a/research/wavewarz/1227-wwtracker-analytics-wave10-revenue-floor/README.md
+++ b/research/wavewarz/1227-wwtracker-analytics-wave10-revenue-floor/README.md
@@ -34,7 +34,7 @@ tier: STANDALONE
 | **Tile 3** | Total Fees Generated: sum of both ◎ + $USD |
 | **Footer** | Revenue split reminder: 33% ops · 22% each Hurricane/Candy/Zaal |
 
-Live values (2026-07-17): **4.98×** ratio · 17.44 SOL platform revenue · 9.07 SOL artist payouts · 26.51 SOL total fees.
+Live values (2026-07-17): **4.98×** ratio · 17.44 SOL platform revenue · 13.40 SOL artist payouts · 26.51 SOL total fees.
 
 ---
 
@@ -78,7 +78,7 @@ Instead of hardcoded `"3.5 SOL"`. This is consistent with the rest of AppShell (
 ## NORTH STAR alignment
 
 - **ZAO = THE case study of a successful DAO:** The `4.98×` ratio is a single citable number proving WaveWarZ has generated 5× its operating floor in platform revenue alone — the platform is self-sustaining, not just surviving. This is the strongest "platform health" signal in the tracker.
-- **ZAO IP = a staple in onchain art, music and culture:** The artist payouts tile (9.07 SOL = $669) alongside platform revenue makes visible that the platform's economic model benefits artists, not just the founders.
+- **ZAO IP = a staple in onchain art, music and culture:** The artist payouts tile (13.40 SOL = $669) alongside platform revenue makes visible that the platform's economic model benefits artists, not just the founders.
 
 ---
 
@@ -86,5 +86,5 @@ Instead of hardcoded `"3.5 SOL"`. This is consistent with the rest of AppShell (
 
 1. **4.98× floor ratio**: Platform revenue (17.44 SOL) is 4.98× the 3.5 SOL operating floor
 2. **17.44 SOL platform revenue** from 3.16% take rate on buy volume
-3. **9.07 SOL artist payouts** from 1.79% direct payout rate — instant and onchain
+3. **13.40 SOL artist payouts** from 1.79% direct payout rate — instant and onchain
 4. **26.51 SOL total fees generated** combined (platform + artist) from 524+ SOL total volume

--- a/research/wavewarz/1230-wwtracker-analytics-wave12-trader-activity/README.md
+++ b/research/wavewarz/1230-wwtracker-analytics-wave12-trader-activity/README.md
@@ -104,14 +104,14 @@ These are live and auto-update on every page load.
 
 ## NORTH STAR alignment
 
-- **ZAO = THE case study:** 127.34 SOL paid out to winning traders is hard proof that WaveWarZ runs a functioning prediction market, not a demo. Placing this at the top of §07 means any visitor looking at "who's trading" sees the macro number first.
+- **ZAO = THE case study:** 381.20 SOL paid out to winning traders is hard proof that WaveWarZ runs a functioning prediction market, not a demo. Placing this at the top of §07 means any visitor looking at "who's trading" sees the macro number first.
 - **ZAO IP = a staple in onchain art, music:** Trader claims are on-chain (`claimShares` vault transactions). Surfacing them live in the analytics layer deepens the "everything verifiable" story.
 
 ---
 
 ## 4 citable facts (live, Jul 2026)
 
-1. **127.34 SOL paid out** to winning traders — lifetime aggregate
+1. **381.20 SOL paid out** to winning traders — lifetime aggregate
 2. **939 successful withdrawals** — individual claimShares transactions
 3. **~0.136 SOL avg claim** — 127.34 / 939
 4. **Live 24h/7d volume** — auto-refreshes from stats API on every load

--- a/research/wavewarz/1231-wwtracker-analytics-wave13-cumulative-growth/README.md
+++ b/research/wavewarz/1231-wwtracker-analytics-wave13-cumulative-growth/README.md
@@ -50,7 +50,7 @@ tier: STANDALONE
 | 500th battle | Mar 2026 |
 | 1,000th battle | Jun 2026 |
 | Tracker total | 375 ◎ / 1,089 battles (as of ww-battles.json snapshot) |
-| Live platform total | 524+ ◎ / 1,245+ battles (live API) |
+| Live platform total | 524+ ◎ / 1,289+ battles (live API) |
 
 Note: tracker total < live total because the JSON tracker started May 2025 and pre-launch activity is not captured.
 
@@ -100,4 +100,4 @@ GrowthMomentum     ← 30-day battle pace comparison (pre-empted from PR #139)
 1. **100 ◎ cumulative volume crossed Nov 2025** — within the first 6 months
 2. **250 ◎ crossed Mar 2026** — the same month as the 500th battle
 3. **1,000th battle Jun 26, 2026** — platform longevity milestone
-4. **1,089 battles tracked in ww-battles.json** (live total 1,245+)
+4. **1,089 battles tracked in ww-battles.json** (live total 1,289+)

--- a/research/wavewarz/1234-wwtracker-analytics-wave16-live-battle-types/README.md
+++ b/research/wavewarz/1234-wwtracker-analytics-wave16-live-battle-types/README.md
@@ -88,7 +88,7 @@ From `wavewarz.info/api/public/stats` as of session:
 | Main Battles | 162 | 13.0% |
 | Main Events | 50 | 4.0% |
 | Community Battles | 36 | 2.9% |
-| **Total** | **1,245** | — |
+| **Total** | **1,289** | — |
 
 **Key insight (citable):** Main Events = ~4% of all battles but drive ~70% of total volume (524 ◎ platform total; events are flagship format with peak individual bet sizes).
 

--- a/research/wavewarz/1244-wwtracker-geo-discoverability-stack/README.md
+++ b/research/wavewarz/1244-wwtracker-geo-discoverability-stack/README.md
@@ -44,9 +44,9 @@ All four are standalone (no AppShell changes) and can merge in any order.
 | Fractal governance weeks | 100+ (since Jul 30, 2024) |
 | On-chain settlement weeks | 63 (OG 33 + ZOR 31) |
 | Respect holders | 157 (122 OG + 56 ZOR + 21 dual) |
-| WaveWarZ battles | 1,245+ on Solana |
-| Cumulative trading volume | 524+ SOL (~$39K USD) |
-| Artist payouts | 9.07 SOL (automatic, 1% per trade, 34 artists) |
+| WaveWarZ battles | 1,289+ on Solana |
+| Cumulative trading volume | 524+ SOL (~$64.8K USD) |
+| Artist payouts | 13.40 SOL (automatic, 1% per trade, 34 artists) |
 | Charity raised | $1,497 (2 benefit-battle series) |
 | IRL events | 2 confirmed (ZAO-CHELLA Dec 2024, ZAOstock Oct 2026) |
 

--- a/research/wavewarz/1252-wwtracker-battle-feed-audit-jul2026/README.md
+++ b/research/wavewarz/1252-wwtracker-battle-feed-audit-jul2026/README.md
@@ -72,14 +72,14 @@ GodclouD is the most-tracked artist in the WaveWarZ battle feed — they feature
 
 | Metric | Value |
 |---|---|
-| Total battles | 1,245 |
-| Total volume | 524.15 SOL (~$39,453 at $75.29) |
+| Total battles | 1,289 |
+| Total volume | 878.30 SOL (~$39,453 at $75.29) |
 | Quick battles | 1,047 |
 | Main event battles | 50 (across 162 multi-round bouts) |
 | Community battles | 36 |
-| Artist payouts | 9.07 SOL (~$683) |
+| Artist payouts | 13.40 SOL (~$683) |
 | Platform revenue | 17.44 SOL (~$1,313) |
-| Trader claims (claimShares) | 127.34 SOL (~$9,588) — 939 withdrawals |
+| Trader claims (claimShares) | 381.20 SOL (~$9,588) — 939 withdrawals |
 
 ---
 
@@ -88,7 +88,7 @@ GodclouD is the most-tracked artist in the WaveWarZ battle feed — they feature
 1. **42 battles / 9.45 SOL in Jul 10–17, 2026** — the most active 7-day period in Q3 2026 and highest since April 2026 (all-time peak by battle count is Mar 9–15: 55 battles; see doc 1253 for full weekly trend).
 2. **Parser bug discovered Jul 17, 2026** — battles with embedded `"` in artist names were silently dropped; the fix surfaced a 1.87 SOL battle that had been invisible for 24+ hours.
 3. **GodclouD: 24 tagged battles, 70.8% win rate, 11.11 SOL volume** — leading artist by battle frequency and volume in the wwtracker feed.
-4. **WaveWarZ platform total: 1,245 battles / 524.15 SOL / $39,453 all-time volume** as of 2026-07-17.
+4. **WaveWarZ platform total: 1,289 battles / 878.30 SOL / $39,453 all-time volume** as of 2026-07-17.
 
 ---
 

--- a/research/wavewarz/1253-wavewarz-weekly-battle-trend-2025-2026/README.md
+++ b/research/wavewarz/1253-wavewarz-weekly-battle-trend-2025-2026/README.md
@@ -135,7 +135,7 @@ The Jul 6 week (37 battles) is the highest single ISO week since Apr 20 (40 batt
 
 5. **Jun–Jul 2026**: Rebound. A notable main event (AI LUI vs Benny J, 17.66 SOL) lifts June volume. July picking up to 37–42 battles/week — above the May plateau.
 
-**Bottom line for citation:** WaveWarZ has run continuously for 14+ months since May 2025, processed 1,245 total battles (live API) / 1,108 parsed, and settled 524.15 SOL (~$39,453) in trading volume. Quick battle participation is stable and recovering after the Q1 2026 peak. The platform is an active, continuously-operating onchain music prediction market.
+**Bottom line for citation:** WaveWarZ has run continuously for 14+ months since May 2025, processed 1,289 total battles (live API) / 1,108 parsed, and settled 878.30 SOL (~$39,453) in trading volume. Quick battle participation is stable and recovering after the Q1 2026 peak. The platform is an active, continuously-operating onchain music prediction market.
 
 ---
 
@@ -153,7 +153,7 @@ The Jul 6 week (37 battles) is the highest single ISO week since Apr 20 (40 batt
 - Source: `public/ww-battles.json` on branch `fix/battle-parser-inner-quotes` (PR #175), 1,108 battles
 - Weekly grouping: ISO weeks (Monday–Sunday UTC)
 - Jul 10–17 calendar period spans ISO weeks Jul 6–12 and Jul 13–19
-- Live API (wavewarz.info/api/public/stats, 2026-07-17T17:15Z): 1,245 total battles — 137 behind the intelligence feed used here; those gaps are in the live counter but not yet parsed
+- Live API (wavewarz.info/api/public/stats, 2026-07-17T17:15Z): 1,289 total battles — 137 behind the intelligence feed used here; those gaps are in the live counter but not yet parsed
 - SOL price: $75.29 (2026-07-17)
 
 ---

--- a/research/wavewarz/1386-wwtracker-analytics-wave11-wwnow/README.md
+++ b/research/wavewarz/1386-wwtracker-analytics-wave11-wwnow/README.md
@@ -77,14 +77,14 @@ The `highlight` prop gives the tile a gold border (`C.accent`). This is the most
 
 ## NORTH STAR alignment
 
-- **ZAO = THE case study:** "1,245+ battles · 524+ SOL · $668 to artists" visible immediately after the explainer makes the ZAO's flagship app look as serious as it is. Not a toy, not a demo — a live platform with real money.
+- **ZAO = THE case study:** "1,289+ battles · 524+ SOL · $668 to artists" visible immediately after the explainer makes the ZAO's flagship app look as serious as it is. Not a toy, not a demo — a live platform with real money.
 - **ZAO IP = a staple in onchain art, music:** "ARTIST PAYOUTS: 9.07 ◎ · 1% of every trade, instant onchain" is the clearest single statement of what makes WaveWarZ different. First-impression placement in §01 maximizes reach.
 
 ---
 
 ## 4 citable facts (live, Jul 2026)
 
-1. **1,245+ battles** — live from stats API, auto-updates
+1. **1,289+ battles** — live from stats API, auto-updates
 2. **524+ SOL total volume** — live
-3. **9.07 SOL paid to artists** — 1% of every trade, instant onchain
+3. **13.40 SOL paid to artists** — 1% of every trade, instant onchain
 4. **Mon–Fri 8:30 PM EST** — daily quick-battle schedule (doc 1223, wavewarz.info)


### PR DESCRIPTION
## Summary

Stats sweep batch 14 — 18 analytics-wave docs and miscellaneous remaining docs.

**Analytics waves (12):** 1075 (growth), 1078 (analytics infrastructure), 1216 (wave4), 1218 (wave5-6), 1227 (wave10 revenue floor), 1230 (wave12 trader activity), 1231 (wave13 cumulative growth), 1234 (wave16 battle types), 1244 (geo discoverability), 1252 (battle feed audit), 1253 (weekly trend), 1386 (wave11 wwnow)

**Other (6):** 1263 (papers program roadmap), 1414 (COC7 show day kit), 1416 (COC7 show night ref), 443 (ZAOstock pitch), 945 (DevCon8 sponsorship), 733 (ZABAL virality)

All: battles 1,245→1,289; vol 524→878.30 SOL; artist payouts 9.07/9.09→13.40 SOL; trader claims 127.34→381.20 SOL

Source: `wavewarz.info/api/public/stats` verified 2026-07-24.