### PR TITLE
test(events): fix makePostRequest signature drift (route proven correct)

### DIFF
--- a/research/dev-workflows/2146-app-vitest-runner-restored/README.md
+++ b/research/dev-workflows/2146-app-vitest-runner-restored/README.md
@@ -28,13 +28,13 @@ All predate this session's work; none are caused by it (verified by reading each
 
 | Suite | Count | Symptom | Likely cause |
 |-------|-------|---------|--------------|
-| `api/events/create` | 3 | route returns **400** where the test expects 409/201/500 | schema drift - the test fixtures no longer satisfy the route's current Zod schema; the request is rejected at validation before reaching the tested branch |
+| `api/events/create` | 3 (+5 false-pass) | route returned **400** where the test expected 409/201/500 | **FIXED (PR follows):** NOT schema drift - the test called `makePostRequest(valid)` with ONE arg, but the helper signature is `(path, body)`, so `valid` became the URL and the body was undefined -> `json()` empty -> 400. 5 other tests in the file were FALSE-PASSING (200/403 for the wrong reason). Route proven correct (returns 201) with a proper call. Fix: pass the path arg to all 8 calls. |
 | `api/streaks` (GET) | 1 | `isActiveToday`/`isAtRisk` mismatch | date-dependent: computed against the real wall clock, not a frozen one |
 | `api/streaks/record` | 2 | "same-day re-record" branch not taken | date-dependent: "today" comparison drifts with the real date |
 | `api/music/history` | 1 | "filters last_played_at for today" wrong bound | date-dependent: same "today" window drift |
 | `api/livepeer/clip` | 1 | "unique default names on successive calls" | FLAKY: `Date.now()`-based default name collides when two calls land in the same ms (passed on one of two runs) |
 
-Two clean fix batches for a focused session: (a) the 4 date-dependent suites want an injected/frozen clock (they assert "today" against `new Date()`); (b) the events/create fixtures need re-aligning to the current schema (or the schema tightened intentionally and the fixtures were never updated).
+events/create is FIXED (helper-signature drift, proven route-correct). The remaining 4 date-dependent suites (streaks x2, streaks/record, music/history) use the helper correctly and are genuine date/timezone issues - they want an injected/frozen clock and a careful read of the route's "today" computation (a blind fix could mask a real TZ off-by-one), so they stay for a focused session. livepeer's "unique default names" is a Date.now() collision in the route, inherently flaky.
 
 ## Why this PR does NOT fix those 8
 

--- a/src/app/api/events/create/__tests__/route.test.ts
+++ b/src/app/api/events/create/__tests__/route.test.ts
@@ -43,29 +43,29 @@ beforeEach(() => {
 describe('POST /api/events/create', () => {
   it('403s when not admin', async () => {
     mockGetSessionData.mockResolvedValue({ fid: 123, isAdmin: false });
-    const res = await POST(makePostRequest(valid));
+    const res = await POST(makePostRequest('/api/events/create', valid));
     expect(res.status).toBe(403);
   });
 
   it('403s when unauthenticated', async () => {
     mockGetSessionData.mockResolvedValue(null);
-    const res = await POST(makePostRequest(valid));
+    const res = await POST(makePostRequest('/api/events/create', valid));
     expect(res.status).toBe(403);
   });
 
   it('400s on invalid input (bad slug)', async () => {
-    const res = await POST(makePostRequest({ ...valid, slug: 'Bad Slug!' }));
+    const res = await POST(makePostRequest('/api/events/create', { ...valid, slug: 'Bad Slug!' }));
     expect(res.status).toBe(400);
   });
 
   it('400s when title is missing', async () => {
-    const res = await POST(makePostRequest({ slug: 'x', is_published: false }));
+    const res = await POST(makePostRequest('/api/events/create', { slug: 'x', is_published: false }));
     expect(res.status).toBe(400);
   });
 
   it('409s on a duplicate slug', async () => {
     mockFrom.mockReturnValue(queuedChain([{ data: { id: 'existing-uuid' } }]));
-    const res = await POST(makePostRequest(valid));
+    const res = await POST(makePostRequest('/api/events/create', valid));
     expect(res.status).toBe(409);
   });
 
@@ -76,7 +76,7 @@ describe('POST /api/events/create', () => {
         { data: { id: 'new-uuid', slug: valid.slug, title: valid.title, is_published: true } },
       ]),
     );
-    const res = await POST(makePostRequest(valid));
+    const res = await POST(makePostRequest('/api/events/create', valid));
     expect(res.status).toBe(201);
     const json = await res.json();
     expect(json.ok).toBe(true);
@@ -87,12 +87,12 @@ describe('POST /api/events/create', () => {
     mockFrom.mockReturnValue(
       queuedChain([{ data: null }, { error: { message: 'db down' } }]),
     );
-    const res = await POST(makePostRequest(valid));
+    const res = await POST(makePostRequest('/api/events/create', valid));
     expect(res.status).toBe(500);
   });
 
   it('rejects a bad lock_address', async () => {
-    const res = await POST(makePostRequest({ ...valid, lock_address: 'nope' }));
+    const res = await POST(makePostRequest('/api/events/create', { ...valid, lock_address: 'nope' }));
     expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
Now that the app runner is back (#2720), root-caused an events/create failure: the tests called makePostRequest(valid) with one arg, but the helper is (path, body) - valid became the URL, body was undefined, so json() was empty and every body test hit the 400 path. 3 failed, 5 false-passed. Proven route-correct (returns 201/409/500 with a proper call - invoked the real handler). Fixed all 8 calls; no route change. Doc 2146 updated (helper drift, not schema drift; 4 remaining date-dependent failures left for a focused pass to avoid masking a real TZ bug).

Generated with [Claude Code](https://claude.com/claude-code)