### PR TITLE
feat(zoe): instant relay route-back - kill the 5-min tick lag

### DIFF
--- a/bot/src/zoe/__tests__/relay-bridge.test.ts
+++ b/bot/src/zoe/__tests__/relay-bridge.test.ts
@@ -7,6 +7,7 @@ import {
   laneFromReplyQid,
   formatInboundDm,
   pushInboundRelays,
+  tryInstantRelayReply,
   type RelayMsg,
 } from '../relay-bridge';
 
@@ -78,6 +79,40 @@ describe('formatInboundDm', () => {
     expect(out).toContain('zoostr');
     expect(out).toContain('13:45');
     expect(out).toContain('shipped');
+  });
+});
+
+describe('tryInstantRelayReply', () => {
+  it('returns false for a non-relay qid and does no IO', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await tryInstantRelayReply('q1', 'hi', 't')).toBe(false);
+    expect(await tryInstantRelayReply('research-topic', 'hi', 't')).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('routes a relay qid to its lane and returns true', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://x.test';
+    process.env.COWORK_TRACKER_KEY = 'k';
+    const hub = { id: 'h1', metadata: { relays: [] as RelayMsg[] } };
+    let patched: unknown;
+    const fetchMock = vi.fn(async (_url: string, init?: { method?: string; body?: string }) => {
+      if (init?.method === 'PATCH') {
+        patched = JSON.parse(init.body || '{}');
+        return { ok: true, text: async () => '' } as unknown as Response;
+      }
+      return { ok: true, text: async () => JSON.stringify([hub]) } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const ok = await tryInstantRelayReply('rl-cowork', 'on it', 'ts1');
+    expect(ok).toBe(true);
+    // the appended reply targets the cowork lane with from:zoe
+    const relays = (patched as { metadata: { relays: RelayMsg[] } }).metadata.relays;
+    expect(relays.at(-1)).toMatchObject({ from: 'zoe', to: 'cowork', msg: 'on it', read: false });
+    vi.unstubAllGlobals();
+    delete process.env.COWORK_TRACKER_URL;
+    delete process.env.COWORK_TRACKER_KEY;
   });
 });
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -97,6 +97,7 @@ import {
 } from './tg-interactions';
 import { recordMessageContext, getMessageContext, clearMessageContext } from './message-context';
 import { takePendingAnswer } from './pending-answers';
+import { tryInstantRelayReply } from './relay-bridge';
 import { commitResearchDoc } from './research-doc';
 import { extractFirstUrl, wasResearched } from './research-dedupe';
 import { enqueueTurn } from './turn-queue';
@@ -1395,6 +1396,13 @@ bot.on('message:text', async (ctx) => {
     const awaitingQid = pendingTypeAnswers.get(chatId);
     if (awaitingQid) {
       pendingTypeAnswers.delete(chatId);
+      // Relay answer -> route instantly + skip the [answer] log (tick would double-route).
+      if (await tryInstantRelayReply(awaitingQid, text, new Date().toISOString())) {
+        await ctx
+          .reply(`Sent to ${awaitingQid.replace(/^rl-/, '')}.`, threadId ? { message_thread_id: threadId } : {})
+          .catch(() => {});
+        return;
+      }
       await pushRecent(
         { from: 'zaal', text: `[answer:${awaitingQid}] ${text}`, sender: 'zaalbotz-type' },
         String(zaalBotzGroupId),
@@ -1413,6 +1421,13 @@ bot.on('message:text', async (ctx) => {
     if (!threadId) {
       const armedQid = takePendingAnswer(zaalBotzGroupId);
       if (armedQid) {
+        // Relay answer -> route to its lane INSTANTLY (no 5-min tick lag) and do
+        // NOT log [answer] (the tick would double-route). Non-relay (orchestrator
+        // question) falls through to the tick path.
+        if (await tryInstantRelayReply(armedQid, text, new Date().toISOString())) {
+          await ctx.reply(`Sent to ${armedQid.replace(/^rl-/, '')}.`).catch(() => {});
+          return;
+        }
         await pushRecent(
           { from: 'zaal', text: `[answer:${armedQid}] ${text}`, sender: 'zaalbotz-general' },
           String(zaalBotzGroupId),

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -150,6 +150,22 @@ export async function sendRelayReply(lane: string, msg: string, ts: string): Pro
   return saveHubRelays(hub.id, appendReply(hub.relays, lane, msg, ts));
 }
 
+/**
+ * If `qid` is a relay-reply qid (`rl-<lane>`), route `text` back to that lane
+ * IMMEDIATELY and return true - so the answer reaches the sending terminal now,
+ * not up to 5 min later on the next orchestrator tick. Returns false for a
+ * non-relay qid (an orchestrator question) so the caller logs it for the tick.
+ *
+ * IMPORTANT: when this returns true, the caller MUST NOT also log `[answer:qid]`
+ * - the tick would re-route it and the lane would get the reply twice.
+ */
+export async function tryInstantRelayReply(qid: string, text: string, ts: string): Promise<boolean> {
+  const lane = laneFromReplyQid(qid);
+  if (!lane) return false;
+  await sendRelayReply(lane, text, ts).catch(() => {});
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // The tick step (push inbound relays to Zaal's DM)
 // ---------------------------------------------------------------------------

--- a/bot/src/zoe/tg-interactions.ts
+++ b/bot/src/zoe/tg-interactions.ts
@@ -312,6 +312,12 @@ export async function handleReplyRoute(
     }
 
     if (context.qid) {
+      // Relay answer -> route to its lane INSTANTLY (no tick lag); don't log
+      // [answer] (the tick would re-route). Non-relay falls through to the log.
+      const { tryInstantRelayReply } = await import('./relay-bridge');
+      if (await tryInstantRelayReply(context.qid, text, new Date().toISOString())) {
+        return { handled: true, contextType: 'question', id: context.qid };
+      }
       const logText = `[answer:${context.qid}] ${text}`;
       try {
         await pushRecent(


### PR DESCRIPTION
## What
Kills the up-to-5-min lag between answering a relay and it reaching the terminal that sent it. The route-back now fires the instant you send your answer, instead of waiting for the next orchestrator tick.

## How
- `tryInstantRelayReply(qid, text, ts)`: if `qid` is a relay qid (`rl-<lane>`), route to that lane immediately via `sendRelayReply` and return true. For a non-relay qid (an orchestrator question) it returns false, so those still log `[answer:qid]` for the tick.
- Wired at **all three** capture points: General just-type, the Reply-button (`pendingTypeAnswers`), and native swipe-reply (`handleReplyRoute`).
- Each one **skips the `[answer]` log when it routes instantly**, so the tick never double-routes the same answer.
- Reply confirmation is now `Sent to <lane>.` for a relay answer.

## Verification
- 2 new tests (routes `rl-` and mutates the hub; no-op + zero IO for a non-relay qid); **41 tests green**
- 0 new tsc errors (46 pre-existing, unrelated)

## Effect
Type an answer in General (or swipe-reply, or tap Reply) -> it lands in the sending terminal's inbox immediately, not on the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
