### PR TITLE
fix(zoe): chunk every unbounded Telegram send - kill the truncation class

### DIFF
--- a/bot/src/zoe/__tests__/tg-chunk.test.ts
+++ b/bot/src/zoe/__tests__/tg-chunk.test.ts
@@ -48,3 +48,82 @@ describe('sendChunkedToTelegram', () => {
     expect(send.mock.calls.length).toBeGreaterThan(1); // continued past the failure
   });
 });
+
+describe('sendChunkedToTelegram - opts, markup placement, return value', () => {
+  const longText = `${'A'.repeat(3900)}\n\n${'B'.repeat(2000)}`;
+
+  it('passes baseOpts on every chunk', async () => {
+    const calls: Array<{ text: string; opts?: Record<string, unknown> }> = [];
+    await sendChunkedToTelegram(
+      async (_cid, text, opts) => {
+        calls.push({ text, opts });
+        return { message_id: calls.length };
+      },
+      1,
+      longText,
+      { baseOpts: { message_thread_id: 77 } },
+    );
+    expect(calls.length).toBeGreaterThan(1);
+    for (const c of calls) expect(c.opts?.message_thread_id).toBe(77);
+  });
+
+  it("markupOn 'first' puts the keyboard only on chunk 1 (router behavior)", async () => {
+    const calls: Array<Record<string, unknown> | undefined> = [];
+    await sendChunkedToTelegram(
+      async (_cid, _text, opts) => {
+        calls.push(opts);
+        return { message_id: calls.length };
+      },
+      1,
+      longText,
+      { replyMarkup: { inline_keyboard: [] } },
+    );
+    expect(calls[0]?.reply_markup).toBeDefined();
+    for (const c of calls.slice(1)) expect(c?.reply_markup).toBeUndefined();
+  });
+
+  it("markupOn 'last' puts the keyboard only on the final chunk and returns THAT message", async () => {
+    const calls: Array<Record<string, unknown> | undefined> = [];
+    const result = await sendChunkedToTelegram(
+      async (_cid, _text, opts) => {
+        calls.push(opts);
+        return { message_id: calls.length };
+      },
+      1,
+      longText,
+      { replyMarkup: { inline_keyboard: [] }, markupOn: 'last' },
+    );
+    expect(calls[calls.length - 1]?.reply_markup).toBeDefined();
+    for (const c of calls.slice(0, -1)) expect(c?.reply_markup).toBeUndefined();
+    expect((result as { message_id: number }).message_id).toBe(calls.length);
+  });
+
+  it('short text sends once with no prefix and returns the message', async () => {
+    const calls: string[] = [];
+    const result = await sendChunkedToTelegram(
+      async (_cid, text) => {
+        calls.push(text);
+        return { message_id: 42 };
+      },
+      1,
+      'short',
+    );
+    expect(calls).toEqual(['short']);
+    expect((result as { message_id: number }).message_id).toBe(42);
+  });
+
+  it('a failed chunk does not abort the rest; returns last success', async () => {
+    let n = 0;
+    const result = await sendChunkedToTelegram(
+      async () => {
+        n++;
+        if (n === 1) throw new Error('boom');
+        return { message_id: n };
+      },
+      1,
+      longText,
+    );
+    expect(n).toBeGreaterThan(1);
+    expect((result as { message_id: number }).message_id).toBe(n);
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -15,6 +15,7 @@
  *   OR: systemd user unit zoe-bot.service
  */
 import { config as loadEnv } from 'dotenv';
+import { sendChunkedToTelegram } from './tg-chunk';
 loadEnv();
 
 import { Bot, Context, InlineKeyboard } from 'grammy';
@@ -520,10 +521,12 @@ bot.command('zoldraft', async (ctx) => {
   }
   const id = 'zol-' + Date.now().toString(36);
   putDraft('zol-cast', text, id);
-  await bot.api.sendMessage(gid, `ZOL draft:\n${text}`, {
-    message_thread_id: zolThread,
-    reply_markup: draftKeyboard(id),
-  });
+  await sendChunkedToTelegram(
+    (cid, t, o) => bot.api.sendMessage(cid, t, o as never),
+    gid,
+    `ZOL draft:\n${text}`,
+    { baseOpts: { message_thread_id: zolThread }, replyMarkup: draftKeyboard(id), markupOn: 'last' },
+  );
   await ctx.reply('Staged in the ZOL topic with Post/Skip/Edit.');
 });
 
@@ -1538,12 +1541,14 @@ bot.on('message:text', async (ctx) => {
       }
       const id = `${action.draftKind}-${Date.now().toString(36)}`;
       putDraft(action.draftKind, text, id);
-      await bot.api
-        .sendMessage(chatId, `${action.label}:\n${text}`, {
-          ...threadOpt,
-          reply_markup: draftKeyboard(id),
-        })
-        .catch(() => {});
+      // Draft text is LLM-length; chunk the send, keyboard on the LAST chunk
+      // so Post/Skip/Edit sits at the bottom of the draft.
+      await sendChunkedToTelegram(
+        (cid, t, o) => bot.api.sendMessage(cid, t, o as never),
+        chatId,
+        `${action.label}:\n${text}`,
+        { baseOpts: { ...threadOpt }, replyMarkup: draftKeyboard(id), markupOn: 'last' },
+      ).catch(() => {});
       return;
     }
 

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -23,6 +23,8 @@
  * is OFF unless ZOE_RELAY_TG_ENABLED === 'true'.
  */
 
+import { sendChunkedToTelegram } from './tg-chunk';
+
 const HUB_LEGACY_ID = '9000';
 
 /** One relay message in the hub. `tg_pushed` is this bridge's dedup marker. */
@@ -212,7 +214,15 @@ export async function pushInboundRelays(deps: RelayBridgeDeps): Promise<number> 
   const pushedTs = new Set<string>();
   for (const r of pending) {
     try {
-      const sent = await deps.sendMessage(deps.chatId, formatInboundDm(r), { reply_markup: replyKeyboard(r.from) });
+      // A relayed message can be arbitrarily long (a terminal can relay a
+      // paste) - chunk it; the Reply/Ack keyboard rides the LAST chunk and the
+      // returned message is that one, so reply-context arms on the right mid.
+      const sent = await sendChunkedToTelegram(
+        (cid, t, o) => deps.sendMessage(cid, t, o as never),
+        deps.chatId,
+        formatInboundDm(r),
+        { replyMarkup: replyKeyboard(r.from), markupOn: 'last' },
+      );
       pushedTs.add(r.ts);
       // Register message_id -> rl-<lane> so a plain reply to THIS message routes
       // back to the lane (no button tap). Best-effort - never blocks the push.

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -114,7 +114,8 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
   void runPreflight(async (report: string) => {
     const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
     const target = gid || opts.zaalTgId;
-    if (target) await opts.bot.api.sendMessage(target, report).then(() => {});
+    if (target)
+      await sendChunkedToTelegram((cid, t, o) => opts.bot.api.sendMessage(cid, t, o as never), target, report);
   });
 
   // Morning brief — 09:00 UTC = 05:00 EDT, 04:00 EST. We anchor to UTC; Zaal in EST/EDT.
@@ -154,8 +155,14 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (opts.routingDeps) {
             await sendToZaalRouted(opts.routingDeps, brief, { kind: 'status', replyMarkup: vetoKeyboard });
           } else {
-            const sendOpts = vetoKeyboard ? { reply_markup: vetoKeyboard } : {};
-            await opts.bot.api.sendMessage(opts.zaalTgId, brief, sendOpts);
+            // Brief is LLM-generated and can exceed 4096 - chunk the fallback
+            // send too (the routed path already chunks). Keyboard on chunk 1.
+            await sendChunkedToTelegram(
+              (cid, t, o) => opts.bot.api.sendMessage(cid, t, o as never),
+              opts.zaalTgId,
+              brief,
+              vetoKeyboard ? { replyMarkup: vetoKeyboard } : undefined,
+            );
           }
           console.log('[zoe/scheduler] morning brief sent (cockpit)' + (vetoKeyboard?.inline_keyboard.length ? ' + veto keyboard' : ''));
           // Mirror to Discord #zao-status if DISCORD_WEBHOOK_STATUS is set (doc 1135 Stage 1a).
@@ -300,7 +307,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (opts.routingDeps) {
             await sendToZaalRouted(opts.routingDeps, recap, { kind: 'status' });
           } else {
-            await opts.bot.api.sendMessage(opts.zaalTgId, recap);
+            await sendChunkedToTelegram((cid, t, o) => opts.bot.api.sendMessage(cid, t, o as never), opts.zaalTgId, recap);
           }
           console.log('[zoe/scheduler] nightly recap sent');
         } catch (err) {
@@ -711,9 +718,9 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         if (shouldPauseAutonomousWork()) return; // cost hard-stop
         // Chunk the send: audits routinely exceed Telegram's 4096-char limit and
         // were getting truncated mid-sentence (tg-chunk.ts). Never raw-send long text.
-        await runRepoImproverTick((text: string) =>
-          sendChunkedToTelegram((cid, t) => opts.bot.api.sendMessage(cid, t), gid, text),
-        );
+        await runRepoImproverTick(async (text: string) => {
+          await sendChunkedToTelegram((cid, t) => opts.bot.api.sendMessage(cid, t), gid, text);
+        });
       },
       { timezone: 'UTC' },
     ),

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -21,28 +21,9 @@
 
 import { ZAAL_DM_ID, ZAAL_BOTZ_GROUP_ID, ZAAL_BOTZ_RESEARCH_THREAD } from './env';
 
-const TELEGRAM_MAX = 3900;
-
-/**
- * Split a long string into Telegram-sized chunks, preferring paragraph then
- * line then word boundaries. Falls back to a hard cut only if no boundary is
- * found in the back half of the window.
- */
-function chunkLongMessage(text: string, max = TELEGRAM_MAX): string[] {
-  if (text.length <= max) return [text];
-  const chunks: string[] = [];
-  let remaining = text;
-  while (remaining.length > max) {
-    let cut = remaining.lastIndexOf('\n\n', max);
-    if (cut < max * 0.5) cut = remaining.lastIndexOf('\n', max);
-    if (cut < max * 0.5) cut = remaining.lastIndexOf(' ', max);
-    if (cut < max * 0.5) cut = max;
-    chunks.push(remaining.slice(0, cut).trimEnd());
-    remaining = remaining.slice(cut).trimStart();
-  }
-  if (remaining.length > 0) chunks.push(remaining);
-  return chunks;
-}
+// Chunking is shared with every other long-send path (tg-chunk.ts) so the
+// boundary logic can never drift between the router and direct sends.
+import { chunkForTelegram } from './tg-chunk';
 
 export type MessageKind = 'question' | 'status' | 'whisper';
 
@@ -84,7 +65,7 @@ export async function sendToZaal(
   opts: SendToZaalOptions = {},
 ): Promise<any> {
   const kind = opts.kind ?? 'status';
-  const chunks = chunkLongMessage(text);
+  const chunks = chunkForTelegram(text);
 
   // Determine target chat id based on message kind. Questions AND whispers both
   // go to Zaal's DM (questions need a reply, whispers are private notifications);

--- a/bot/src/zoe/tg-chunk.ts
+++ b/bot/src/zoe/tg-chunk.ts
@@ -30,21 +30,50 @@ export function chunkForTelegram(text: string, max = TELEGRAM_MAX): string[] {
   return chunks;
 }
 
+export interface SendChunkedOpts {
+  /** Options attached to EVERY chunk (e.g. message_thread_id). */
+  baseOpts?: Record<string, unknown>;
+  /** Inline keyboard attached to exactly one chunk. */
+  replyMarkup?: unknown;
+  /** Which chunk carries replyMarkup. Default 'first' (matches the router);
+   *  use 'last' when a reply/keyboard must be at the bottom (drafts, relays). */
+  markupOn?: 'first' | 'last';
+}
+
 /** Send a possibly-long message to a chat as one or more Telegram messages,
  *  prefixed "(n/m)" when split. Best-effort - a failed chunk does not abort the
- *  rest. `send` is bot.api.sendMessage (injected for testability). */
+ *  rest. `send` is bot.api.sendMessage (injected for testability).
+ *  Returns the result of the last SUCCESSFUL send (null if every chunk failed) -
+ *  callers that arm reply-context need the message that carries the keyboard,
+ *  so pair `markupOn: 'last'` with the returned message. */
 export async function sendChunkedToTelegram(
-  send: (chatId: number, text: string) => Promise<unknown>,
+  send: (chatId: number, text: string, opts?: Record<string, unknown>) => Promise<unknown>,
   chatId: number,
   text: string,
-): Promise<void> {
+  opts?: SendChunkedOpts,
+): Promise<unknown> {
   const chunks = chunkForTelegram(text);
+  const markupOn = opts?.markupOn ?? 'first';
+  let last: unknown = null;
+  let markupResult: unknown = null;
   for (let i = 0; i < chunks.length; i++) {
     const prefix = chunks.length > 1 ? `(${i + 1}/${chunks.length}) ` : '';
+    const carriesMarkup =
+      opts?.replyMarkup !== undefined &&
+      (markupOn === 'first' ? i === 0 : i === chunks.length - 1);
+    const sendOpts: Record<string, unknown> = { ...(opts?.baseOpts ?? {}) };
+    if (carriesMarkup) sendOpts.reply_markup = opts?.replyMarkup;
     try {
-      await send(chatId, prefix + chunks[i]);
+      // Arity preserved for plain sends - some grammy call sites (and their
+      // tests) treat a trailing undefined options arg as a different call.
+      last = Object.keys(sendOpts).length
+        ? await send(chatId, prefix + chunks[i], sendOpts)
+        : await send(chatId, prefix + chunks[i]);
+      if (carriesMarkup) markupResult = last;
     } catch {
       // one chunk failing must not drop the others
     }
   }
+  // Context-arming callers need the message that carries the keyboard.
+  return markupResult ?? last;
 }


### PR DESCRIPTION
## Kill the Telegram truncation class

PR #2703 chunked one send site (repo-improver audit). This PR closes the whole class - a >4096-char sendMessage does not truncate, it HARD-FAILS and the message is lost entirely.

### Sites fixed (each verified unbounded before wrapping)
- scheduler: preflight report, morning-brief fallback, nightly-recap fallback (the routed path chunked; these fallbacks did not)
- index: /zoldraft staging, draft-action sends (LLM-length text + draft keyboard - keyboard now rides the LAST chunk, under the draft)
- relay-bridge: inbound relay pushes (a terminal can relay a paste); Reply/Ack keyboard on last chunk, reply-context arms on that message_id

### Structural
- tg-chunk.sendChunkedToTelegram: baseOpts (thread ids) on every chunk, replyMarkup on first or last chunk, returns the markup-carrying message; plain-send arity preserved
- telegram-routing now imports the shared chunker instead of its byte-identical private copy - boundary logic can never drift between the router and direct sends

### Verification
- bot vitest: 130/131 files green, 1699 tests, 1 failed = the pre-existing meetings.test.ts date failure (identical on untouched main)
- bot tsc: 46 errors = exactly the pre-existing 46 (diffed error sets against baseline)
- app typecheck: 0 errors
- 5 new tg-chunk tests: opts propagation, first/last markup placement, return value, partial-failure resilience

Generated with [Claude Code](https://claude.com/claude-code)
