### PR TITLE
refactor(heart): app-Heart behavior-preserving shim to shared core (Option A, doc 2149)

### DIFF
--- a/src/lib/heart/__tests__/lease-manager-delegation.test.ts
+++ b/src/lib/heart/__tests__/lease-manager-delegation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { acquireLease, reclaimExpiredLeases } from '../lease-manager';
+import { MemoryLeaseStore } from '../../../../packages/heart-fleet/src/index';
+import type { AgentRunRow } from '../types';
+
+/**
+ * Happy-path coverage for the shared-core delegation (doc 2149 Option A).
+ * The pre-existing lease-manager tests only exercised input VALIDATION (the DB
+ * path "fails in test env"); this suite injects a MemoryLeaseStore via the new
+ * `opts.store` seam to prove the DELEGATED acquire + reclaim actually behave -
+ * coverage the module never had - and that `maxRetries: Infinity` preserves the
+ * historical no-quarantine behavior (no run ever goes to 'quarantined').
+ */
+
+const RUN_ID = '550e8400-e29b-41d4-a716-446655440000';
+const T0 = new Date('2026-07-20T10:00:00.000Z');
+
+function makeRow(over?: Partial<AgentRunRow>): Omit<AgentRunRow, 'created_at' | 'updated_at'> {
+  return {
+    id: RUN_ID, task_id: null, assignment_id: 'a', objective: 'o', required_capabilities: [],
+    status: 'ready', assigned_agent: null, lease_owner: null, lease_expires_at: null, retries: 0,
+    budget: null, approval_state: 'auto', visibility: 'team', idempotency_key: 'k', created_by: 't',
+    ...over,
+  };
+}
+
+let store: MemoryLeaseStore;
+
+beforeEach(() => {
+  store = new MemoryLeaseStore(T0);
+});
+
+describe('acquireLease (delegated)', () => {
+  it('acquires a ready run and returns it leased', async () => {
+    store.insert(makeRow());
+    const res = await acquireLease({ runId: RUN_ID, owner: 'agent-1', ttlSeconds: 60 }, { store });
+    expect(res.acquired).toBe(true);
+    expect(res.run?.status).toBe('leased');
+    expect(res.run?.lease_owner).toBe('agent-1');
+  });
+
+  it('collides when the run is already leased and NOT expired', async () => {
+    store.insert(makeRow());
+    await acquireLease({ runId: RUN_ID, owner: 'agent-1', ttlSeconds: 60 }, { store });
+    const res = await acquireLease({ runId: RUN_ID, owner: 'agent-2', ttlSeconds: 60 }, { store });
+    expect(res.acquired).toBe(false);
+  });
+
+  it('takes over an EXPIRED lease', async () => {
+    store.insert(makeRow());
+    await acquireLease({ runId: RUN_ID, owner: 'agent-1', ttlSeconds: 60 }, { store });
+    store.advance(61_000); // past the TTL
+    const res = await acquireLease({ runId: RUN_ID, owner: 'agent-2', ttlSeconds: 60 }, { store });
+    expect(res.acquired).toBe(true);
+    expect(res.run?.lease_owner).toBe('agent-2');
+  });
+
+  it('returns a not-found reason for a missing run (no throw)', async () => {
+    const res = await acquireLease({ runId: RUN_ID, owner: 'agent-1', ttlSeconds: 60 }, { store });
+    expect(res.acquired).toBe(false);
+    expect(res.run).toBeNull();
+  });
+});
+
+describe('reclaimExpiredLeases (delegated)', () => {
+  it('resets an expired lease to ready and increments retries', async () => {
+    store.insert(makeRow());
+    await acquireLease({ runId: RUN_ID, owner: 'agent-1', ttlSeconds: 60 }, { store });
+    store.advance(61_000);
+    const summary = await reclaimExpiredLeases({ store });
+    expect(summary.reclaimedIds).toEqual([RUN_ID]);
+    const row = await store.getRun(RUN_ID);
+    expect(row?.status).toBe('ready');
+    expect(row?.retries).toBe(1);
+    expect(row?.lease_owner).toBeNull();
+  });
+
+  it('does NOT reclaim a live (unexpired) lease', async () => {
+    store.insert(makeRow());
+    await acquireLease({ runId: RUN_ID, owner: 'agent-1', ttlSeconds: 60 }, { store });
+    store.advance(30_000); // still inside TTL
+    const summary = await reclaimExpiredLeases({ store });
+    expect(summary.reclaimedCount).toBe(0);
+  });
+
+  it('NEVER quarantines - preserves the historical no-ceiling behavior (maxRetries Infinity)', async () => {
+    store.insert(makeRow());
+    // Bounce the run through many acquire/expire/reclaim cycles - far past the
+    // package's default retry ceiling of 5. With Infinity it must stay reclaimable.
+    for (let i = 0; i < 8; i++) {
+      await acquireLease({ runId: RUN_ID, owner: `agent-${i}`, ttlSeconds: 60 }, { store });
+      store.advance(61_000);
+      const summary = await reclaimExpiredLeases({ store });
+      expect(summary.reclaimedIds).toEqual([RUN_ID]);
+    }
+    const row = await store.getRun(RUN_ID);
+    expect(row?.status).toBe('ready'); // NOT 'quarantined'
+    expect(row?.retries).toBe(8);
+  });
+});

--- a/src/lib/heart/lease-manager.ts
+++ b/src/lib/heart/lease-manager.ts
@@ -10,6 +10,26 @@
 
 import { z } from 'zod';
 import type { RunStatus, AgentRunRow, LeaseAcquisitionResult, ExpiredLeaseRecoverySummary } from './types';
+import {
+  HeartFleet,
+  SupabaseLeaseStore,
+  type LeaseStore,
+  type SupabaseLikeClient,
+} from '../../../packages/heart-fleet/src/index';
+
+/**
+ * Build a HeartFleet over the shared lease core (packages/heart-fleet). This is
+ * the ONE lease implementation; acquireLease + reclaimExpiredLeases delegate to
+ * it. `maxRetries: Infinity` preserves this module's historical behavior of
+ * re-readying an expired lease forever (the package would otherwise QUARANTINE
+ * at a ceiling - that stricter behavior is the deliberate Option-B follow-up,
+ * doc 2149, gated behind the canary; NOT changed here). A `store` may be
+ * injected for tests; production wraps the Supabase admin client.
+ */
+function buildFleet(store?: LeaseStore): HeartFleet {
+  const leaseStore = store ?? new SupabaseLeaseStore(getSupabaseAdmin() as unknown as SupabaseLikeClient);
+  return new HeartFleet({ store: leaseStore, maxRetries: Number.POSITIVE_INFINITY });
+}
 
 // Import Supabase admin client for production use.
 // Tests use FakeAgentRunsStore and don't call these async functions.
@@ -115,6 +135,7 @@ export function canAcquire(run: AgentRunRow, now: Date | string): boolean {
  */
 export async function acquireLease(
   input: unknown,
+  opts?: { store?: LeaseStore },
 ): Promise<LeaseAcquisitionResult> {
   const parsed = AcquireLeaseInputSchema.safeParse(input);
   if (!parsed.success) {
@@ -126,102 +147,13 @@ export async function acquireLease(
   }
 
   const { runId, owner, ttlSeconds } = parsed.data;
-  const db = getSupabaseAdmin();
-  const now = new Date();
-  const leaseExpiresAt = new Date(now.getTime() + ttlSeconds * 1000).toISOString();
 
   try {
-    // Fetch current run to check its state
-    const { data: currentRun, error: fetchError } = await db
-      .from('agent_runs')
-      .select('*')
-      .eq('id', runId)
-      .single();
-
-    if (fetchError || !currentRun) {
-      return {
-        acquired: false,
-        run: null,
-        reason: `Run not found: ${fetchError?.message ?? 'unknown error'}`,
-      };
-    }
-
-    const run = currentRun as AgentRunRow;
-
-    // Check if we can acquire this run
-    if (!canAcquire(run, now)) {
-      return {
-        acquired: false,
-        run,
-        reason: `Cannot acquire: run status is '${run.status}' and lease is not expired`,
-      };
-    }
-
-    // Atomic conditional UPDATE: only succeed if status matches expected value
-    // For ready: update from ready to leased
-    // For leased/running with expired lease: update but only if the lease is expired
-    let updateResult;
-
-    if (run.status === 'ready') {
-      const { data: updated, error } = await db
-        .from('agent_runs')
-        .update({
-          lease_owner: owner,
-          lease_expires_at: leaseExpiresAt,
-          status: 'leased' as RunStatus,
-          updated_at: now.toISOString(),
-        })
-        .eq('id', runId)
-        .eq('status', 'ready')
-        .select('*')
-        .single();
-
-      updateResult = { data: updated, error };
-    } else if ((run.status === 'leased' || run.status === 'running') && isLeaseExpired(run, now)) {
-      // Lease is expired; try to reclaim it
-      const { data: updated, error } = await db
-        .from('agent_runs')
-        .update({
-          lease_owner: owner,
-          lease_expires_at: leaseExpiresAt,
-          status: 'leased' as RunStatus,
-          updated_at: now.toISOString(),
-        })
-        .eq('id', runId)
-        .eq('status', run.status)
-        .eq('lease_expires_at', run.lease_expires_at) // Ensure lease hasn't been renewed
-        .select('*')
-        .single();
-
-      updateResult = { data: updated, error };
-    } else {
-      return {
-        acquired: false,
-        run,
-        reason: `Unexpected state: cannot determine acquisition path`,
-      };
-    }
-
-    if (updateResult.error) {
-      return {
-        acquired: false,
-        run,
-        reason: `Update failed: ${updateResult.error.message}`,
-      };
-    }
-
-    if (!updateResult.data) {
-      return {
-        acquired: false,
-        run,
-        reason: `Collision: another owner beat this request to the lease`,
-      };
-    }
-
-    return {
-      acquired: true,
-      run: updateResult.data as AgentRunRow,
-    };
+    // Delegate to the shared lease core. Its acquire does the same
+    // fetch-then-conditional-UPDATE (ready OR expired-takeover on exact
+    // expiry) this module did by hand - one implementation now.
+    const result = await buildFleet(opts?.store).acquire(runId, owner, ttlSeconds);
+    return { acquired: result.acquired, run: result.run, reason: result.reason };
   } catch (error: unknown) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     return {
@@ -331,75 +263,22 @@ export async function releaseLease(input: unknown): Promise<AgentRunRow | null> 
  * @returns Summary of reclaimed runs and any errors
  */
 export async function reclaimExpiredLeases(
-  options?: { maxReclaimsPerCycle?: number },
+  options?: { maxReclaimsPerCycle?: number; store?: LeaseStore },
 ): Promise<ExpiredLeaseRecoverySummary> {
   const maxReclaims = options?.maxReclaimsPerCycle ?? 100;
-  const db = getSupabaseAdmin();
-  const now = new Date();
 
   try {
-    // Step 1: Find expired leases
-    const { data: expiredRuns, error: fetchError } = await db
-      .from('agent_runs')
-      .select('*')
-      .in('status', ['leased', 'running'] as RunStatus[])
-      .lt('lease_expires_at', now.toISOString())
-      .limit(maxReclaims);
-
-    if (fetchError) {
-      return {
-        reclaimedCount: 0,
-        reclaimedIds: [],
-        errors: [{ runId: 'unknown', error: `Fetch error: ${fetchError.message}` }],
-      };
-    }
-
-    if (!expiredRuns || expiredRuns.length === 0) {
-      return {
-        reclaimedCount: 0,
-        reclaimedIds: [],
-        errors: [],
-      };
-    }
-
-    const reclaimedIds: string[] = [];
-    const errors: Array<{ runId: string; error: string }> = [];
-
-    // Step 2: Reset each expired run
-    for (const run of expiredRuns as AgentRunRow[]) {
-      try {
-        const { data: updated, error: updateError } = await db
-          .from('agent_runs')
-          .update({
-            status: 'ready' as RunStatus,
-            lease_owner: null,
-            lease_expires_at: null,
-            retries: (run.retries ?? 0) + 1,
-            updated_at: now.toISOString(),
-          })
-          .eq('id', run.id)
-          .eq('lease_expires_at', run.lease_expires_at) // Ensure lease hasn't been renewed
-          .select('id')
-          .single();
-
-        if (updateError || !updated) {
-          errors.push({
-            runId: run.id,
-            error: updateError?.message ?? 'No rows updated (collision)',
-          });
-        } else {
-          reclaimedIds.push(run.id);
-        }
-      } catch (error: unknown) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        errors.push({ runId: run.id, error: errorMsg });
-      }
-    }
-
+    // Delegate to the shared lease core. It finds expired leases the same way
+    // (status in leased/running, lease_expires_at < now) and resets each with a
+    // conditional UPDATE on the exact expiry. maxRetries: Infinity (buildFleet)
+    // means it NEVER quarantines - identical to this module's historical
+    // re-ready-and-increment behavior. quarantinedIds is therefore always empty
+    // and dropped to preserve the exact ExpiredLeaseRecoverySummary shape.
+    const summary = await buildFleet(options?.store).reclaimExpired({ limit: maxReclaims });
     return {
-      reclaimedCount: reclaimedIds.length,
-      reclaimedIds,
-      errors,
+      reclaimedCount: summary.reclaimedCount,
+      reclaimedIds: summary.reclaimedIds,
+      errors: summary.errors,
     };
   } catch (error: unknown) {
     const errorMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## App-Heart Option A: behavior-preserving shim (doc 2149)

You chose A. This makes `src/lib/heart` delegate its two most complex, highest-value functions to the shared `packages/heart-fleet` core - ONE lease implementation for the mutex + the recovery cron - with ZERO live-behavior change.

### What delegates (cleanly equivalent)
- `acquireLease` -> `HeartFleet.acquire` (same fetch-then-conditional-UPDATE: ready OR expired-takeover on exact expiry).
- `reclaimExpiredLeases` -> `HeartFleet.reclaimExpired` with **`maxRetries: Infinity`**, which preserves this module's historical re-ready-forever behavior (the package would otherwise quarantine at a ceiling - that stricter behavior is the deliberate Option-B follow-up, gated behind the canary, NOT changed here).

### What stays app-side (on purpose)
- `renewLease` / `releaseLease`: the package's versions are STRICTER (fenced on exact expiry) than the app's (owner-string). Swapping them would CHANGE behavior, so they stay until the Option-B fencing adoption. Documented.
- `reclaimDeadInstanceRuns` (liveness) + the pure predicates: unchanged.

### Proof (this is live recovery-cron + agent-runner code that deploys to Vercel)
- App tsc: 0 errors.
- Heart tests: 64/64 (the 57 pre-existing stay green UNCHANGED + 7 NEW happy-path tests via an injected MemoryLeaseStore proving the delegated acquire/reclaim actually behave - coverage the DB path never had - including an 8-cycle test proving NO quarantine).
- **Production `npm run build`: GREEN** (verified with real node_modules; the cross-package relative import bundles cleanly for the Vercel deploy).

No flag - behavior is identical. Option B (adopt quarantine + fencing) remains the documented next step behind the existing canary.

Generated with [Claude Code](https://claude.com/claude-code)
