### PR TITLE
fix: untrack bot/node_modules symlink (unblocks ZOE deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 /node_modules
+**/node_modules
 /.pnp
 .pnp.*
 __pycache__

--- a/bot/node_modules
+++ b/bot/node_modules
@@ -1,1 +1,0 @@
-/Users/zaalpanthaki/Documents/ZAO OS V1/bot/node_modules


### PR DESCRIPTION
## Root cause of ZOE's stuck deploy (self-inflicted, now fixed)

PR #2568 accidentally committed `bot/node_modules` as a **symlink to a Mac path** (`/Users/.../bot/node_modules`). Build worktrees symlink `node_modules` to save space, and `git add -A` swept the symlink in; `.gitignore` only ignored root `/node_modules`, not `bot/node_modules`.

On the VPS live clone that symlink is a dead path and the real npm dir replaces it, so `git status` is **permanently dirty** (`D bot/node_modules`) -> the autodeploy guard skips every cycle -> **ZOE has been stuck ~23 commits behind since noon.** It also explains the flood of "autodeploy SKIPPED: live clone has TRACKED changes" alerts.

### Fix
- `git rm --cached bot/node_modules` - untrack the symlink (the real gitignored dir is untouched).
- `.gitignore`: add `**/node_modules` so nested node_modules can never be tracked again.

Two-line diff, no code touched. After merge: the VPS live clone resets clean to origin/main and ZOE restarts onto current code (all of today's fixes). Workflow lesson captured: never `git add -A` in a worktree with a symlinked node_modules.