### PR TITLE
feat(outbox): wire the transactional outbox to a live channel (flag-gated)

### DIFF
--- a/bot/src/zoe/heart-canary.ts
+++ b/bot/src/zoe/heart-canary.ts
@@ -20,17 +20,80 @@ import { randomUUID } from 'node:crypto';
 import {
   HeartFleet,
   SupabaseLeaseStore,
+  DurableEffectLedger,
   executeWithLease,
+  sendOnce,
+  effectKey,
   deterministicResourceId,
   type SupabaseLikeClient,
+  type OutboxClient,
+  type FencingToken,
 } from '../../../packages/heart-fleet/src/index';
 import { db } from '../supabase';
 
 const CANARY_KIND = 'zoe.heart.canary';
 const CANARY_KEY = 'singleton';
 
+/** Fixed demo content - a deterministic effect_key, so it sends ONCE ever then
+ *  dedupes on every subsequent beat (that IS the at-most-once proof). */
+const OUTBOX_DEMO_TEXT = '[outbox-demo] ZOE outbox is live - this message was delivered exactly once via the transactional outbox (doc 2145).';
+
 export function heartCanaryEnabled(): boolean {
   return process.env.ZOE_HEART_FLEET_CANARY === 'true';
+}
+
+/** Second flag: also exercise the transactional outbox on each canary beat. */
+export function outboxDemoEnabled(): boolean {
+  return process.env.ZOE_OUTBOX_DEMO === 'true';
+}
+
+/** Send capability + target the outbox demo needs (injected from the scheduler). */
+export interface CanaryDeps {
+  send?: (chatId: number, text: string) => Promise<{ message_id?: number }>;
+  groupId?: number;
+}
+
+let _ledger: DurableEffectLedger | null = null;
+function ledger(): DurableEffectLedger {
+  if (_ledger) return _ledger;
+  _ledger = new DurableEffectLedger({ client: db() as unknown as OutboxClient });
+  return _ledger;
+}
+
+/**
+ * Send the fixed demo message through the transactional outbox, exactly once.
+ * Runs INSIDE the canary's leased work so it has a live fence. Graceful: if the
+ * effect_intents table is not applied yet (scripts/2148), it logs and returns
+ * without breaking the canary. Returns the outcome for the beat log.
+ */
+async function runOutboxDemo(
+  h: HeartFleet,
+  fence: FencingToken,
+  deps: CanaryDeps,
+): Promise<string> {
+  if (!deps.send || !deps.groupId) return 'no-send-deps';
+  try {
+    const outcome = await sendOnce(h, ledger(), {
+      fence,
+      channel: 'telegram',
+      effectKey: effectKey('telegram', { chatId: deps.groupId, text: OUTBOX_DEMO_TEXT }),
+      payload: { chatId: deps.groupId, text: OUTBOX_DEMO_TEXT },
+      send: () => deps.send!(deps.groupId!, OUTBOX_DEMO_TEXT),
+      toExternalRef: (r) => ({ message_id: r.message_id ?? null }),
+    });
+    console.log(`[zoe/heart-canary] outbox demo: ${JSON.stringify(outcome.sent ? { sent: true } : outcome)}`);
+    return outcome.sent ? 'sent' : outcome.reason;
+  } catch (err) {
+    const msg = (err as Error)?.message ?? String(err);
+    // The most likely cause is the migration not applied yet - say so clearly.
+    console.warn(
+      `[zoe/heart-canary] outbox demo skipped: ${msg}` +
+        (/relation .*effect_intents.* does not exist|effect_intents/i.test(msg)
+          ? ' (apply scripts/2148-transactional-outbox.sql first)'
+          : ''),
+    );
+    return 'error';
+  }
 }
 
 let _heart: HeartFleet | null = null;
@@ -91,8 +154,11 @@ async function ensureCanaryRun(): Promise<string | null> {
  * One canary beat. Safe to call every tick; no-ops when the flag is off.
  * Returns what happened for the caller's log line.
  */
-export async function runHeartFleetCanary(owner?: string): Promise<
-  { skipped: 'disabled' | 'no-run' } | { ran: boolean; reason?: string; metrics: Record<string, number> }
+export async function runHeartFleetCanary(
+  owner?: string,
+  deps?: CanaryDeps,
+): Promise<
+  { skipped: 'disabled' | 'no-run' } | { ran: boolean; reason?: string; outbox?: string; metrics: Record<string, number> }
 > {
   if (!heartCanaryEnabled()) return { skipped: 'disabled' };
 
@@ -101,8 +167,14 @@ export async function runHeartFleetCanary(owner?: string): Promise<
 
   const h = heart();
   const instance = owner ?? `zoe:${process.env.HOSTNAME ?? 'host'}:${process.pid}`;
-  const outcome = await executeWithLease(h, { runId, owner: instance, ttlSeconds: 60 }, async () => {
-    // Deliberate no-op: the canary proves the lease path, not work.
+  let outboxResult: string | undefined;
+  const outcome = await executeWithLease(h, { runId, owner: instance, ttlSeconds: 60 }, async (fence) => {
+    // The canary proves the lease path; when ZOE_OUTBOX_DEMO is on it ALSO
+    // exercises the transactional outbox end-to-end on the real table, using
+    // this beat's live fence. Deterministic effect_key -> sends once, dedupes after.
+    if (outboxDemoEnabled() && deps) {
+      outboxResult = await runOutboxDemo(h, fence(), deps);
+    }
     return 'ok';
   });
 
@@ -119,12 +191,15 @@ export async function runHeartFleetCanary(owner?: string): Promise<
   const summary = {
     ran: outcome.ran,
     ...(outcome.ran ? {} : { reason: outcome.reason }),
+    ...(outboxResult ? { outbox: outboxResult } : {}),
     metrics: {
       acquireWins: m.acquireWins,
       acquireCollisions: m.acquireCollisions,
       renews: m.renews,
       releases: m.releases,
       fenceRejections: m.fenceRejections,
+      effectCommits: m.effectCommits,
+      effectDedupes: m.effectDedupes,
     },
   };
   console.log(`[zoe/heart-canary] beat: ${JSON.stringify(summary)}`);

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -738,7 +738,16 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       async () => {
         if (!heartCanaryEnabled()) return; // flag off = zero work, zero logs
         try {
-          await runHeartFleetCanary();
+          // Pass a send + target so the canary can exercise the transactional
+          // outbox end-to-end when ZOE_OUTBOX_DEMO is also on (still no-op when
+          // that flag is off). Target = the ZAAL BOTZ ops group (internal).
+          const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+          await runHeartFleetCanary(undefined, {
+            groupId: gid || undefined,
+            send: gid
+              ? (chatId, text) => opts.bot.api.sendMessage(chatId, text) as Promise<{ message_id?: number }>
+              : undefined,
+          });
         } catch (err) {
           console.error('[zoe/scheduler] heart canary beat failed:', (err as Error)?.message);
         }


### PR DESCRIPTION
Proves the crash-safe at-most-once path end-to-end on the real agent_runs/effect_intents tables. When ZOE_OUTBOX_DEMO=true (+ the heart canary on), each beat sends one fixed internal status message through sendOnce inside its leased work - deterministic effect_key means it delivers EXACTLY ONCE then dedupes forever after (visible in effectCommits/effectDedupes). Graceful if the migration isn't applied yet. Default OFF.

Verified: bot tsc = baseline 46, bot vitest green (only the pre-existing meetings date test fails), esbuild bundles clean. To go live: apply scripts/2148, flip both flags, restart the bot.

Generated with [Claude Code](https://claude.com/claude-code)