### PR TITLE
fix(1454): bracket stale $104K/$1,820 in article lede — verify-on-publish annotation missing

### DIFF
--- a/research/identity/1454-mirror-article-1-zao-story-draft/README.md
+++ b/research/identity/1454-mirror-article-1-zao-story-draft/README.md
@@ -25,7 +25,7 @@
 
 ### The DAO That Makes Losing Pay
 
-**In two years, a music DAO built entirely in public has run 63 consecutive weekly governance sessions, generated $104,000 in trading volume, and paid $1,820 to artists who *lost*. This is what that looks like from the inside.**
+**In two years, a music DAO built entirely in public has run [ZAAL: update week count — was 63 at draft] consecutive weekly governance sessions, generated $[ZAAL: update total_volume_usd — was ~$64,844 at Jul 24 2026 ($73.89/SOL); verify via wavewarz.info/api/public/stats on publish day] in trading volume, and paid $[ZAAL: update artist_payouts_usd — was ~$989 at Jul 24 2026 (13.40 SOL)] to artists who *lost*. This is what that looks like from the inside.**
 
 ---
 


### PR DESCRIPTION
## What

The Mirror Article 1 lede (doc 1454, line 28) had hardcoded `$104,000` and `$1,820` with no `[ZAAL: verify]` annotation. The article body (line 62) already has proper per-publish-day verification instructions, but the lede was missed by PR #2602.

## Problem

If Zaal publishes Aug 1 without editing the lede, these stale dollar amounts go live. At Jul 24 live API prices ($73.89/SOL):
- Total volume: ~$64,844 (not $104,000)
- Artist payouts: ~$989 (not $1,820)

$104,000 appears to be from a prior SOL price (~$119/SOL era). The article body already uses `$[ZAAL: update total_volume_usd]` style placeholders — this PR brings the lede into the same pattern.

## Change

Single line in `research/identity/1454-mirror-article-1-zao-story-draft/README.md`:
- `63 consecutive weekly governance sessions` → `[ZAAL: update week count — was 63 at draft]` (the "63" was the only hardcoded week count not bracketed; lines 46/84/104 already have brackets)
- `generated $104,000 in trading volume` → `generated $[ZAAL: update total_volume_usd — was ~$64,844 at Jul 24 2026 ($73.89/SOL); verify via wavewarz.info/api/public/stats on publish day]`
- `paid $1,820 to artists who *lost*` → `paid $[ZAAL: update artist_payouts_usd — was ~$989 at Jul 24 2026 (13.40 SOL)]`

## Doc 2077 alignment

Uses "Jul 24 2026" and wavewarz.info/api/public/stats as the canonical source, matching doc 2077. No press-facing claims changed — only annotation added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)