### PR TITLE
feat(rules): thread-discipline (anti-sprawl) + doc 2134 date fix

### DIFF
--- a/.claude/rules/thread-discipline.md
+++ b/.claude/rules/thread-discipline.md
@@ -1,0 +1,46 @@
+# Thread Discipline (anti-sprawl / executive-function support)
+
+Established 2026-07-29 after a marathon session opened ~10 threads fast and left
+several half-done ("we moved too fast and lots of things got left behind"). This
+is the in-session complement to `workflow-discipline.md` rule 1 (one thread
+finished, then the next) and to Zaal's capture->triage->crush loop
+([[project_capture_triage_crush_loop]]): that loop catches thoughts Zaal
+deliberately captures; this rule catches threads that open MID-SESSION and would
+otherwise evaporate from the chat. Externalizing the open loops is the point -
+don't hold them in working memory or the transcript alone.
+
+## The three behaviors (behavior-changing)
+
+1. **LIVE LEDGER - hold every open thread in the Task tools, all session.** The
+   moment a new thread/task opens, `TaskCreate` it (status in_progress). On
+   finish, `TaskUpdate` -> completed. This keeps the open loops externalized and
+   visible, so a fast pivot can't silently drop one. The ledger is the source of
+   truth for "what's still open," not the chat scrollback.
+
+2. **PARK-ON-PIVOT - when Zaal jumps threads before the current one is done,
+   capture the leaving thread to the inbox FIRST, then follow.** Run
+   `todo "<the parked thread + its next step>"` so it lands in the cowork inbox
+   and enters triage->crush. Never let a pivot leave a thread living only in the
+   conversation. A one-line `todo` is cheap; a lost thread is not. (If `todo` is
+   unavailable, mark it parked in the ledger and surface it in the end recap.)
+
+3. **END RECAP - on a natural stop, a `/compact`, or when asked, surface the
+   ledger in three buckets:** DONE (shipped, with proof - PR#/file), PARKED
+   (captured to inbox/board, will resurface via crush), DROPPED (open, needs a
+   decision). Never end a long session without this - it's the "nothing left
+   behind" checkpoint. Honest DONE vs PARKED vs DROPPED (per `anti-fabrication.md`).
+
+## Guards
+
+- Parking is NOT doing. `todo` captures the thread; it does not execute it (iron
+  rule from the capture loop: capture never = do-it-now).
+- Don't over-capture: only park a thread that has real remaining work. A finished
+  or trivial aside doesn't go to the inbox.
+- The ledger reuses Zaal's existing loop - a parked thread flows todo -> zao-triage
+  -> crush -> morning-pick. No new system; this is discipline + the Task tools.
+
+## Source
+
+2026-07-29 marathon-session retro. Siblings: `workflow-discipline.md` (one thread
+at a time), `agent-loops.md` (rule 4: never leave a broken state),
+`[[project_capture_triage_crush_loop]]`, doc 606 (second-brain system).

--- a/research/events/2134-heart-of-ellsworth-promo-jul28/README.md
+++ b/research/events/2134-heart-of-ellsworth-promo-jul28/README.md
@@ -17,7 +17,7 @@ Laurel, Joy, Zaal, Chesnee, Leslie. Date: 2026-07-28, 5:30pm, Franklin Street Pa
 
 ## The ZAO slice (what actually touches Zaal / The ZAO)
 **Art of Ellsworth, Oct 1-4 - ZAO Stock confirmed:**
-- Zaal confirmed **ZAO Stock for Art of Ellsworth, Saturday 12-6 pm** (Saturday = Oct 4 within the Oct 1-4 window). NOTE: reconcile with the known ZAO Stock date (Oct 3, Franklin St Parklet) - confirm whether these are the same event/day or two slots.
+- Zaal confirmed **ZAO Stock for Art of Ellsworth, Saturday 12-6 pm** (Saturday = Oct 3, within the Oct 1-4 window; confirmed by Zaal 2026-07-29). Same day as the known ZAO Stock date (Oct 3, Franklin St Parklet) - one event, no conflict.
 - **Black Moon** may host an after-party; **projection mapping** planned after dark.
 - **Sen** confirmed to perform.
 - Zaal said content from a **recent Maryland event** will help promote the October event, and the **HofE org-story video** will help introduce the town/community to ZAO's audience.
@@ -38,19 +38,19 @@ Laurel, Joy, Zaal, Chesnee, Leslie. Date: 2026-07-28, 5:30pm, Franklin Street Pa
 ## Zaal's action items (extracted - the rest of the committee ACTION ITEMS are Chesnee's)
 | Action | Owner | Why | Done when | Confidence |
 |--------|-------|-----|-----------|------------|
-| Confirm the ZAO Stock date/slot at Art of Ellsworth (Sat 12-6) vs the known Oct 3 ZAO Stock date | Zaal | avoid a double/date-conflict on the flagship event | before Oct 1 | high |
+| ZAO Stock @ Art of Ellsworth confirmed = Oct 3 (Saturday) 12-6, same as the known date | Zaal | avoid a double/date-conflict on the flagship event | before Oct 1 | high |
 | Reach out to Courthouse Gallery + Flexit as possible additional Art-of-Ellsworth venues | Zaal | expand the ZAO footprint at the event | before Oct 1 | high |
 | Confirm Sen's performance + Black Moon after-party + projection-mapping logistics | Zaal | locks the ZAO Stock program | before Oct 1 | medium |
 | Package the Maryland-event content + the HofE org video into the Oct promo | Zaal | agreed promo support | Sept | medium |
 
 ## VERIFY (for Zaal)
-- The "Saturday 12-6" ZAO Stock slot at Art of Ellsworth (Oct 4) vs the ZAO Stock date in memory ([[project_zao_stock_confirmed]] says Oct 3, Franklin St Parklet) - CONFIRM these are the same event or two distinct things before it goes on any calendar/promo.
+- RESOLVED (Zaal 2026-07-29): Oct 3 IS the Saturday, so the Art of Ellsworth ZAO Stock slot and the known ZAO Stock date ([[project_zao_stock_confirmed]]) are the SAME event on Oct 3. No conflict.
 - These are committee minutes, not a transcript - attributions are as written in the minutes.
 
 ## Next Actions
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
-| Reconcile the ZAO Stock date (Oct 3 vs Art of Ellsworth Sat Oct 4) | @Zaal | decision | 2026-08-15 |
+| ZAO Stock @ Art of Ellsworth = Oct 3 (Sat) 12-6 - CONFIRMED, no reconcile needed |  | done | 2026-07-29 |
 | Reach out to Courthouse Gallery + Flexit re: Art of Ellsworth venues | @Zaal | outreach | 2026-09-01 |
 | Confirm Sen + Black Moon after-party + projection mapping | @Zaal | confirm | 2026-09-15 |
 | Assemble Oct promo (Maryland content + HofE org video) | @Zaal | content | 2026-09-15 |


### PR DESCRIPTION
The anti-sprawl fix Zaal asked for. New .claude/rules/thread-discipline.md: LIVE LEDGER (Task tools hold every open thread), PARK-ON-PIVOT (leaving thread -> todo inbox before following a pivot), END RECAP (done/parked/dropped). Reuses the capture->triage->crush loop, no new system. Plus fixes doc 2134's ZAO Stock date to Oct 3 (Zaal confirmed Oct 3 is the Saturday).