### PR TITLE
feat(zoe): reply to a relay in Telegram directly, no button tap

### DIFF
--- a/bot/src/zoe/__tests__/relay-bridge.test.ts
+++ b/bot/src/zoe/__tests__/relay-bridge.test.ts
@@ -94,4 +94,25 @@ describe('pushInboundRelays', () => {
     if (prevUrl) process.env.COWORK_TRACKER_URL = prevUrl;
     if (prevKey) process.env.COWORK_TRACKER_KEY = prevKey;
   });
+
+  it('registers message_id -> rl-<lane> so a native reply can route back', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://x.test';
+    process.env.COWORK_TRACKER_KEY = 'k';
+    const hub = { id: 'h1', metadata: { relays: [rel({ from: 'cowork', to: 'zoe', ts: 'a', tg_pushed: false })] } };
+    // GET hub -> row; PATCH -> ok. fetchHub is called twice (initial + re-fetch before mark).
+    const fetchMock = vi.fn(async (_url: string, init?: { method?: string }) => {
+      if (init?.method === 'PATCH') return { ok: true, text: async () => '' } as unknown as Response;
+      return { ok: true, text: async () => JSON.stringify([hub]) } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const sendMessage = vi.fn(async () => ({ message_id: 42 }));
+    const recordContext = vi.fn(async () => {});
+    const n = await pushInboundRelays({ chatId: 999, sendMessage, now: () => 't', recordContext });
+    expect(n).toBe(1);
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(recordContext).toHaveBeenCalledWith(42, 'rl-cowork');
+    vi.unstubAllGlobals();
+    delete process.env.COWORK_TRACKER_URL;
+    delete process.env.COWORK_TRACKER_KEY;
+  });
 });

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -1368,6 +1368,23 @@ bot.on('message:text', async (ctx) => {
       }
     }
 
+    // NATIVE REPLY ROUTING: if Zaal replied DIRECTLY to a message with recorded
+    // context (e.g. a relay push, qid "rl-<lane>"), route it as "[answer:<qid>]"
+    // so the orchestrator reads it the same way the "Type my own" button does -
+    // no button tap needed. Mirrors the private-DM handleReplyRoute path so a
+    // plain reply to a relay message routes back to its lane.
+    if (ctx.message.reply_to_message?.message_id) {
+      const routed = await handleReplyRoute(ctx, { isFromZaal: isFromZaal(ctx) }).catch(
+        () => ({ handled: false as const }),
+      );
+      if (routed.handled && routed.contextType === 'question') {
+        await ctx
+          .reply(`Got your answer for "${routed.id}".`, threadId ? { message_thread_id: threadId } : {})
+          .catch(() => {});
+        return;
+      }
+    }
+
     // Per-topic behavior (topic = intent, Zaal 2026-07-11): dropping a plain
     // message into a topic auto-acts per that topic. Internal actions fire now;
     // outbound casts are drafted with an Approve button (money/public gate).

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -36,6 +36,7 @@ import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQue
 import { pushRecent, ZOE_PATHS } from './memory';
 import { enqueueWork } from './work-loop';
 import { pushInboundRelays, sendRelayReply, laneFromReplyQid } from './relay-bridge';
+import { recordMessageContext } from './message-context';
 import { refillOpenThings, clearOpenThing, topicFromQid, type TopicOpenThingState } from './always-open-topics';
 import { topicNameForThread } from './topic-router';
 
@@ -585,6 +586,8 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
           chatId: deps.groupId,
           sendMessage: (id, text, opts) => deps.bot.api.sendMessage(id, text, opts as never),
           now: () => deps.now.toISOString(),
+          // register message_id -> rl-<lane> so a plain Telegram reply routes back
+          recordContext: (mid, qid) => recordMessageContext(mid, { qid }),
         });
         if (pushed > 0) console.log(`[zoe/relay-bridge] pushed ${pushed} inbound relay(s) to topic`);
       } catch (err) {

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -75,10 +75,11 @@ export function laneFromReplyQid(qid: string): string | null {
   return lane || null;
 }
 
-/** Human-readable DM body for an inbound relay. */
+/** Human-readable DM body for an inbound relay. The hint tells Zaal he can just
+ *  reply to the message directly (native Telegram reply) - no button tap needed. */
 export function formatInboundDm(r: RelayMsg): string {
   const when = (r.ts || '').slice(11, 16);
-  return `Relay from ${r.from}${when ? ` (${when})` : ''}:\n\n${r.msg}`;
+  return `Relay from ${r.from}${when ? ` (${when})` : ''}:\n\n${r.msg}\n\n(Reply to this message to answer, or tap Reply/Ack.)`;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,10 +157,13 @@ export async function sendRelayReply(lane: string, msg: string, ts: string): Pro
 export interface RelayBridgeDeps {
   /** Zaal's DM chat id (ZAAL_DM_ID). */
   chatId: number;
-  /** grammy bot.api.sendMessage, injected for testability. */
-  sendMessage: (chatId: number, text: string, options?: unknown) => Promise<unknown>;
+  /** grammy bot.api.sendMessage - returns the sent Message (we read message_id). */
+  sendMessage: (chatId: number, text: string, options?: unknown) => Promise<{ message_id?: number } | unknown>;
   /** Monotonic timestamp for the mark-pushed write (injected so tests are deterministic). */
   now: () => string;
+  /** Register the sent message's id -> reply-qid so a NATIVE Telegram reply to the
+   *  relay message routes back to the lane with no button tap. Best-effort, optional. */
+  recordContext?: (messageId: number, qid: string) => Promise<void>;
 }
 
 /** One "Reply" (arms freetext) + one "Ack" quick button, both routed by qid. */
@@ -189,8 +193,14 @@ export async function pushInboundRelays(deps: RelayBridgeDeps): Promise<number> 
   const pushedTs = new Set<string>();
   for (const r of pending) {
     try {
-      await deps.sendMessage(deps.chatId, formatInboundDm(r), { reply_markup: replyKeyboard(r.from) });
+      const sent = await deps.sendMessage(deps.chatId, formatInboundDm(r), { reply_markup: replyKeyboard(r.from) });
       pushedTs.add(r.ts);
+      // Register message_id -> rl-<lane> so a plain reply to THIS message routes
+      // back to the lane (no button tap). Best-effort - never blocks the push.
+      const mid = (sent as { message_id?: number } | null)?.message_id;
+      if (mid && deps.recordContext) {
+        await deps.recordContext(mid, relayReplyQid(r.from)).catch(() => {});
+      }
     } catch {
       // one send failure does not block the others; leave it unpushed to retry next tick
     }


### PR DESCRIPTION
## What
Reply to a relay in Telegram **directly** - no button tap. Before, answering a relay push meant tapping Reply (which armed freetext) then typing. Now a plain/native Telegram reply to the relay message routes straight back to the sender's lane.

## How
- The relay push now registers the sent `message_id -> rl-<lane>` via `recordMessageContext`, so a reply to that exact message is recognized (this was the missing piece).
- The ZAAL BOTZ group handler now runs `handleReplyRoute` on a reply-to-message - it was private-DM-only. It logs `[answer:rl-<lane>]`, which the orchestrator tick already routes to `sendRelayReply`. The `reply-thread` sender passes `detectNewAnswers`' filter (only `zsk*`/`zvl*` are excluded), so the tick picks it up.
- DM body now hints "Reply to this message to answer". The Reply/Ack buttons still work as a fallback.

## Verification
- 10 bridge tests (new: `recordContext` called with `message_id` + `rl-<lane>`) + 24 orchestrator tests green
- 0 new tsc errors (46 pre-existing, all in unrelated files)

## Result
The round-trip is one action: relay lands on your phone -> reply to it -> routes back to the terminal that sent it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
