### PR TITLE
feat(zoe/grill): top-few-not-96 + self-explaining cards; kill dead devz-tip cron

### DIFF
--- a/bot/src/zoe/__tests__/grill.test.ts
+++ b/bot/src/zoe/__tests__/grill.test.ts
@@ -80,13 +80,23 @@ describe('pickNext', () => {
 });
 
 describe('formatGrill', () => {
-  it('frames a review as build-to-test with a link + remaining counter', () => {
+  it('frames a review as build-to-test with a link + calm cockpit pointer (no guilt-count)', () => {
     const { text, buttons } = formatGrill({ key: 'u', kind: 'review', title: 'PR X', link: 'https://gh/pr/1', priority: 2 }, 3);
     expect(text).toContain('review/test');
     expect(text).toContain('https://gh/pr/1');
-    expect(text).toContain('3 more waiting');
+    // reframed: the old "N more waiting" guilt-count is gone; the rest live in /cockpit
+    expect(text).toContain('/cockpit');
+    expect(text).not.toContain('more waiting');
     expect(buttons[0][0].text).toBe('Reviewed');
     expect(buttons[0].map((b) => b.data)).toEqual(['grill:done', 'grill:skip', 'grill:snooze']);
+  });
+  it('renders one-line context from task notes so the card explains itself', () => {
+    const { text } = formatGrill(
+      { key: 'k', kind: 'decision', title: 'lock token config', priority: 1, context: 'freezes supply + 50%/mo emissions' },
+      0,
+    );
+    expect(text).toContain('lock token config');
+    expect(text).toContain('freezes supply');
   });
   it('frames a decision plainly with no counter when none remain', () => {
     const { text } = formatGrill({ key: 'a', kind: 'decision', title: 'pick 1 or 2', priority: 0 }, 0);

--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -38,6 +38,8 @@ export interface GrillItem {
   title: string;
   link?: string;
   priority: number; // lower = more urgent
+  /** One-line context from the task notes, so the card explains itself. */
+  context?: string;
 }
 
 export interface GrillItemState {
@@ -57,7 +59,15 @@ export interface GrillState {
   /** message_id of the pinned open question, so we can unpin it on answer. */
   activeMessageId?: number | null;
   lastAskedAt: string | null;
+  /** How many items ZOE has proactively pushed today, so it caps at DAILY_PUSH_CAP
+   * (top-N-not-96). Reset when the date rolls. /grill and post-answer advances
+   * bypass the cap - it only gates unsolicited cron pushes. */
+  daySurfaced?: { date: string; count: number };
 }
+
+/** ZOE proactively pushes at most this many items/day (the "top few, not 96"
+ * fix). Zaal can always pull more with /grill; answering also flows past it. */
+const DAILY_PUSH_CAP = 5;
 
 /**
  * Extract one-click answer options from a decision title, if it cleanly has any.
@@ -121,11 +131,16 @@ export function toQueue(tasks: CockpitTask[], prs: ReviewPR[], events: GrillEven
     link: e.link,
     priority: -1,
   }));
+  const firstLine = (s: string | null | undefined): string | undefined => {
+    const line = (s ?? '').split('\n').map((l) => l.trim()).find(Boolean);
+    return line ? line.slice(0, 140) : undefined;
+  };
   const decisions: GrillItem[] = needsYou(tasks).map((t) => ({
     key: t.legacy_id ?? String(t.id),
     kind: 'decision',
     title: t.title,
     priority: priorityRank(t.priority),
+    context: firstLine(t.notes),
   }));
   const reviews: GrillItem[] = prs.map((p) => ({
     key: p.url,
@@ -139,6 +154,7 @@ export function toQueue(tasks: CockpitTask[], prs: ReviewPR[], events: GrillEven
     kind: 'blocked',
     title: t.title,
     priority: 3,
+    context: firstLine(t.notes),
   }));
   // dedupe by key, keep the most-urgent instance
   const byKey = new Map<string, GrillItem>();
@@ -175,8 +191,13 @@ export function formatGrill(
         : item.kind === 'blocked'
           ? `Blocked, needs you to unblock:\n${item.title}`
           : `Decision needed:\n${item.title}`;
+  // One-line context from the task notes makes the card self-explaining, so Zaal
+  // decides at a glance without opening anything.
+  const context = item.context ? `\n${item.context}` : '';
   const link = item.link ? `\n${item.link}` : '';
-  const tail = remaining > 0 ? `\n\n${remaining} more waiting under this - answer and the next pops up.` : '';
+  // No more "96 more waiting" guilt-count. ZOE caps its daily pushes (top few, not
+  // the whole backlog); the rest lives in /cockpit, pulled on demand.
+  const tail = remaining > 0 ? `\n\n(+${remaining} more in /cockpit when you want them)` : '';
 
   // Events are informational (acknowledge, don't resolve). Everything else: a reply
   // to the (pinned) question IS the resolve path - Zaal can voice/text his call and
@@ -211,7 +232,7 @@ export function formatGrill(
             : { text: 'Approve', data: 'grill:approve' };
     buttons = [[resolveBtn, { text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }]];
   }
-  return { text: `${lead}${link}${resolveHint}${tail}`, buttons };
+  return { text: `${lead}${context}${link}${resolveHint}${tail}`, buttons };
 }
 
 export interface SurfaceGrillDeps {
@@ -225,6 +246,9 @@ export interface SurfaceGrillDeps {
   fetchTasks?: () => Promise<CockpitTask[]>;
   fetchPRs?: () => Promise<ReviewPR[]>;
   fetchEvents?: () => Promise<GrillEvent[]>;
+  /** When true, ignore the daily push cap (Zaal pulled it via /grill, or is
+   * actively answering and advancing). The cap only gates unsolicited crons. */
+  bypassCap?: boolean;
 }
 
 /** Today's calendar events -> grill events. Best-effort; [] if the calendar is off. */
@@ -259,6 +283,14 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
   const events = await (deps.fetchEvents ?? (() => todaysGrillEvents(now)))().catch(() => [] as GrillEvent[]);
   const queue = toQueue(tasks, prs, events);
   const state = await readGrillState();
+
+  // Daily push cap: ZOE surfaces at most DAILY_PUSH_CAP items/day unsolicited, so
+  // it drives the top few instead of firehosing all 88. /grill + post-answer
+  // advances pass bypassCap=true so Zaal can always flow past it on demand.
+  const today = new Date(now).toISOString().slice(0, 10);
+  const day = state.daySurfaced?.date === today ? state.daySurfaced : { date: today, count: 0 };
+  if (!deps.bypassCap && day.count >= DAILY_PUSH_CAP) return { sent: false };
+
   const item = pickNext(queue, state, now);
   if (!item) return { sent: false };
 
@@ -283,6 +315,7 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
   state.activeKind = item.kind;
   state.activeMessageId = messageId ?? null;
   state.lastAskedAt = new Date(now).toISOString();
+  state.daySurfaced = { date: today, count: day.count + 1 };
   await writeGrillState(state);
   return { sent: true, item };
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -417,7 +417,7 @@ function grillDeps(chatId: number) {
 // /grill - surface the next item that needs you, on demand (also runs on a cron).
 bot.command('grill', async (ctx) => {
   if (!isFromZaal(ctx)) return;
-  const r = await surfaceGrill(grillDeps(zaalId));
+  const r = await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true });
   if (!r.sent) await ctx.reply('Nothing needs you right now - the queue is clear.');
 });
 
@@ -1215,7 +1215,7 @@ bot.on('message:text', async (ctx) => {
         );
         await ctx.api.unpinChatMessage(zaalId, replyToId).catch(() => {});
         await ctx.reply(`Resolved: ${gr.value}. Logged it and moved it off your plate.`);
-        await surfaceGrill(grillDeps(zaalId)).catch((e) =>
+        await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
           console.error('[zoe/grill] advance failed:', (e as Error)?.message),
         );
         return;
@@ -2766,7 +2766,7 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
       console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
     );
   }
-  await surfaceGrill(grillDeps(zaalId)).catch((e) =>
+  await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),
   );
 });
@@ -2791,7 +2791,7 @@ bot.callbackQuery('grill:approve', async (ctx) => {
       console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
     );
   }
-  await surfaceGrill(grillDeps(zaalId)).catch((e) =>
+  await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),
   );
 });
@@ -2807,7 +2807,7 @@ bot.callbackQuery(/^grill:(done|skip|snooze)$/, async (ctx) => {
   // Unpin the answered question - only OPEN questions stay pinned.
   { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
   // Advance: surface the next item that needs him.
-  await surfaceGrill(grillDeps(zaalId)).catch((e) =>
+  await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),
   );
 });

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -597,19 +597,9 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
     ),
   );
 
-  // Phase 4 - hourly Devz tip cron (group target). Stays gated on devzChatId.
-  if (opts.devzChatId) {
-    tasks.push(
-      cron.schedule(
-        '15 * * * *',
-        async () => {
-          // TODO Phase 4 - generate tip via Claude CLI similar to brief.ts but tip-flavored
-          console.log('[zoe/scheduler] devz tip cron fired (Phase 4 - implementation pending)');
-        },
-        { timezone: 'UTC' },
-      ),
-    );
-  }
+  // (Removed 2026-07-26: the Phase-4 Devz-tip cron was a stub that fired every
+  // 15 min and only logged "implementation pending" - dead weight. Bring it back
+  // as a real feature if hourly Devz tips are ever wanted, not as a no-op timer.)
 
   // Watcher (doc 927) - daily dispatch-health supervisor. Reads the run
   // telemetry dispatch.ts records and pings Zaal ONLY on a cost / failure /


### PR DESCRIPTION
Reinvents the grill UX Zaal flagged (the '96 more waiting' firehose of jargon decisions with no context).

- **Daily push cap (5/day):** ZOE proactively surfaces at most 5 items/day instead of serializing all 88 `next_owner=me` tasks. `/grill` + answering flow past it (bypassCap); only cold cron pushes are capped.
- **Self-explaining cards:** each item now shows a one-line context from the task notes under the title - decide at a glance, no opening anything.
- **Killed the guilt-count:** '96 more waiting under this' -> calm '(+N in /cockpit when you want them)'.
- **Removed the dead devz-tip cron** (fired every 15min, only logged 'implementation pending').

Verified unnecessary (dropped from scope, honestly): setMyCommands already exists + ZOE_COMMANDS is already admin-free (audit was wrong); hourly-bundle parallelize skipped as background-job optimization theater.

tsc 46 (baseline, +0), esbuild boot graph clean, grill tests 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMLdjC5LsjHMKc6tV2DfQF