### PR TITLE
feat(heart): port dead-instance liveness reclaim into the shared package

### DIFF
--- a/bot/src/zoe/__tests__/heart-liveness.test.ts
+++ b/bot/src/zoe/__tests__/heart-liveness.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LivenessReclaimer,
+  isInstanceExpired,
+  deadInstanceIds,
+  runsLeasedToDeadInstances,
+  type LivenessStore,
+  type AgentInstanceRow,
+  type AgentRunRow,
+} from '../../../../packages/heart-fleet/src/index';
+
+/**
+ * Ported dead-instance liveness reclaim (doc 2149). Pure helpers + the
+ * LivenessReclaimer over an in-memory LivenessStore. Proves: a stale-heartbeat
+ * instance is declared dead and its leased runs reset to ready; a run re-leased
+ * by a live worker mid-reclaim is NOT clobbered (conditional update).
+ */
+
+const NOW = new Date('2026-07-30T10:00:00.000Z');
+
+function inst(id: string, secsAgo: number, status: AgentInstanceRow['status'] = 'alive'): AgentInstanceRow {
+  return {
+    instance_id: id,
+    hostname: 'h',
+    pid: 1,
+    status,
+    started_at: NOW.toISOString(),
+    last_heartbeat: new Date(NOW.getTime() - secsAgo * 1000).toISOString(),
+    metadata: null,
+  };
+}
+
+function run(id: string, owner: string | null, status: AgentRunRow['status'] = 'leased'): AgentRunRow {
+  return {
+    id, task_id: null, assignment_id: 'a', objective: 'o', required_capabilities: [],
+    status, assigned_agent: null, lease_owner: owner, lease_expires_at: NOW.toISOString(), retries: 0,
+    budget: null, approval_state: 'auto', visibility: 'internal', idempotency_key: id, created_by: 't',
+    created_at: NOW.toISOString(), updated_at: NOW.toISOString(),
+  };
+}
+
+describe('pure liveness helpers', () => {
+  it('isInstanceExpired: stale heartbeat or dead status', () => {
+    expect(isInstanceExpired(inst('a', 200), NOW)).toBe(true); // 200s > 90s TTL
+    expect(isInstanceExpired(inst('a', 10), NOW)).toBe(false);
+    expect(isInstanceExpired(inst('a', 1, 'dead'), NOW)).toBe(true);
+  });
+
+  it('deadInstanceIds filters by TTL', () => {
+    expect(deadInstanceIds([inst('a', 200), inst('b', 5), inst('c', 100)], NOW)).toEqual(['a', 'c']);
+  });
+
+  it('runsLeasedToDeadInstances: only leased/running owned by dead ids', () => {
+    const runs = [run('1', 'a'), run('2', 'b'), run('3', 'a', 'completed'), run('4', null)];
+    expect(runsLeasedToDeadInstances(runs, ['a']).map((r) => r.id)).toEqual(['1']);
+  });
+});
+
+class MemLivenessStore implements LivenessStore {
+  instances: AgentInstanceRow[] = [];
+  runs = new Map<string, AgentRunRow>();
+  now() { return NOW; }
+  async liveInstances() { return this.instances.filter((i) => i.status !== 'dead'); }
+  async markInstancesDead(ids: string[]) {
+    for (const i of this.instances) if (ids.includes(i.instance_id)) i.status = 'dead';
+  }
+  async runsOwnedBy(owners: string[], limit: number) {
+    return [...this.runs.values()]
+      .filter((r) => r.lease_owner !== null && owners.includes(r.lease_owner) && ['leased', 'running'].includes(r.status))
+      .slice(0, limit);
+  }
+  async reclaimRun(runId: string, expectedOwner: string, retries: number) {
+    const r = this.runs.get(runId);
+    if (!r || r.lease_owner !== expectedOwner) return false; // conditional: still owned
+    this.runs.set(runId, { ...r, status: 'ready', lease_owner: null, lease_expires_at: null, retries });
+    return true;
+  }
+}
+
+describe('LivenessReclaimer', () => {
+  it('reclaims runs owned by a dead instance and marks it dead', async () => {
+    const store = new MemLivenessStore();
+    store.instances = [inst('dead-1', 200), inst('live-1', 5)];
+    store.runs.set('r1', run('r1', 'dead-1'));
+    store.runs.set('r2', run('r2', 'live-1'));
+    const reclaimer = new LivenessReclaimer({ store });
+
+    const summary = await reclaimer.reclaimDeadInstanceRuns();
+    expect(summary.deadInstanceIds).toEqual(['dead-1']);
+    expect(summary.reclaimedIds).toEqual(['r1']);
+    expect(store.runs.get('r1')?.status).toBe('ready');
+    expect(store.runs.get('r1')?.retries).toBe(1);
+    expect(store.runs.get('r2')?.status).toBe('leased'); // live owner untouched
+    expect(store.instances.find((i) => i.instance_id === 'dead-1')?.status).toBe('dead');
+  });
+
+  it('does not clobber a run re-leased by a live worker mid-reclaim', async () => {
+    const store = new MemLivenessStore();
+    store.instances = [inst('dead-1', 200)];
+    store.runs.set('r1', run('r1', 'dead-1'));
+    // Simulate: between the read and the write, a live worker re-leases r1.
+    const original = store.reclaimRun.bind(store);
+    store.reclaimRun = async (runId, expectedOwner, retries) => {
+      const r = store.runs.get(runId);
+      if (r) store.runs.set(runId, { ...r, lease_owner: 'live-2' }); // re-leased
+      return original(runId, expectedOwner, retries);
+    };
+    const summary = await new LivenessReclaimer({ store }).reclaimDeadInstanceRuns();
+    expect(summary.reclaimedIds).toEqual([]); // NOT reclaimed
+    expect(store.runs.get('r1')?.lease_owner).toBe('live-2'); // live worker keeps it
+  });
+
+  it('no dead instances = zero work', async () => {
+    const store = new MemLivenessStore();
+    store.instances = [inst('live-1', 5)];
+    const summary = await new LivenessReclaimer({ store }).reclaimDeadInstanceRuns();
+    expect(summary.reclaimedCount).toBe(0);
+    expect(summary.deadInstanceIds).toEqual([]);
+  });
+});

--- a/packages/heart-fleet/src/index.ts
+++ b/packages/heart-fleet/src/index.ts
@@ -32,3 +32,15 @@ export {
   type DurableEffectLedgerOpts,
 } from './durable-effect-ledger';
 export { sendOnce, effectKey, type SendOnceInput, type SendOnceOutcome } from './outbox';
+export {
+  LivenessReclaimer,
+  isInstanceExpired,
+  deadInstanceIds,
+  runsLeasedToDeadInstances,
+  DEFAULT_LIVENESS_TTL_MS,
+  type LivenessStore,
+  type LivenessOptions,
+  type AgentInstanceRow,
+  type InstanceStatus,
+  type DeadInstanceReclaimSummary,
+} from './liveness';

--- a/packages/heart-fleet/src/liveness.ts
+++ b/packages/heart-fleet/src/liveness.ts
@@ -1,0 +1,154 @@
+/**
+ * LivenessReclaimer - PROACTIVE recovery for the shared fleet core.
+ *
+ * The lease reclaim (lease.ts) is REACTIVE: it waits for each run's TTL to
+ * expire. This adds proactive recovery: workers heartbeat an agent_instances
+ * row; when an instance goes stale (heartbeat older than the liveness TTL) it
+ * is declared dead and ALL of its leased/running runs are reset at once - no
+ * waiting per-run. Port of the app-side `src/lib/heart/liveness.ts` into the
+ * package so the whole fleet shares one liveness implementation (doc 2149).
+ *
+ * The store is INJECTED (structural, no dependency) like every other adapter
+ * here. Pure helpers are exported for reuse + unit tests.
+ */
+import type { AgentRunRow } from './types';
+
+export type InstanceStatus = 'alive' | 'draining' | 'dead';
+
+export interface AgentInstanceRow {
+  instance_id: string;
+  hostname: string | null;
+  pid: number | null;
+  status: InstanceStatus;
+  started_at: string;
+  last_heartbeat: string;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface DeadInstanceReclaimSummary {
+  deadInstanceIds: string[];
+  reclaimedCount: number;
+  reclaimedIds: string[];
+  errors: Array<{ id: string; error: string }>;
+}
+
+/** Default liveness TTL: an instance silent this long is presumed dead (3 missed 30s beats). */
+export const DEFAULT_LIVENESS_TTL_MS = 90_000;
+
+const RECLAIMABLE: readonly string[] = ['leased', 'running'];
+
+function toMs(v: Date | string): number {
+  return (v instanceof Date ? v : new Date(v)).getTime();
+}
+
+// --- pure helpers (no I/O) --------------------------------------------------
+
+/** True if an instance's last heartbeat is older than the TTL as of `now`. */
+export function isInstanceExpired(
+  instance: Pick<AgentInstanceRow, 'last_heartbeat' | 'status'>,
+  now: Date | string,
+  ttlMs: number = DEFAULT_LIVENESS_TTL_MS,
+): boolean {
+  if (instance.status === 'dead') return true;
+  return toMs(now) - toMs(instance.last_heartbeat) > ttlMs;
+}
+
+/** Ids of every instance considered dead as of `now`. */
+export function deadInstanceIds(
+  instances: AgentInstanceRow[],
+  now: Date | string,
+  ttlMs: number = DEFAULT_LIVENESS_TTL_MS,
+): string[] {
+  return instances.filter((i) => isInstanceExpired(i, now, ttlMs)).map((i) => i.instance_id);
+}
+
+/** Runs that should be reclaimed because their lease_owner is a dead instance. */
+export function runsLeasedToDeadInstances(runs: AgentRunRow[], deadIds: string[]): AgentRunRow[] {
+  const dead = new Set(deadIds);
+  return runs.filter(
+    (r) => r.lease_owner !== null && dead.has(r.lease_owner) && RECLAIMABLE.includes(r.status),
+  );
+}
+
+// --- injected store ---------------------------------------------------------
+
+/** Minimal store the reclaimer needs (agent_instances + agent_runs). */
+export interface LivenessStore {
+  now(): Date;
+  /** All non-dead instances. */
+  liveInstances(): Promise<AgentInstanceRow[]>;
+  /** Mark the given instance ids dead (best-effort). */
+  markInstancesDead(ids: string[]): Promise<void>;
+  /** Leased/running runs owned by any of these instances. */
+  runsOwnedBy(ownerIds: string[], limit: number): Promise<AgentRunRow[]>;
+  /**
+   * Reset a run to 'ready' ONLY if still owned by `expectedOwner` (conditional
+   * update). Returns true iff it mutated (false = re-leased by a live worker).
+   */
+  reclaimRun(runId: string, expectedOwner: string, retries: number): Promise<boolean>;
+}
+
+export interface LivenessOptions {
+  store: LivenessStore;
+  ttlMs?: number;
+}
+
+export class LivenessReclaimer {
+  private readonly store: LivenessStore;
+  private readonly ttlMs: number;
+
+  constructor(opts: LivenessOptions) {
+    this.store = opts.store;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_LIVENESS_TTL_MS;
+  }
+
+  /**
+   * Find dead instances, mark them dead, and reset every leased/running run
+   * they own back to 'ready' (conditional on still-owned, so a run re-leased
+   * mid-reclaim is never clobbered).
+   */
+  async reclaimDeadInstanceRuns(options?: { maxReclaimsPerCycle?: number }): Promise<DeadInstanceReclaimSummary> {
+    const maxReclaims = options?.maxReclaimsPerCycle ?? 200;
+    const now = this.store.now();
+    const summary: DeadInstanceReclaimSummary = { deadInstanceIds: [], reclaimedCount: 0, reclaimedIds: [], errors: [] };
+
+    let instances: AgentInstanceRow[];
+    try {
+      instances = await this.store.liveInstances();
+    } catch (err: unknown) {
+      summary.errors.push({ id: 'instances', error: err instanceof Error ? err.message : String(err) });
+      return summary;
+    }
+
+    const dead = deadInstanceIds(instances, now, this.ttlMs);
+    if (dead.length === 0) return summary;
+    summary.deadInstanceIds = dead;
+
+    try {
+      await this.store.markInstancesDead(dead);
+    } catch {
+      // best-effort; reclaim proceeds regardless
+    }
+
+    let runs: AgentRunRow[];
+    try {
+      runs = await this.store.runsOwnedBy(dead, maxReclaims);
+    } catch (err: unknown) {
+      summary.errors.push({ id: 'runs', error: err instanceof Error ? err.message : String(err) });
+      return summary;
+    }
+
+    for (const run of runs) {
+      try {
+        const ok = await this.store.reclaimRun(run.id, run.lease_owner as string, (run.retries ?? 0) + 1);
+        if (ok) summary.reclaimedIds.push(run.id);
+        else summary.errors.push({ id: run.id, error: 'no rows (re-leased)' });
+      } catch (err: unknown) {
+        summary.errors.push({ id: run.id, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    summary.reclaimedCount = summary.reclaimedIds.length;
+    return summary;
+  }
+}


### PR DESCRIPTION
The last blocker for full app-Heart consolidation (doc 2149): the package had no dead-instance reclaim, so it couldn't fully replace the app's recovery cron. Now it does - LivenessReclaimer (proactive recovery over an injected LivenessStore) + the pure helpers, ported from src/lib/heart/liveness.ts. 6 tests incl. the conditional-update guard (a run re-leased mid-reclaim isn't clobbered). Pure package addition, no live change - the app-liveness delegation is a follow-up mirroring the Option A shim.

Generated with [Claude Code](https://claude.com/claude-code)