### PR TITLE
feat(zoe): gesture-free relay answers - General = just-type-to-answer

### DIFF
--- a/bot/src/zoe/__tests__/pending-answers.test.ts
+++ b/bot/src/zoe/__tests__/pending-answers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  armPendingAnswer,
+  takePendingAnswer,
+  peekPendingAnswer,
+  clearPendingAnswer,
+} from '../pending-answers';
+
+describe('pending-answers', () => {
+  it('arms then takes once (consumed on take)', () => {
+    armPendingAnswer(1001, 'rl-cowork');
+    expect(peekPendingAnswer(1001)).toBe('rl-cowork');
+    expect(takePendingAnswer(1001)).toBe('rl-cowork');
+    expect(takePendingAnswer(1001)).toBeUndefined(); // consumed
+  });
+
+  it('last-write-wins (answer the most recent thing)', () => {
+    armPendingAnswer(1002, 'rl-zoostr');
+    armPendingAnswer(1002, 'rl-cowork');
+    expect(takePendingAnswer(1002)).toBe('rl-cowork');
+  });
+
+  it('is scoped per chat id', () => {
+    armPendingAnswer(2001, 'q1');
+    armPendingAnswer(2002, 'q2');
+    expect(takePendingAnswer(2002)).toBe('q2');
+    expect(takePendingAnswer(2001)).toBe('q1');
+  });
+
+  it('clear drops the arm without consuming a message', () => {
+    armPendingAnswer(3001, 'rl-ww');
+    clearPendingAnswer(3001);
+    expect(takePendingAnswer(3001)).toBeUndefined();
+  });
+
+  it('take on an unarmed chat is undefined', () => {
+    expect(takePendingAnswer(9999)).toBeUndefined();
+  });
+});

--- a/bot/src/zoe/__tests__/relay-bridge.test.ts
+++ b/bot/src/zoe/__tests__/relay-bridge.test.ts
@@ -107,10 +107,13 @@ describe('pushInboundRelays', () => {
     vi.stubGlobal('fetch', fetchMock);
     const sendMessage = vi.fn(async () => ({ message_id: 42 }));
     const recordContext = vi.fn(async () => {});
-    const n = await pushInboundRelays({ chatId: 999, sendMessage, now: () => 't', recordContext });
+    const armPending = vi.fn();
+    const n = await pushInboundRelays({ chatId: 999, sendMessage, now: () => 't', recordContext, armPending });
     expect(n).toBe(1);
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(recordContext).toHaveBeenCalledWith(42, 'rl-cowork');
+    // gesture-free path: General armed so the next plain message answers this relay
+    expect(armPending).toHaveBeenCalledWith(999, 'rl-cowork');
     vi.unstubAllGlobals();
     delete process.env.COWORK_TRACKER_URL;
     delete process.env.COWORK_TRACKER_KEY;

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -96,6 +96,7 @@ import {
   classifyIntent,
 } from './tg-interactions';
 import { recordMessageContext, getMessageContext, clearMessageContext } from './message-context';
+import { takePendingAnswer } from './pending-answers';
 import { commitResearchDoc } from './research-doc';
 import { extractFirstUrl, wasResearched } from './research-dedupe';
 import { enqueueTurn } from './turn-queue';
@@ -1402,6 +1403,23 @@ bot.on('message:text', async (ctx) => {
         .reply(`Got your answer for "${awaitingQid}".`, threadId ? { message_thread_id: threadId } : {})
         .catch(() => {});
       return;
+    }
+
+    // COMBO (Zaal 2026-07-29): General is the gesture-free ANSWER surface. A plain
+    // typed message in General (no topic thread) answers the last relay/question ZOE
+    // pushed - no swipe, no button. Topics + DM stay normal chat, so this fires ONLY
+    // in General (threadId falsy) and only when something is armed. "use zaalbots as
+    // just a response, normal chat -> DM."
+    if (!threadId) {
+      const armedQid = takePendingAnswer(zaalBotzGroupId);
+      if (armedQid) {
+        await pushRecent(
+          { from: 'zaal', text: `[answer:${armedQid}] ${text}`, sender: 'zaalbotz-general' },
+          String(zaalBotzGroupId),
+        ).catch((e) => console.error('[zoe/index] general-answer log failed:', (e as Error)?.message));
+        await ctx.reply(`Got your answer for "${armedQid}".`).catch(() => {});
+        return;
+      }
     }
 
     const topicName = await topicNameForThread(threadId).catch(() => undefined);

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -37,6 +37,7 @@ import { pushRecent, ZOE_PATHS } from './memory';
 import { enqueueWork } from './work-loop';
 import { pushInboundRelays, sendRelayReply, laneFromReplyQid } from './relay-bridge';
 import { recordMessageContext } from './message-context';
+import { armPendingAnswer } from './pending-answers';
 import { refillOpenThings, clearOpenThing, topicFromQid, type TopicOpenThingState } from './always-open-topics';
 import { topicNameForThread } from './topic-router';
 
@@ -547,6 +548,8 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
             await deps.bot.api.sendMessage(deps.groupId, qText, {
               reply_markup: questionKeyboard(action.nextQuestion.qid, action.nextQuestion.options),
             });
+            // arm General: Zaal's next plain typed message answers this question
+            armPendingAnswer(deps.groupId, action.nextQuestion.qid);
             actioned++;
             console.log(
               `[zoe/orchestrator] posted ${action.nextQuestion.qid} after answer (${answer.qid}, "${answer.value}")`,
@@ -588,6 +591,8 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
           now: () => deps.now.toISOString(),
           // register message_id -> rl-<lane> so a plain Telegram reply routes back
           recordContext: (mid, qid) => recordMessageContext(mid, { qid }),
+          // arm General so Zaal's next plain typed message answers this relay
+          armPending: (chatId, qid) => armPendingAnswer(chatId, qid),
         });
         if (pushed > 0) console.log(`[zoe/relay-bridge] pushed ${pushed} inbound relay(s) to topic`);
       } catch (err) {

--- a/bot/src/zoe/pending-answers.ts
+++ b/bot/src/zoe/pending-answers.ts
@@ -1,0 +1,42 @@
+/**
+ * pending-answers.ts - "the last thing ZOE asked in a chat," so Zaal can answer
+ * it by just typing (no swipe, no button).
+ *
+ * The combo (Zaal 2026-07-29): the ZAAL BOTZ General surface is the gesture-free
+ * ANSWER surface - a plain typed message there routes to the last relay/question
+ * ZOE pushed. Normal chat lives in the DM and in group topics. So when ZOE pushes
+ * a relay or a question to General, it ARMS the qid here; the General handler
+ * TAKES it on the next plain message and routes it as "[answer:<qid>]".
+ *
+ * Separate from index.ts's `pendingTypeAnswers` (which is armed by a Reply-button
+ * tap and consumed anywhere in the group). This one is armed automatically on push
+ * and consumed only in General - that scoping is what keeps topic chat untouched.
+ *
+ * In-memory + last-write-wins ("answer the most recent thing"). Resets on bot
+ * restart, which is fine: a dropped arm just means Zaal taps Reply or swipes, the
+ * fallbacks that always work.
+ */
+
+const armed = new Map<number, string>(); // chatId -> qid
+
+/** ZOE pushed something answerable to this chat; the next plain message answers it. */
+export function armPendingAnswer(chatId: number, qid: string): void {
+  armed.set(chatId, qid);
+}
+
+/** Consume the armed qid for this chat (returns + clears it), or undefined if none. */
+export function takePendingAnswer(chatId: number): string | undefined {
+  const qid = armed.get(chatId);
+  if (qid !== undefined) armed.delete(chatId);
+  return qid;
+}
+
+/** Read without consuming (for tests / diagnostics). */
+export function peekPendingAnswer(chatId: number): string | undefined {
+  return armed.get(chatId);
+}
+
+/** Clear a chat's armed answer without consuming a message (e.g. Zaal chatted instead). */
+export function clearPendingAnswer(chatId: number): void {
+  armed.delete(chatId);
+}

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -164,6 +164,9 @@ export interface RelayBridgeDeps {
   /** Register the sent message's id -> reply-qid so a NATIVE Telegram reply to the
    *  relay message routes back to the lane with no button tap. Best-effort, optional. */
   recordContext?: (messageId: number, qid: string) => Promise<void>;
+  /** Arm the chat so Zaal's NEXT plain typed message (in General) answers this relay -
+   *  the gesture-free "just type" path. Best-effort, optional. */
+  armPending?: (chatId: number, qid: string) => void;
 }
 
 /** One "Reply" (arms freetext) + one "Ack" quick button, both routed by qid. */
@@ -201,6 +204,8 @@ export async function pushInboundRelays(deps: RelayBridgeDeps): Promise<number> 
       if (mid && deps.recordContext) {
         await deps.recordContext(mid, relayReplyQid(r.from)).catch(() => {});
       }
+      // Arm the gesture-free path: the next plain message in General answers this relay.
+      deps.armPending?.(deps.chatId, relayReplyQid(r.from));
     } catch {
       // one send failure does not block the others; leave it unpushed to retry next tick
     }


### PR DESCRIPTION
## What
The combo you asked for. Fixes the "I typed Testing and it went to normal chat" miss by making **General the gesture-free answer surface** while keeping normal chat in the DM and group topics.

## The three surfaces
- **General (ZAAL BOTZ) = just-type-to-answer.** When ZOE pushes a relay or orchestrator question there, your next plain typed message routes to it - no swipe, no button.
- **DM + group topics (Research, Handoffs, ...) = normal chat.** Unchanged.
- **Swipe-reply still works everywhere** to answer a *specific* older message.

## How
- `pending-answers.ts` (new): in-memory arm/take/peek/clear, per-chat, last-write-wins ("answer the most recent thing"). Separate from the button-tap `pendingTypeAnswers`, and **consumed only in General** (`threadId` falsy) so topic chat is never hijacked.
- Relay push (`relay-bridge`) and orchestrator `ask_next` both arm on push.
- `index.ts` General branch takes the armed qid and routes it as `[answer:<qid>]` before falling through to chat.

## Why it's safe
The discriminator is `threadId`: General has none, topics have one. So the just-type routing fires only in General. Normal chat in topics + DM is untouched. In-memory state resets on restart - a dropped arm just falls back to swipe/button, which always work.

## Verification
- 5 new `pending-answers` tests + a relay-bridge arm assertion; **39 tests green**
- 0 new tsc errors (46 pre-existing, unrelated files)

## Note
This assumes you move normal chat to the DM (or a topic) as you said - a plain message in General now means "answer the last thing ZOE sent."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
