### PR TITLE
feat(zoe/grill): a resolve path - reply or Approve actually acts + clears the board

### DIFF
--- a/bot/src/cockpit/adapters.ts
+++ b/bot/src/cockpit/adapters.ts
@@ -314,3 +314,63 @@ export async function applyWriteProposal(p: WriteProposal): Promise<{ ok: boolea
     return { ok: false, error: e instanceof Error ? e.message : 'patch failed' };
   }
 }
+
+/**
+ * Resolve a grilled decision ON THE BOARD: record Zaal's call in the task's
+ * metadata + notes and hand execution to the agent lane (next_owner='agent') so
+ * it LEAVES his needs-you queue. Without this, answering a grill only cleared
+ * ZOE's local state - the source task stayed "needs you" on the board forever.
+ *
+ * `key` is the grill key (a task id or legacy_id). A PR url is ignored (PRs are
+ * resolved by merge, not here). Metadata is GET-merged so existing keys survive.
+ * Best-effort: returns {ok:false,...} on any miss rather than throwing.
+ */
+export async function resolveTaskDecision(
+  key: string,
+  decision: string,
+): Promise<{ ok: boolean; error?: string }> {
+  if (/^https?:\/\//.test(key)) return { ok: false, error: 'pr-not-task' };
+  const base = process.env.COWORK_TRACKER_URL;
+  const apiKey = process.env.COWORK_TRACKER_KEY;
+  if (!base || !apiKey) return { ok: false, error: 'tracker not configured' };
+  const root = base.replace(/\/$/, '');
+  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` };
+
+  const fetchRow = async (col: string): Promise<RawRow | null> => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      const res = await fetch(
+        `${root}/rest/v1/tasks?${col}=eq.${encodeURIComponent(key)}&select=id,notes,metadata&limit=1`,
+        { headers, signal: controller.signal, cache: 'no-store' },
+      ).finally(() => clearTimeout(timer));
+      if (!res.ok) return null;
+      const rows = (await res.json()) as RawRow[];
+      return rows[0] ?? null;
+    } catch {
+      return null;
+    }
+  };
+
+  const row = (await fetchRow('id')) ?? (await fetchRow('legacy_id'));
+  if (!row) return { ok: false, error: 'task not found' };
+
+  const decidedAt = new Date().toISOString();
+  const mergedMeta = { ...(row.metadata ?? {}), next_owner: 'agent', decision, decided_at: decidedAt };
+  const note = `${row.notes ? `${row.notes}\n` : ''}[decided ${decidedAt.slice(0, 10)}] ${decision}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const res = await fetch(`${root}/rest/v1/tasks?id=eq.${encodeURIComponent(row.id)}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json', Prefer: 'return=minimal' },
+      body: JSON.stringify({ metadata: mergedMeta, notes: note }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+    if (!res.ok) return { ok: false, error: `patch returned ${res.status}` };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'patch failed' };
+  }
+}

--- a/bot/src/zoe/__tests__/grill.test.ts
+++ b/bot/src/zoe/__tests__/grill.test.ts
@@ -116,8 +116,26 @@ describe('formatGrill one-click buttons', () => {
     // second row = Skip / Later
     expect(buttons[1].map((b) => b.data)).toEqual(['grill:skip', 'grill:snooze']);
   });
-  it('falls back to Done/Skip/Later when a decision has no options', () => {
-    const { buttons } = formatGrill({ key: 'k', kind: 'decision', title: 'Onboard Brandon to Discord', priority: 1 }, 0);
-    expect(buttons[0].map((b) => b.data)).toEqual(['grill:done', 'grill:skip', 'grill:snooze']);
+  it('a no-option decision offers Approve (resolve) / Skip / Later', () => {
+    const { buttons, text } = formatGrill(
+      { key: 'k', kind: 'decision', title: 'Onboard Brandon to Discord', priority: 1 },
+      0,
+    );
+    expect(buttons[0].map((b) => b.data)).toEqual(['grill:approve', 'grill:skip', 'grill:snooze']);
+    expect(buttons[0][0].text).toBe('Approve');
+    // the reply-to-resolve path is surfaced in the text
+    expect(text).toContain('Reply with your call');
+  });
+  it('a review offers Reviewed (grill:done) + a reply-with-a-note hint', () => {
+    const { buttons, text } = formatGrill(
+      { key: 'https://github.com/x/y/pull/1', kind: 'review', title: 'a PR', link: 'u', priority: 2 },
+      0,
+    );
+    expect(buttons[0][0]).toEqual({ text: 'Reviewed', data: 'grill:done' });
+    expect(text).toContain('Reply with a note');
+  });
+  it('a blocked item offers Unblock (grill:approve)', () => {
+    const { buttons } = formatGrill({ key: 'k', kind: 'blocked', title: 'stuck on X', priority: 3 }, 0);
+    expect(buttons[0][0]).toEqual({ text: 'Unblock', data: 'grill:approve' });
   });
 })

--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -44,6 +44,8 @@ export interface GrillState {
   items: Record<string, GrillItemState>;
   activeKey: string | null;
   activeTitle?: string | null;
+  /** kind of the active item, so a text-reply resolve knows how to route it. */
+  activeKind?: GrillKind | null;
   /** message_id of the pinned open question, so we can unpin it on answer. */
   activeMessageId?: number | null;
   lastAskedAt: string | null;
@@ -158,24 +160,35 @@ export function formatGrill(
   const link = item.link ? `\n${item.link}` : '';
   const tail = remaining > 0 ? `\n\n${remaining} more waiting under this - answer and the next pops up.` : '';
 
+  // A reply to the (pinned) question IS the resolve path for any item - Zaal can
+  // voice/text his call and ZOE logs it + moves it off his plate. Tell him so;
+  // the buttons alone never made "resolve" discoverable (the gap he flagged).
+  const resolveHint =
+    item.kind === 'review'
+      ? '\n\nReply with a note, or tap Reviewed to clear it.'
+      : '\n\nReply with your call and I log it + move it off your plate. Or use the buttons.';
+
   // If the decision has baked-in options ("pick 1/2/3", "yes/no"), make THOSE
-  // the buttons so Zaal answers in one tap. Otherwise generic Done/Skip/Later.
+  // the buttons so Zaal answers in one tap. Otherwise a kind-specific resolve
+  // button (Approve/Reviewed/Unblock) that actually acts, + Skip/Later.
   const options = item.kind === 'decision' ? parseOptions(item.title) : [];
   let buttons: { text: string; data: string }[][];
   if (options.length >= 2) {
     const answerRow = options.map((o) => ({ text: o.label.slice(0, 28), data: `grill:ans:${o.value}`.slice(0, 60) }));
     buttons = [answerRow, [{ text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }]];
   } else {
-    const doneLabel = item.kind === 'review' ? 'Reviewed' : 'Done';
-    buttons = [
-      [
-        { text: doneLabel, data: 'grill:done' },
-        { text: 'Skip', data: 'grill:skip' },
-        { text: 'Later', data: 'grill:snooze' },
-      ],
-    ];
+    // grill:approve resolves a single-action decision ("yes, do this") - it
+    // records the call AND moves the source task off the needs-you queue.
+    // Reviews/blocked use grill:done (mark handled). Skip = not mine, Later = snooze.
+    const resolveBtn =
+      item.kind === 'review'
+        ? { text: 'Reviewed', data: 'grill:done' }
+        : item.kind === 'blocked'
+          ? { text: 'Unblock', data: 'grill:approve' }
+          : { text: 'Approve', data: 'grill:approve' };
+    buttons = [[resolveBtn, { text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }]];
   }
-  return { text: `${lead}${link}${tail}`, buttons };
+  return { text: `${lead}${link}${resolveHint}${tail}`, buttons };
 }
 
 export interface SurfaceGrillDeps {
@@ -218,6 +231,7 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
   state.items[item.key] = { askedAt: new Date(now).toISOString(), status: 'asked' };
   state.activeKey = item.key;
   state.activeTitle = item.title;
+  state.activeKind = item.kind;
   state.activeMessageId = messageId ?? null;
   state.lastAskedAt = new Date(now).toISOString();
   await writeGrillState(state);
@@ -254,7 +268,36 @@ export async function applyGrillAnswer(
   state.items[key] = { ...state.items[key], status: 'done', answer: value };
   state.activeKey = null;
   state.activeTitle = null;
+  state.activeKind = null;
   state.activeMessageId = null;
   await writeGrillState(state);
   return { note: `Locked in: ${value}. Next one coming.`, key, title, value };
+}
+
+/**
+ * Resolve the active grill item by a TEXT REPLY to its pinned message. This is
+ * the general "resolve" path: Zaal replies (voice/text) with his call, ZOE
+ * captures it, marks the item done, and hands the key/kind back so the caller
+ * can record the decision + move the source task off the board's needs-you queue.
+ * Returns null when the reply was not to the currently-active pinned question
+ * (so normal message handling continues).
+ */
+export async function resolveGrillByReply(
+  repliedMessageId: number,
+  replyText: string,
+  now = Date.now(),
+): Promise<{ key: string; kind: GrillKind; title: string | null; value: string } | null> {
+  const state = await readGrillState();
+  if (!state.activeMessageId || state.activeMessageId !== repliedMessageId) return null;
+  const key = state.activeKey;
+  if (!key || !state.items[key]) return null;
+  const title = state.activeTitle ?? null;
+  const kind = state.activeKind ?? 'decision';
+  state.items[key] = { ...state.items[key], status: 'done', answer: replyText };
+  state.activeKey = null;
+  state.activeTitle = null;
+  state.activeKind = null;
+  state.activeMessageId = null;
+  await writeGrillState(state);
+  return { key, kind, title, value: replyText };
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -19,7 +19,8 @@ loadEnv();
 
 import { Bot, Context, InlineKeyboard } from 'grammy';
 import { BUTTON_BAR, ZOE_COMMANDS, isBarLabel } from './button-bar';
-import { surfaceGrill, applyGrillAction, applyGrillAnswer } from './grill';
+import { surfaceGrill, applyGrillAction, applyGrillAnswer, resolveGrillByReply } from './grill';
+import { resolveTaskDecision } from '../cockpit/adapters';
 import type { Client } from 'discord.js';
 import { bootDiscordClient } from './discord';
 import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, type TaskStatus } from '../lib/cowork';
@@ -1198,6 +1199,28 @@ bot.on('message:text', async (ctx) => {
   if (chatType === 'private' && isFromZaal(ctx) && ctx.message.reply_to_message?.message_id) {
     const replyToId = ctx.message.reply_to_message.message_id;
     try {
+      // Resolve-by-reply: if Zaal replied to the pinned OPEN grill question, his
+      // text is the resolution. Record it, move the source task off the board's
+      // needs-you queue, unpin, and advance to the next grill item. This is the
+      // "what do I press to resolve" answer - a reply IS the resolve.
+      const gr = await resolveGrillByReply(replyToId, text.trim());
+      if (gr) {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        await pushRecent(
+          { from: 'zaal', text: `[grill-resolve] ${gr.title ?? gr.key}: ${gr.value}`, sender: 'grill' },
+          String(gid || zaalId),
+        ).catch((e) => console.error('[zoe/grill] resolve log failed:', (e as Error)?.message));
+        await resolveTaskDecision(gr.key, gr.value).catch((e) =>
+          console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
+        );
+        await ctx.api.unpinChatMessage(zaalId, replyToId).catch(() => {});
+        await ctx.reply(`Resolved: ${gr.value}. Logged it and moved it off your plate.`);
+        await surfaceGrill(grillDeps(zaalId)).catch((e) =>
+          console.error('[zoe/grill] advance failed:', (e as Error)?.message),
+        );
+        return;
+      }
+
       // Try draft flow first
       const draft = await getPendingDraft(replyToId);
       if (draft) {
@@ -2738,6 +2761,35 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
       { from: 'zaal', text: `[grill-answer] ${r.title ?? r.key}: ${value}`, sender: 'grill' },
       String(gid || zaalId),
     ).catch((e) => console.error('[zoe/grill] answer log failed:', (e as Error)?.message));
+    // Move the resolved decision off the board's needs-you queue (best-effort).
+    await resolveTaskDecision(r.key, value).catch((e) =>
+      console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
+    );
+  }
+  await surfaceGrill(grillDeps(zaalId)).catch((e) =>
+    console.error('[zoe/grill] advance failed:', (e as Error)?.message),
+  );
+});
+
+// grill:approve - the one-tap resolve for a single-action decision ("yes, do
+// this") or an unblock. Records the call AND moves the source task off the
+// board's needs-you queue, then advances. This is what "resolve" means for an
+// item that has no clean 1/2/3 options.
+bot.callbackQuery('grill:approve', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const r = await applyGrillAnswer('approved');
+  await ctx.answerCallbackQuery({ text: r.note }).catch(() => {});
+  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
+  if (r.key) {
+    const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    await pushRecent(
+      { from: 'zaal', text: `[grill-approve] ${r.title ?? r.key}: approved`, sender: 'grill' },
+      String(gid || zaalId),
+    ).catch((e) => console.error('[zoe/grill] approve log failed:', (e as Error)?.message));
+    await resolveTaskDecision(r.key, 'approved').catch((e) =>
+      console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
+    );
   }
   await surfaceGrill(grillDeps(zaalId)).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),


### PR DESCRIPTION
## The grill had no resolve path

Zaal flagged it: on a grilled decision the only buttons were Done / Skip / Later, and none of them actually resolve anything - Done just cleared ZOE's local state, the source task stayed "needs you" on the board forever, and a single-action decision (no 1/2/3 options) had no "yes, do this" button.

## What this adds

- **`grill:approve`** - one-tap resolve for a no-option decision (**Approve**) or a blocked item (**Unblock**). Records the call AND moves the source task off the needs-you queue.
- **Reply-to-resolve** - a text/voice reply to the pinned open question IS the resolution. ZOE logs it, resolves the board task, unpins, advances. Surfaced in the DM text so it is discoverable ("Reply with your call and I log it + move it off your plate").
- **`resolveTaskDecision`** (cockpit/adapters) - GET-merges the task metadata, sets `next_owner='agent'` + records the decision in metadata + notes, PATCHes. This is what takes a resolved decision off the board. Best-effort; PR urls are ignored (PRs resolve by merge). `grill:ans` (option answers) now calls it too, so tapping 1/2/3 also clears the board.
- grill state tracks `activeKind` so a reply-resolve routes correctly.

## Verify
- tsc: 46 errors (baseline, unchanged - all pre-existing discord.js / zai)
- esbuild boot graph: clean
- grill tests: 15/15
- cockpit tests: 106/106

Builds on #2619 (pin only the open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMLdjC5LsjHMKc6tV2DfQF
