### PR TITLE
feat(zoe): captures land in the grill WITH context (input reinvent)

### DIFF
--- a/bot/src/zoe/__tests__/team-tracker.test.ts
+++ b/bot/src/zoe/__tests__/team-tracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, type TeamTask } from '../team-tracker';
+import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, capturePriority, type TeamTask } from '../team-tracker';
 
 describe('zaalFocusForBrief', () => {
   it('returns null when nothing is dated and nothing needs Zaal', () => {
@@ -61,6 +61,22 @@ describe('buildTeamTaskRow', () => {
   });
   it('includes priority when given', () => {
     expect(buildTeamTaskRow({ title: 'x', project: 'p', priority: 'P1' }).priority).toBe('P1');
+  });
+  it('writes notes (context) when given, and omits them when empty', () => {
+    expect(buildTeamTaskRow({ title: 'x', project: 'p', notes: '  freezes supply + 50%/mo  ' }).notes).toBe(
+      'freezes supply + 50%/mo',
+    );
+    expect('notes' in buildTeamTaskRow({ title: 'x', project: 'p', notes: '   ' })).toBe(false);
+    expect('notes' in buildTeamTaskRow({ title: 'x', project: 'p' })).toBe(false);
+  });
+});
+
+describe('capturePriority', () => {
+  it('maps ZoeTask high/med/low -> tracker P1/P2/P3', () => {
+    expect(capturePriority('high')).toBe('P1');
+    expect(capturePriority('med')).toBe('P2');
+    expect(capturePriority('low')).toBe('P3');
+    expect(capturePriority('whatever')).toBe('P2');
   });
 });
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -36,7 +36,7 @@ import { readFleetStatus, formatLoopsStatus, formatLoopDetail } from './loops-st
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
 import { runCrmOps, summarizeCrmResults } from './crm';
-import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured, addTeamTask } from './team-tracker';
+import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured, addTeamTask, mirrorCapturesToTracker } from './team-tracker';
 import { decomposeGoal, renderPlanForApproval, shouldDecompose } from './decompose';
 import {
   buildMemoryBlocks,
@@ -2089,7 +2089,14 @@ async function dispatchConcierge(
     });
 
     if (result.task_ops.length > 0) {
-      await applyTaskOps(result.task_ops);
+      const { added } = await applyTaskOps(result.task_ops);
+      // Mirror new captures into the Supabase tracker WITH context, so a voice/
+      // forward/DM capture becomes a self-explaining grill card (not a bare title).
+      if (added.length > 0) {
+        await mirrorCapturesToTracker(added).catch((e) =>
+          console.warn('[zoe/index] capture->tracker mirror failed (nbd):', (e as Error).message),
+        );
+      }
     }
 
     if (result.quest_ops.length > 0) {
@@ -2955,7 +2962,13 @@ async function main(): Promise<void> {
         senderLabel: 'Board',
         context: { zaal_tg_id: zaalId, workspace_dir: repoDir, current_date: currentDateString() },
       });
-      if (result.task_ops.length > 0) await applyTaskOps(result.task_ops);
+      if (result.task_ops.length > 0) {
+        const { added } = await applyTaskOps(result.task_ops);
+        if (added.length > 0)
+          await mirrorCapturesToTracker(added).catch((e) =>
+            console.warn('[zoe/index] capture->tracker mirror failed (nbd):', (e as Error).message),
+          );
+      }
       let todoMarked = false;
       if (todoId) {
         const r = await markDone(todoId, 'completed by ZOE via control plane');

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -107,6 +107,8 @@ export interface NewTeamTask {
   title: string;
   project: string;
   priority?: string;
+  /** Rich context stored on the task, so the grill card explains itself. */
+  notes?: string;
 }
 
 /**
@@ -124,6 +126,7 @@ export function buildTeamTaskRow(t: NewTeamTask): Record<string, unknown> {
     legacy_source: 'zoe-bot',
   };
   if (t.priority) row.priority = t.priority;
+  if (t.notes && t.notes.trim()) row.notes = t.notes.trim();
   // Doc 983 Rec #4: auto-tag on the write-path so every ZOE-created task lands
   // pre-classified (brand / category / themes / next_owner) instead of naked.
   const c = classifyTask({ title: t.title });
@@ -204,6 +207,36 @@ export async function addTeamTask(t: NewTeamTask): Promise<AddTeamTaskResult> {
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : 'insert failed' };
   }
+}
+
+/** ZoeTask's high/med/low -> the tracker's P1/P2/P3 (P0 is reserved for true urgents). */
+export function capturePriority(p: 'high' | 'med' | 'low' | string): string {
+  return p === 'high' ? 'P1' : p === 'low' ? 'P3' : 'P2';
+}
+
+/**
+ * Mirror concierge-captured tasks into the Supabase tracker (what the grill +
+ * board read) WITH the description as notes, so a voice/forward capture becomes
+ * a self-explaining grill card - not a title with no context. Best-effort: the
+ * local ZoeTask store is still the source for ZOE's brief/reflect/nudge
+ * reasoning; this is an additive write so the item also reaches the day-driver.
+ * Returns how many mirrored. Never throws.
+ */
+export async function mirrorCapturesToTracker(
+  captured: Array<{ title: string; description?: string; priority?: string }>,
+): Promise<number> {
+  let n = 0;
+  for (const t of captured) {
+    if (!t.title?.trim()) continue;
+    const r = await addTeamTask({
+      title: t.title,
+      project: 'zaodevz',
+      priority: capturePriority(t.priority ?? 'med'),
+      notes: t.description?.trim() || undefined,
+    }).catch(() => ({ ok: false }) as { ok: boolean });
+    if (r.ok) n++;
+  }
+  return n;
 }
 
 const MAX_SHOWN = 15;


### PR DESCRIPTION
Closes the loop with the grill-card upgrade. When Zaal captures by DM / voice-note / forward, the concierge LLM already extracts a ZoeTask (with a description) - but that only hit the local tasks.json (ZOE's brief/reflect reasoning), never the Supabase tracker the grill reads, and never with notes. So cards stayed thin.

Now: after applyTaskOps, each new capture is mirrored into the Supabase tracker WITH the description as notes, so a talked/forwarded capture becomes a self-explaining grill card instead of a bare title. Additive + best-effort (local store stays the source for brief/reflect/nudge).

- team-tracker: NewTeamTask.notes + buildTeamTaskRow writes the notes column; capturePriority (high/med/low -> P1/P2/P3); mirrorCapturesToTracker helper.
- index: both concierge apply sites mirror added captures (best-effort).

Voice-in already routes through the concierge; forwards arrive as DM text - so both flow to rich cards. tsc 46 (baseline), esbuild clean, team-tracker 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMLdjC5LsjHMKc6tV2DfQF