### PR TITLE
docs(zabal): August = mentor pairing at the core - pods for all + draft day

### DIFF
--- a/research/business/2137-zabal-gamez-august-concept-options/MENTOR-PAIRING-CORE.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/MENTOR-PAIRING-CORE.md
@@ -1,0 +1,103 @@
+# August rework: MENTOR PAIRING is the core (Zaal, 2026-07-30 03:20)
+
+> Zaal's overnight directive: "make August a way to pair you with a ZAO mentor - mentor being the main goal and idea of this whole ZABAL Gamez." This reframes the README in this folder: the competition structure stays, but it is now the ENGINE for pairing, not the point. The point is: **submit anything in July, and a ZAO mentor builds August with you.**
+
+## The reframe in one line
+
+Old headline: "August is comprised of the July submitters."
+New headline: **"August is comprised of the July submitters - and every one of them gets a ZAO mentor."**
+
+The tournament (qualifier -> battles) stays exactly as locked, but it becomes how mentorship gets FOCUSED, not the reward. Pairing happens week 1, for everyone, not top-8-only in week 3.
+
+## Pairing mechanism options
+
+### Option A (recommended): Mentor PODS for all, from day 1
+- Every July submitter is placed in a mentor pod in week 1 (nobody unpaired).
+- With ~8-13 mentors and the July pool, pods land at roughly 2-5 builders per mentor, grouped by track (artist / builder / creator) then by what they are building.
+- Pod cadence: one 30-min pod session per week (the June-workshop muscle, reused) + async in the pod's thread.
+- Weeks 3-4: the top 2 per track ALSO get 1:1 deep sessions with their mentor for the battles.
+- Why recommended: it makes the promise literal - submit in July, get a mentor in August. Pods keep mentor load sane and make even non-finalists' August real.
+
+### Option B: MENTOR DRAFT DAY (Option A's pairing moment, made into content)
+- Pairing happens LIVE on the Saturday kickoff stream: mentors browse the submissions board and draft their pods, snake-draft style, on camera.
+- Every submitter hears a mentor say their name and why they picked them - that moment IS the ZABAL Gamez ethos on video.
+- Fallbacks: mentors who cannot attend submit ranked picks beforehand; undrafted submitters are assigned by track before the stream ends (NOBODY leaves undrafted - the rule that protects the whole idea).
+- This is not a separate option so much as the delivery of A. Strong recommendation to run it: it turns admin work (matching) into the season's best content.
+
+### Option C: Earned pairing (rejected)
+- Daily updates in week 1 earn the pairing. Filters ghosts, but contradicts the directive - if mentorship is the goal, it cannot be a prize. Rejected.
+
+### Option D: Application-based matching (rejected)
+- Submitters rank mentors, mentors rank submitters, stable matching. Fairest on paper, slowest in practice, and invisible as content. Rejected for a 30-person pool.
+
+## What mentors do (so the ask to them is concrete)
+
+1. Draft/receive a pod (2-5 builders, their track) at kickoff.
+2. One 30-min pod session weekly (4 total) + async nudges in the pod thread.
+3. Share their evaluation criteria openly in week 1 (already the ICM-box promise).
+4. Weeks 3-4: 1:1 with their finalist(s) if their pod produced one.
+5. Optional: appear on the finale stream.
+
+Ask-size honesty: ~4-6 hours across the month. That is the pitch to mentors.
+
+## Mentor roster (CANDIDATES - each needs a yes before any public naming)
+
+From the ZABAL mentor memory roster: Tyler Stambaugh, Jordan Oram, Adrian (Empire Builder), Arthur (Neynar), KMac, Jonathan Colton, Shriyash Soni, Arun, Rodrigo, Duo Do, Deez, Vlad, Cannon Jones - 13 candidates. Public copy below says "ZAO mentors" generically; names appear only after individual confirmation (no unauthorized commitments).
+
+## Scoring: one adjustment to the locked format
+
+The 50/50 (daily updates / community votes) qualifier stands. One addition worth Zaal's yes/no: mentors get a small fixed weight (e.g. 10-15% carved from the update side) for their own pod ONLY in week 2, so mentor judgment shows up in who advances without letting mentors kingmake across pods. If that is too much change before Saturday: keep 50/50, mentors advise only. Either works; announce whichever Zaal picks.
+
+## Updated Saturday copy (replaces the versions in announcement-copy.md)
+
+### Farcaster (main + /zabal)
+```
+August is comprised of the July submitters - and every one of them gets a ZAO mentor.
+
+That is the whole idea of ZABAL Gamez. Not a hackathon with judges. A community where submitting ANYTHING - a track, a build, a draft - gets you a mentor from The ZAO building alongside you for a month.
+
+How August works:
+- Kickoff: mentors draft their pods from the July submissions board, live on stream.
+- Weeks 1-2: build with your mentor pod. Daily public updates + community votes pick the top 2 per track.
+- Weeks 3-4: head-to-head battles on stream, 1:1 mentor support. One winner, end of August.
+
+Three tracks: artist / builder / creator.
+
+You submitted in July? You are in, and you are getting drafted: PAGE_URL
+```
+
+### X (@bettercallzaal)
+```
+August is comprised of the July submitters - and every one of them gets a ZAO mentor.
+
+That was always the point of ZABAL Gamez. Submit anything in July, and in August a ZAO mentor builds WITH you - pod sessions weekly, criteria shared in the open, all the way to the finals.
+
+Kickoff: mentors draft their pods live on stream from the submissions board. Nobody goes undrafted.
+
+Then: 2 weeks of building (daily updates + community votes pick top 2 per track), 2 weeks of streamed head-to-head battles. One winner.
+
+The pool: PAGE_URL
+```
+
+### YouTube community post
+```
+ZABAL Gamez was never really a competition - it is a mentorship machine with a scoreboard. In August, every single July submitter gets paired with a ZAO mentor: live draft on the kickoff stream, weekly pod sessions, open evaluation criteria, and the top 2 per track battle head-to-head with 1:1 mentor support in the final two weeks.
+
+If you submitted anything in July - even a draft - you have a mentor waiting. Watch the draft and follow the battles here and on Farcaster (/zabal). PAGE_URL
+```
+
+### Telegram GC / Discord
+```
+August reframe, and it is the whole point of ZABAL Gamez: every July submitter gets a ZAO mentor. Mentors draft their pods LIVE on the kickoff stream (nobody goes undrafted), weekly pod sessions through the month, top 2 per track advance to streamed battles with 1:1 mentor support. If you submitted in July you are in. PAGE_URL
+```
+
+## Page draft delta (website-page-draft.html)
+
+Swap the hero + add a mentorship section. Hero: "August is comprised of the July submitters - and every one of them gets a ZAO mentor." New section "Your mentor" above "How August works": the pod promise (weekly session, open criteria, draft day, nobody undrafted). The rest of the page stands. (Zaal deploys; the HTML edit is a 10-line change he or the next session can make when he confirms Options A+B.)
+
+## Needs Zaal's yes (none block Saturday IF he answers by Friday)
+
+1. Options A+B (pods for all + live draft day) - the recommendation.
+2. Mentor scoring weight in week 2: 10-15% carve-out, or keep 50/50 with mentors advisory.
+3. Green light to ASK the 13 roster candidates (the outreach itself is his or ZOE-drafted-he-sends).
+4. Kickoff stream time Saturday (the draft needs a slot).

--- a/research/business/2137-zabal-gamez-august-concept-options/README.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/README.md
@@ -12,6 +12,8 @@ tier: STANDARD
 
 > **Goal:** Everything Zaal needs for the Saturday (2026-08-01) announcement: the concept locked in one line, every format option on the table with a recommendation, a deployable website page draft, and the announcement copy per platform. Announcement is PUBLIC = Zaal approves and posts; nothing here auto-publishes.
 
+> **REWORKED 2026-07-30 03:20 (Zaal's directive): mentor pairing is the CORE.** See [MENTOR-PAIRING-CORE.md](./MENTOR-PAIRING-CORE.md) in this folder - the headline is now "every July submitter gets a ZAO mentor" (pods for all + live draft day recommended); the announcement copy there SUPERSEDES the versions in announcement-copy.md. The tournament structure below stands as the engine.
+
 ## The concept (one line)
 
 **August is comprised of the July submitters.** Everyone who submitted anything in July - any format, partial counts (per the zabalgamez ICM box) - IS the finals pool. No new application, no gate. July was the open door; August is what the people who walked through it do next.


### PR DESCRIPTION
Zaal's 03:20 directive: mentorship IS ZABAL Gamez. Doc 2137 gains MENTOR-PAIRING-CORE.md - new headline (every July submitter gets a ZAO mentor), pairing options with recommendation (pods for all + LIVE mentor draft on the kickoff stream, nobody undrafted), concrete mentor ask, rewritten Saturday copy superseding the earlier versions. Locked tournament structure unchanged as the engine. 4 confirms for Zaal (A+B yes/no, mentor scoring weight, roster outreach green-light, stream slot) - none block Saturday.

Generated with [Claude Code](https://claude.com/claude-code)