### PR TITLE
fix(strategy): CI owns the research index - stop doc PRs colliding

### DIFF
--- a/.github/workflows/research-index.yml
+++ b/.github/workflows/research-index.yml
@@ -1,32 +1,52 @@
-name: Research index guard
-
-# The pre-commit hook checks a committer's OWN staged docs, so a research doc can
-# still land on main missing its folder-index row (e.g. when a branch's index-row
-# edit is dropped in a merge conflict) and then linger unindexed with nothing at
-# merge time to catch it - happened with docs 1076, 1174, and 1176, each found and
-# repaired only later by a manual `--all` audit. This runs that full --all audit on
-# every PR that touches research/, so an unindexed doc fails CI before it can merge.
+name: Research index (CI-owned)
+# CI OWNS the research folder index so PRs never hand-edit the shared
+# research/<topic>/README.md (which made concurrent doc PRs collide and stall).
 #
-# The push trigger below re-runs --all AFTER every merge into main so that a
-# squash-merge that drops a folder-index row (conflict between two agents both
-# appending to the same README) shows as a failing check on main rather than
-# silently becoming a gap discovered only on the next PR.
+# - On push to main: backfill any missing index rows and commit them back
+#   ([skip ci] so it does not loop). The index self-heals; PRs do not touch it.
+# - On a PR: advisory only. It reports unindexed docs as a warning but NEVER
+#   blocks - the merge will backfill them. This replaces the old blocking
+#   check-research-index guard that forced every PR to add its own row.
 on:
   pull_request:
     paths:
       - 'research/**'
-      - 'scripts/check-research-index.sh'
   push:
     branches:
       - main
     paths:
       - 'research/**'
-      - 'scripts/check-research-index.sh'
-
+      - 'scripts/backfill-research-index.sh'
+permissions:
+  contents: write
 jobs:
   research-index:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Every research doc must be listed in its folder index
-        run: bash scripts/check-research-index.sh --all
+      - name: Backfill missing folder-index rows
+        run: bash scripts/backfill-research-index.sh
+
+      - name: Commit backfilled rows (main only, never fatal)
+        if: github.event_name == 'push'
+        run: |
+          if ! git diff --quiet -- research; then
+            git config user.name "zao-index-bot"
+            git config user.email "zao-index-bot@users.noreply.github.com"
+            git add research/*/README.md
+            git commit -m "chore(research): CI backfill folder index rows [skip ci]"
+            git push || echo "::warning::index backfill could not push (branch protection?) - nightly backfill will catch it"
+          else
+            echo "index already complete"
+          fi
+
+      - name: Advisory index report (PRs never block on this)
+        if: github.event_name == 'pull_request'
+        run: |
+          # PRs no longer need to add their own index row - CI backfills on merge.
+          # Surface anything unindexed as a non-blocking warning only.
+          if bash scripts/check-research-index.sh --all; then
+            echo "index complete"
+          else
+            echo "::warning::some docs not yet in their folder index - CI will backfill on merge (non-blocking)"
+          fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,6 +8,7 @@ bash "$(git rev-parse --show-toplevel)/scripts/check-research-doc-collisions.sh"
 # 2. Block secrets in the staged diff (.claude/rules/secret-hygiene.md, doc 683).
 bash "$(git rev-parse --show-toplevel)/scripts/git-secret-scan.sh" || exit 1
 
-# 3. Block research/ index drift: a newly added doc must be listed in its
-#    folder README. From the 2026-06-06 session that backfilled 313+ rows.
-bash "$(git rev-parse --show-toplevel)/scripts/check-research-index.sh" || exit 1
+# 3. Research index is now CI-OWNED (research-index.yml backfills on merge), so a
+#    missing folder-index row NO LONGER blocks a commit - PRs must not hand-edit
+#    the shared README (that caused concurrent doc PRs to collide). Advisory only.
+bash "$(git rev-parse --show-toplevel)/scripts/check-research-index.sh" || echo "[research-index] note: doc(s) not indexed yet - CI backfills on merge (not blocking)"

--- a/scripts/backfill-research-index.sh
+++ b/scripts/backfill-research-index.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# backfill-research-index.sh - CI OWNS the research folder index.
+#
+# The old model made every research doc PR hand-append its own row to the shared
+# research/<topic>/README.md index. When several doc PRs were open at once they
+# all appended to the same file and COLLIDED on merge (GitHub cannot run a union
+# merge driver), which is why doc PRs kept getting stuck with conflicts.
+#
+# New model: PRs do NOT touch the index. This script backfills every missing row
+# and runs in CI on push-to-main (and can be run manually / nightly). Idempotent,
+# additive-only, and it never rewrites existing rows - so it cannot cause a noisy
+# reformat. Same row format as the retired skill helper add-index-row.sh.
+#
+# Usage: backfill-research-index.sh [repo-root]
+# Exit 0 always (advisory). Prints what it backfilled; sets no error on a clean index.
+set -uo pipefail
+REPO="${1:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[ -d "$REPO/research" ] || { echo "[backfill-index] no research/ dir, skipping"; exit 0; }
+
+changed=0
+for docdir in "$REPO"/research/*/[0-9]*-*/; do
+  [ -d "$docdir" ] || continue
+  docdir="${docdir%/}"
+  slug="$(basename "$docdir")"
+  case "$slug" in _*) continue ;; esac
+  num="$(printf '%s' "$slug" | grep -oE '^[0-9]{3,4}')"
+  [ -n "$num" ] || continue
+  readme="$docdir/README.md"; [ -f "$readme" ] || continue
+  topic_readme="$(dirname "$docdir")/README.md"; [ -f "$topic_readme" ] || continue
+  # already indexed? (either the link or a leading "| <num> |" row)
+  grep -qF "(./$slug/)" "$topic_readme" && continue
+  grep -qE "^\|[[:space:]]*$num[[:space:]]*\|" "$topic_readme" && continue
+  # derive the row from the doc's own H1 + Goal line (same as add-index-row.sh)
+  title="$(grep -m1 -E '^#[[:space:]]+[0-9]{3,4}' "$readme" | sed -E 's/^#[[:space:]]+[0-9]{3,4}[[:space:]]*[—-][[:space:]]*//' || true)"
+  [ -n "$title" ] || title="$(grep -m1 -E '^#[[:space:]]+' "$readme" | sed -E 's/^#[[:space:]]+//' || true)"
+  [ -n "$title" ] || title="Doc $num"
+  summary="$(grep -m1 -E '^>[[:space:]]*\*\*Goal:\*\*' "$readme" | sed -E 's/^>[[:space:]]*\*\*Goal:\*\*[[:space:]]*//' || true)"
+  [ -n "$summary" ] || summary="Research doc $num."
+  title="${title//|/-}"; summary="${summary//|/-}"
+  [ -z "$(tail -c1 "$topic_readme")" ] || printf '\n' >> "$topic_readme"
+  printf '| %s | [%s](./%s/) | STANDALONE | %s |\n' "$num" "$title" "$slug" "$summary" >> "$topic_readme"
+  echo "[backfill-index] backfilled doc $num -> $(basename "$(dirname "$docdir")")/README.md"
+  changed=1
+done
+[ "$changed" = 0 ] && echo "[backfill-index] index already complete"
+exit 0


### PR DESCRIPTION
The durable 'too many PRs' fix. Doc PRs hand-appended rows to the shared folder README -> concurrent ones collided on merge (today's #2510/#2512/#2561). Now CI backfills the index on merge (scripts/backfill-research-index.sh, additive+idempotent, verified on 11 real gaps), the pre-commit + PR check are advisory (never block), so PRs never touch the shared index and stop colliding. Pairs with daily-batching to cut PR count at the source.