### PR TITLE
chore(vercel): skip builds for non-app changes (kills the Build CPU cost)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "fluid": true,
+  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- src public package.json package-lock.json next.config.ts tsconfig.json community.config.ts vercel.json",
   "functions": {
     "src/app/api/auth/verify/route.ts": {
       "memory": 1024,


### PR DESCRIPTION
Vercel was building zaoos.com on every push including doc/bot-only PRs (the $10.90 Build CPU). Adds an ignoreCommand that builds ONLY when src/public/package.json/next.config.ts/tsconfig.json/community.config.ts/vercel.json change. Docs/bot/scripts/.claude/markdown skip the build. Exit 0=skip, non-zero=build; empty previous SHA falls back to build, so app deploys are never wrongly skipped. Makes research docs free again.