### PR TITLE
feat(spore): Phase 2 - portable receipt.v1 (federation evidence envelope)

### DIFF
--- a/src/lib/spore/__tests__/receipt.test.ts
+++ b/src/lib/spore/__tests__/receipt.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { createObservation } from '@/lib/eyes';
+import { observationToSpore } from '../spore';
+import {
+  sporeToReceipt, observationToReceipt, verifyReceipt, computeReceiptDigest, RECEIPT_SCHEMA,
+} from '../receipt';
+
+const ISSUER = 'zao-organism-1';
+function obs() {
+  return createObservation(
+    { sensor: 'coinbase-eth-usd', kind: 'market.price', subjectKey: 'eth-usd',
+      payload: { pair: 'ETH-USD', price: 1877.69 }, confidence: 1,
+      provenance: { method: 'poll', endpoint: 'https://api.coinbase.com/v2/prices/ETH-USD/spot' } },
+    { observerId: 'blood-1', now: '2026-07-24T00:00:00.000Z' },
+  );
+}
+
+describe('Phase 2 - portable receipt.v1', () => {
+  it('mints a receipt with schema, UUID id, digest, and provenance', () => {
+    const r = observationToReceipt(obs(), ISSUER, { now: '2026-07-24T00:00:00.000Z' });
+    expect(r.schemaVersion).toBe(RECEIPT_SCHEMA);
+    expect(r.receiptId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(r.digest).toMatch(/^sha256:dreamnet-sorted-json:v0:[0-9a-f]{64}$/);
+    expect(r.provenance.method).toBe('poll');
+    expect(r.verificationStatus).toBe('unverified');
+  });
+
+  it('is replay-safe: same content -> new id, but IDENTICAL deterministic digest', () => {
+    const spore = observationToSpore(obs());
+    const a = sporeToReceipt(spore, ISSUER, { now: '2026-01-01T00:00:00.000Z' });
+    const b = sporeToReceipt(spore, ISSUER, { now: '2026-12-31T00:00:00.000Z' });
+    expect(a.receiptId).not.toBe(b.receiptId);      // unique per receipt
+    expect(a.digest).toBe(b.digest);                 // deterministic over content+issuer, not id/time
+    expect(a.digest).toBe(computeReceiptDigest(spore, ISSUER));
+  });
+
+  it('is immutable (frozen)', () => {
+    const r = sporeToReceipt(observationToSpore(obs()), ISSUER);
+    expect(Object.isFrozen(r)).toBe(true);
+    expect(() => { (r as { issuer: string }).issuer = 'evil'; }).toThrow();
+  });
+
+  it('verifies a valid receipt with protocol only', () => {
+    expect(verifyReceipt(sporeToReceipt(observationToSpore(obs()), ISSUER))).toBe(true);
+  });
+
+  it('rejects a tampered payload (contentHash no longer covers content)', () => {
+    const r = sporeToReceipt(observationToSpore(obs()), ISSUER);
+    const tampered = { ...r, spore: { ...r.spore, payload: { pair: 'ETH-USD', price: 999999 } } };
+    expect(verifyReceipt(tampered)).toBe(false);
+  });
+
+  it('rejects a tampered digest', () => {
+    const r = sporeToReceipt(observationToSpore(obs()), ISSUER);
+    const tampered = { ...r, digest: 'sha256:dreamnet-sorted-json:v0:' + '0'.repeat(64) };
+    expect(verifyReceipt(tampered)).toBe(false);
+  });
+
+  it('rejects a different issuer (digest bound to issuer)', () => {
+    const spore = observationToSpore(obs());
+    const r = sporeToReceipt(spore, ISSUER);
+    expect(verifyReceipt({ ...r, issuer: 'someone-else' })).toBe(false);
+  });
+});

--- a/src/lib/spore/index.ts
+++ b/src/lib/spore/index.ts
@@ -10,3 +10,4 @@
 export { SPORE_HASH_ALG } from './types';
 export type { Spore, SporeHashAlg, SporeHashInput } from './types';
 export { sporeContentHash, verifySpore, observationToSpore } from './spore';
+export * from './receipt';

--- a/src/lib/spore/receipt.ts
+++ b/src/lib/spore/receipt.ts
@@ -1,0 +1,97 @@
+/**
+ * Portable Receipts - DreamNet Spore federation, Phase 2 (Portable Receipt Interchange).
+ *
+ * A `receipt.v1` is the immutable, portable evidence envelope that wraps a ZAO
+ * Spore (which wraps an Observation). It is what travels across the federation
+ * boundary: another organism can verify it with ONLY the deterministic protocol
+ * (canonical hash + digest), no shared runtime.
+ *
+ * Contracts (from Brandon's v0.2 Phase 2):
+ *  - UUID receipt ids (replay-safe: same content, new receipt -> new id)
+ *  - deterministic digest (same content + issuer -> same digest, regardless of id/time)
+ *  - immutable (frozen at creation)
+ *  - complete provenance
+ *
+ * The digest reuses ZAO's `canonicalize` + `sha256Hex`, which are proven
+ * byte-identical to DreamNet's reference (see dreamnet-conformance.test.ts).
+ */
+import { randomUUID } from 'crypto';
+import { canonicalize, sha256Hex } from '@/lib/eyes';
+import type { Observation } from '@/lib/eyes';
+import { SPORE_HASH_ALG, type Spore } from './types';
+import { observationToSpore } from './spore';
+
+export const RECEIPT_SCHEMA = 'dreamnet.receipt.v1' as const;
+
+export type ReceiptVerification = 'unverified' | 'verified' | 'rejected';
+
+export interface PortableReceipt {
+  readonly schemaVersion: typeof RECEIPT_SCHEMA;
+  /** UUID unique to THIS receipt. Replay-safe: re-issuing the same content mints a new id. */
+  readonly receiptId: string;
+  /** The subject this receipt attests to (content + portable content hash). */
+  readonly spore: Spore;
+  /** Who issued the receipt (the ZAO organism/instance id). */
+  readonly issuer: string;
+  /** When the receipt was issued (ISO). Provenance, NOT part of the digest. */
+  readonly issuedAt: string;
+  /** How the underlying content was obtained. */
+  readonly provenance: { method: string; endpoint?: string; query?: string };
+  /** `<alg>:<hex>` - deterministic over content + issuer (id/time excluded). */
+  readonly digest: string;
+  readonly verificationStatus: ReceiptVerification;
+}
+
+/** The stable fields the digest covers - deterministic across id/time/status. */
+function digestInput(spore: Spore, issuer: string) {
+  return { subjectKey: spore.subjectKey, kind: spore.kind, contentHash: spore.contentHash, issuer };
+}
+
+/** Compute the deterministic receipt digest. Same content + issuer -> same digest. */
+export function computeReceiptDigest(spore: Spore, issuer: string): string {
+  return `${SPORE_HASH_ALG}:${sha256Hex(canonicalize(digestInput(spore, issuer)))}`;
+}
+
+/** Build an immutable portable receipt from a ZAO Spore. */
+export function sporeToReceipt(
+  spore: Spore,
+  issuer: string,
+  opts?: { now?: string; provenance?: PortableReceipt['provenance'] },
+): PortableReceipt {
+  const receipt: PortableReceipt = {
+    schemaVersion: RECEIPT_SCHEMA,
+    receiptId: randomUUID(),
+    spore,
+    issuer,
+    issuedAt: opts?.now ?? new Date().toISOString(),
+    provenance: opts?.provenance ?? { method: 'observation' },
+    digest: computeReceiptDigest(spore, issuer),
+    verificationStatus: 'unverified',
+  };
+  return Object.freeze(receipt);
+}
+
+/** Build a portable receipt straight from a ZAO Observation (every observation -> portable evidence). */
+export function observationToReceipt(obs: Observation, issuer: string, opts?: { now?: string }): PortableReceipt {
+  return sporeToReceipt(observationToSpore(obs), issuer, {
+    now: opts?.now,
+    provenance: { method: obs.provenance.method, endpoint: obs.provenance.endpoint, query: obs.provenance.query },
+  });
+}
+
+/**
+ * Verify a receipt with deterministic protocol only (no shared runtime):
+ *  - the spore's contentHash actually covers its content
+ *  - the receipt digest is correct for (content, issuer)
+ * Returns false on any tamper. This is the primitive Phase 3 cross-runtime
+ * verification builds on.
+ */
+export function verifyReceipt(receipt: PortableReceipt): boolean {
+  if (receipt.schemaVersion !== RECEIPT_SCHEMA) return false;
+  const expectedContentHash = `${SPORE_HASH_ALG}:${sha256Hex(
+    canonicalize({ kind: receipt.spore.kind, subjectKey: receipt.spore.subjectKey, payload: receipt.spore.payload }),
+  )}`;
+  if (receipt.spore.contentHash !== expectedContentHash) return false;
+  if (receipt.digest !== computeReceiptDigest(receipt.spore, receipt.issuer)) return false;
+  return true;
+}


### PR DESCRIPTION
DreamNet federation Phase 2 (our side - no SDK needed). receipt.v1 = immutable, UUID-id'd, deterministic-digest portable evidence wrapping a Spore. Replay-safe, verifiable with protocol only. Reuses the Phase-1-proven byte-identical canonicalize. 7 tests incl. tamper rejection. Has code - left for Zaal's review. Phase 3 (cross-runtime vs DreamNet's impl) still blocked on the private SDK.