### PR TITLE
fix(zoe): chunk the repo-improver audit send - the real truncation fix

### DIFF
--- a/bot/src/zoe/__tests__/tg-chunk.test.ts
+++ b/bot/src/zoe/__tests__/tg-chunk.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { chunkForTelegram, sendChunkedToTelegram } from '../tg-chunk';
+
+describe('chunkForTelegram', () => {
+  it('returns one chunk when under the limit', () => {
+    expect(chunkForTelegram('short')).toEqual(['short']);
+  });
+
+  it('splits long text into <=3900-char chunks', () => {
+    const text = 'a'.repeat(10000);
+    const chunks = chunkForTelegram(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(3900);
+    expect(chunks.join('').length).toBe(10000);
+  });
+
+  it('prefers paragraph/line boundaries over hard cuts', () => {
+    const para = 'x'.repeat(3800);
+    const text = `${para}\n\n${para}`;
+    const chunks = chunkForTelegram(text);
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]).toBe(para); // split on the \n\n, not mid-para
+  });
+});
+
+describe('sendChunkedToTelegram', () => {
+  it('sends one message unprefixed when short', async () => {
+    const send = vi.fn(async (_c: number, _t: string) => {});
+    await sendChunkedToTelegram(send, 42, 'hi');
+    expect(send).toHaveBeenCalledExactlyOnceWith(42, 'hi');
+  });
+
+  it('sends multiple prefixed messages for long text, in order', async () => {
+    const send = vi.fn(async (_c: number, _t: string) => {});
+    await sendChunkedToTelegram(send, 42, 'a'.repeat(8000));
+    expect(send.mock.calls.length).toBeGreaterThan(1);
+    expect(send.mock.calls[0][1]).toMatch(/^\(1\/\d+\) /);
+    expect(send.mock.calls.every((c) => (c[1] as string).length <= 3900 + 8)).toBe(true);
+  });
+
+  it('one failing chunk does not abort the rest', async () => {
+    let n = 0;
+    const send = vi.fn(async (_c: number, _t: string) => {
+      n += 1;
+      if (n === 1) throw new Error('telegram 400');
+    });
+    await sendChunkedToTelegram(send, 42, 'a'.repeat(8000));
+    expect(send.mock.calls.length).toBeGreaterThan(1); // continued past the failure
+  });
+});

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -34,6 +34,7 @@ import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { runErrorRemediationTick, defaultRemediationDeps } from './error-remediation';
 import { runRepoImproverTick } from './repo-improver-io';
+import { sendChunkedToTelegram } from './tg-chunk';
 import { runPreflight } from './preflight';
 import { shouldFireAlert, shouldPauseAutonomousWork, formatSpendStatus } from './cost-governance';
 import { surfaceNewHandoffs } from './handoffs-surface';
@@ -708,7 +709,11 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         if (!gid) return; // not configured
         if (!process.env.OPENROUTER_API_KEY?.trim()) return; // scout needs the cheap model
         if (shouldPauseAutonomousWork()) return; // cost hard-stop
-        await runRepoImproverTick((text: string) => opts.bot.api.sendMessage(gid, text).then(() => {}));
+        // Chunk the send: audits routinely exceed Telegram's 4096-char limit and
+        // were getting truncated mid-sentence (tg-chunk.ts). Never raw-send long text.
+        await runRepoImproverTick((text: string) =>
+          sendChunkedToTelegram((cid, t) => opts.bot.api.sendMessage(cid, t), gid, text),
+        );
       },
       { timezone: 'UTC' },
     ),

--- a/bot/src/zoe/tg-chunk.ts
+++ b/bot/src/zoe/tg-chunk.ts
@@ -1,0 +1,50 @@
+/**
+ * tg-chunk.ts - split + send long text to Telegram in <=4096-char messages.
+ *
+ * Telegram hard-rejects (or truncates) any single message over 4096 chars. Long
+ * bot output - repo-improver/site audits especially - was sent via a raw
+ * bot.api.sendMessage and got cut off mid-sentence (the ZONEXUS / The-ZAO audits,
+ * 2026-07-29). Raising the LLM output cap made it WORSE (longer text -> hit the
+ * Telegram limit harder). The real fix is chunking the SEND. Shared so any
+ * autonomous-notify path can use it, not just the concierge reply.
+ */
+
+// 3900 leaves headroom under 4096 for the "(n/m) " prefix + markdown.
+const TELEGRAM_MAX = 3900;
+
+/** Split into Telegram-sized chunks, preferring paragraph -> line -> word
+ *  boundaries; hard-cuts only if no boundary is found in the back half. Pure. */
+export function chunkForTelegram(text: string, max = TELEGRAM_MAX): string[] {
+  if (text.length <= max) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > max) {
+    let cut = remaining.lastIndexOf('\n\n', max);
+    if (cut < max * 0.5) cut = remaining.lastIndexOf('\n', max);
+    if (cut < max * 0.5) cut = remaining.lastIndexOf(' ', max);
+    if (cut < max * 0.5) cut = max;
+    chunks.push(remaining.slice(0, cut).trimEnd());
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
+}
+
+/** Send a possibly-long message to a chat as one or more Telegram messages,
+ *  prefixed "(n/m)" when split. Best-effort - a failed chunk does not abort the
+ *  rest. `send` is bot.api.sendMessage (injected for testability). */
+export async function sendChunkedToTelegram(
+  send: (chatId: number, text: string) => Promise<unknown>,
+  chatId: number,
+  text: string,
+): Promise<void> {
+  const chunks = chunkForTelegram(text);
+  for (let i = 0; i < chunks.length; i++) {
+    const prefix = chunks.length > 1 ? `(${i + 1}/${chunks.length}) ` : '';
+    try {
+      await send(chatId, prefix + chunks[i]);
+    } catch {
+      // one chunk failing must not drop the others
+    }
+  }
+}


### PR DESCRIPTION
The audits kept cutting off. Real cause: scheduler.ts posts the audit via a RAW bot.api.sendMessage, and Telegram truncates >4096 chars. #2695 (token cap) made it worse (longer output). Fix: new tg-chunk.ts (chunkForTelegram + sendChunkedToTelegram) + scheduler sends chunked. 6 tests, 0 new tsc errors.