### PR TITLE
feat(zoe/grill): one-click answers - the decision options ARE the buttons

### DIFF
--- a/bot/src/zoe/__tests__/grill.test.ts
+++ b/bot/src/zoe/__tests__/grill.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toQueue, pickNext, formatGrill, type GrillState } from '../grill';
+import { toQueue, pickNext, formatGrill, parseOptions, type GrillState } from '../grill';
 import type { CockpitTask, ReviewPR } from '../../cockpit/types';
 
 function task(over: Partial<CockpitTask>): CockpitTask {
@@ -85,3 +85,39 @@ describe('formatGrill', () => {
     expect(text).not.toContain('more waiting');
   });
 });
+
+describe('parseOptions (one-click)', () => {
+  it('parses numbered options with labels', () => {
+    const o = parseOptions('Creator Studio: pick 1 (intro test) / 2 (map) / 3 (both)');
+    expect(o.map((x) => x.value)).toEqual(['1', '2', '3']);
+    expect(o[0].label).toBe('1: intro test');
+    expect(o[2].label).toBe('3: both');
+  });
+  it('parses word options', () => {
+    expect(parseOptions('Publish the box: publish / hold').map((x) => x.value)).toEqual(['publish', 'hold']);
+    expect(parseOptions('yes / no').map((x) => x.value)).toEqual(['yes', 'no']);
+  });
+  it('returns [] when there is no clean option set', () => {
+    expect(parseOptions('Finish the whitepaper docs and schedule the stream')).toEqual([]);
+    expect(parseOptions('a / b / c / d / e')).toEqual([]); // >4
+    expect(parseOptions('review this long descriptive title with slashes / and more prose here that is too long')).toEqual([]);
+  });
+});
+
+describe('formatGrill one-click buttons', () => {
+  it('renders the actual options as answer buttons for a decision', () => {
+    const { buttons } = formatGrill(
+      { key: 'k', kind: 'decision', title: 'Creator Studio: pick 1 (intro test) / 2 (map) / 3 (both)', priority: 0 },
+      5,
+    );
+    // first row = the 3 answer options, mapped to grill:ans:<value>
+    expect(buttons[0].map((b) => b.data)).toEqual(['grill:ans:1', 'grill:ans:2', 'grill:ans:3']);
+    expect(buttons[0][0].text).toBe('1: intro test');
+    // second row = Skip / Later
+    expect(buttons[1].map((b) => b.data)).toEqual(['grill:skip', 'grill:snooze']);
+  });
+  it('falls back to Done/Skip/Later when a decision has no options', () => {
+    const { buttons } = formatGrill({ key: 'k', kind: 'decision', title: 'Onboard Brandon to Discord', priority: 1 }, 0);
+    expect(buttons[0].map((b) => b.data)).toEqual(['grill:done', 'grill:skip', 'grill:snooze']);
+  });
+})

--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -36,12 +36,47 @@ export interface GrillItemState {
   askedAt: string;
   status: 'asked' | 'done' | 'skipped' | 'snoozed';
   snoozeUntil?: string;
+  /** The one-click answer Zaal chose, if any. */
+  answer?: string;
 }
 
 export interface GrillState {
   items: Record<string, GrillItemState>;
   activeKey: string | null;
+  activeTitle?: string | null;
   lastAskedAt: string | null;
+}
+
+/**
+ * Extract one-click answer options from a decision title, if it cleanly has any.
+ * Handles "pick 1 (intro) / 2 (map) / 3 (both)", "yes / no", "publish / hold".
+ * Returns [] when there is no clean 2-4 option set (falls back to Done/Skip/Later).
+ */
+export function parseOptions(title: string): { value: string; label: string }[] {
+  const body = title.includes(':') ? title.slice(title.lastIndexOf(':') + 1) : title;
+  const parts = body
+    .split('/')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length < 2 || parts.length > 4) return [];
+  const opts: { value: string; label: string }[] = [];
+  for (const part of parts) {
+    const num = part.match(/^(?:pick\s+)?(\d+)\s*(?:\(([^)]+)\))?/i);
+    if (num) {
+      const v = num[1];
+      const paren = num[2]?.trim();
+      opts.push({ value: v, label: paren ? `${v}: ${paren}` : v });
+      continue;
+    }
+    const word = part.replace(/[()]/g, '').trim();
+    if (/^[A-Za-z][A-Za-z0-9 -]{0,13}$/.test(word)) {
+      opts.push({ value: word.toLowerCase().split(' ')[0], label: word });
+      continue;
+    }
+    return []; // a part did not parse cleanly -> generic buttons
+  }
+  if (new Set(opts.map((o) => o.value)).size !== opts.length) return []; // colliding values
+  return opts;
 }
 
 const ASK_COOLDOWN_MS = 3 * 60 * 60 * 1000; // don't re-surface a still-open item within 3h
@@ -120,14 +155,24 @@ export function formatGrill(
         : `Decision needed:\n${item.title}`;
   const link = item.link ? `\n${item.link}` : '';
   const tail = remaining > 0 ? `\n\n${remaining} more waiting under this - answer and the next pops up.` : '';
-  const doneLabel = item.kind === 'review' ? 'Reviewed' : 'Done';
-  const buttons = [
-    [
-      { text: doneLabel, data: 'grill:done' },
-      { text: 'Skip', data: 'grill:skip' },
-      { text: 'Later', data: 'grill:snooze' },
-    ],
-  ];
+
+  // If the decision has baked-in options ("pick 1/2/3", "yes/no"), make THOSE
+  // the buttons so Zaal answers in one tap. Otherwise generic Done/Skip/Later.
+  const options = item.kind === 'decision' ? parseOptions(item.title) : [];
+  let buttons: { text: string; data: string }[][];
+  if (options.length >= 2) {
+    const answerRow = options.map((o) => ({ text: o.label.slice(0, 28), data: `grill:ans:${o.value}`.slice(0, 60) }));
+    buttons = [answerRow, [{ text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }]];
+  } else {
+    const doneLabel = item.kind === 'review' ? 'Reviewed' : 'Done';
+    buttons = [
+      [
+        { text: doneLabel, data: 'grill:done' },
+        { text: 'Skip', data: 'grill:skip' },
+        { text: 'Later', data: 'grill:snooze' },
+      ],
+    ];
+  }
   return { text: `${lead}${link}${tail}`, buttons };
 }
 
@@ -159,6 +204,7 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
 
   state.items[item.key] = { askedAt: new Date(now).toISOString(), status: 'asked' };
   state.activeKey = item.key;
+  state.activeTitle = item.title;
   state.lastAskedAt = new Date(now).toISOString();
   await writeGrillState(state);
   return { sent: true, item };
@@ -175,4 +221,24 @@ export async function applyGrillAction(action: 'done' | 'skip' | 'snooze', now =
   state.activeKey = null;
   await writeGrillState(state);
   return action === 'done' ? 'Done - next one coming.' : action === 'skip' ? 'Skipped.' : 'Snoozed for a bit.';
+}
+
+/**
+ * Record a one-click ANSWER to the active grill item (e.g. Zaal tapped "2 (map)").
+ * Marks it done + stores the answer, and returns the key/title/value so the caller
+ * can log the decision where ZOE's brain + loops will act on it.
+ */
+export async function applyGrillAnswer(
+  value: string,
+  now = Date.now(),
+): Promise<{ note: string; key: string | null; title: string | null; value: string }> {
+  const state = await readGrillState();
+  const key = state.activeKey;
+  const title = state.activeTitle ?? null;
+  if (!key || !state.items[key]) return { note: 'Nothing active to answer.', key: null, title: null, value };
+  state.items[key] = { ...state.items[key], status: 'done', answer: value };
+  state.activeKey = null;
+  state.activeTitle = null;
+  await writeGrillState(state);
+  return { note: `Locked in: ${value}. Next one coming.`, key, title, value };
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -19,7 +19,7 @@ loadEnv();
 
 import { Bot, Context, InlineKeyboard } from 'grammy';
 import { BUTTON_BAR, ZOE_COMMANDS, isBarLabel } from './button-bar';
-import { surfaceGrill, applyGrillAction } from './grill';
+import { surfaceGrill, applyGrillAction, applyGrillAnswer } from './grill';
 import type { Client } from 'discord.js';
 import { bootDiscordClient } from './discord';
 import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, type TaskStatus } from '../lib/cowork';
@@ -2714,6 +2714,27 @@ async function applyLearnProposals(
   );
   console.log(`[zoe/index] learnings applied: ${applied.join(', ')}`);
 }
+
+// One-click ANSWER: for a decision with baked-in options (pick 1/2/3, yes/no),
+// the buttons ARE the options. Tapping records the answer, logs the decision so
+// ZOE's brain + loops act on it, then surfaces the next item.
+bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const value = ctx.match[1];
+  const r = await applyGrillAnswer(value);
+  await ctx.answerCallbackQuery({ text: r.note }).catch(() => {});
+  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  if (r.key) {
+    const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    await pushRecent(
+      { from: 'zaal', text: `[grill-answer] ${r.title ?? r.key}: ${value}`, sender: 'grill' },
+      String(gid || zaalId),
+    ).catch((e) => console.error('[zoe/grill] answer log failed:', (e as Error)?.message));
+  }
+  await surfaceGrill({ sendDM: grillSendDM(zaalId) }).catch((e) =>
+    console.error('[zoe/grill] advance failed:', (e as Error)?.message),
+  );
+});
 
 // Grill buttons (Done / Skip / Later) act on the active grill item, then the
 // next item pops immediately - the "answer and the next one comes" behavior.


### PR DESCRIPTION
Zaal wanted to answer a decision (pick 1/2/3) in one tap. Now the grill parses baked-in options from a decision title and renders THEM as the buttons (grill:ans:<value>), with Skip/Later. Tapping records the answer, logs the decision to recent/ so ZOE acts on it, and advances to the next. Falls back to Done/Skip/Later when there's no clean option set. Tests 13/13, esbuild clean, zero new type errors. Deploys build-free.