### PR TITLE
feat(zoe): bot->agent upgrade - the proactive grill loop

### DIFF
--- a/bot/src/zoe/__tests__/grill.test.ts
+++ b/bot/src/zoe/__tests__/grill.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { toQueue, pickNext, formatGrill, type GrillState } from '../grill';
+import type { CockpitTask, ReviewPR } from '../../cockpit/types';
+
+function task(over: Partial<CockpitTask>): CockpitTask {
+  return {
+    id: '1',
+    title: 'a task',
+    status: 'todo',
+    priority: 'P2',
+    due: null,
+    legacy_id: null,
+    next_owner: null,
+    ...over,
+  } as CockpitTask;
+}
+function pr(over: Partial<ReviewPR>): ReviewPR {
+  return { url: 'https://github.com/x/y/pull/1', title: 'a PR', ...over } as ReviewPR;
+}
+
+const emptyState: GrillState = { items: {}, activeKey: null, lastAskedAt: null };
+
+describe('toQueue', () => {
+  it('includes need-you decisions, review PRs, and blocked - ranked by urgency', () => {
+    const tasks = [
+      task({ id: '1', title: 'P0 decision', priority: 'P0', next_owner: 'me' }),
+      task({ id: '2', title: 'not mine', next_owner: null, priority: 'P2' }), // excluded
+      task({ id: '3', title: 'blocked thing', next_owner: 'blocked' }),
+    ];
+    const prs = [pr({ url: 'u1', title: 'review me' })];
+    const q = toQueue(tasks, prs);
+    const kinds = q.map((i) => i.kind);
+    // P0 decision (0) < review (2) < blocked (3)
+    expect(q[0].title).toBe('P0 decision');
+    expect(kinds).toContain('review');
+    expect(kinds).toContain('blocked');
+    expect(q.map((i) => i.title)).not.toContain('not mine');
+  });
+
+  it('dedupes by key keeping the most urgent', () => {
+    const tasks = [task({ id: '5', legacy_id: 'k', title: 'P1', priority: 'P1', next_owner: 'me' })];
+    const q = toQueue([...tasks, ...tasks], []);
+    expect(q.filter((i) => i.key === 'k')).toHaveLength(1);
+  });
+});
+
+describe('pickNext', () => {
+  const queue = toQueue([task({ id: '1', legacy_id: 'a', title: 'A', priority: 'P0', next_owner: 'me' })], []);
+
+  it('picks a never-asked item', () => {
+    expect(pickNext(queue, emptyState, 1000)?.key).toBe('a');
+  });
+  it('skips a done item', () => {
+    const s: GrillState = { ...emptyState, items: { a: { askedAt: '2026-07-25T00:00:00Z', status: 'done' } } };
+    expect(pickNext(queue, s, Date.now())).toBeNull();
+  });
+  it('does not re-nag an asked item within cooldown', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const s: GrillState = { ...emptyState, items: { a: { askedAt: '2026-07-25T00:00:00Z', status: 'asked' } } };
+    expect(pickNext(queue, s, now + 60_000)).toBeNull(); // 1 min later, still cooling
+    expect(pickNext(queue, s, now + 4 * 3600_000)?.key).toBe('a'); // 4h later, re-surface
+  });
+  it('re-surfaces a skipped item + respects snooze window', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const skipped: GrillState = { ...emptyState, items: { a: { askedAt: '2026-07-25T00:00:00Z', status: 'skipped' } } };
+    expect(pickNext(queue, skipped, now)?.key).toBe('a');
+    const snoozed: GrillState = { ...emptyState, items: { a: { askedAt: '2026-07-25T00:00:00Z', status: 'snoozed', snoozeUntil: '2026-07-25T06:00:00Z' } } };
+    expect(pickNext(queue, snoozed, now + 3600_000)).toBeNull(); // still snoozed
+    expect(pickNext(queue, snoozed, Date.parse('2026-07-25T07:00:00Z'))?.key).toBe('a'); // snooze elapsed
+  });
+});
+
+describe('formatGrill', () => {
+  it('frames a review as build-to-test with a link + remaining counter', () => {
+    const { text, buttons } = formatGrill({ key: 'u', kind: 'review', title: 'PR X', link: 'https://gh/pr/1', priority: 2 }, 3);
+    expect(text).toContain('review/test');
+    expect(text).toContain('https://gh/pr/1');
+    expect(text).toContain('3 more waiting');
+    expect(buttons[0][0].text).toBe('Reviewed');
+    expect(buttons[0].map((b) => b.data)).toEqual(['grill:done', 'grill:skip', 'grill:snooze']);
+  });
+  it('frames a decision plainly with no counter when none remain', () => {
+    const { text } = formatGrill({ key: 'a', kind: 'decision', title: 'pick 1 or 2', priority: 0 }, 0);
+    expect(text).toContain('Decision needed');
+    expect(text).not.toContain('more waiting');
+  });
+});

--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -1,0 +1,178 @@
+/**
+ * grill - the bot->agent upgrade. Instead of waiting to be messaged, ZOE pulls
+ * what actually needs Zaal (cockpit need-you decisions + open PRs to review/test
+ * + blocked items) and DMs him ONE at a time, advancing as he answers. This is
+ * the proactive, goal-directed loop the reactive bot lacked.
+ *
+ * Design:
+ * - Queue is built fresh each tick from the cockpit (single source of truth).
+ * - ONE active item at a time. Buttons act on the active item (Done/Skip/Snooze),
+ *   so callback_data stays tiny (no long PR urls in it).
+ * - State (grill_state.json) records what was asked/answered so it never repeats
+ *   within a cooldown and always advances to the next unanswered item.
+ * - Sends to Zaal's DM, never a group (the old nudge bug).
+ *
+ * Boundary: grill only SURFACES + tracks. It does not act on Zaal's behalf; the
+ * decisions/merges/tests stay his.
+ */
+
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { fetchCockpitTasks, fetchReviewPRs, needsYou, blocked, priorityRank } from '../cockpit/adapters';
+import type { CockpitTask, ReviewPR } from '../cockpit/types';
+
+export type GrillKind = 'decision' | 'review' | 'blocked';
+
+export interface GrillItem {
+  key: string; // stable id: task legacy_id/id, or PR url
+  kind: GrillKind;
+  title: string;
+  link?: string;
+  priority: number; // lower = more urgent
+}
+
+export interface GrillItemState {
+  askedAt: string;
+  status: 'asked' | 'done' | 'skipped' | 'snoozed';
+  snoozeUntil?: string;
+}
+
+export interface GrillState {
+  items: Record<string, GrillItemState>;
+  activeKey: string | null;
+  lastAskedAt: string | null;
+}
+
+const ASK_COOLDOWN_MS = 3 * 60 * 60 * 1000; // don't re-surface a still-open item within 3h
+const SNOOZE_MS = 6 * 60 * 60 * 1000;
+
+const DEFAULT_STATE: GrillState = { items: {}, activeKey: null, lastAskedAt: null };
+const stateFile = () => join(homedir(), '.zao', 'zoe', 'grill_state.json');
+
+export async function readGrillState(): Promise<GrillState> {
+  try {
+    const raw = await fs.readFile(stateFile(), 'utf8');
+    return { ...DEFAULT_STATE, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+export async function writeGrillState(s: GrillState): Promise<void> {
+  await fs.mkdir(join(homedir(), '.zao', 'zoe'), { recursive: true });
+  await fs.writeFile(stateFile(), JSON.stringify(s, null, 2));
+}
+
+/** Build the ranked grill queue from cockpit tasks + review PRs. Pure. */
+export function toQueue(tasks: CockpitTask[], prs: ReviewPR[]): GrillItem[] {
+  const decisions: GrillItem[] = needsYou(tasks).map((t) => ({
+    key: t.legacy_id ?? String(t.id),
+    kind: 'decision',
+    title: t.title,
+    priority: priorityRank(t.priority),
+  }));
+  const reviews: GrillItem[] = prs.map((p) => ({
+    key: p.url,
+    kind: 'review',
+    title: p.title,
+    link: p.url,
+    priority: 2, // a PR waiting on you sits at P2 urgency
+  }));
+  const blk: GrillItem[] = blocked(tasks).map((t) => ({
+    key: t.legacy_id ?? String(t.id),
+    kind: 'blocked',
+    title: t.title,
+    priority: 3,
+  }));
+  // dedupe by key, keep the most-urgent instance
+  const byKey = new Map<string, GrillItem>();
+  for (const it of [...decisions, ...reviews, ...blk]) {
+    const cur = byKey.get(it.key);
+    if (!cur || it.priority < cur.priority) byKey.set(it.key, it);
+  }
+  return [...byKey.values()].sort((a, b) => a.priority - b.priority);
+}
+
+/** Pick the next item to grill: most urgent that is not done and not on cooldown/snooze. */
+export function pickNext(queue: GrillItem[], state: GrillState, now: number): GrillItem | null {
+  for (const item of queue) {
+    const s = state.items[item.key];
+    if (!s) return item; // never asked
+    if (s.status === 'done') continue;
+    if (s.status === 'snoozed' && s.snoozeUntil && Date.parse(s.snoozeUntil) > now) continue;
+    if (s.status === 'asked' && now - Date.parse(s.askedAt) < ASK_COOLDOWN_MS) continue; // waiting on a reply, don't nag yet
+    return item; // skipped / cooled-down / snooze-elapsed -> re-surface
+  }
+  return null;
+}
+
+/** Format the DM text + inline buttons for one grill item. Pure. */
+export function formatGrill(
+  item: GrillItem,
+  remaining: number,
+): { text: string; buttons: { text: string; data: string }[][] } {
+  const lead =
+    item.kind === 'review'
+      ? `Built and waiting on you - review/test:\n${item.title}`
+      : item.kind === 'blocked'
+        ? `Blocked, needs you to unblock:\n${item.title}`
+        : `Decision needed:\n${item.title}`;
+  const link = item.link ? `\n${item.link}` : '';
+  const tail = remaining > 0 ? `\n\n${remaining} more waiting under this - answer and the next pops up.` : '';
+  const doneLabel = item.kind === 'review' ? 'Reviewed' : 'Done';
+  const buttons = [
+    [
+      { text: doneLabel, data: 'grill:done' },
+      { text: 'Skip', data: 'grill:skip' },
+      { text: 'Later', data: 'grill:snooze' },
+    ],
+  ];
+  return { text: `${lead}${link}${tail}`, buttons };
+}
+
+export interface SurfaceGrillDeps {
+  sendDM: (text: string, buttons: { text: string; data: string }[][]) => Promise<unknown>;
+  now?: number;
+  /** Injectable fetchers for tests. */
+  fetchTasks?: () => Promise<CockpitTask[]>;
+  fetchPRs?: () => Promise<ReviewPR[]>;
+}
+
+/** One proactive tick: DM Zaal the next item that needs him. Returns what it did. */
+export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: boolean; item?: GrillItem }> {
+  const now = deps.now ?? Date.now();
+  const tasks = await (deps.fetchTasks ?? fetchCockpitTasks)();
+  const prs = await (deps.fetchPRs ?? fetchReviewPRs)().catch(() => [] as ReviewPR[]);
+  const queue = toQueue(tasks, prs);
+  const state = await readGrillState();
+  const item = pickNext(queue, state, now);
+  if (!item) return { sent: false };
+
+  const remaining = queue.filter((q) => {
+    const s = state.items[q.key];
+    return q.key !== item.key && (!s || s.status !== 'done');
+  }).length;
+
+  const { text, buttons } = formatGrill(item, remaining);
+  await deps.sendDM(text, buttons);
+
+  state.items[item.key] = { askedAt: new Date(now).toISOString(), status: 'asked' };
+  state.activeKey = item.key;
+  state.lastAskedAt = new Date(now).toISOString();
+  await writeGrillState(state);
+  return { sent: true, item };
+}
+
+/** Apply a button action to the currently-active grill item. */
+export async function applyGrillAction(action: 'done' | 'skip' | 'snooze', now = Date.now()): Promise<string> {
+  const state = await readGrillState();
+  const key = state.activeKey;
+  if (!key || !state.items[key]) return 'Nothing active.';
+  if (action === 'done') state.items[key] = { ...state.items[key], status: 'done' };
+  else if (action === 'skip') state.items[key] = { ...state.items[key], status: 'skipped' };
+  else state.items[key] = { ...state.items[key], status: 'snoozed', snoozeUntil: new Date(now + SNOOZE_MS).toISOString() };
+  state.activeKey = null;
+  await writeGrillState(state);
+  return action === 'done' ? 'Done - next one coming.' : action === 'skip' ? 'Skipped.' : 'Snoozed for a bit.';
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -19,6 +19,7 @@ loadEnv();
 
 import { Bot, Context, InlineKeyboard } from 'grammy';
 import { BUTTON_BAR, ZOE_COMMANDS, isBarLabel } from './button-bar';
+import { surfaceGrill, applyGrillAction } from './grill';
 import type { Client } from 'discord.js';
 import { bootDiscordClient } from './discord';
 import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, type TaskStatus } from '../lib/cowork';
@@ -393,6 +394,24 @@ bot.command('start', async (ctx) => {
 bot.command('menu', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   await ctx.reply('Cockpit bar ready - tap below.', { reply_markup: BUTTON_BAR });
+});
+
+// The agent's proactive grill: DM Zaal the next thing that needs him, one at a
+// time. Sends to his DM (never a group). Reused by /grill and the scheduler cron.
+function grillSendDM(chatId: number) {
+  return (text: string, buttons: { text: string; data: string }[][]) =>
+    bot.api.sendMessage(chatId, text, {
+      reply_markup: {
+        inline_keyboard: buttons.map((row) => row.map((b) => ({ text: b.text, callback_data: b.data }))),
+      },
+    });
+}
+
+// /grill - surface the next item that needs you, on demand (also runs on a cron).
+bot.command('grill', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const r = await surfaceGrill({ sendDM: grillSendDM(zaalId) });
+  if (!r.sent) await ctx.reply('Nothing needs you right now - the queue is clear.');
 });
 
 // /chatid - report this chat's id + (in a forum topic) its topic thread id, so
@@ -2695,6 +2714,20 @@ async function applyLearnProposals(
   );
   console.log(`[zoe/index] learnings applied: ${applied.join(', ')}`);
 }
+
+// Grill buttons (Done / Skip / Later) act on the active grill item, then the
+// next item pops immediately - the "answer and the next one comes" behavior.
+bot.callbackQuery(/^grill:(done|skip|snooze)$/, async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const action = ctx.match[1] as 'done' | 'skip' | 'snooze';
+  const note = await applyGrillAction(action);
+  await ctx.answerCallbackQuery({ text: note }).catch(() => {});
+  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  // Advance: surface the next item that needs him.
+  await surfaceGrill({ sendDM: grillSendDM(zaalId) }).catch((e) =>
+    console.error('[zoe/grill] advance failed:', (e as Error)?.message),
+  );
+});
 
 bot.callbackQuery(/^nudge:(now|later|shelve)$/, async (ctx) => {
   const action = ctx.match[1];

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -40,6 +40,7 @@ import { surfaceNewHandoffs } from './handoffs-surface';
 import { surfaceZaostockApprovals } from './zaostock-approvals-surface';
 import { runOrchestratorTick } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
+import { surfaceGrill } from './grill';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
@@ -163,6 +164,36 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         } catch (err) {
           await releaseFire('morning-brief');
           console.error('[zoe/scheduler] morning brief failed:', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // The AGENT grill loop (bot->agent upgrade). Every 2 hours during waking hours
+  // (10:00-01:00 UTC ~= 6am-9pm ET), DM Zaal the next thing that needs him - one
+  // at a time, to his DM. This is what makes ZOE proactive instead of reactive:
+  // it comes to him with decisions + builds-to-test, he answers, the next pops.
+  // Defensive: surfaceGrill only sends if there is an unanswered item + honours
+  // its own cooldown, so it never nags.
+  tasks.push(
+    cron.schedule(
+      '0 10-23,0,1 * * *',
+      async () => {
+        try {
+          const r = await surfaceGrill({
+            sendDM: (text, buttons) =>
+              opts.bot.api.sendMessage(opts.zaalTgId, text, {
+                reply_markup: {
+                  inline_keyboard: buttons.map((row) =>
+                    row.map((b) => ({ text: b.text, callback_data: b.data })),
+                  ),
+                },
+              }),
+          });
+          if (r.sent) console.log(`[zoe/scheduler] grilled Zaal: ${r.item?.kind} - ${r.item?.title?.slice(0, 50)}`);
+        } catch (err) {
+          console.warn('[zoe/scheduler] grill tick failed (nbd):', (err as Error).message);
         }
       },
       { timezone: 'UTC' },


### PR DESCRIPTION
## Bot -> Agent: the proactive grill loop

The failure last night: ZOE is reactive - it waits to be messaged, and its proactive output leaks to a group, so nothing reached Zaal's DM and nothing continued. This makes ZOE come to him.

- **`grill.ts`** - builds a ranked queue from the cockpit (need-you decisions + open PRs to review/test + blocked), DMs Zaal **one at a time to his DM**. Buttons (Done/Skip/Later) act on the active item; `grill_state.json` tracks asked/answered so it advances and never nags (3h cooldown, 6h snooze). `toQueue`/`pickNext`/`formatGrill` unit-tested (8 cases).
- **index.ts** - `/grill` (on-demand) + the `grill:*` callback that marks the active item and **immediately surfaces the next** ("answer and the next pops up"). Works because #2571 un-swallowed callbacks.
- **scheduler.ts** - a cron every 2h during waking hours that DMs the next item. Only sends when something's unanswered.

Both decisions and builds-to-test flow to his DM. Verified: grill 8/8, esbuild clean, tsc zero new errors. Deploys build-free.