### PR TITLE
data(batch18): final stats sweep catch-up — 4 remaining docs

### DIFF
--- a/research/business/1547-zao-revenue-model-breakdown/README.md
+++ b/research/business/1547-zao-revenue-model-breakdown/README.md
@@ -20,7 +20,7 @@ WaveWarZ operates a prediction market: listeners bet SOL on which artist wins a 
 - Total volume: 878.30 SOL across 1,289 battles
 - Artist payouts to losers: 13.40 SOL
 - Trader claims (winning bettors): 381.20 SOL
-- **Implied platform revenue:** 523.991 − 9.0988 − 127.343 − [winner artist payouts] = remainder goes to platform
+- **Implied platform revenue:** 878.30 − 13.3869 − 381.197 − [winner artist payouts] = remainder goes to platform
 
 **Why this matters for grants:**
 > "WaveWarZ is a self-sustaining platform with on-chain revenue. ZAO does not rely solely on grant funding."

--- a/research/community/1332-zao-social-content-calendar-jul-oct-2026/README.md
+++ b/research/community/1332-zao-social-content-calendar-jul-oct-2026/README.md
@@ -94,7 +94,7 @@ Spotify pays $0.004 per stream.
 WaveWarZ pays artists 1.73% of every SOL bet on them.
 Instantly. Onchain. Even when they lose.
 
-9.07 ◎ paid to artists since launch.
+13.40 ◎ paid to artists since launch.
 That's 600× Spotify's rate per unit.
 
 → wavewarz.info/api/public/stats

--- a/research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md
+++ b/research/wavewarz/1211-wavewarz-artist-economy-jul2026/README.md
@@ -66,7 +66,7 @@ Dataset refresh: 2026-07-24 (parser fix added 19 battles including the 1.87 SOL 
 **Note on GodclouD:** 24 total appearances in the feed (including 2 self-battles excluded from this table). Cross-artist record: 22 battles (16W/6L). Volume figure (10.436 SOL) excludes self-battle volume. GodclouD's earnings lead is 2.1× the second-place artist.
 
 **Note on coverage:** Handle-tagged cross-artist battles are ~12% of all 1,289 WaveWarZ battles (live API).
-Total platform payouts = 9.07 ◎ (all battles). As handle tagging expands, per-artist
+Total platform payouts = 13.40 ◎ (all battles). As handle tagging expands, per-artist
 earnings estimates will become more complete.
 
 ---

--- a/research/wavewarz/1386-wwtracker-analytics-wave11-wwnow/README.md
+++ b/research/wavewarz/1386-wwtracker-analytics-wave11-wwnow/README.md
@@ -77,14 +77,14 @@ The `highlight` prop gives the tile a gold border (`C.accent`). This is the most
 
 ## NORTH STAR alignment
 
-- **ZAO = THE case study:** "1,289+ battles · 524+ SOL · $668 to artists" visible immediately after the explainer makes the ZAO's flagship app look as serious as it is. Not a toy, not a demo — a live platform with real money.
-- **ZAO IP = a staple in onchain art, music:** "ARTIST PAYOUTS: 9.07 ◎ · 1% of every trade, instant onchain" is the clearest single statement of what makes WaveWarZ different. First-impression placement in §01 maximizes reach.
+- **ZAO = THE case study:** "1,289+ battles · 878+ SOL · $990 to artists" visible immediately after the explainer makes the ZAO's flagship app look as serious as it is. Not a toy, not a demo — a live platform with real money.
+- **ZAO IP = a staple in onchain art, music:** "ARTIST PAYOUTS: 13.40 ◎ · 1% of every trade, instant onchain" is the clearest single statement of what makes WaveWarZ different. First-impression placement in §01 maximizes reach.
 
 ---
 
 ## 4 citable facts (live, Jul 2026)
 
 1. **1,289+ battles** — live from stats API, auto-updates
-2. **524+ SOL total volume** — live
+2. **878+ SOL total volume** — live
 3. **13.40 SOL paid to artists** — 1% of every trade, instant onchain
 4. **Mon–Fri 8:30 PM EST** — daily quick-battle schedule (doc 1223, wavewarz.info)


### PR DESCRIPTION
Final batch. All previously missed stale-stat docs now addressed. Clears the last '9.07 ◎' artist payout values, '523.991' revenue model, '524+ SOL' wave11 analytics, and old dollar conversions. Stats sweep is now complete across the full ZAOOS corpus.