### PR TITLE
fix(zoe/grill): clean AFK UX - visible resolve on tap, no pin clutter

### DIFF
--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -195,9 +195,9 @@ export function formatGrill(
   // decides at a glance without opening anything.
   const context = item.context ? `\n${item.context}` : '';
   const link = item.link ? `\n${item.link}` : '';
-  // No more "96 more waiting" guilt-count. ZOE caps its daily pushes (top few, not
-  // the whole backlog); the rest lives in /cockpit, pulled on demand.
-  const tail = remaining > 0 ? `\n\n(+${remaining} more in /cockpit when you want them)` : '';
+  // No running count at all - even "+85" read as a chore when AFK. ZOE caps its
+  // daily pushes (top few); the rest just live in /cockpit, pulled on demand.
+  const tail = remaining > 0 ? `\n\n(more in /cockpit when you want them)` : '';
 
   // Events are informational (acknowledge, don't resolve). Everything else: a reply
   // to the (pinned) question IS the resolve path - Zaal can voice/text his call and

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -402,6 +402,10 @@ bot.command('menu', async (ctx) => {
 // one) so ONLY the question awaiting his answer is ever pinned. Reused by /grill,
 // the callbacks, and the scheduler cron.
 function grillDeps(chatId: number) {
+  // No pin/unpin: pinning each grill item spawned a "ZOE pinned ..." service
+  // message per item, cluttering the DM. With the daily cap (~5/day) the cards
+  // are few and self-resolving (see grillResolvedText), so a pin isn't needed -
+  // and the clutter made the DM unusable AFK (Zaal, 2026-07-26).
   return {
     sendDM: (text: string, buttons: { text: string; data: string }[][]) =>
       bot.api.sendMessage(chatId, text, {
@@ -409,9 +413,16 @@ function grillDeps(chatId: number) {
           inline_keyboard: buttons.map((row) => row.map((b) => ({ text: b.text, callback_data: b.data }))),
         },
       }),
-    pin: (messageId: number) => bot.api.pinChatMessage(chatId, messageId, { disable_notification: true }),
-    unpin: (messageId: number) => bot.api.unpinChatMessage(chatId, messageId),
   };
+}
+
+// Rewrite a grill card to its resolved state so a tap is UNMISTAKABLE. The old
+// callbacks only stripped the buttons + flashed a transient toast, so Skip/Later
+// looked dead. This keeps the decision line, drops the reply/buttons prompt, and
+// appends the outcome - the card visibly becomes "... -> Skipped".
+function grillResolvedText(original: string | undefined, outcome: string): string {
+  const lead = (original ?? 'Item').split('\n\n')[0]; // the "Decision needed:\n<title>" block
+  return `${lead}\n\n-> ${outcome}`;
 }
 
 // /grill - surface the next item that needs you, on demand (also runs on a cron).
@@ -2759,9 +2770,11 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
   const value = ctx.match[1];
   const r = await applyGrillAnswer(value);
   await ctx.answerCallbackQuery({ text: r.note }).catch(() => {});
-  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
-  // Unpin the answered question - only OPEN questions stay pinned.
-  { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
+  await ctx
+    .editMessageText(grillResolvedText(ctx.callbackQuery.message?.text, `Locked in: ${value}`), {
+      reply_markup: { inline_keyboard: [] },
+    })
+    .catch(() => {});
   if (r.key) {
     const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
     await pushRecent(
@@ -2786,8 +2799,11 @@ bot.callbackQuery('grill:approve', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const r = await applyGrillAnswer('approved');
   await ctx.answerCallbackQuery({ text: r.note }).catch(() => {});
-  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
-  { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
+  await ctx
+    .editMessageText(grillResolvedText(ctx.callbackQuery.message?.text, 'Approved - on it.'), {
+      reply_markup: { inline_keyboard: [] },
+    })
+    .catch(() => {});
   if (r.key) {
     const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
     await pushRecent(
@@ -2810,9 +2826,12 @@ bot.callbackQuery(/^grill:(done|skip|snooze)$/, async (ctx) => {
   const action = ctx.match[1] as 'done' | 'skip' | 'snooze';
   const note = await applyGrillAction(action);
   await ctx.answerCallbackQuery({ text: note }).catch(() => {});
-  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
-  // Unpin the answered question - only OPEN questions stay pinned.
-  { const mid = ctx.callbackQuery.message?.message_id; if (mid) await ctx.api.unpinChatMessage(zaalId, mid).catch(() => {}); }
+  const outcome = action === 'done' ? 'Done.' : action === 'skip' ? 'Skipped.' : 'Later - I will bring it back.';
+  await ctx
+    .editMessageText(grillResolvedText(ctx.callbackQuery.message?.text, outcome), {
+      reply_markup: { inline_keyboard: [] },
+    })
+    .catch(() => {});
   // Advance: surface the next item that needs him.
   await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
     console.error('[zoe/grill] advance failed:', (e as Error)?.message),

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -174,8 +174,6 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
                     inline_keyboard: buttons.map((row) => row.map((b) => ({ text: b.text, callback_data: b.data }))),
                   },
                 }),
-              pin: (mid) => opts.bot.api.pinChatMessage(opts.zaalTgId, mid, { disable_notification: true }),
-              unpin: (mid) => opts.bot.api.unpinChatMessage(opts.zaalTgId, mid),
             });
           } catch (grillErr) {
             console.warn('[zoe/scheduler] morning grill kick failed (nbd):', (grillErr as Error).message);
@@ -209,8 +207,6 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
                   ),
                 },
               }),
-            pin: (mid) => opts.bot.api.pinChatMessage(opts.zaalTgId, mid, { disable_notification: true }),
-            unpin: (mid) => opts.bot.api.unpinChatMessage(opts.zaalTgId, mid),
           });
           if (r.sent) console.log(`[zoe/scheduler] grilled Zaal: ${r.item?.kind} - ${r.item?.title?.slice(0, 50)}`);
         } catch (err) {


### PR DESCRIPTION
Zaal: Skip/Later 'just dont do anything' and the DM is too cluttered to use AFK.

- **Visible resolve:** Approve/Skip/Later/answer now rewrite the card to its outcome (`<decision> -> Skipped.` / `Locked in: X` / `Approved - on it.`) instead of only stripping the buttons + a transient toast. A tap is now unmistakable. (The draft/post buttons already did this; the grill never got it.)
- **No pin clutter:** stopped pinning grill items - each pin spawned a 'ZOE pinned ...' service message. With the daily cap (~5/day) the cards are few and self-resolving, so a pin isn't needed. Removed pin/unpin from grillDeps + both scheduler calls.
- Dropped the running '+85 more' count (a chore to see AFK) -> calm '(more in /cockpit ...)'.

tsc 46 (baseline), esbuild clean, grill 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMLdjC5LsjHMKc6tV2DfQF