### PR TITLE
feat(spore): live receipt emission - observations leave as verifiable evidence

### DIFF
--- a/scripts/receipt-emitter-check.ts
+++ b/scripts/receipt-emitter-check.ts
@@ -1,0 +1,90 @@
+/**
+ * Executable proof for the live receipt path (app vitest is broken - rolldown
+ * binding - so this runner is the gate): assemble the REAL organism with a
+ * deterministic offline spike, run ticks, assert every distributed observation
+ * emitted a verifiable Phase 3-conformant receipt. Exit 1 on any failure.
+ *
+ * Run: npx tsx scripts/receipt-emitter-check.ts
+ */
+import { assembleOrganism } from '../src/lib/organism';
+import { createObservation } from '../src/lib/eyes';
+import type { VacuumSpike } from '../src/lib/bloodstream';
+import { verifyReceipt } from '../src/lib/spore/receipt';
+import { toDreamNetReceipt, verifyDreamNetReceipt } from '../src/lib/spore/interop';
+
+let pass = 0;
+let fail = 0;
+function check(name: string, ok: boolean) {
+  if (ok) {
+    pass++;
+    console.log(`PASS  ${name}`);
+  } else {
+    fail++;
+    console.error(`FAIL  ${name}`);
+  }
+}
+
+const NOW = '2026-07-30T05:00:00.000Z';
+let tick = 0;
+const spike: VacuumSpike = {
+  manifest: { spikeId: 'spike:offline', version: '1', riskTier: 'passive', strategy: 'poll', pollIntervalMs: 1, produces: ['market.price'] },
+  ingest: async (ctx) => ({
+    observations: [
+      createObservation(
+        {
+          sensor: 'spike:offline',
+          kind: 'market.price',
+          subjectKey: 'asset:ETH-USD',
+          payload: { price: 3000 + tick }, // changes per tick -> not deduped
+          confidence: 1,
+          provenance: { method: 'api' },
+          health: { status: 'healthy', latencyMs: 1, errorRate: 0, lastOkAt: null, consecutiveFailures: 0 },
+        },
+        { observerId: ctx.observerId, now: NOW },
+      ),
+    ],
+  }),
+};
+
+const sunk: string[] = [];
+const organism = assembleOrganism({
+  now: () => NOW,
+  spike,
+  receiptIssuer: 'organism:zao:main',
+  onReceipt: (r) => {
+    sunk.push(r.receiptId);
+  },
+});
+
+async function main() {
+const t1 = await organism.runTick();
+tick++;
+const t2 = await organism.runTick();
+
+check('tick 1 distributed', t1.circulated[0]?.distributed === 1);
+check('tick 2 distributed (changed payload)', t2.circulated[0]?.distributed === 1);
+
+const receipts = organism.receipts.recent();
+check('2 receipts emitted', receipts.length === 2);
+check('sink received both', sunk.length === 2);
+for (const r of receipts) {
+  check(`receipt ${r.receiptId.slice(0, 8)} self-verifies`, verifyReceipt(r));
+  const dn = toDreamNetReceipt(r);
+  check(
+    `receipt ${r.receiptId.slice(0, 8)} verifies as SDK receipt.v1`,
+    verifyDreamNetReceipt(dn, { kind: r.spore.kind, subjectKey: r.spore.subjectKey, payload: r.spore.payload }).isValid,
+  );
+}
+const snap = organism.snapshot();
+const receiptsOrgan = snap.organs.find((o: { organId: string }) => o.organId === 'receipts');
+check('receipts organ registered + healthy', receiptsOrgan?.status === 'healthy');
+check('emitted metric = 2', organism.receipts.metrics().emitted === 2);
+
+console.log(`\nRESULT: ${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);
+}
+
+main().catch((e: unknown) => {
+  console.error('FATAL:', e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/src/lib/organism/organism.ts
+++ b/src/lib/organism/organism.ts
@@ -23,6 +23,8 @@ import { ControlPlane } from '@/lib/control-plane';
 import type { HealthReport, OrganRegistration, OrganStatus } from '@/lib/control-plane';
 import { Memory } from '@/lib/memory';
 import type { VacuumSpike } from '@/lib/bloodstream';
+import { ReceiptEmitter } from '@/lib/spore/receipt-emitter';
+import type { PortableReceipt } from '@/lib/spore';
 
 export interface OrganismOptions {
   /** Clock - injectable for deterministic tests. */
@@ -33,6 +35,10 @@ export interface OrganismOptions {
   bloodstream?: BloodstreamOptions;
   /** Options for the default Coinbase spike when none is provided. */
   coinbase?: CoinbaseSpikeOptions;
+  /** Receipt issuer identity. Default 'organism:zao:main'. */
+  receiptIssuer?: string;
+  /** Durable/transport sink for emitted receipts (in-memory ring regardless). */
+  onReceipt?: (receipt: PortableReceipt) => void | Promise<void>;
 }
 
 export interface TickResult {
@@ -48,6 +54,8 @@ export interface Organism {
   readonly controlPlane: ControlPlane;
   readonly bloodstream: Bloodstream;
   readonly memory: Memory;
+  /** Every distributed Observation leaves as portable, verifiable evidence. */
+  readonly receipts: ReceiptEmitter;
   /** Pull -> circulate -> store -> heartbeat -> snapshot. One heartbeat of life. */
   runTick(): Promise<TickResult>;
   snapshot(): ReturnType<ControlPlane['snapshot']>;
@@ -82,6 +90,12 @@ export function assembleOrganism(opts: OrganismOptions = {}): Organism {
   // Memory subscribes to the Bloodstream - every distributed Observation is stored.
   bloodstream.subscribe({ id: 'memory', kinds: [], deliver: (obs) => memory.record(obs) });
 
+  // Phase 2 in the live path: every distributed Observation also emits a
+  // portable dreamnet.receipt.v1 (Phase 3-conformant), so the organism's
+  // perception is externally verifiable evidence by default (doc 2138).
+  const receipts = new ReceiptEmitter({ issuer: opts.receiptIssuer ?? 'organism:zao:main', onReceipt: opts.onReceipt, now });
+  bloodstream.subscribe(receipts.subscriber());
+
   // Register the organs so the organism can discover + health-check itself.
   const registrations: OrganRegistration[] = [
     {
@@ -94,6 +108,17 @@ export function assembleOrganism(opts: OrganismOptions = {}): Organism {
       endpoints: [{ name: 'circulate', address: 'internal:bloodstream', protocol: 'internal' }],
       secrets: [],
       health: stamp('starting', { spikes: 1 }),
+    },
+    {
+      organId: 'receipts',
+      name: 'Receipt Emitter (portable evidence)',
+      version: VERSION,
+      layer: 'data',
+      capabilities: [{ name: 'receipt.v1.emit', version: '1', description: 'emits dreamnet.receipt.v1 per observation' }],
+      dependencies: ['bloodstream'],
+      endpoints: [{ name: 'recent', address: 'internal:receipts', protocol: 'internal' }],
+      secrets: [],
+      health: stamp('starting', { emitted: 0 }),
     },
     {
       organId: 'memory',
@@ -119,6 +144,13 @@ export function assembleOrganism(opts: OrganismOptions = {}): Organism {
       deduped: bloodMetrics.deduped,
     }));
 
+    const rm = receipts.metrics();
+    controlPlane.heartbeat('receipts', stamp(rm.sinkErrors > 0 ? 'degraded' : 'healthy', {
+      emitted: rm.emitted,
+      buffered: rm.buffered,
+      sinkErrors: rm.sinkErrors,
+    }));
+
     const mem = memory.snapshot();
     controlPlane.heartbeat('memory', stamp(mem.status, {
       records: mem.total,
@@ -138,6 +170,7 @@ export function assembleOrganism(opts: OrganismOptions = {}): Organism {
     controlPlane,
     bloodstream,
     memory,
+    receipts,
     runTick,
     snapshot: () => controlPlane.snapshot(),
   };

--- a/src/lib/spore/__tests__/receipt-emitter.test.ts
+++ b/src/lib/spore/__tests__/receipt-emitter.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { Bloodstream } from '@/lib/bloodstream';
+import type { VacuumSpike } from '@/lib/bloodstream';
+import { createObservation } from '@/lib/eyes';
+import { ReceiptEmitter } from '../receipt-emitter';
+import { verifyReceipt } from '../receipt';
+import { toDreamNetReceipt, verifyDreamNetReceipt } from '../interop';
+
+/**
+ * ReceiptEmitter - every distributed Observation leaves as verifiable
+ * evidence; dedup means no duplicate receipts; sink failures never break
+ * circulation.
+ */
+
+const NOW = '2026-07-30T05:00:00.000Z';
+
+function fakeSpike(payloads: Array<{ subjectKey: string; price: number }>): VacuumSpike {
+  return {
+    manifest: {
+      spikeId: 'spike:test',
+      version: '1',
+      riskTier: 'passive',
+      strategy: 'poll',
+      pollIntervalMs: 1000,
+      produces: ['market.price'],
+    },
+    ingest: async (ctx) => ({
+      observations: payloads.map((p) =>
+        createObservation(
+          {
+            sensor: 'spike:test',
+            kind: 'market.price',
+            subjectKey: p.subjectKey,
+            payload: { price: p.price },
+            confidence: 1,
+            provenance: { method: 'api' },
+            health: { status: 'healthy', latencyMs: 1, errorRate: 0, lastOkAt: null, consecutiveFailures: 0 },
+          },
+          { observerId: ctx.observerId, now: NOW },
+        ),
+      ),
+    }),
+  };
+}
+
+describe('ReceiptEmitter as a Bloodstream subscriber', () => {
+  it('emits one verifiable receipt per distributed observation', async () => {
+    const blood = new Bloodstream();
+    blood.registerSpike(fakeSpike([{ subjectKey: 'asset:BTC-USD', price: 100 }, { subjectKey: 'asset:ETH-USD', price: 50 }]));
+    const emitter = new ReceiptEmitter({ issuer: 'organism:zao:test', now: () => NOW });
+    blood.subscribe(emitter.subscriber());
+
+    const result = await blood.circulateSpike('spike:test', { observerId: 'o1', config: {}, now: NOW });
+    expect(result.distributed).toBe(2);
+    const receipts = emitter.recent();
+    expect(receipts).toHaveLength(2);
+    for (const r of receipts) {
+      expect(r.schemaVersion).toBe('dreamnet.receipt.v1');
+      expect(r.issuer).toBe('organism:zao:test');
+      expect(verifyReceipt(r)).toBe(true);
+      // ...and it round-trips into the SDK receipt.v1 shape and verifies.
+      const dn = toDreamNetReceipt(r);
+      expect(
+        verifyDreamNetReceipt(dn, { kind: r.spore.kind, subjectKey: r.spore.subjectKey, payload: r.spore.payload }).isValid,
+      ).toBe(true);
+    }
+  });
+
+  it('deduped observations do not emit duplicate receipts', async () => {
+    const blood = new Bloodstream();
+    blood.registerSpike(fakeSpike([{ subjectKey: 'asset:BTC-USD', price: 100 }]));
+    const emitter = new ReceiptEmitter({ issuer: 'organism:zao:test', now: () => NOW });
+    blood.subscribe(emitter.subscriber());
+
+    await blood.circulateSpike('spike:test', { observerId: 'o1', config: {}, now: NOW });
+    await blood.circulateSpike('spike:test', { observerId: 'o1', config: {}, now: NOW });
+    expect(emitter.recent()).toHaveLength(1); // second pass was cache-deduped upstream
+    expect(emitter.metrics().emitted).toBe(1);
+  });
+
+  it('a throwing sink is isolated and counted, circulation continues', async () => {
+    const blood = new Bloodstream();
+    blood.registerSpike(fakeSpike([{ subjectKey: 'asset:BTC-USD', price: 100 }]));
+    const emitter = new ReceiptEmitter({
+      issuer: 'organism:zao:test',
+      now: () => NOW,
+      onReceipt: () => {
+        throw new Error('sink down');
+      },
+    });
+    blood.subscribe(emitter.subscriber());
+
+    const result = await blood.circulateSpike('spike:test', { observerId: 'o1', config: {}, now: NOW });
+    expect(result.ok).toBe(true);
+    expect(result.distributed).toBe(1);
+    expect(emitter.metrics().sinkErrors).toBe(1);
+    // The receipt still landed in the ring before the sink threw.
+    expect(emitter.recent()).toHaveLength(1);
+  });
+
+  it('ring buffer drops oldest beyond bufferSize; byId finds buffered receipts', async () => {
+    const emitter = new ReceiptEmitter({ issuer: 'organism:zao:test', bufferSize: 2, now: () => NOW });
+    const blood = new Bloodstream();
+    blood.registerSpike(
+      fakeSpike([
+        { subjectKey: 'a', price: 1 },
+        { subjectKey: 'b', price: 2 },
+        { subjectKey: 'c', price: 3 },
+      ]),
+    );
+    blood.subscribe(emitter.subscriber());
+    await blood.circulateSpike('spike:test', { observerId: 'o1', config: {}, now: NOW });
+    const recent = emitter.recent();
+    expect(recent).toHaveLength(2);
+    expect(emitter.metrics().emitted).toBe(3);
+    expect(emitter.byId(recent[0].receiptId)?.receiptId).toBe(recent[0].receiptId);
+    expect(emitter.byId('missing')).toBeUndefined();
+  });
+});

--- a/src/lib/spore/receipt-emitter.ts
+++ b/src/lib/spore/receipt-emitter.ts
@@ -1,0 +1,82 @@
+/**
+ * Receipt emitter - Phase 2 completed in the LIVE path.
+ *
+ * A Bloodstream Subscriber that turns every distributed Observation into a
+ * portable `dreamnet.receipt.v1` (Phase 3-conformant, PR #2704) and hands it
+ * to an injectable sink. The Bloodstream transports and never decides; receipt
+ * emission is therefore a SUBSCRIBER, not a core change - unplug the
+ * subscriber and the organism runs exactly as before.
+ *
+ * The default sink is a bounded in-memory ring (drop-oldest), which is enough
+ * for the organism demo + the Phase 4 verify endpoint to serve recent
+ * receipts. A durable sink (DB/outbox) plugs in via `onReceipt` without
+ * touching this module - that is the transactional-outbox milestone
+ * (doc 2142 next focus).
+ */
+import type { Observation } from '@/lib/eyes';
+import type { Subscriber } from '@/lib/bloodstream/types';
+import { observationToReceipt, type PortableReceipt } from './receipt';
+
+export interface ReceiptEmitterOptions {
+  /** Receipt issuer identity, e.g. 'organism:zao:main'. */
+  issuer: string;
+  /** Receive each receipt (durable store, transport, ...). Errors are isolated. */
+  onReceipt?: (receipt: PortableReceipt) => void | Promise<void>;
+  /** Ring size for the in-memory buffer. Default 500. */
+  bufferSize?: number;
+  /** Injectable clock for deterministic tests. */
+  now?: () => string;
+}
+
+export class ReceiptEmitter {
+  private readonly issuer: string;
+  private readonly onReceipt?: ReceiptEmitterOptions['onReceipt'];
+  private readonly bufferSize: number;
+  private readonly nowFn?: () => string;
+  private readonly ring: PortableReceipt[] = [];
+  private emittedCount = 0;
+  private sinkErrors = 0;
+
+  constructor(opts: ReceiptEmitterOptions) {
+    if (!opts.issuer?.trim()) throw new Error('ReceiptEmitter: issuer required');
+    this.issuer = opts.issuer;
+    this.onReceipt = opts.onReceipt;
+    this.bufferSize = opts.bufferSize ?? 500;
+    this.nowFn = opts.now;
+  }
+
+  /** The Bloodstream subscriber. Never throws (delivery isolation is ours too). */
+  subscriber(): Subscriber {
+    return {
+      id: 'receipt-emitter',
+      kinds: [], // every observation becomes portable evidence
+      deliver: async (obs: Observation) => {
+        try {
+          const receipt = observationToReceipt(obs, this.issuer, this.nowFn ? { now: this.nowFn() } : undefined);
+          this.ring.push(receipt);
+          if (this.ring.length > this.bufferSize) this.ring.shift();
+          this.emittedCount++;
+          if (this.onReceipt) await this.onReceipt(receipt);
+        } catch {
+          // A sink failure must never break circulation; count it loudly in
+          // metrics instead of swallowing silently (silent-failure-guard 6).
+          this.sinkErrors++;
+        }
+      },
+    };
+  }
+
+  /** Most-recent receipts, newest last. */
+  recent(limit = 50): readonly PortableReceipt[] {
+    return this.ring.slice(-limit);
+  }
+
+  /** Find a buffered receipt by id (the Phase 4 GET /receipts/:id read). */
+  byId(receiptId: string): PortableReceipt | undefined {
+    return this.ring.find((r) => r.receiptId === receiptId);
+  }
+
+  metrics(): { emitted: number; buffered: number; sinkErrors: number } {
+    return { emitted: this.emittedCount, buffered: this.ring.length, sinkErrors: this.sinkErrors };
+  }
+}


### PR DESCRIPTION
Phase 2 in the live path, on top of the Phase 3 conformance (#2704):

- src/lib/spore/receipt-emitter.ts - Bloodstream SUBSCRIBER (no core changes): every distributed Observation -> dreamnet.receipt.v1, bounded in-memory ring + injectable durable sink, loud sink-error metrics
- Wired into assembleOrganism: 'receipts' organ registered in the control plane with per-tick heartbeat (degraded on sink errors); organism exposes .receipts
- Dedup upstream means no duplicate receipts; a throwing sink never breaks circulation (tested)

Proof (app vitest still broken - rolldown): npx tsx scripts/receipt-emitter-check.ts = 10/10 on a real organism assembly with a deterministic offline spike - every receipt self-verifies AND round-trips into the SDK receipt.v1 shape. App typecheck 0 errors. Vitest suite included for when CI is fixed.

Next (doc 2142): durable sink = effect_intents/outbox migration (ask-first), then the Phase 4 externally-reachable verify endpoint reading this ring.

Generated with [Claude Code](https://claude.com/claude-code)