### PR TITLE
docs(zabal): mentor outreach drafts (13 candidates)

### DIFF
--- a/research/business/2137-zabal-gamez-august-concept-options/MENTOR-OUTREACH-DRAFTS.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/MENTOR-OUTREACH-DRAFTS.md
@@ -1,0 +1,90 @@
+# ZABAL August - mentor outreach drafts (13 candidates)
+
+> The invites to ask the 13 ZABAL mentor candidates. Format = pods (no live draft), the ~4-6h/month ask. YOU send these (outreach is gated - I draft, you approve + send). Each is personalized from what we know; edit the voice to yours. Names are only used here (internal) - no public naming until each says yes.
+
+## The shared ask (what everyone's saying yes to)
+
+- Take a mentor pod: 2-5 August builders in your track, matched to what they're building.
+- One 30-min pod session per week (4 total) + async nudges in the pod thread.
+- Share your evaluation criteria openly in week 1.
+- Weeks 3-4: 1:1 with any of your builders who reach the head-to-head battles.
+- Optional: appear on the finale stream.
+- ~4-6 hours across the whole month.
+
+## The reusable core (paste + personalize the opener)
+
+```
+[personal opener - see per-person below]
+
+Quick ask: be a mentor for ZABAL Games' August finals. August is the July submitters - everyone who built in July gets matched to a ZAO mentor pod, and I'd love one of those pods to be yours.
+
+What it is: 2-5 builders in [their track], one 30-min pod session a week for the month, you share how you'd evaluate the work up front, and if any of your builders reach the final head-to-head rounds you go 1:1 with them. Roughly 4-6 hours total across August. Optional cameo on the finale stream.
+
+You'd be a great fit because [reason]. In or out - no pressure either way, and if you're in I'll send the pod + the criteria template.
+```
+
+## Per-person openers + fit line
+
+**Tyler Stambaugh (Magnetic)** - creator track
+- Opener: "You've been the glue on ZABAL from the start - want to make it official for the finals?"
+- Fit: "the SNAPS/emotional-loyalty lens is exactly what the creator-track builders need to hear on retention."
+
+**Jordan Oram (Empire Builder)** - builder track
+- Opener: "The whole ZABAL shape came out of our May call - want to mentor the builders using Empire Builder in the finals?"
+- Fit: "tokenless-empire-first is the mental model half these builders are missing."
+
+**Adrian (Empire Builder, API side)** - builder track
+- Opener: "You recorded the Empire Builder API workshop - want to mentor the builders actually wiring it up in August?"
+- Fit: "you're the one who can unstick anyone integrating V3 endpoints or a leaderboard."
+
+**Arthur (Neynar)** - builder track (contracts/security)
+- Opener: "You already signed up as a ZABAL mentor - here's the concrete August shape."
+- Fit: "the EVM/contract-security eye is gold for any builder touching WaveWarZ-Base or on-chain." (Note: he's virtual-only around Oct 3 - fine, pods are remote.)
+
+**KMac (kmac.eth)** - builder track (Farcaster/snaps)
+- Opener: "Your snap-builder + JFS-tiering work is exactly the depth the Farcaster builders need."
+- Fit: "anyone building a snap or mini-app in August should be in your pod."
+
+**Jonathan Colton (FounderCheck)** - creator/builder track
+- Opener: "FounderCheck's 'get Who right' thesis is the thing most builders skip - want to mentor a pod on it?"
+- Fit: "you can drill the who/what/channel/adoption pillars + the Meme-Lord virality angle."
+
+**Shriyash Soni (ApnaCoding)** - builder track
+- Opener: "~100 OSS projects and an ApnaCoding community - you'd mentor builders like you've onboarded hundreds."
+- Fit: "strong open-source + hackathon-shipping muscle for the daily-update builders."
+
+**Arun Phillips (DreamStarter)** - creator/AI track
+- Opener: "The DreamStarter clipper + agentic-marketing angle is a track of its own - want a creator pod?"
+- Fit: "AI creator-marketing automation + web3 music is a lane no other mentor covers."
+
+**Rodrigo (MezuriDAO / DeSci)** - builder/impact track
+- Opener: "A DeSci/regen mentor would open a track we've never had - interested for August?"
+- Fit: "conservation/DeSci builders finally get a mentor who's shipped in that space."
+
+**Duo Do (Clementine + Santiago)** - artist track
+- Opener: "You two are the musician-on-Farcaster voice - want to mentor the artist-track builders?"
+- Fit: "the artist track needs working musicians, not coders, guiding it - that's you."
+
+**Deez (d333z)** - builder track (token/launch)
+- Opener: "Your token-level fee-protection design is exactly the depth launch-focused builders need."
+- Fit: "anyone launching or tokenizing in August should get your Clanker-failure-mode lens."
+
+**Vlad (Singularity / Respect Game)** - builder/governance track
+- Opener: "The Respect Game / DAO-of-the-Apes work maps straight onto ZABAL's leaderboard - mentor a pod?"
+- Fit: "fractal-governance + on-chain-respect is the governance track no one else can teach."
+
+**Cannon Jones** - track TBD (confirm his current focus before sending)
+- Opener: "You've been in ZAO since spring - want a mentor pod for the August finals?"
+- Fit: [confirm his build focus first - our memory note is thin; ask what he'd want to mentor.]
+
+## Sending notes
+
+- Channel: whatever you normally reach each on (Farcaster DM / TG / the ZABAL group). Most are Farcaster-native.
+- Batch: send the 4 already-warm ones first (Tyler, Jordan, Arthur, Adrian - all previously said yes to ZABAL involvement), then the rest.
+- On a yes: send them the pod + the evaluation-criteria template (I can draft that template next if you want it).
+- Track replies on the board so we know the mentor count before Saturday's public post (the copy says "ZAO mentors" generically, so you can post before all 13 confirm).
+
+## Still needs you (from doc 2137)
+
+- Mentor scoring weight decision (50/50 vs a 10-15% mentor carve in week 2) - not blocking the invites.
+- Whether to name confirmed mentors publicly in a later post (get each one's OK first).


### PR DESCRIPTION
The invites to ask the 13 ZABAL mentor candidates. Reusable core message (pods, ~4-6h/month, no live draft) + a personalized opener + fit line per person (from memory) + track suggestion + sending notes (the 4 already-warm ones first). You send - outreach is gated, this is the draft. One name (Cannon) flagged to confirm focus before sending. Offer to draft the evaluation-criteria template next on a yes.

Generated with [Claude Code](https://claude.com/claude-code)