### PR TITLE
fix(vercel): ignoreCommand >256 chars broke every deploy - move to script

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Vercel ignoreCommand logic. Exit 0 = SKIP the build, non-zero = BUILD.
+# Lives in a file because Vercel caps the inline `ignoreCommand` at 256 chars
+# (a longer inline value fails vercel.json schema validation and errors EVERY
+# deploy - see the 2026-07-27 incident).
+#
+# 1. Only ever build production. Preview/branch deploys skip entirely - saves
+#    the (over-budget) Vercel spend and stops failing-preview emails.
+[ "${VERCEL_ENV:-}" = "production" ] || exit 0
+# 2. Production: if the previous deploy's SHA is missing from the shallow clone,
+#    build (safe default - can't diff, so don't risk skipping a real change).
+git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null || exit 1
+# 3. Build only if a build-relevant file changed since that SHA. git diff --quiet
+#    exits 0 (no change -> SKIP) or 1 (changed -> BUILD); that becomes our exit.
+git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" -- \
+  src public package.json package-lock.json next.config.ts tsconfig.json community.config.ts vercel.json

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "fluid": true,
-  "ignoreCommand": "if [ \"$VERCEL_ENV\" != production ]; then exit 0; fi; git cat-file -e $VERCEL_GIT_PREVIOUS_SHA 2>/dev/null && git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- src public package.json package-lock.json next.config.ts tsconfig.json community.config.ts vercel.json",
+  "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "functions": {
     "src/app/api/auth/verify/route.ts": {
       "memory": 1024,


### PR DESCRIPTION
My #2641 made ignoreCommand 279 chars; Vercel caps it at 256, so vercel.json failed schema validation and every production deploy errored in ~8s. Moved the logic to scripts/vercel-ignore.sh (ignoreCommand now 29 chars). Same behavior (skip non-prod, guard missing PREVIOUS_SHA, build prod on relevant change), unit-tested. Merging to un-break production.