### PR TITLE
feat(zoe): grill decision-UX - contextual buttons + multi-choice + typed capture (#51)

### DIFF
--- a/bot/src/zoe/__tests__/grill.test.ts
+++ b/bot/src/zoe/__tests__/grill.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { toQueue, pickNext, formatGrill, parseOptions, type GrillState } from '../grill';
+import {
+  toQueue,
+  pickNext,
+  formatGrill,
+  parseOptions,
+  matchTypedAnswer,
+  toggleSelection,
+  multiKeyboard,
+  type GrillState,
+} from '../grill';
 import type { CockpitTask, ReviewPR } from '../../cockpit/types';
 
 function task(over: Partial<CockpitTask>): CockpitTask {
@@ -132,8 +141,8 @@ describe('formatGrill one-click buttons', () => {
     // first row = the 3 answer options, mapped to grill:ans:<value>
     expect(buttons[0].map((b) => b.data)).toEqual(['grill:ans:1', 'grill:ans:2', 'grill:ans:3']);
     expect(buttons[0][0].text).toBe('1: intro test');
-    // second row = Skip / Later
-    expect(buttons[1].map((b) => b.data)).toEqual(['grill:skip', 'grill:snooze']);
+    // second row = Pick multiple (3+ options, #51) then Skip / Later
+    expect(buttons[1].map((b) => b.data)).toEqual(['grill:multi', 'grill:skip', 'grill:snooze']);
   });
   it('a no-option decision offers Approve (resolve) / Skip / Later', () => {
     const { buttons, text } = formatGrill(
@@ -167,3 +176,99 @@ describe('formatGrill one-click buttons', () => {
     expect(text).toContain('Reply if you want me to prep');
   });
 })
+
+describe('parseOptions - #51 colon forms (the "solid" Creator Studio example)', () => {
+  it('parses "1: intro test / 2: map / 3: both" with a colon prefix in the title', () => {
+    const o = parseOptions('Creator Studio decision: 1: intro test / 2: map / 3: both');
+    expect(o.map((x) => x.value)).toEqual(['1', '2', '3']);
+    expect(o.map((x) => x.label)).toEqual(['1: intro test', '2: map', '3: both']);
+  });
+
+  it('still parses the paren form after a prefix colon', () => {
+    const o = parseOptions('Creator Studio: pick 1 (intro test) / 2 (map) / 3 (both)');
+    expect(o.map((x) => x.value)).toEqual(['1', '2', '3']);
+    expect(o[0].label).toBe('1: intro test');
+  });
+
+  it('parses dash-labeled options', () => {
+    const o = parseOptions('Ship it: 1 - now / 2 - after review');
+    expect(o.map((x) => x.label)).toEqual(['1: now', '2: after review']);
+  });
+});
+
+describe('matchTypedAnswer - #51 typed capture', () => {
+  const opts = [
+    { value: '1', label: '1: intro test' },
+    { value: '2', label: '2: map' },
+    { value: '3', label: '3: both' },
+  ];
+
+  it('matches a bare value, a full label, and a label tail', () => {
+    expect(matchTypedAnswer('2', opts)).toBe('2');
+    expect(matchTypedAnswer('2: map', opts)).toBe('2');
+    expect(matchTypedAnswer('map', opts)).toBe('2');
+    expect(matchTypedAnswer('BOTH', opts)).toBe('3');
+  });
+
+  it('matches multi forms and joins values', () => {
+    expect(matchTypedAnswer('1,2', opts)).toBe('1,2');
+    expect(matchTypedAnswer('1 and 3', opts)).toBe('1,3');
+    expect(matchTypedAnswer('1 2 3', opts)).toBe('1,2,3');
+  });
+
+  it('never eats normal chat', () => {
+    expect(matchTypedAnswer('can you also check the deploy logs', opts)).toBeNull();
+    expect(matchTypedAnswer('1 but only after the map is done', opts)).toBeNull();
+    expect(matchTypedAnswer('', opts)).toBeNull();
+    expect(matchTypedAnswer('yes', opts)).toBeNull(); // not one of THESE options
+    expect(matchTypedAnswer('anything', [])).toBeNull();
+  });
+
+  it('dedupes repeated tokens in a multi answer', () => {
+    expect(matchTypedAnswer('1, 1, 2', opts)).toBe('1,2');
+  });
+});
+
+describe('toggleSelection + multiKeyboard - #51 multi-choice', () => {
+  const opts = [
+    { value: '1', label: '1: intro test' },
+    { value: '2', label: '2: map' },
+    { value: '3', label: '3: both' },
+  ];
+
+  it('toggles on/off and keeps option order', () => {
+    let sel = toggleSelection([], '3', opts);
+    sel = toggleSelection(sel, '1', opts);
+    expect(sel).toEqual(['1', '3']);
+    sel = toggleSelection(sel, '3', opts);
+    expect(sel).toEqual(['1']);
+  });
+
+  it('renders [x]/[ ] rows plus Send/Cancel', () => {
+    const rows = multiKeyboard(opts, ['2']);
+    expect(rows).toHaveLength(4);
+    expect(rows[0][0].text).toBe('[ ] 1: intro test');
+    expect(rows[1][0].text).toBe('[x] 2: map');
+    expect(rows[1][0].data).toBe('grill:tog:2');
+    expect(rows[3].map((b) => b.data)).toEqual(['grill:multisend', 'grill:multicancel']);
+    expect(rows[3][0].text).toBe('Send (1)');
+  });
+});
+
+describe('formatGrill - Pick multiple appears only for 3+ option decisions', () => {
+  it('adds the multi button for a 3-option decision', () => {
+    const { buttons } = formatGrill(
+      { key: 'k', kind: 'decision', title: 'Pick: 1: a / 2: b / 3: c', priority: 0 },
+      0,
+    );
+    expect(buttons[1].map((b) => b.data)).toEqual(['grill:multi', 'grill:skip', 'grill:snooze']);
+  });
+
+  it('keeps the plain tail for a 2-option decision', () => {
+    const { buttons } = formatGrill(
+      { key: 'k', kind: 'decision', title: 'Publish: yes / no', priority: 0 },
+      0,
+    );
+    expect(buttons[1].map((b) => b.data)).toEqual(['grill:skip', 'grill:snooze']);
+  });
+});

--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -58,6 +58,11 @@ export interface GrillState {
   activeKind?: GrillKind | null;
   /** message_id of the pinned open question, so we can unpin it on answer. */
   activeMessageId?: number | null;
+  /** Parsed one-click options of the active decision, so typed answers and the
+   * multi-select keyboard can match against them (#51). */
+  activeOptions?: { value: string; label: string }[] | null;
+  /** Values toggled on in multi-select mode (order follows activeOptions). */
+  activeMulti?: string[] | null;
   lastAskedAt: string | null;
   /** How many items ZOE has proactively pushed today, so it caps at DAILY_PUSH_CAP
    * (top-N-not-96). Reset when the date rolls. /grill and post-answer advances
@@ -75,7 +80,24 @@ const DAILY_PUSH_CAP = 5;
  * Returns [] when there is no clean 2-4 option set (falls back to Done/Skip/Later).
  */
 export function parseOptions(title: string): { value: string; label: string }[] {
-  const body = title.includes(':') ? title.slice(title.lastIndexOf(':') + 1) : title;
+  // The options may themselves contain colons ("... 1: intro test / 2: map"),
+  // so neither first- nor last-colon splitting alone is safe. Try candidates
+  // from longest to shortest; the first that parses cleanly into 2-4 options
+  // wins: after the FIRST colon, after the LAST colon, then the whole title.
+  const candidates: string[] = [];
+  const firstColon = title.indexOf(':');
+  const lastColon = title.lastIndexOf(':');
+  if (firstColon >= 0) candidates.push(title.slice(firstColon + 1));
+  if (lastColon > firstColon) candidates.push(title.slice(lastColon + 1));
+  candidates.push(title);
+  for (const body of candidates) {
+    const opts = parseOptionsBody(body);
+    if (opts.length >= 2) return opts;
+  }
+  return [];
+}
+
+function parseOptionsBody(body: string): { value: string; label: string }[] {
   const parts = body
     .split('/')
     .map((p) => p.trim())
@@ -83,11 +105,13 @@ export function parseOptions(title: string): { value: string; label: string }[] 
   if (parts.length < 2 || parts.length > 4) return [];
   const opts: { value: string; label: string }[] = [];
   for (const part of parts) {
-    const num = part.match(/^(?:pick\s+)?(\d+)\s*(?:\(([^)]+)\))?/i);
+    // Numbered option: "1 (intro test)", "1: intro test", "1 - intro test",
+    // "pick 1 (intro)", or a bare "3".
+    const num = part.match(/^(?:pick\s+)?(\d+)\s*(?:\(([^)]+)\)|[:.\-]\s*(.+))?$/i);
     if (num) {
       const v = num[1];
-      const paren = num[2]?.trim();
-      opts.push({ value: v, label: paren ? `${v}: ${paren}` : v });
+      const label = (num[2] ?? num[3])?.trim();
+      opts.push({ value: v, label: label ? `${v}: ${label}` : v });
       continue;
     }
     const word = part.replace(/[()]/g, '').trim();
@@ -99,6 +123,67 @@ export function parseOptions(title: string): { value: string; label: string }[] 
   }
   if (new Set(opts.map((o) => o.value)).size !== opts.length) return []; // colliding values
   return opts;
+}
+
+/**
+ * Match a TYPED message against the active decision's options, so a plain
+ * typed answer registers without a button tap (the #51 capture fix). Returns
+ * the option value, a comma-joined multi ("1,3"), or null when the text is not
+ * option-shaped - null means "this is normal chat, leave it alone".
+ */
+export function matchTypedAnswer(
+  text: string,
+  options: { value: string; label: string }[],
+): string | null {
+  if (!options.length) return null;
+  const t = text.trim().toLowerCase();
+  if (!t || t.length > 80) return null;
+  for (const o of options) {
+    if (t === o.value.toLowerCase() || t === o.label.toLowerCase()) return o.value;
+    // "2: map" typed as just "map" (the label tail)
+    const tail = o.label.toLowerCase().replace(/^\d+:\s*/, '');
+    if (tail && t === tail) return o.value;
+  }
+  // Multi-choice: "1,2", "1 and 3", "1 2", "1 & 2" - every token must be a value.
+  const values = new Set(options.map((o) => o.value.toLowerCase()));
+  const tokens = t.split(/\s*(?:,|\band\b|&|\+|\s)\s*/).filter(Boolean);
+  if (tokens.length >= 2 && tokens.every((tok) => values.has(tok))) {
+    const uniq = [...new Set(tokens)];
+    if (uniq.length >= 2) return uniq.join(',');
+  }
+  return null;
+}
+
+/** Pure multi-select toggle: add/remove a value, preserving option order. */
+export function toggleSelection(
+  selected: string[],
+  value: string,
+  options: { value: string; label: string }[],
+): string[] {
+  const next = selected.includes(value) ? selected.filter((v) => v !== value) : [...selected, value];
+  const order = options.map((o) => o.value);
+  return next.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}
+
+/**
+ * Keyboard rows for multi-select mode: each option toggles ([x]/[ ] prefix),
+ * plus Send/Cancel. Pure - index.ts renders it into grammy's shape.
+ */
+export function multiKeyboard(
+  options: { value: string; label: string }[],
+  selected: string[],
+): { text: string; data: string }[][] {
+  const rows = options.map((o) => [
+    {
+      text: `${selected.includes(o.value) ? '[x]' : '[ ]'} ${o.label.slice(0, 24)}`,
+      data: `grill:tog:${o.value}`.slice(0, 60),
+    },
+  ]);
+  rows.push([
+    { text: `Send${selected.length ? ` (${selected.length})` : ''}`, data: 'grill:multisend' },
+    { text: 'Cancel', data: 'grill:multicancel' },
+  ]);
+  return rows;
 }
 
 const ASK_COOLDOWN_MS = 3 * 60 * 60 * 1000; // don't re-surface a still-open item within 3h
@@ -182,7 +267,7 @@ export function pickNext(queue: GrillItem[], state: GrillState, now: number): Gr
 export function formatGrill(
   item: GrillItem,
   remaining: number,
-): { text: string; buttons: { text: string; data: string }[][] } {
+): { text: string; buttons: { text: string; data: string }[][]; options: { value: string; label: string }[] } {
   const lead =
     item.kind === 'event'
       ? `On your calendar today:\n${item.title}`
@@ -217,7 +302,10 @@ export function formatGrill(
   let buttons: { text: string; data: string }[][];
   if (options.length >= 2) {
     const answerRow = options.map((o) => ({ text: o.label.slice(0, 28), data: `grill:ans:${o.value}`.slice(0, 60) }));
-    buttons = [answerRow, [{ text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }]];
+    const tailRow = [{ text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }];
+    // 3+ options: offer multi-select ("1 and 3"), single taps still instant.
+    if (options.length >= 3) tailRow.unshift({ text: 'Pick multiple', data: 'grill:multi' });
+    buttons = [answerRow, tailRow];
   } else {
     // grill:approve resolves a single-action decision ("yes, do this") - it
     // records the call AND moves the source task off the needs-you queue.
@@ -232,7 +320,7 @@ export function formatGrill(
             : { text: 'Approve', data: 'grill:approve' };
     buttons = [[resolveBtn, { text: 'Skip', data: 'grill:skip' }, { text: 'Later', data: 'grill:snooze' }]];
   }
-  return { text: `${lead}${context}${link}${resolveHint}${tail}`, buttons };
+  return { text: `${lead}${context}${link}${resolveHint}${tail}`, buttons, options };
 }
 
 export interface SurfaceGrillDeps {
@@ -302,7 +390,7 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
   // Unpin the previous open question so at most ONE question is ever pinned.
   if (deps.unpin && state.activeMessageId) await deps.unpin(state.activeMessageId).catch(() => {});
 
-  const { text, buttons } = formatGrill(item, remaining);
+  const { text, buttons, options } = formatGrill(item, remaining);
   const sent = (await deps.sendDM(text, buttons)) as { message_id?: number } | undefined;
   const messageId = sent && typeof sent === 'object' ? sent.message_id : undefined;
 
@@ -314,6 +402,8 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
   state.activeTitle = item.title;
   state.activeKind = item.kind;
   state.activeMessageId = messageId ?? null;
+  state.activeOptions = options.length ? options : null;
+  state.activeMulti = null;
   state.lastAskedAt = new Date(now).toISOString();
   state.daySurfaced = { date: today, count: day.count + 1 };
   await writeGrillState(state);
@@ -352,8 +442,57 @@ export async function applyGrillAnswer(
   state.activeTitle = null;
   state.activeKind = null;
   state.activeMessageId = null;
+  state.activeOptions = null;
+  state.activeMulti = null;
   await writeGrillState(state);
   return { note: `Locked in: ${value}. Next one coming.`, key, title, value };
+}
+
+/**
+ * Read the active decision's options + current multi selection (for the
+ * multi-select keyboard and typed-answer matching). Null when nothing active
+ * or the active item has no parsed options.
+ */
+export async function getActiveGrill(): Promise<{
+  key: string;
+  options: { value: string; label: string }[];
+  selected: string[];
+  messageId: number | null;
+} | null> {
+  const state = await readGrillState();
+  if (!state.activeKey || !state.activeOptions?.length) return null;
+  return {
+    key: state.activeKey,
+    options: state.activeOptions,
+    selected: state.activeMulti ?? [],
+    messageId: state.activeMessageId ?? null,
+  };
+}
+
+/** Toggle a value in multi-select mode; returns the new keyboard state. */
+export async function toggleGrillMulti(
+  value: string,
+): Promise<{ options: { value: string; label: string }[]; selected: string[] } | null> {
+  const state = await readGrillState();
+  if (!state.activeKey || !state.activeOptions?.length) return null;
+  const selected = toggleSelection(state.activeMulti ?? [], value, state.activeOptions);
+  state.activeMulti = selected;
+  await writeGrillState(state);
+  return { options: state.activeOptions, selected };
+}
+
+/**
+ * Commit the multi selection as the answer ("1,3"). Returns the same shape as
+ * applyGrillAnswer so index.ts reuses one resolve path; null when nothing is
+ * selected (the tap is answered with a hint instead).
+ */
+export async function commitGrillMulti(
+  now = Date.now(),
+): Promise<{ note: string; key: string | null; title: string | null; value: string } | null> {
+  const state = await readGrillState();
+  const selected = state.activeMulti ?? [];
+  if (!state.activeKey || selected.length === 0) return null;
+  return applyGrillAnswer(selected.join(','), now);
 }
 
 /**
@@ -380,6 +519,8 @@ export async function resolveGrillByReply(
   state.activeTitle = null;
   state.activeKind = null;
   state.activeMessageId = null;
+  state.activeOptions = null;
+  state.activeMulti = null;
   await writeGrillState(state);
   return { key, kind, title, value: replyText };
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -20,7 +20,17 @@ loadEnv();
 
 import { Bot, Context, InlineKeyboard } from 'grammy';
 import { BUTTON_BAR, ZOE_COMMANDS, isBarLabel } from './button-bar';
-import { surfaceGrill, applyGrillAction, applyGrillAnswer, resolveGrillByReply } from './grill';
+import {
+  surfaceGrill,
+  applyGrillAction,
+  applyGrillAnswer,
+  resolveGrillByReply,
+  getActiveGrill,
+  matchTypedAnswer,
+  toggleGrillMulti,
+  commitGrillMulti,
+  multiKeyboard,
+} from './grill';
 import { resolveTaskDecision } from '../cockpit/adapters';
 import type { Client } from 'discord.js';
 import { bootDiscordClient } from './discord';
@@ -404,6 +414,10 @@ bot.command('menu', async (ctx) => {
 // a time, to his DM (never a group). PIN the open question (and unpin the prior
 // one) so ONLY the question awaiting his answer is ever pinned. Reused by /grill,
 // the callbacks, and the scheduler cron.
+function toGrammyRows(rows: { text: string; data: string }[][]) {
+  return rows.map((row) => row.map((b) => ({ text: b.text, callback_data: b.data })));
+}
+
 function grillDeps(chatId: number) {
   // No pin/unpin: pinning each grill item spawned a "ZOE pinned ..." service
   // message per item, cluttering the DM. With the daily cap (~5/day) the cards
@@ -1332,6 +1346,43 @@ bot.on('message:text', async (ctx) => {
   // DM path: Zaal-only allowlist preserved.
   if (chatType === 'private') {
     if (!isFromZaal(ctx)) return;
+    // #51 typed-answer capture: a PLAIN typed message that is option-shaped for
+    // the active grill decision ("2", "map", "1 and 3") resolves it directly -
+    // previously only button taps and exact swipe-replies registered, so a
+    // typed answer sat unregistered until Zaal tapped Later. Only fires on an
+    // exact option match, so normal DM chat is never eaten.
+    if (!ctx.message.reply_to_message) {
+      try {
+        const active = await getActiveGrill();
+        const matched = active ? matchTypedAnswer(text, active.options) : null;
+        if (active && matched) {
+          const r = await applyGrillAnswer(matched);
+          if (r.key) {
+            const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+            await pushRecent(
+              { from: 'zaal', text: `[grill-answer] ${r.title ?? r.key}: ${matched}`, sender: 'grill' },
+              String(gid || zaalId),
+            ).catch((e) => console.error('[zoe/grill] typed-answer log failed:', (e as Error)?.message));
+            await resolveTaskDecision(r.key, matched).catch((e) =>
+              console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
+            );
+            // Strip the now-answered card's buttons (best-effort).
+            if (active.messageId) {
+              await ctx.api
+                .editMessageReplyMarkup(zaalId, active.messageId, { reply_markup: { inline_keyboard: [] } })
+                .catch(() => {});
+            }
+            await ctx.reply(`Locked in: ${matched}. Logged it and moved it off your plate.`);
+            await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
+              console.error('[zoe/grill] advance failed:', (e as Error)?.message),
+            );
+            return;
+          }
+        }
+      } catch (e: unknown) {
+        console.error('[zoe/grill] typed-answer capture failed:', (e as Error)?.message);
+      }
+    }
     // Thread context: when Zaal QUOTE-REPLIES a message, fold what he replied to
     // into the turn so a short reply ("zol yes") anchors to the right draft
     // instead of arriving context-free. Telegram only gives us the quoted text.
@@ -2838,6 +2889,74 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
     ).catch((e) => console.error('[zoe/grill] answer log failed:', (e as Error)?.message));
     // Move the resolved decision off the board's needs-you queue (best-effort).
     await resolveTaskDecision(r.key, value).catch((e) =>
+      console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
+    );
+  }
+  await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
+    console.error('[zoe/grill] advance failed:', (e as Error)?.message),
+  );
+});
+
+// #51 multi-choice: "Pick multiple" swaps the card's keyboard for toggle rows
+// ([x]/[ ] per option) + Send/Cancel. Single taps elsewhere stay instant.
+bot.callbackQuery('grill:multi', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const active = await getActiveGrill();
+  if (!active) {
+    await ctx.answerCallbackQuery({ text: 'Nothing active.' }).catch(() => {});
+    return;
+  }
+  await ctx.answerCallbackQuery().catch(() => {});
+  await ctx
+    .editMessageReplyMarkup({ reply_markup: { inline_keyboard: toGrammyRows(multiKeyboard(active.options, active.selected)) } })
+    .catch(() => {});
+});
+
+bot.callbackQuery(/^grill:tog:(.+)$/, async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const r = await toggleGrillMulti(ctx.match[1]);
+  if (!r) {
+    await ctx.answerCallbackQuery({ text: 'Nothing active.' }).catch(() => {});
+    return;
+  }
+  await ctx.answerCallbackQuery().catch(() => {});
+  await ctx
+    .editMessageReplyMarkup({ reply_markup: { inline_keyboard: toGrammyRows(multiKeyboard(r.options, r.selected)) } })
+    .catch(() => {});
+});
+
+bot.callbackQuery('grill:multicancel', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const active = await getActiveGrill();
+  await ctx.answerCallbackQuery().catch(() => {});
+  if (!active) return;
+  // Back to single-tap rows (same shape formatGrill builds for a decision).
+  const answerRow = active.options.map((o) => ({ text: o.label.slice(0, 28), callback_data: `grill:ans:${o.value}`.slice(0, 60) }));
+  const tailRow = [{ text: 'Skip', callback_data: 'grill:skip' }, { text: 'Later', callback_data: 'grill:snooze' }];
+  if (active.options.length >= 3) tailRow.unshift({ text: 'Pick multiple', callback_data: 'grill:multi' });
+  await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [answerRow, tailRow] } }).catch(() => {});
+});
+
+bot.callbackQuery('grill:multisend', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const r = await commitGrillMulti();
+  if (!r) {
+    await ctx.answerCallbackQuery({ text: 'Toggle at least one option first.' }).catch(() => {});
+    return;
+  }
+  await ctx.answerCallbackQuery({ text: r.note }).catch(() => {});
+  await ctx
+    .editMessageText(grillResolvedText(ctx.callbackQuery.message?.text, `Locked in: ${r.value}`), {
+      reply_markup: { inline_keyboard: [] },
+    })
+    .catch(() => {});
+  if (r.key) {
+    const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    await pushRecent(
+      { from: 'zaal', text: `[grill-answer] ${r.title ?? r.key}: ${r.value}`, sender: 'grill' },
+      String(gid || zaalId),
+    ).catch((e) => console.error('[zoe/grill] multi log failed:', (e as Error)?.message));
+    await resolveTaskDecision(r.key, r.value).catch((e) =>
       console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
     );
   }


### PR DESCRIPTION
## Board #51: orchestrator decision-UX

Closes the three gaps Zaal hit on the "Decision needed" cards:

### 1. Contextual option buttons (the "solid" example now parses)
"Creator Studio: 1: intro test / 2: map / 3: both" previously fell back to generic Approve/Skip/Later - the old parser split on the LAST colon, which lands inside option 3. parseOptions now tries first-colon / last-colon / whole-title candidates and supports "1 (label)", "1: label", "1 - label", bare words.

### 2. Multi-choice
- Buttons: 3+ option decisions get "Pick multiple" - keyboard swaps to [x]/[ ] toggle rows + Send/Cancel via editMessageReplyMarkup (no message spam). Send commits "1,3" through the same resolve path as single taps.
- Typed: "1 and 3", "1,2", "1 2 3" match and commit joined.

### 3. Typed-answer capture (the dead-typed-reply bug)
A plain typed DM matching an option (value / label / label tail / multi combo) resolves the active decision: logs [grill-answer], resolves the board task, strips the card's buttons, advances to the next item. Strictly option-shaped matches only - "1 but only after the map is done" and normal chat fall through to the concierge untouched (test-pinned).

### Verification
- bot vitest: 130/131 files green (1716 tests; 1 fail = pre-existing meetings.test.ts, identical on main)
- grill suite: 29/29
- bot tsc: 46 = exactly the pre-existing 46
- app typecheck untouched (no app files changed)

Generated with [Claude Code](https://claude.com/claude-code)
