### PR TITLE
feat(events): POST /api/events/create - source-of-truth event writer

### DIFF
--- a/src/app/api/events/create/__tests__/route.test.ts
+++ b/src/app/api/events/create/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/** FIFO chain: create does (1) select/maybeSingle (slug dup), (2) insert/select/single. */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['from', 'select', 'insert', 'eq']) chain[m] = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(q.shift()));
+  chain.single = vi.fn(() => Promise.resolve(q.shift()));
+  return chain;
+}
+
+const valid = {
+  slug: 'zao-fractal-aug',
+  title: 'ZAO Fractal - August',
+  starts_at: '2026-08-04T22:00:00Z',
+  is_published: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSessionData.mockResolvedValue({ fid: 19640, isAdmin: true });
+});
+
+describe('POST /api/events/create', () => {
+  it('403s when not admin', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, isAdmin: false });
+    const res = await POST(makePostRequest(valid));
+    expect(res.status).toBe(403);
+  });
+
+  it('403s when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await POST(makePostRequest(valid));
+    expect(res.status).toBe(403);
+  });
+
+  it('400s on invalid input (bad slug)', async () => {
+    const res = await POST(makePostRequest({ ...valid, slug: 'Bad Slug!' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('400s when title is missing', async () => {
+    const res = await POST(makePostRequest({ slug: 'x', is_published: false }));
+    expect(res.status).toBe(400);
+  });
+
+  it('409s on a duplicate slug', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: { id: 'existing-uuid' } }]));
+    const res = await POST(makePostRequest(valid));
+    expect(res.status).toBe(409);
+  });
+
+  it('201s and returns the created event', async () => {
+    mockFrom.mockReturnValue(
+      queuedChain([
+        { data: null }, // no dup
+        { data: { id: 'new-uuid', slug: valid.slug, title: valid.title, is_published: true } },
+      ]),
+    );
+    const res = await POST(makePostRequest(valid));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.event.slug).toBe(valid.slug);
+  });
+
+  it('500s when the insert fails', async () => {
+    mockFrom.mockReturnValue(
+      queuedChain([{ data: null }, { error: { message: 'db down' } }]),
+    );
+    const res = await POST(makePostRequest(valid));
+    expect(res.status).toBe(500);
+  });
+
+  it('rejects a bad lock_address', async () => {
+    const res = await POST(makePostRequest({ ...valid, lock_address: 'nope' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/events/create/route.ts
+++ b/src/app/api/events/create/route.ts
@@ -1,0 +1,89 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
+
+/**
+ * POST /api/events/create - the source-of-truth writer for ZAO events.
+ *
+ * Admin-only. Turns "edit the SQL migration" into "make an event". The `events`
+ * table is the canonical registry (doc 2099); the Unlock collectible + Google
+ * Calendar + lu.ma surfaces are projections of a row created here. lock_address /
+ * unlock_event_url are optional at create time - paste them after creating the
+ * lock on events.unlock-protocol.com (v1), or a later factory-deploy fills them.
+ */
+const createEventSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z0-9-]+$/, 'slug must be lowercase letters, numbers, and hyphens'),
+  title: z.string().min(1).max(200),
+  description: z.string().max(5000).optional(),
+  starts_at: z.string().datetime({ offset: true }).optional(),
+  ends_at: z.string().datetime({ offset: true }).optional(),
+  location: z.string().max(500).optional(),
+  lock_address: z
+    .string()
+    .regex(/^0x[a-fA-F0-9]{40}$/, 'lock_address must be a 0x EVM address')
+    .optional(),
+  unlock_event_url: z.string().url().max(1000).optional(),
+  chain_id: z.number().int().positive().default(8453),
+  is_published: z.boolean().default(false),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSessionData();
+    if (!session?.isAdmin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => null);
+    const parsed = createEventSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    // slug is unique - reject a collision with a clear status, not a raw DB error.
+    const { data: existing } = await supabase
+      .from('events')
+      .select('id')
+      .eq('slug', parsed.data.slug)
+      .maybeSingle();
+    if (existing) {
+      return NextResponse.json(
+        { error: 'An event with that slug already exists' },
+        { status: 409 },
+      );
+    }
+
+    const { data, error: insertError } = await supabase
+      .from('events')
+      .insert(parsed.data)
+      .select('id, slug, title, is_published')
+      .single();
+
+    if (insertError) {
+      logger.error('[events/create] insert failed:', insertError);
+      return NextResponse.json(
+        { ok: false, error: 'Could not create the event, please try again' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, event: data }, { status: 201 });
+  } catch (error: unknown) {
+    logger.error('[events/create] unexpected error:', error);
+    return NextResponse.json(
+      { ok: false, error: 'Could not create the event, please try again' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
First build from doc 2099 (one event -> lu.ma + GCal + Unlock collectible). Gap #1: there was no create-event endpoint - events were seeded via SQL. This adds an admin-gated, Zod-validated POST that writes the `events` table (the canonical registry all surfaces project from). slug collision -> 409; DB failure -> 500 (real status); lock_address/unlock_event_url optional at create (paste after making the lock on events.unlock-protocol.com). 8 tests mirror the rsvp test's mock pattern. NOTE: local vitest couldn't run (this install is missing the rolldown native binding) - CI's fresh npm ci runs them.