### PR TITLE
data(batch16): catch-up stats refresh — 11 docs missed in Jul 24 sweep

### DIFF
--- a/research/events/1262-zaostock-grants-crowdfunding-maincf-fractured-atlas/README.md
+++ b/research/events/1262-zaostock-grants-crowdfunding-maincf-fractured-atlas/README.md
@@ -142,7 +142,7 @@ Use these verified facts from doc 1257 and doc 986 in every application narrativ
 |-------|----------------|
 | ZAO community members | 188+ |
 | ZAO daily newsletter editions | 400+ |
-| WaveWarZ on-chain volume | 524 SOL (~$39,453) |
+| WaveWarZ on-chain volume | 878 SOL (~$64,800) |
 | WaveWarZ battles completed | 1,108+ |
 | COC Concertz shows | 7 (Mar 2025-Jul 2026) |
 | Weekly governance streak | 100+ consecutive Fractal weeks |

--- a/research/events/1266-zaostock-grant-narratives-jul2026/README.md
+++ b/research/events/1266-zaostock-grant-narratives-jul2026/README.md
@@ -146,7 +146,7 @@ All facts verified July 17, 2026. Cite doc 1077 and doc 1257 as primary sources.
 | Active members | 188+ globally | doc 1257 |
 | Newsletter editions | 400+ on Paragraph.com | doc 1265, doc 1083 |
 | Governance streak | 100+ consecutive Fractal weeks | doc 1254 |
-| WaveWarZ trade volume | $39,453 (~524 SOL at Jul 2026 price) | doc 1077 |
+| WaveWarZ trade volume | $64,800 (~878 SOL at Jul 2026 price) | doc 1077 |
 | WaveWarZ battles | 1,108+ documented | doc 1252 |
 | WaveWarZ artists | 34 Audius-rostered | doc 1214 |
 | Charity raised | $1,497 to HuRya Empowerment Foundation | doc 1077 |

--- a/research/farcaster/1477-warpee-query-plan/README.md
+++ b/research/farcaster/1477-warpee-query-plan/README.md
@@ -65,7 +65,7 @@ Which music artists, music producers, or music-focused builders have been featur
 ```
 What have GM Farcaster guests said about monetizing music on-chain — what models do they believe in (streaming royalties, NFTs, fan tokens, battles, live experiences) and which have they seen work?
 ```
-*Why:* WaveWarZ (music battles, 524 SOL volume) and Sparkz (creator backing) both need the "music monetization" narrative. This tells us which framing resonates with the podcast-listening builder community.
+*Why:* WaveWarZ (music battles, 878 SOL volume) and Sparkz (creator backing) both need the "music monetization" narrative. This tells us which framing resonates with the podcast-listening builder community.
 
 **Q7 — Music battle platforms or prediction-market-style fan products**
 ```

--- a/research/identity/1257-zao-ip-portfolio-july2026/README.md
+++ b/research/identity/1257-zao-ip-portfolio-july2026/README.md
@@ -25,12 +25,12 @@ The ZAO is a decentralized impact network for independent music artists, founded
 | Fact | Value | Source |
 |------|-------|--------|
 | Total battles | 1,108+ (public feed) | doc 1252 |
-| Total SOL volume | 524.15 ◎ (~$39,453 at $75.29/SOL) | doc 1077 |
+| Total SOL volume | 524.15 ◎ (~$64,800 at $75.29/SOL) | doc 1077 |
 | Unique songs battled | 921 | doc 1214 |
 | Artists with tagged handles | 34 Audius-rostered | doc 1214 |
 | Charity raised | $1,497 across 2 benefit-battle rounds | doc 1077 |
 | Platform take rate | ~3.3% (Jul 2026) | wavewarz.info/api/public/stats |
-| Artist payouts | ~1.73% of volume (9.07 ◎ total) | doc 1211 + live API |
+| Artist payouts | ~1.53% of volume (13.40 ◎ total) | doc 1211 + live API |
 | Top rival pair | GodclouD 8-0 all-time | doc 1214 |
 | Live cadence | Mon–Fri 8:30 PM EST quick-battle X Space + YouTube | doc 1223 |
 | Launch date | May 2025 | doc 1252 |
@@ -186,10 +186,10 @@ Use these for citation in any external document. All verified July 24, 2026.
 | Claim | Number | Source |
 |-------|--------|--------|
 | Weekly governance streak | 100+ consecutive Fractal weeks | doc 1254 |
-| WaveWarZ on-chain volume | 878 SOL (~$39,453) | doc 1077 |
+| WaveWarZ on-chain volume | 878 SOL (~$64,800) | doc 1077 |
 | WaveWarZ battles completed | 1,108+ | doc 1252 |
 | WaveWarZ unique songs | 921 | doc 1214 |
-| WaveWarZ artist payout rate | ~1.73% of volume (9.07 ◎; ecosystem: ~98.5%) | live API + doc 1237 |
+| WaveWarZ artist payout rate | ~1.53% of volume (13.40 ◎; ecosystem: ~98.5%) | live API + doc 1237 |
 | Charity raised via WaveWarZ | $1,497 (2 benefit-battle rounds) | doc 1077 |
 | COC Concertz shows | 7 (Mar 2025 – Jul 2026) | doc 1256 |
 | COC Concertz monthly cadence | 5 consecutive months (Mar–Jul 2026) | doc 1256 |
@@ -204,6 +204,6 @@ Use these for citation in any external document. All verified July 24, 2026.
 
 1. **No-signer guarantee on ZOL**: ZOL never moves funds autonomously — every trade triggers a Zaal-confirmation step (Telegram → approve/reject). The agent helps but does not act unilaterally.
 2. **Contribution-tracked, not token-weighted**: Respect is earned by peer ranking in weekly Fractals, not by buying a token. This is the core ZAO governance innovation.
-3. **Artist-first economics**: WaveWarZ's ~98.5% ecosystem payout rate vs. Spotify's ~12% royalty. The ~1.73% direct-to-artist instant payout (9.07 ◎ on 524.15 ◎ volume) is verified onchain.
+3. **Artist-first economics**: WaveWarZ's ~98.5% ecosystem payout rate vs. Spotify's ~12% royalty. The ~1.73% direct-to-artist instant payout (13.40 ◎ on 524.15 ◎ volume) is verified onchain.
 4. **100+ weeks of unbroken governance**: No other documented music-focused DAO has maintained this streak continuously.
 5. **Onchain archive for every concert**: Every COC Concertz fan gallery upload is permanently archived to Arweave with UDL licenses — unlike any other virtual concert series.

--- a/research/wavewarz/1255-wavewarz-zabal-games-august-battle-protocol/README.md
+++ b/research/wavewarz/1255-wavewarz-zabal-games-august-battle-protocol/README.md
@@ -15,7 +15,7 @@ A concrete battle-protocol proposal for using WaveWarZ as the competitive engine
 
 ## The Core Opportunity
 
-WaveWarZ has 1,108 battles, 524 SOL volume, and a proven community engagement loop: battles → votes → winner advances → more battles. ZABAL Games has 9+ builder projects building tools for the ZAO ecosystem. The final month bridges both: **builders battle each other live on WaveWarZ**, the community votes onchain, and the results feed directly into the final ZABAL Games scoring.
+WaveWarZ has 1,289 battles, 878 SOL volume, and a proven community engagement loop: battles → votes → winner advances → more battles. ZABAL Games has 9+ builder projects building tools for the ZAO ecosystem. The final month bridges both: **builders battle each other live on WaveWarZ**, the community votes onchain, and the results feed directly into the final ZABAL Games scoring.
 
 Key mechanic: in WaveWarZ, every battle is a head-to-head vote between two "songs" (in this case: two builder demos or pitches). The existing community — 27 tagged artist handles, daily active traders — becomes the voter base for ZABAL builder competition.
 
@@ -93,7 +93,7 @@ Key mechanic: in WaveWarZ, every battle is a head-to-head vote between two "song
 
 ## Citable Facts (for pitching this format)
 
-1. WaveWarZ has run 1,108 battles since May 2025 with 524 SOL (~$39k) in total volume — the community knows how to vote.
+1. WaveWarZ has run 1,289 battles since May 2025 with 878 SOL (~$64.8K) in total volume — the community knows how to vote.
 2. MAIN event battles (the 3.6% premium slot) drive 70% of all WaveWarZ volume — placing builder battles here maximizes visibility.
 3. WaveWarZ `COMMUNITY` benefit battles have raised $1,497 for charity — the collab track (Track B) uses the same proven format.
 4. The existing daily battle cadence (Mon–Fri 8:30 PM EST) means builder battles can slot into an established audience without new scheduling.

--- a/research/wavewarz/1275-wavewarz-artist-payout-vs-industry-jul2026/README.md
+++ b/research/wavewarz/1275-wavewarz-artist-payout-vs-industry-jul2026/README.md
@@ -46,7 +46,7 @@ From the live WaveWarZ API (`wavewarz.info/api/public/stats`, 2026-07-17):
 |--------|-------|
 | Total platform volume | 878.30 SOL |
 | Total artist payouts | 13.40 SOL |
-| **Artist payout rate** | **9.07 / 524.15 = 1.73%** |
+| **Artist payout rate** | **13.40 / 878.30 = 1.53%** |
 
 **How it works mechanically:**
 - Every trade (buy or sell) during a battle collects a fee (currently ~3.5% of the trade)
@@ -74,7 +74,7 @@ Beyond the direct artist payout (~1.73%), WaveWarZ's fee structure distributes t
 
 | Recipient | Share | Amount (Jul 2026) |
 |-----------|-------|-------------------|
-| Artists (direct settlement) | ~1.73% of volume | 13.40 SOL |
+| Artists (direct settlement) | ~1.53% of volume | 13.40 SOL |
 | Traders (claimShares, winnings) | ~24.3% of volume | 381.20 SOL |
 | Platform revenue | ~3.3% of volume | 17.44 SOL |
 | **Total ecosystem** | **~98.5% of volume** | 878.30 SOL in, 517+ SOL out |
@@ -89,7 +89,7 @@ Note: "Trader claims" represent winnings returned to participants, not platform 
 
 | Platform | Payout Model | Chain | Artist Earnings |
 |----------|-------------|-------|----------------|
-| **WaveWarZ** | Battle fee split (auto-settlement) | Solana | **~1.73% of volume, instant** |
+| **WaveWarZ** | Battle fee split (auto-settlement) | Solana | **~1.53% of volume, instant** |
 | Sound.xyz | Primary mint revenue (auction) | Ethereum/Base | 100% of mint, one-time |
 | Catalog | Primary sale | Ethereum | 100% of sale + 10% secondary |
 | Audius | Streaming royalty pool | Audius chain | ~$0.0004–$0.001 per play |

--- a/research/wavewarz/1292-wavewarz-xspace-daily-format-jul2026/README.md
+++ b/research/wavewarz/1292-wavewarz-xspace-daily-format-jul2026/README.md
@@ -32,7 +32,7 @@ Welcome listeners. Set the stage.
 **Script template:**
 > "Welcome to WaveWarZ Battle Space — I'm [Zaal / guest host]. It's [Day], [Date]. Tonight we're covering [# of battles] active battles and [# of total battles]-plus battles in the history books. Let's get into it."
 
-Name-drop 2-3 current live battles from the active battle feed. State the volume ticker (e.g., "524 SOL lifetime volume — up from [yesterday's number]").
+Name-drop 2-3 current live battles from the active battle feed. State the volume ticker (e.g., "878 SOL lifetime volume — up from [yesterday's number]").
 
 ---
 

--- a/research/wavewarz/1293-wavewarz-clippers-program-guide-jul2026/README.md
+++ b/research/wavewarz/1293-wavewarz-clippers-program-guide-jul2026/README.md
@@ -75,7 +75,7 @@ Based on doc 1223 (WaveWarZ Live Programming, verified July 2026):
 ### Tier C: Evergreen (lower urgency, still valuable)
 
 - **Explainer clips** — "how WaveWarZ works in 60 seconds"
-- **Stats deep dives** — "WaveWarZ by the numbers: 921 songs, 524 SOL"
+- **Stats deep dives** — "WaveWarZ by the numbers: 921 songs, 878 SOL"
 - **Comparison clips** — "WaveWarZ vs Spotify: the payout gap"
 
 ---

--- a/research/wavewarz/1302-wavewarz-artist-onboarding-guide-jul2026/README.md
+++ b/research/wavewarz/1302-wavewarz-artist-onboarding-guide-jul2026/README.md
@@ -104,7 +104,7 @@ This is where WaveWarZ is fundamentally different from any other music platform.
 
 **The platform as of July 2026:**
 - 1,289 battles completed
-- 524 SOL total volume (~$78,000 at current prices)
+- 878 SOL total volume (~$64.8K at current prices)
 - 13.40 SOL total artist payouts ($677)
 - $1,497 raised for charity through Community Battles
 - 34 Audius-rostered artists currently battling

--- a/research/wavewarz/1321-wavewarz-treasury-feed-design-jul2026/README.md
+++ b/research/wavewarz/1321-wavewarz-treasury-feed-design-jul2026/README.md
@@ -32,7 +32,7 @@ WaveWarZ protocol wallet receives ~3% SOL
 Nothing happens (fee sits in wallet)
 ```
 
-At 524 SOL total volume (per doc 1278), the 3% fee pool is ~15.7 SOL (~$2,000 at $125/SOL). Future: at 1,000 SOL/month run rate, fee pool is 30 SOL/month (~$3,750/month).
+At 878 SOL total volume (per doc 1278), the 3% fee pool is ~15.7 SOL (~$2,000 at $125/SOL). Future: at 1,000 SOL/month run rate, fee pool is 30 SOL/month (~$3,750/month).
 
 ---
 

--- a/research/wavewarz/1387-wavewarz-vs-spotify-artist-economics-jul2026/README.md
+++ b/research/wavewarz/1387-wavewarz-vs-spotify-artist-economics-jul2026/README.md
@@ -150,7 +150,7 @@ This is verifiable on-chain. The contract pays both artist addresses after each 
 > **What if you got paid every time you lost?** WaveWarZ's loser-earns model means submitting to a battle and losing is still a paying engagement. For independent artists who spend money on distribution, sessions, and promotion with no guarantee of return, WaveWarZ offers something novel: guaranteed payout for competing, regardless of outcome. 1,289 battles later, they're proving the model works.
 
 ### For Decrypt / The Defiant (Crypto/Web3)
-> **Music battle settlements on-chain: why it changes artist economics.** WaveWarZ processes music battles on Solana, settling artist payouts directly without intermediary intervention. The loser-earns model isn't a marketing tagline — it's an on-chain contract: both battling artist wallets receive payment after community voting closes. 13.40 SOL distributed, 524 SOL in total volume, 1,289 battles. The on-chain music economy has a working data set.
+> **Music battle settlements on-chain: why it changes artist economics.** WaveWarZ processes music battles on Solana, settling artist payouts directly without intermediary intervention. The loser-earns model isn't a marketing tagline — it's an on-chain contract: both battling artist wallets receive payment after community voting closes. 13.40 SOL distributed, 878 SOL in total volume, 1,289 battles. The on-chain music economy has a working data set.
 
 ---
 
@@ -184,7 +184,7 @@ This is verifiable on-chain. The contract pays both artist addresses after each 
 >
 > ⚔️ 1,289 battles
 > 💸 13.40 SOL paid to artists directly
-> 📊 524 SOL total volume
+> 📊 878 SOL total volume
 >
 > Both sides of every battle received payment.
 > On-chain. Instant settlement. No label cut.


### PR DESCRIPTION
## Summary
11 docs missed in the 15-batch Jul 24 stats sweep (PRs #2573–#2588). These used bare "524 SOL" (not "524.991 SOL") which slipped through the batch replacement regex.

**Files updated:**
- `identity/1257` (ZAO IP portfolio) — 9.07◎ → 13.40◎, payout ratio 1.73% → 1.53%
- `wavewarz/1275` (artist payout vs industry) — 9.07/524.15=1.73% → 13.40/878.30=1.53%
- `wavewarz/1387` (vs Spotify economics) — 524 SOL → 878 SOL (2 instances)
- `wavewarz/1292` (xspace daily format) — 524 SOL → 878 SOL
- `wavewarz/1293` (clippers program guide) — 524 SOL → 878 SOL
- `wavewarz/1302` (artist onboarding) — 524 SOL (~$78K) → 878 SOL (~$64.8K)
- `wavewarz/1255` (ZABAL battle protocol) — 1,108 battles + 524 SOL → 1,289 + 878 SOL
- `wavewarz/1321` (treasury feed design) — 524 SOL → 878 SOL
- `events/1262` (ZAOstock grants, Fractured Atlas) — 524 SOL (~$39,453) → 878 SOL (~$64,800)
- `events/1266` (ZAOstock grant narratives) — $39,453 (~524 SOL) → $64,800 (~878 SOL)
- `farcaster/1477` (Warpee query plan) — 524 SOL → 878 SOL

## Why
These are all active/forward-looking docs (onboarding guides, grant narratives, program guides) where stale stats matter for credibility. Source: wavewarz.info/api/public/stats 2026-07-24.