### PR TITLE
fix(ci): doc-collision-guard fails closed on git error (audit 2143-1)

### DIFF
--- a/.github/workflows/doc-collision-guard.yml
+++ b/.github/workflows/doc-collision-guard.yml
@@ -44,7 +44,15 @@ jobs:
 
           # Only ADDED doc dirs can introduce a NEW collision. A modified doc
           # cannot, and filtering to additions keeps renames from false-firing.
-          newdirs=$(git diff --name-only --diff-filter=A "$base"...HEAD \
+          #
+          # Run the git command as its OWN step and check IT failed, so a git
+          # error aborts (fail closed) instead of yielding empty output that the
+          # guard reads as "nothing to check" and passes vacuously
+          # (silent-failure-guard rule 5). grep's expected no-match stays benign
+          # via the inner `|| true` on the grep pipe only.
+          added=$(git diff --name-only --diff-filter=A "$base"...HEAD) \
+            || { echo "::error title=doc-guard git diff failed::cannot compute added files - failing closed"; exit 1; }
+          newdirs=$(printf '%s\n' "$added" \
             | grep -oE '^research/[^_/][^/]*/[0-9]{3,4}-[^/]+/' \
             | sort -u || true)
 
@@ -54,7 +62,9 @@ jobs:
           fi
 
           # Every doc number that already exists on the base branch.
-          existing=$(git ls-tree -r --name-only "$base" \
+          basetree=$(git ls-tree -r --name-only "$base") \
+            || { echo "::error title=doc-guard git ls-tree failed::cannot read base tree - failing closed"; exit 1; }
+          existing=$(printf '%s\n' "$basetree" \
             | grep -oE '^research/[^_/][^/]*/[0-9]{3,4}-[^/]+/' \
             | sed -E 's|^research/[^/]+/([0-9]{3,4})-.*|\1|' \
             | sort -u || true)


### PR DESCRIPTION
Closes finding 1 of the ZAOOS audit (doc 2143). The doc-collision guard's gate-determining git calls masked their own failure via a trailing || true on the pipe: a git error yielded empty output that read as 'nothing to check' -> vacuous pass (silent-failure-guard rule 5). Now the git calls run as their own step and fail the job on error; grep's benign no-match keeps its || true. Both paths simulated (git-ok-no-dirs passes; git-fail aborts). YAML validated.

Generated with [Claude Code](https://claude.com/claude-code)