### PR TITLE
feat(heart): wire the Heart into the execution path (executeWithLease, flag-guarded)

### DIFF
--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -13,6 +13,7 @@ import { logAgentEvent } from './events';
 import { getSwapQuote, getZabalPrice } from './swap';
 import { type AgentAction, type AgentName, TOKENS } from './types';
 import { executeSwap } from './wallet';
+import { executeWithLease } from '@/lib/heart';
 
 export interface AgentRunResult {
   action: AgentAction;
@@ -61,7 +62,36 @@ async function withRetry<T>(fn: () => Promise<T>, delayMs = 5000): Promise<T> {
  * Run the standard agent routine for any agent.
  * Checks config, budget, balance, executes buy_zabal, burns, posts, auto-stakes.
  */
+/**
+ * Per-agent lease resource ids (stable UUIDs). Each agent is one resource, so
+ * only one instance of an agent may run at a time when lease enforcement is on.
+ */
+const AGENT_RUN_IDS: Record<AgentName, string> = {
+  VAULT: 'a11ceed0-0000-4000-8000-0000000000a1',
+  BANKER: 'a11ceed0-0000-4000-8000-0000000000b2',
+  DEALER: 'a11ceed0-0000-4000-8000-0000000000d3',
+};
+
+/**
+ * runAgent - the entrypoint. Behind HEART_LEASE_ENFORCE=1 it acquires a Heart
+ * lease first, so two instances (e.g. overlapping crons) cannot both trade the
+ * same agent. When the flag is off, it is exactly runAgentUnguarded (zero change).
+ * The pre-existing atomic budget claim still applies inside; this adds run-level
+ * fencing on top. Requires the per-agent agent_runs rows to be seeded before
+ * enabling; the recovery cron reclaims a lease if a process dies mid-run.
+ */
 export async function runAgent(agentName: AgentName): Promise<AgentRunResult> {
+  if (process.env.HEART_LEASE_ENFORCE !== '1') return runAgentUnguarded(agentName);
+  const owner = process.env.HOSTNAME || process.env.FLY_MACHINE_ID || 'agent-runner';
+  const outcome = await executeWithLease(
+    { runId: AGENT_RUN_IDS[agentName], owner, ttlSeconds: 180 },
+    () => runAgentUnguarded(agentName),
+  );
+  if (outcome.ran) return outcome.result;
+  return { action: 'report', status: 'skipped', details: `Heart lease held - ${agentName} is already running on another instance (${outcome.reason})` };
+}
+
+export async function runAgentUnguarded(agentName: AgentName): Promise<AgentRunResult> {
   const config = await getAgentConfig(agentName);
   if (!config) {
     return { action: 'report', status: 'failed', details: `No config found for ${agentName}` };

--- a/src/lib/heart/__tests__/execute-with-lease.test.ts
+++ b/src/lib/heart/__tests__/execute-with-lease.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const acquireLease = vi.fn();
+const renewLease = vi.fn().mockResolvedValue(null);
+const releaseLease = vi.fn().mockResolvedValue(null);
+vi.mock('../lease-manager', () => ({ acquireLease: (i: unknown) => acquireLease(i), renewLease: (i: unknown) => renewLease(i), releaseLease: (i: unknown) => releaseLease(i) }));
+
+import { executeWithLease } from '../execute-with-lease';
+const OPTS = { runId: '11111111-1111-1111-1111-111111111111', owner: 'inst-a', ttlSeconds: 4 };
+
+beforeEach(() => { acquireLease.mockReset(); renewLease.mockClear(); releaseLease.mockClear(); renewLease.mockResolvedValue(null); releaseLease.mockResolvedValue(null); });
+
+describe('executeWithLease', () => {
+  it('runs the work and releases as completed when the lease is acquired', async () => {
+    acquireLease.mockResolvedValue({ acquired: true, run: { id: OPTS.runId } });
+    const out = await executeWithLease(OPTS, async () => 42);
+    expect(out).toEqual({ ran: true, result: 42 });
+    expect(releaseLease).toHaveBeenCalledWith(expect.objectContaining({ runId: OPTS.runId, owner: 'inst-a', nextStatus: 'completed' }));
+  });
+
+  it('SKIPS the work (no double-execution) when another owner holds the lease', async () => {
+    acquireLease.mockResolvedValue({ acquired: false, run: { id: OPTS.runId }, reason: 'held by inst-b' });
+    const work = vi.fn();
+    const out = await executeWithLease(OPTS, work as () => Promise<unknown>);
+    expect(out).toEqual({ ran: false, reason: 'lease-held' });
+    expect(work).not.toHaveBeenCalled();
+    expect(releaseLease).not.toHaveBeenCalled();
+  });
+
+  it('releases as failed and rethrows when the work throws', async () => {
+    acquireLease.mockResolvedValue({ acquired: true, run: { id: OPTS.runId } });
+    await expect(executeWithLease(OPTS, async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    expect(releaseLease).toHaveBeenCalledWith(expect.objectContaining({ nextStatus: 'failed' }));
+  });
+
+  it('reports lease-error when the run cannot be found/parsed', async () => {
+    acquireLease.mockResolvedValue({ acquired: false, run: null });
+    const out = await executeWithLease(OPTS, async () => 1);
+    expect(out).toEqual({ ran: false, reason: 'lease-error' });
+  });
+});

--- a/src/lib/heart/execute-with-lease.ts
+++ b/src/lib/heart/execute-with-lease.ts
@@ -1,0 +1,64 @@
+/**
+ * executeWithLease - the connective tissue that wires the Heart into the
+ * execution path. Before this, the Heart's lease-manager governed nothing that
+ * actually runs (nothing outside src/lib/heart called acquireLease).
+ *
+ * Given a run identity, it acquires a lease (fencing: if another owner holds it,
+ * the work is SKIPPED, not double-run), runs the work while renewing the lease
+ * on a heartbeat, and releases it on completion/failure. The recovery cron
+ * reclaims the lease if the process dies mid-run.
+ *
+ * This is the one-instance-per-resource guarantee made real. Flag-guarded at the
+ * call sites (default off) so it can be enabled deliberately and rolled back
+ * instantly.
+ */
+import { acquireLease, renewLease, releaseLease } from './lease-manager';
+
+export interface LeaseGuardOpts {
+  /** UUID of the agent_runs row that represents this resource (per-resource for a mutex). */
+  runId: string;
+  /** This instance's identity (hostname/process id). */
+  owner: string;
+  /** Lease TTL in seconds. */
+  ttlSeconds: number;
+  /** How often to renew (ms). Default: ttl/2, min 1s. */
+  renewEveryMs?: number;
+}
+
+export type LeaseGuardOutcome<T> =
+  | { ran: true; result: T }
+  | { ran: false; reason: 'lease-held' | 'lease-error' };
+
+/**
+ * Run `work` only if we can acquire the lease. Fencing + heartbeat + release.
+ * Never throws for lease reasons; rethrows an error thrown BY `work` (after
+ * releasing with nextStatus 'failed').
+ */
+export async function executeWithLease<T>(
+  opts: LeaseGuardOpts,
+  work: () => Promise<T>,
+): Promise<LeaseGuardOutcome<T>> {
+  const acq = await acquireLease({ runId: opts.runId, owner: opts.owner, ttlSeconds: opts.ttlSeconds });
+  if (!acq || acq.acquired !== true) {
+    // run === null means acquireLease could not even find/parse the run (a real
+    // error); otherwise another owner holds the lease (a normal collision -> skip).
+    const reason = acq && acq.run === null ? 'lease-error' : 'lease-held';
+    return { ran: false, reason };
+  }
+
+  const renewMs = opts.renewEveryMs ?? Math.max(1000, Math.floor((opts.ttlSeconds * 1000) / 2));
+  const heartbeat = setInterval(() => {
+    void renewLease({ runId: opts.runId, owner: opts.owner, ttlSeconds: opts.ttlSeconds }).catch(() => {});
+  }, renewMs);
+  if (typeof heartbeat === 'object' && 'unref' in heartbeat) (heartbeat as { unref: () => void }).unref();
+
+  let ok = false;
+  try {
+    const result = await work();
+    ok = true;
+    return { ran: true, result };
+  } finally {
+    clearInterval(heartbeat);
+    await releaseLease({ runId: opts.runId, owner: opts.owner, nextStatus: ok ? 'completed' : 'failed' }).catch(() => {});
+  }
+}

--- a/src/lib/heart/index.ts
+++ b/src/lib/heart/index.ts
@@ -26,3 +26,4 @@ export type {
   InstanceStatus,
   DeadInstanceReclaimSummary,
 } from './types';
+export * from './execute-with-lease';


### PR DESCRIPTION
Wires the Heart into the execution path - closing the standing organism gap (nothing outside `src/lib/heart` called `acquireLease`).

**What's implemented**
- `executeWithLease(opts, work)` - the connective tissue: acquire a lease, run the work while renewing on a heartbeat, release on completion/failure. If another owner holds the lease, the work is **skipped, not double-run** (fencing). 4 tests (run+release, skip-on-collision, release-failed+rethrow, lease-error).
- `runAgent` is now a thin wrapper over `runAgentUnguarded`, gated on `HEART_LEASE_ENFORCE`. **Flag off (default) = byte-identical behavior.** Flag on = each agent (VAULT/BANKER/DEALER) is a lease resource; two instances can't both trade it.

**Architect's Progress Report**
1. *Implemented:* executeWithLease + flag-guarded runAgent wiring + 4 tests + heart index export.
2. *Architecture change:* the Heart is now wired into execution. Run-level fencing on top of the existing atomic budget claim.
3. *Organism health:* this makes it more **RESILIENT** (not more intelligent or feature-rich) - one-instance-per-resource + the recovery cron now govern real execution. Evidence: the skip-on-collision test proves double-execution is prevented.
4. *Remaining tech debt / to activate:* the per-agent `agent_runs` rows must be seeded before flipping the flag (acquireLease needs the row). The other runners (`bot/src/zoe/workers.ts`, `bot/src/hermes/runner.ts`) are not yet wired - same pattern applies.
5. *Failure modes:* if rows aren't seeded, acquireLease returns lease-error and runAgent **skips** (safe - won't trade unfenced when enforced). Process death mid-run -> recovery cron reclaims the lease.
6. *Highest-leverage next:* seed the 3 agent rows, enable the flag on the trading agents (highest double-spend risk), then wire the ZOE workers.
7. *Self-critique:* a simpler alternative was per-agent DB advisory locks, but reusing the existing lease-manager keeps ONE fencing mechanism the recovery suite already covers - fewer moving parts, more resilient.

**Note:** I couldn't run vitest locally (missing native binding earlier in the session) - CI runs the tests. Flag-off = zero behavioral change, so this is safe to merge before enabling. Has code -> your review.
