### PR TITLE
data(batch19): fix stale-stat duplicates in governance docs (522 SOL leftover)

### DIFF
--- a/research/governance/1206-zao-comparative-dao-state-july2026/README.md
+++ b/research/governance/1206-zao-comparative-dao-state-july2026/README.md
@@ -103,7 +103,7 @@ Synthesizing Sections 1 and 2, ZAO's claim to be THE DAO governance case study r
 
 ### Advantage 3: The Only Music DAO that Works
 
-DAOs for creative communities (music, art) are almost entirely theoretical or failed experiments. NFT projects with governance (Nouns, etc.) govern treasury allocations, not creative work. ZAO Fractal governs who advances music, art, and technology within an active music community (188 members, 22-artist roster, WaveWarZ platform with 1,289 live battles and 522 SOL trading volume). The governance is not separate from the creative work — it IS the creative work.
+DAOs for creative communities (music, art) are almost entirely theoretical or failed experiments. NFT projects with governance (Nouns, etc.) govern treasury allocations, not creative work. ZAO Fractal governs who advances music, art, and technology within an active music community (188 members, 22-artist roster, WaveWarZ platform with 1,289 live battles and 878.30 SOL trading volume). The governance is not separate from the creative work — it IS the creative work.
 DAOs for creative communities (music, art) are almost entirely theoretical or failed experiments. NFT projects with governance (Nouns, etc.) govern treasury allocations, not creative work. ZAO Fractal governs who advances music, art, and technology within an active music community (188 members, 22-artist roster, WaveWarZ platform with 1,289 live battles and 878.30 SOL trading volume). The governance is not separate from the creative work — it IS the creative work.
 
 *Cite:* Doc 718g (ZAO distinctness), Doc 051 (ZAO whitepaper), WaveWarZ stats (live API, July 2026)
@@ -174,11 +174,11 @@ These are the citable facts for any ZAO governance claim:
 | ZOR OREC total transactions | 242 (as of 2026-05-19) | Doc 718c, 1202 | Optimism Blockscout OREC contract |
 | Active members per weekly session | ~40 | Doc 718g | Discord session records |
 | WaveWarZ battles (July 2026) | 1,289 | Live API: wavewarz.info/api/public/stats | Authoritative live source |
-| WaveWarZ trading volume | 522 SOL (~$39K) | Live API: wavewarz.info/api/public/stats | Authoritative live source |
+| WaveWarZ trading volume | 878.30 SOL (~$64.8K) | Live API: wavewarz.info/api/public/stats | Authoritative live source |
 | ZAO member community size | 188 | Doc 718g, 050 | Community roster |
 
 **Cite discipline (copy-paste ready):**
-> "ZAO Fractal has run 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism (OG: 33 + ZOR: 31 distinct settlement weeks, Blockscout-verified). ZAO is the only active fractal DAO on Optimism Mainnet as of July 2026, and the only music-focused fractal in the ecosystem. WaveWarZ, ZAO's companion music-battle prediction market, has run 1,289 battles with 522 SOL in trading volume (live API, July 2026)."
+> "ZAO Fractal has run 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism (OG: 33 + ZOR: 31 distinct settlement weeks, Blockscout-verified). ZAO is the only active fractal DAO on Optimism Mainnet as of July 2026, and the only music-focused fractal in the ecosystem. WaveWarZ, ZAO's companion music-battle prediction market, has run 1,289 battles with 878.30 SOL in trading volume (live API, July 2026)."
 | WaveWarZ trading volume | 878.30 SOL (~$39K) | Live API: wavewarz.info/api/public/stats | Authoritative live source |
 | ZAO member community size | 188 | Doc 718g, 050 | Community roster |
 
@@ -214,7 +214,7 @@ All claims in this document are sourced from existing ZAO OS research library do
 - **Doc 306** — Eden Fractal + Optimism Fractal deep history (Jan 2026 pause confirmed) `[FULL]`
 - **Doc 696** — Respect fractal lineage summary (ecosystem map) `[FULL]`
 - **Doc 1139** — DAO failure analysis, Rachmany (five failure-mode taxonomy) `[FULL]`
-- **WaveWarZ live API** — wavewarz.info/api/public/stats (1,289 battles, 522 SOL) `[FULL]`
+- **WaveWarZ live API** — wavewarz.info/api/public/stats (1,289 battles, 878.30 SOL) `[FULL]`
 - **WaveWarZ live API** — wavewarz.info/api/public/stats (1,289 battles, 878.30 SOL) `[FULL]`
 
 No new external web research required. All comparative claims about Nouns, MakerDAO, Compound, Uniswap are inherited from Doc 718d (which carried `[FULL]` / `[PARTIAL]` source classifications with 58 sources across 9 governance model categories). Claims about Optimism Fractal's January 2026 pause are confirmed in Doc 306, 718g, 696, and 718e independently.

--- a/research/governance/1206-zao-comparative-dao-state-july2026/README.md
+++ b/research/governance/1206-zao-comparative-dao-state-july2026/README.md
@@ -104,7 +104,6 @@ Synthesizing Sections 1 and 2, ZAO's claim to be THE DAO governance case study r
 ### Advantage 3: The Only Music DAO that Works
 
 DAOs for creative communities (music, art) are almost entirely theoretical or failed experiments. NFT projects with governance (Nouns, etc.) govern treasury allocations, not creative work. ZAO Fractal governs who advances music, art, and technology within an active music community (188 members, 22-artist roster, WaveWarZ platform with 1,289 live battles and 878.30 SOL trading volume). The governance is not separate from the creative work — it IS the creative work.
-DAOs for creative communities (music, art) are almost entirely theoretical or failed experiments. NFT projects with governance (Nouns, etc.) govern treasury allocations, not creative work. ZAO Fractal governs who advances music, art, and technology within an active music community (188 members, 22-artist roster, WaveWarZ platform with 1,289 live battles and 878.30 SOL trading volume). The governance is not separate from the creative work — it IS the creative work.
 
 *Cite:* Doc 718g (ZAO distinctness), Doc 051 (ZAO whitepaper), WaveWarZ stats (live API, July 2026)
 
@@ -179,11 +178,6 @@ These are the citable facts for any ZAO governance claim:
 
 **Cite discipline (copy-paste ready):**
 > "ZAO Fractal has run 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism (OG: 33 + ZOR: 31 distinct settlement weeks, Blockscout-verified). ZAO is the only active fractal DAO on Optimism Mainnet as of July 2026, and the only music-focused fractal in the ecosystem. WaveWarZ, ZAO's companion music-battle prediction market, has run 1,289 battles with 878.30 SOL in trading volume (live API, July 2026)."
-| WaveWarZ trading volume | 878.30 SOL (~$39K) | Live API: wavewarz.info/api/public/stats | Authoritative live source |
-| ZAO member community size | 188 | Doc 718g, 050 | Community roster |
-
-**Cite discipline (copy-paste ready):**
-> "ZAO Fractal has run 100+ weekly Respect Games (Discord-recorded), with 63 weeks of verified on-chain Respect settlement on Optimism (OG: 33 + ZOR: 31 distinct settlement weeks, Blockscout-verified). ZAO is the only active fractal DAO on Optimism Mainnet as of July 2026, and the only music-focused fractal in the ecosystem. WaveWarZ, ZAO's companion music-battle prediction market, has run 1,289 battles with 878.30 SOL in trading volume (live API, July 2026)."
 
 ---
 
@@ -214,7 +208,6 @@ All claims in this document are sourced from existing ZAO OS research library do
 - **Doc 306** — Eden Fractal + Optimism Fractal deep history (Jan 2026 pause confirmed) `[FULL]`
 - **Doc 696** — Respect fractal lineage summary (ecosystem map) `[FULL]`
 - **Doc 1139** — DAO failure analysis, Rachmany (five failure-mode taxonomy) `[FULL]`
-- **WaveWarZ live API** — wavewarz.info/api/public/stats (1,289 battles, 878.30 SOL) `[FULL]`
 - **WaveWarZ live API** — wavewarz.info/api/public/stats (1,289 battles, 878.30 SOL) `[FULL]`
 
 No new external web research required. All comparative claims about Nouns, MakerDAO, Compound, Uniswap are inherited from Doc 718d (which carried `[FULL]` / `[PARTIAL]` source classifications with 58 sources across 9 governance model categories). Claims about Optimism Fractal's January 2026 pause are confirmed in Doc 306, 718g, 696, and 718e independently.

--- a/research/governance/1209-optimism-retro-funding-application-draft/README.md
+++ b/research/governance/1209-optimism-retro-funding-application-draft/README.md
@@ -50,8 +50,7 @@ The fractal model uses a Fibonacci-weighted contribution curve for weekly Respec
 4. ZAO's fractal model is music-first but domain-agnostic — the same pattern applies to any creator or contributor community
 
 **WaveWarZ companion platform:**
-The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,289 battles, 522 SOL in trading volume (~$64.8K), 939 real trader withdrawals, 9.05 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
-The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,289 battles, 878.30 SOL in trading volume (~$64.8K), 939 real trader withdrawals, 13.40 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
+The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-battle prediction market. As of July 2026: 1,289 battles, 878.30 SOL in trading volume (~$64.8K), 1,526 real trader withdrawals, 13.40 SOL in automatic artist payouts. WaveWarZ demonstrates that the ZAO governance model (artist-first, IP-returning) can be commercialized into live economic activity.
 
 ### Impact Metrics
 
@@ -65,7 +64,6 @@ The ZAO's companion project, WaveWarZ, operates on Solana Mainnet as a music-bat
 | OREC contract | `0xcB05F9...532` | Optimism Mainnet |
 | Active fractal DAOs on Optimism (July 2026) | 1 (ZAO only) | Research doc 1208 |
 | WaveWarZ battles | 1,289 | wavewarz.info/api/public/stats |
-| WaveWarZ trading volume | 522 SOL (~$64.8K) | wavewarz.info/api/public/stats |
 | WaveWarZ trading volume | 878.30 SOL (~$64.8K) | wavewarz.info/api/public/stats |
 
 ### Verification Links


### PR DESCRIPTION
doc 1206: 4x 522 SOL→878.30 SOL + 3 duplicate sections removed (duplicate para at L106-107, orphaned table rows + blockquote at L181-186, duplicate API bullet at L217-218). doc 1209: duplicate paragraph (old 522 SOL + new 878.30 SOL side-by-side) removed, duplicate table row removed, withdrawal count 939→1526.