### PR TITLE
feat(zoe): Telegram relay bridge - answer fleet relays from your phone

### DIFF
--- a/bot/src/zoe/__tests__/relay-bridge.test.ts
+++ b/bot/src/zoe/__tests__/relay-bridge.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  pendingInbound,
+  markPushed,
+  appendReply,
+  relayReplyQid,
+  laneFromReplyQid,
+  formatInboundDm,
+  pushInboundRelays,
+  type RelayMsg,
+} from '../relay-bridge';
+
+const rel = (o: Partial<RelayMsg>): RelayMsg => ({
+  from: 'cowork',
+  to: 'zoe',
+  msg: 'hi',
+  ts: '2026-07-29T13:00:00Z',
+  ...o,
+});
+
+describe('pendingInbound', () => {
+  it('returns only zoe-addressed relays not yet pushed to TG', () => {
+    const relays = [
+      rel({ to: 'zoe', tg_pushed: false, ts: 'a' }),
+      rel({ to: 'zoe', tg_pushed: true, ts: 'b' }), // already pushed
+      rel({ to: 'cowork', tg_pushed: false, ts: 'c' }), // not for zoe
+      rel({ to: 'zoe', ts: 'd' }), // undefined tg_pushed = pending
+    ];
+    expect(pendingInbound(relays).map((r) => r.ts)).toEqual(['a', 'd']);
+  });
+
+  it('ignores the read flag (a terminal-read relay can still be unpushed)', () => {
+    const relays = [rel({ to: 'zoe', read: true, tg_pushed: false, ts: 'x' })];
+    expect(pendingInbound(relays).map((r) => r.ts)).toEqual(['x']);
+  });
+});
+
+describe('markPushed', () => {
+  it('sets tg_pushed only on the matched timestamps, immutably', () => {
+    const relays = [rel({ ts: 'a' }), rel({ ts: 'b' }), rel({ ts: 'c' })];
+    const out = markPushed(relays, new Set(['a', 'c']));
+    expect(out.map((r) => Boolean(r.tg_pushed))).toEqual([true, false, true]);
+    expect(relays.every((r) => r.tg_pushed === undefined)).toBe(true); // original untouched
+  });
+});
+
+describe('appendReply', () => {
+  it('appends a zoe->lane reply with read:false, immutably', () => {
+    const relays = [rel({ ts: 'a' })];
+    const out = appendReply(relays, 'cowork', 'on it', 'z');
+    expect(out).toHaveLength(2);
+    expect(out[1]).toEqual({ from: 'zoe', to: 'cowork', msg: 'on it', ts: 'z', read: false });
+    expect(relays).toHaveLength(1); // original untouched
+  });
+});
+
+describe('qid encode/decode', () => {
+  it('round-trips a lane through the qid', () => {
+    expect(relayReplyQid('cowork')).toBe('rl-cowork');
+    expect(laneFromReplyQid('rl-cowork')).toBe('cowork');
+    expect(laneFromReplyQid('rl-zabalgamez')).toBe('zabalgamez');
+  });
+
+  it('rejects non-relay qids', () => {
+    expect(laneFromReplyQid('q1')).toBeNull();
+    expect(laneFromReplyQid('research-topic')).toBeNull();
+    expect(laneFromReplyQid('rl-')).toBeNull(); // empty lane
+  });
+
+  it('qid never contains the callback delimiter', () => {
+    expect(relayReplyQid('cowork')).not.toContain(':');
+  });
+});
+
+describe('formatInboundDm', () => {
+  it('shows sender, time, and body', () => {
+    const out = formatInboundDm(rel({ from: 'zoostr', msg: 'shipped', ts: '2026-07-29T13:45:00Z' }));
+    expect(out).toContain('zoostr');
+    expect(out).toContain('13:45');
+    expect(out).toContain('shipped');
+  });
+});
+
+describe('pushInboundRelays', () => {
+  it('returns 0 and never sends when unconfigured (no creds)', async () => {
+    const prevUrl = process.env.COWORK_TRACKER_URL;
+    const prevKey = process.env.COWORK_TRACKER_KEY;
+    delete process.env.COWORK_TRACKER_URL;
+    delete process.env.COWORK_TRACKER_KEY;
+    const sendMessage = vi.fn();
+    const n = await pushInboundRelays({ chatId: 123, sendMessage, now: () => 't' });
+    expect(n).toBe(0);
+    expect(sendMessage).not.toHaveBeenCalled();
+    if (prevUrl) process.env.COWORK_TRACKER_URL = prevUrl;
+    if (prevKey) process.env.COWORK_TRACKER_KEY = prevKey;
+  });
+});

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -35,6 +35,7 @@ import { homedir } from 'node:os';
 import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQuestion } from './questions';
 import { pushRecent, ZOE_PATHS } from './memory';
 import { enqueueWork } from './work-loop';
+import { pushInboundRelays, sendRelayReply, laneFromReplyQid } from './relay-bridge';
 import { refillOpenThings, clearOpenThing, topicFromQid, type TopicOpenThingState } from './always-open-topics';
 import { topicNameForThread } from './topic-router';
 
@@ -476,6 +477,20 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
     // Stage 2: Process each new answer via action classification
     let actioned = 0;
     for (const answer of answers) {
+      // Relay-bridge: a 'rl-<lane>' answer is Zaal replying to an inbound fleet
+      // relay from Telegram. Route his answer back to that lane and consume it -
+      // do NOT run the orchestrator classifier on it. Off unless ZOE_RELAY_TG_ENABLED.
+      if (process.env.ZOE_RELAY_TG_ENABLED === 'true') {
+        const replyLane = laneFromReplyQid(answer.qid);
+        if (replyLane) {
+          const body = answer.value === 'ack' ? '[acked by Zaal]' : answer.value;
+          const ok = await sendRelayReply(replyLane, body, deps.now.toISOString());
+          console.log(`[zoe/relay-bridge] reply -> ${replyLane}: ${ok ? 'sent' : 'FAILED'}`);
+          if (ok) actioned++; // advance the answer pointer so it is not re-sent next tick
+          continue;
+        }
+      }
+
       // Check if this is a topic-based open-thing answer (e.g., "coding-pr-...", "research-...")
       // If so, clear that topic so refillOpenThings will post a new one.
       const topicForAnswer = topicFromQid(answer.qid);
@@ -552,6 +567,22 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
       await writeState({ lastSeenTs: latestTs });
       await bumpToday(dateStr);
       console.log(`[zoe/orchestrator] tick: ${answers.length} answer(s), ${posted} action(s) executed`);
+    }
+
+    // Relay-bridge: surface NEW inbound fleet relays (addressed to the `zoe` lane)
+    // in this topic with a Reply button, so Zaal answers them from Telegram. Runs
+    // every tick regardless of answers. Off unless ZOE_RELAY_TG_ENABLED. Best-effort.
+    if (process.env.ZOE_RELAY_TG_ENABLED === 'true') {
+      try {
+        const pushed = await pushInboundRelays({
+          chatId: deps.groupId,
+          sendMessage: (id, text, opts) => deps.bot.api.sendMessage(id, text, opts as never),
+          now: () => deps.now.toISOString(),
+        });
+        if (pushed > 0) console.log(`[zoe/relay-bridge] pushed ${pushed} inbound relay(s) to topic`);
+      } catch (err) {
+        console.error('[zoe/relay-bridge] push failed:', (err as Error)?.message);
+      }
     }
 
     // Refill any topics that lost their open items (after processing answers)

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -1,0 +1,204 @@
+/**
+ * relay-bridge.ts - Telegram <-> fleet-relay bridge for ZOE.
+ *
+ * The fleet relay (`~/bin/zao-relay` / `relay`) lets terminals message each other
+ * through one shared hub row (tasks.legacy_id = 9000, metadata.relays[]) in the
+ * cowork tracker. Terminals pull their own inbox at the shell. This bridge gives
+ * Zaal the SAME inbox on his phone: when a relay is addressed to the `zoe` lane,
+ * ZOE DMs it to him with a Reply button; his tap/typed answer is relayed back to
+ * the original sender's lane - no terminal needed.
+ *
+ * Why a separate `tg_pushed` flag (not `read`): the terminal auto-grab hook acks
+ * with `read`, and the two consumers must not steal messages from each other
+ * (one-instance-per-resource, agent-loops rule 9). `tg_pushed` is the bridge's
+ * own dedup marker; `read` stays the terminal's. A relay can therefore surface in
+ * BOTH the terminal and Telegram - that is the "both options" design, on purpose.
+ *
+ * Reuses the cowork-tracker REST creds (COWORK_TRACKER_URL/KEY) - the relay hub
+ * lives in the same tasks table team-tracker.ts already reads. All IO is
+ * best-effort and never throws; the pure helpers are exported for unit tests.
+ *
+ * SAFETY: reply-to-lane is an INTERNAL fleet message (terminal-to-terminal), not
+ * an outbound post/DM to a third party - so it is not a gated action. The bridge
+ * is OFF unless ZOE_RELAY_TG_ENABLED === 'true'.
+ */
+
+const HUB_LEGACY_ID = '9000';
+
+/** One relay message in the hub. `tg_pushed` is this bridge's dedup marker. */
+export interface RelayMsg {
+  from: string;
+  to: string;
+  msg: string;
+  ts: string;
+  read?: boolean;
+  tg_pushed?: boolean;
+}
+
+interface HubRow {
+  id: string;
+  relays: RelayMsg[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested, no network)
+// ---------------------------------------------------------------------------
+
+/** Relays addressed to the `zoe` lane that have not yet been pushed to Telegram.
+ *  We do NOT filter on `read` - a relay the terminal already handled still may
+ *  not have reached Zaal's phone, and vice versa; `tg_pushed` is the only gate. */
+export function pendingInbound(relays: RelayMsg[]): RelayMsg[] {
+  return relays.filter((r) => r.to === 'zoe' && !r.tg_pushed);
+}
+
+/** Return a NEW relay array with `tg_pushed` set true on the messages whose `ts`
+ *  is in `pushedTs`. Pure - the caller PATCHes the result back. */
+export function markPushed(relays: RelayMsg[], pushedTs: Set<string>): RelayMsg[] {
+  return relays.map((r) => (pushedTs.has(r.ts) ? { ...r, tg_pushed: true } : r));
+}
+
+/** Append a ZOE reply to a lane. Pure - returns the new relays array. */
+export function appendReply(relays: RelayMsg[], lane: string, msg: string, ts: string): RelayMsg[] {
+  return [...relays, { from: 'zoe', to: lane, msg, ts, read: false }];
+}
+
+/** qid encoding for a relay-reply question. A qid must not contain ':' (the
+ *  question callback parser splits on it), so the lane is joined with '-'. */
+export function relayReplyQid(lane: string): string {
+  return `rl-${lane}`;
+}
+
+/** Extract the target lane from a relay-reply qid, or null if not one. */
+export function laneFromReplyQid(qid: string): string | null {
+  if (!qid.startsWith('rl-')) return null;
+  const lane = qid.slice(3);
+  return lane || null;
+}
+
+/** Human-readable DM body for an inbound relay. */
+export function formatInboundDm(r: RelayMsg): string {
+  const when = (r.ts || '').slice(11, 16);
+  return `Relay from ${r.from}${when ? ` (${when})` : ''}:\n\n${r.msg}`;
+}
+
+// ---------------------------------------------------------------------------
+// Hub IO (best-effort; never throws)
+// ---------------------------------------------------------------------------
+
+export function relayBridgeConfigured(): boolean {
+  return Boolean(process.env.COWORK_TRACKER_URL && process.env.COWORK_TRACKER_KEY);
+}
+
+function creds(): { base: string; key: string } | null {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return null;
+  return { base: base.replace(/\/$/, ''), key };
+}
+
+async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
+  const c = creds();
+  if (!c) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    const res = await fetch(url, {
+      ...init,
+      headers: { apikey: c.key, Authorization: `Bearer ${c.key}`, 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    return text ? JSON.parse(text) : [];
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Read the hub row. Returns null on any error/unconfigured. */
+export async function fetchHub(): Promise<HubRow | null> {
+  const c = creds();
+  if (!c) return null;
+  const rows = (await fetchJson(
+    `${c.base}/rest/v1/tasks?legacy_id=eq.${HUB_LEGACY_ID}&select=id,metadata`,
+  )) as Array<{ id: string; metadata?: { relays?: RelayMsg[] } }> | null;
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  return { id: rows[0].id, relays: rows[0].metadata?.relays ?? [] };
+}
+
+/** Write the relays array back onto the hub row. Best-effort; returns success. */
+export async function saveHubRelays(id: string, relays: RelayMsg[]): Promise<boolean> {
+  const c = creds();
+  if (!c) return false;
+  const out = await fetchJson(`${c.base}/rest/v1/tasks?id=eq.${id}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify({ metadata: { relays: relays.slice(-500) } }),
+  });
+  return out !== null;
+}
+
+/** Append a ZOE reply to a lane and persist. Best-effort; returns success.
+ *  Re-fetches the hub first so a concurrent terminal write is not clobbered. */
+export async function sendRelayReply(lane: string, msg: string, ts: string): Promise<boolean> {
+  const hub = await fetchHub();
+  if (!hub) return false;
+  return saveHubRelays(hub.id, appendReply(hub.relays, lane, msg, ts));
+}
+
+// ---------------------------------------------------------------------------
+// The tick step (push inbound relays to Zaal's DM)
+// ---------------------------------------------------------------------------
+
+export interface RelayBridgeDeps {
+  /** Zaal's DM chat id (ZAAL_DM_ID). */
+  chatId: number;
+  /** grammy bot.api.sendMessage, injected for testability. */
+  sendMessage: (chatId: number, text: string, options?: unknown) => Promise<unknown>;
+  /** Monotonic timestamp for the mark-pushed write (injected so tests are deterministic). */
+  now: () => string;
+}
+
+/** One "Reply" (arms freetext) + one "Ack" quick button, both routed by qid. */
+function replyKeyboard(lane: string): unknown {
+  const qid = relayReplyQid(lane);
+  // TYPE_SENTINEL '__type__' arms index.ts pendingTypeAnswers so the next typed
+  // message is captured as this qid's answer. 'ack' is a one-tap acknowledgement.
+  return {
+    inline_keyboard: [
+      [{ text: 'Reply', callback_data: `q:${qid}:${Buffer.from('__type__', 'utf8').toString('base64url')}` }],
+      [{ text: 'Ack', callback_data: `q:${qid}:${Buffer.from('ack', 'utf8').toString('base64url')}` }],
+    ],
+  };
+}
+
+/**
+ * Push every not-yet-pushed inbound `zoe` relay to Zaal's DM with a Reply button,
+ * then mark them pushed. Best-effort; returns the count pushed. Caller gates on
+ * ZOE_RELAY_TG_ENABLED.
+ */
+export async function pushInboundRelays(deps: RelayBridgeDeps): Promise<number> {
+  const hub = await fetchHub();
+  if (!hub) return 0;
+  const pending = pendingInbound(hub.relays);
+  if (pending.length === 0) return 0;
+
+  const pushedTs = new Set<string>();
+  for (const r of pending) {
+    try {
+      await deps.sendMessage(deps.chatId, formatInboundDm(r), { reply_markup: replyKeyboard(r.from) });
+      pushedTs.add(r.ts);
+    } catch {
+      // one send failure does not block the others; leave it unpushed to retry next tick
+    }
+  }
+  if (pushedTs.size > 0) {
+    // Re-fetch so a concurrent terminal write is not clobbered, then mark pushed.
+    const fresh = (await fetchHub()) ?? hub;
+    await saveHubRelays(fresh.id, markPushed(fresh.relays, pushedTs));
+  }
+  return pushedTs.size;
+}


### PR DESCRIPTION
## What
The AFK half of terminal-to-terminal relay. When a fleet relay is addressed to the `zoe` lane, ZOE surfaces it in the ZAAL BOTZ orchestrator topic with a **Reply** button. Zaal taps or types a reply on his phone and it routes back to the sender's lane through the relay hub - no terminal needed.

Pairs with the terminal side (`relay` / `relay back`, auto-grab hook). Same hub, two surfaces: terminal for at-desk, Telegram for away.

## How
- `bot/src/zoe/relay-bridge.ts` (new): pure helpers (`pendingInbound`, `markPushed`, `appendReply`, qid codec, `formatInboundDm`) + best-effort hub IO over the existing `COWORK_TRACKER_URL/KEY` REST creds - the relay hub row (`tasks.legacy_id = 9000`) lives in the same table `team-tracker.ts` already reads. No new creds.
- Dedup on a **new `tg_pushed` flag**, independent of the terminal auto-grab's `read` flag. The two consumers never steal each other's messages (agent-loops rule 9), and a relay can appear in **both** surfaces on purpose.
- Wired into `orchestrator-tick.ts` (the existing 5-min cron): pushes new inbound relays each tick, and routes `rl-<lane>` answers back to their lane. The answer pointer advances on a routed reply, so a relay is never re-sent.
- Reuses the existing question/answer machinery (`questions.ts` callback codec, `pendingTypeAnswers` freetext capture) - Reply arms freetext, Ack is one-tap.

## Safety
- **OFF by default.** Needs `ZOE_ORCHESTRATOR_ENABLED=true` (shares the cron tick) AND `ZOE_RELAY_TG_ENABLED=true`.
- Reply-to-lane is an **internal fleet message** (terminal-to-terminal), not an outbound post/DM to a third party - not a gated action.
- All hub IO is best-effort and never throws; one send failure leaves that relay unpushed to retry next tick.

## Verification
- `tsc --noEmit`: **0 new errors** (46 pre-existing on main, 46 on this branch - I added none; all in unrelated test files).
- `vitest`: **9 new tests pass**; **24 existing orchestrator-tick tests still green** (no regression).
- Not boot-verified against the live poller (rule 21 - never import the entrypoint). CI runs the full suite.

## Known limitation (v1)
The hub is a single row, so a concurrent terminal write + a bridge `tg_pushed` write can race (last-write-wins on the `metadata.relays` array). `pushInboundRelays` re-fetches before marking to shrink the window. Low frequency; a proper fix is per-message rows, deferred.

## To enable after merge
Set both env flags on the VPS ZOE bot and restart. The bridge then rides the existing orchestrator cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
