### PR TITLE
fix(zoe/grill): pin only the open question (unpin on answer)

### DIFF
--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -44,6 +44,8 @@ export interface GrillState {
   items: Record<string, GrillItemState>;
   activeKey: string | null;
   activeTitle?: string | null;
+  /** message_id of the pinned open question, so we can unpin it on answer. */
+  activeMessageId?: number | null;
   lastAskedAt: string | null;
 }
 
@@ -177,8 +179,12 @@ export function formatGrill(
 }
 
 export interface SurfaceGrillDeps {
-  sendDM: (text: string, buttons: { text: string; data: string }[][]) => Promise<unknown>;
+  /** Send the DM; returns the sent message so we can pin it. */
+  sendDM: (text: string, buttons: { text: string; data: string }[][]) => Promise<{ message_id?: number } | unknown>;
   now?: number;
+  /** Pin the open question so ONLY it is pinned; unpin the previous one. Optional. */
+  pin?: (messageId: number) => Promise<unknown>;
+  unpin?: (messageId: number) => Promise<unknown>;
   /** Injectable fetchers for tests. */
   fetchTasks?: () => Promise<CockpitTask[]>;
   fetchPRs?: () => Promise<ReviewPR[]>;
@@ -199,12 +205,20 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
     return q.key !== item.key && (!s || s.status !== 'done');
   }).length;
 
+  // Unpin the previous open question so at most ONE question is ever pinned.
+  if (deps.unpin && state.activeMessageId) await deps.unpin(state.activeMessageId).catch(() => {});
+
   const { text, buttons } = formatGrill(item, remaining);
-  await deps.sendDM(text, buttons);
+  const sent = (await deps.sendDM(text, buttons)) as { message_id?: number } | undefined;
+  const messageId = sent && typeof sent === 'object' ? sent.message_id : undefined;
+
+  // Pin the new open question (silent) so it stays easy to find until answered.
+  if (deps.pin && messageId) await deps.pin(messageId).catch(() => {});
 
   state.items[item.key] = { askedAt: new Date(now).toISOString(), status: 'asked' };
   state.activeKey = item.key;
   state.activeTitle = item.title;
+  state.activeMessageId = messageId ?? null;
   state.lastAskedAt = new Date(now).toISOString();
   await writeGrillState(state);
   return { sent: true, item };
@@ -219,6 +233,7 @@ export async function applyGrillAction(action: 'done' | 'skip' | 'snooze', now =
   else if (action === 'skip') state.items[key] = { ...state.items[key], status: 'skipped' };
   else state.items[key] = { ...state.items[key], status: 'snoozed', snoozeUntil: new Date(now + SNOOZE_MS).toISOString() };
   state.activeKey = null;
+  state.activeMessageId = null;
   await writeGrillState(state);
   return action === 'done' ? 'Done - next one coming.' : action === 'skip' ? 'Skipped.' : 'Snoozed for a bit.';
 }
@@ -239,6 +254,7 @@ export async function applyGrillAnswer(
   state.items[key] = { ...state.items[key], status: 'done', answer: value };
   state.activeKey = null;
   state.activeTitle = null;
+  state.activeMessageId = null;
   await writeGrillState(state);
   return { note: `Locked in: ${value}. Next one coming.`, key, title, value };
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -396,21 +396,27 @@ bot.command('menu', async (ctx) => {
   await ctx.reply('Cockpit bar ready - tap below.', { reply_markup: BUTTON_BAR });
 });
 
-// The agent's proactive grill: DM Zaal the next thing that needs him, one at a
-// time. Sends to his DM (never a group). Reused by /grill and the scheduler cron.
-function grillSendDM(chatId: number) {
-  return (text: string, buttons: { text: string; data: string }[][]) =>
-    bot.api.sendMessage(chatId, text, {
-      reply_markup: {
-        inline_keyboard: buttons.map((row) => row.map((b) => ({ text: b.text, callback_data: b.data }))),
-      },
-    });
+// The agent's proactive grill deps: DM Zaal the next thing that needs him, one at
+// a time, to his DM (never a group). PIN the open question (and unpin the prior
+// one) so ONLY the question awaiting his answer is ever pinned. Reused by /grill,
+// the callbacks, and the scheduler cron.
+function grillDeps(chatId: number) {
+  return {
+    sendDM: (text: string, buttons: { text: string; data: string }[][]) =>
+      bot.api.sendMessage(chatId, text, {
+        reply_markup: {
+          inline_keyboard: buttons.map((row) => row.map((b) => ({ text: b.text, callback_data: b.data }))),
+        },
+      }),
+    pin: (messageId: number) => bot.api.pinChatMessage(chatId, messageId, { disable_notification: true }),
+    unpin: (messageId: number) => bot.api.unpinChatMessage(chatId, messageId),
+  };
 }
 
 // /grill - surface the next item that needs you, on demand (also runs on a cron).
 bot.command('grill', async (ctx) => {
   if (!isFromZaal(ctx)) return;
-  const r = await surfaceGrill({ sendDM: grillSendDM(zaalId) });
+  const r = await surfaceGrill(grillDeps(zaalId));
   if (!r.sent) await ctx.reply('Nothing needs you right now - the queue is clear.');
 });
 
@@ -2724,6 +2730,8 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
   const r = await applyGrillAnswer(value);
   await ctx.answerCallbackQuery({ text: r.note }).catch(() => {});
   await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  // Unpin the answered question - only OPEN questions stay pinned.
+  { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
   if (r.key) {
     const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
     await pushRecent(
@@ -2731,7 +2739,7 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
       String(gid || zaalId),
     ).catch((e) => console.error('[zoe/grill] answer log failed:', (e as Error)?.message));
   }
-  await surfaceGrill({ sendDM: grillSendDM(zaalId) }).catch((e) =>
+  await surfaceGrill(grillDeps(zaalId)).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),
   );
 });
@@ -2744,8 +2752,10 @@ bot.callbackQuery(/^grill:(done|skip|snooze)$/, async (ctx) => {
   const note = await applyGrillAction(action);
   await ctx.answerCallbackQuery({ text: note }).catch(() => {});
   await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  // Unpin the answered question - only OPEN questions stay pinned.
+  { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
   // Advance: surface the next item that needs him.
-  await surfaceGrill({ sendDM: grillSendDM(zaalId) }).catch((e) =>
+  await surfaceGrill(grillDeps(zaalId)).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),
   );
 });

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -190,6 +190,8 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
                   ),
                 },
               }),
+            pin: (mid) => opts.bot.api.pinChatMessage(opts.zaalTgId, mid, { disable_notification: true }),
+            unpin: (mid) => opts.bot.api.unpinChatMessage(opts.zaalTgId, mid),
           });
           if (r.sent) console.log(`[zoe/scheduler] grilled Zaal: ${r.item?.kind} - ${r.item?.title?.slice(0, 50)}`);
         } catch (err) {


### PR DESCRIPTION
Zaal's DMs were cluttered with pins. Now the grill pins at most ONE message - the question awaiting his answer - and unpins it the moment he answers (and unpins the prior open one before pinning a new). Cleared the existing clutter via unpinAllChatMessages. grill 13/13, esbuild clean, zero new type errors. Deploys build-free.