### PR TITLE
docs(zabal): finalize August - mentor pods, no live draft (your call)

### DIFF
--- a/research/business/2137-zabal-gamez-august-concept-options/FINAL-SATURDAY-COPY.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/FINAL-SATURDAY-COPY.md
@@ -1,0 +1,70 @@
+# ZABAL August - FINAL Saturday copy (Zaal's decision: pods, NO live draft)
+
+> Zaal chose 2026-07-30: mentor PODS for everyone (the core), but NO on-stream mentor draft. Pods are matched by track behind the scenes. This SUPERSEDES the draft-day copy in MENTOR-PAIRING-CORE.md and announcement-copy.md. Replace PAGE_URL with the deployed page link before posting. PUBLIC - Zaal approves + posts.
+
+## The one line
+
+**August is comprised of the July submitters - and every one of them gets a ZAO mentor.**
+
+The tournament is the engine; the mentor is the point. No live draft - you submit in July, you get matched to a mentor pod by track, and you build August with them.
+
+## Farcaster (main feed + /zabal)
+
+```
+August is comprised of the July submitters - and every one of them gets a ZAO mentor.
+
+That's the whole idea of ZABAL Gamez. Not a hackathon with judges - a community where submitting ANYTHING in July (a track, a build, a draft) gets you matched with a ZAO mentor who builds alongside you for a month.
+
+How August works:
+- You're matched to a mentor pod by track (artist / builder / creator).
+- Weeks 1-2: build with your pod. Daily public updates + community votes pick the top 2 per track.
+- Weeks 3-4: head-to-head battles on stream, with 1:1 mentor support. One winner, end of August.
+
+Submitted in July? You're in, and you've got a mentor: PAGE_URL
+```
+
+## X (@bettercallzaal)
+
+```
+August is comprised of the July submitters - and every one of them gets a ZAO mentor.
+
+That was always the point of ZABAL Gamez. Submit anything in July, and in August a ZAO mentor builds WITH you - pod sessions weekly, evaluation criteria shared in the open, all the way to the finals.
+
+Aug 3-16: build with your mentor pod (daily updates + community votes pick top 2 per track).
+Aug 17-30: streamed head-to-head battles, 1:1 mentor support. One winner.
+
+The pool: PAGE_URL
+```
+
+## YouTube community post
+
+```
+ZABAL Gamez was never really a competition - it's a mentorship machine with a scoreboard. In August, every single July submitter gets matched with a ZAO mentor pod: weekly pod sessions, evaluation criteria shared openly, and the top 2 per track battle head-to-head with 1:1 mentor support in the final two weeks.
+
+Submitted anything in July - even a draft? You've got a mentor waiting. Follow the build and the battles here and on Farcaster (/zabal). PAGE_URL
+```
+
+## Telegram GC / Discord
+
+```
+August is the whole point of ZABAL Gamez: every July submitter gets matched with a ZAO mentor pod (by track). Weekly pod sessions through the month; top 2 per track advance to streamed battles with 1:1 mentor support. Submitted in July? You're in. PAGE_URL
+```
+
+## What mentors do (the ask - unchanged)
+
+~4-6 hours across the month: take a pod (2-5 builders, their track), one 30-min pod session weekly + async nudges, share evaluation criteria in week 1, 1:1 with any finalist in weeks 3-4, optional finale-stream appearance.
+
+## Rollout (Saturday 2026-08-01)
+
+| Time (ET) | Action | Surface |
+|-----------|--------|---------|
+| 9-10am | Main announcement | Farcaster (/zabal + feed) + X via Firefly |
+| midday | Community post | YouTube |
+| midday | Group drops | Telegram GC, Discord ZABAL |
+| Mon Aug 3 | "Week 1 - post your first update + meet your pod" follow-up | Farcaster |
+
+## Still needs Zaal (none block the post)
+
+1. Mentor scoring weight in week 2 (10-15% carve-out, or keep 50/50 with mentors advisory) - copy above is silent on it, safe either way.
+2. Green light to ASK the 13 mentor candidates (outreach is yours or ZOE-drafted-you-send).
+3. Any prize/pool beyond status + mentorship - name it before posting or leave it out (nothing invented).

--- a/research/business/2137-zabal-gamez-august-concept-options/MENTOR-PAIRING-CORE.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/MENTOR-PAIRING-CORE.md
@@ -1,5 +1,11 @@
 # August rework: MENTOR PAIRING is the core (Zaal, 2026-07-30 03:20)
 
+> **DECIDED 2026-07-30: Option A (pods for all) YES, Option B (live on-stream draft) NO.**
+> Pods are matched by track behind the scenes, no on-camera draft. The FINAL
+> Saturday copy is in `FINAL-SATURDAY-COPY.md` (this folder) - it SUPERSEDES the
+> draft-day copy below. The page draft's hero + mentorship section are updated to
+> match. The mechanism sections below are kept for the record; ignore the live-draft framing.
+
 > Zaal's overnight directive: "make August a way to pair you with a ZAO mentor - mentor being the main goal and idea of this whole ZABAL Gamez." This reframes the README in this folder: the competition structure stays, but it is now the ENGINE for pairing, not the point. The point is: **submit anything in July, and a ZAO mentor builds August with you.**
 
 ## The reframe in one line

--- a/research/business/2137-zabal-gamez-august-concept-options/README.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/README.md
@@ -12,7 +12,7 @@ tier: STANDARD
 
 > **Goal:** Everything Zaal needs for the Saturday (2026-08-01) announcement: the concept locked in one line, every format option on the table with a recommendation, a deployable website page draft, and the announcement copy per platform. Announcement is PUBLIC = Zaal approves and posts; nothing here auto-publishes.
 
-> **REWORKED 2026-07-30 03:20 (Zaal's directive): mentor pairing is the CORE.** See [MENTOR-PAIRING-CORE.md](./MENTOR-PAIRING-CORE.md) in this folder - the headline is now "every July submitter gets a ZAO mentor" (pods for all + live draft day recommended); the announcement copy there SUPERSEDES the versions in announcement-copy.md. The tournament structure below stands as the engine.
+> **REWORKED 2026-07-30 03:20 (Zaal's directive): mentor pairing is the CORE.** See [MENTOR-PAIRING-CORE.md](./MENTOR-PAIRING-CORE.md) in this folder - the headline is now "every July submitter gets a ZAO mentor" (pods for all + live draft day recommended); the announcement copy there SUPERSEDES announcement-copy.md. FINAL DECISION 2026-07-30: pods YES, live-draft NO - the DEFINITIVE Saturday copy is FINAL-SATURDAY-COPY.md. The tournament structure below stands as the engine.
 
 ## The concept (one line)
 

--- a/research/business/2137-zabal-gamez-august-concept-options/website-page-draft.html
+++ b/research/business/2137-zabal-gamez-august-concept-options/website-page-draft.html
@@ -31,10 +31,21 @@
 <body>
 <main>
   <p class="kicker">ZABAL Games - Final Month</p>
-  <h1>August is comprised of the July submitters.</h1>
-  <p class="lead">If you submitted anything in July - a track, a build, a draft, a work in progress - you are already in the August Finals. No application. No gate. July was the open door; August is what you do with it.</p>
+  <h1>August is comprised of the July submitters - and every one of them gets a ZAO mentor.</h1>
+  <p class="lead">If you submitted anything in July - a track, a build, a draft, a work in progress - you are already in the August Finals, and you get matched with a ZAO mentor. No application. No gate. The tournament is the engine; the mentor is the point.</p>
 
   <a class="cta" href="/submissions">See the finals pool - the submissions board</a>
+
+  <h2>Your mentor</h2>
+  <div class="card">
+    <h3>Every July submitter is matched to a mentor pod</h3>
+    <ul>
+      <li>You are placed in a mentor pod by track (artist / builder / creator) - nobody builds August alone.</li>
+      <li>One 30-minute pod session each week with your ZAO mentor, plus async support in your pod thread.</li>
+      <li>Your mentor shares their evaluation criteria openly in week 1 - you always know what you are building toward.</li>
+      <li>Reach the head-to-head rounds and your mentor goes 1:1 with you for the battles.</li>
+    </ul>
+  </div>
 
   <h2>How August works</h2>
   <div class="weeks">


### PR DESCRIPTION
Your decision applied: pods for every July submitter (the core), NO on-stream draft - pods matched by track behind the scenes. FINAL-SATURDAY-COPY.md is the definitive copy (FC/X/YT/TG, supersedes the draft-day versions); the page draft gets the mentor hero + a 'Your mentor' section. Ready for Saturday - you approve + post. 3 non-blocking confirms still flagged (mentor scoring weight, green-light to ask the 13 candidates, prize/pool wording).

Generated with [Claude Code](https://claude.com/claude-code)