### PR TITLE
fix(crm/capture): real 500 status on DB failure (not silent ok:true)

### DIFF
--- a/src/app/api/crm/capture/route.ts
+++ b/src/app/api/crm/capture/route.ts
@@ -221,7 +221,11 @@ export async function POST(req: NextRequest) {
 
         if (updateErr) {
           logger.error('[crm/capture] update failed:', updateErr);
-          return NextResponse.json({ ok: true }); // soft-fail: don't expose internal errors
+          // Real status so a dropped contact is visible; internal error logged, not exposed.
+          return NextResponse.json(
+            { ok: false, error: 'Could not save right now, please try again' },
+            { status: 500 },
+          );
         }
       } else {
         // Insert new
@@ -231,7 +235,10 @@ export async function POST(req: NextRequest) {
 
         if (insertErr) {
           logger.error('[crm/capture] insert failed:', insertErr);
-          return NextResponse.json({ ok: true }); // soft-fail
+          return NextResponse.json(
+            { ok: false, error: 'Could not save right now, please try again' },
+            { status: 500 },
+          );
         }
       }
     } else {
@@ -242,7 +249,10 @@ export async function POST(req: NextRequest) {
 
       if (insertErr) {
         logger.error('[crm/capture] insert failed:', insertErr);
-        return NextResponse.json({ ok: true }); // soft-fail
+        return NextResponse.json(
+          { ok: false, error: 'Could not save right now, please try again' },
+          { status: 500 },
+        );
       }
     }
 
@@ -259,7 +269,11 @@ export async function POST(req: NextRequest) {
     );
   } catch (error: unknown) {
     logger.error('[crm/capture] unexpected error:', error);
-    return NextResponse.json({ ok: true }, { status: 200 }); // soft-fail: never expose errors
+    // Real status on unexpected failure; internal error logged, not exposed to the client.
+    return NextResponse.json(
+      { ok: false, error: 'Could not save right now, please try again' },
+      { status: 500 },
+    );
   }
 }
 


### PR DESCRIPTION
Your call from doc 2093: return a real status. A failed CRM contact write returned {ok:true} 200 (leads silently dropped). All 4 failure paths now return {ok:false,error} 500; error still logged, message generic (no internal leak); success still 201. Small mechanical change; CI will typecheck.