### PR TITLE
refactor(heart): app liveness delegates to the shared LivenessReclaimer (doc 2149)

### DIFF
--- a/src/lib/heart/__tests__/liveness-delegation.test.ts
+++ b/src/lib/heart/__tests__/liveness-delegation.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { reclaimDeadInstanceRuns } from '../liveness';
+import type { LivenessStore, AgentInstanceRow } from '../../../../packages/heart-fleet/src/index';
+import type { AgentRunRow } from '../types';
+
+/**
+ * Happy-path coverage for the delegated reclaimDeadInstanceRuns (doc 2149).
+ * The pre-existing liveness tests cover the pure helpers; the DB reclaim path
+ * had none. This injects a fake LivenessStore via the new `opts.store` seam to
+ * prove the delegation behaves: a dead instance's leased runs are reset, a live
+ * instance's runs are untouched.
+ */
+
+const NOW = new Date('2026-07-30T10:00:00.000Z');
+
+class FakeStore implements LivenessStore {
+  instances: AgentInstanceRow[] = [];
+  runs = new Map<string, AgentRunRow>();
+  now() { return NOW; }
+  async liveInstances() { return this.instances.filter((i) => i.status !== 'dead'); }
+  async markInstancesDead(ids: string[]) {
+    for (const i of this.instances) if (ids.includes(i.instance_id)) i.status = 'dead';
+  }
+  async runsOwnedBy(owners: string[], limit: number) {
+    return [...this.runs.values()]
+      .filter((r) => r.lease_owner !== null && owners.includes(r.lease_owner) && ['leased', 'running'].includes(r.status))
+      .slice(0, limit);
+  }
+  async reclaimRun(runId: string, expectedOwner: string, retries: number) {
+    const r = this.runs.get(runId);
+    if (!r || r.lease_owner !== expectedOwner) return false;
+    this.runs.set(runId, { ...r, status: 'ready', lease_owner: null, lease_expires_at: null, retries });
+    return true;
+  }
+}
+
+function inst(id: string, secsAgo: number): AgentInstanceRow {
+  return { instance_id: id, hostname: 'h', pid: 1, status: 'alive', started_at: NOW.toISOString(), last_heartbeat: new Date(NOW.getTime() - secsAgo * 1000).toISOString(), metadata: null };
+}
+function run(id: string, owner: string): AgentRunRow {
+  return { id, task_id: null, assignment_id: 'a', objective: 'o', required_capabilities: [], status: 'leased', assigned_agent: null, lease_owner: owner, lease_expires_at: NOW.toISOString(), retries: 0, budget: null, approval_state: 'auto', visibility: 'team', idempotency_key: id, created_by: 't', created_at: NOW.toISOString(), updated_at: NOW.toISOString() };
+}
+
+describe('reclaimDeadInstanceRuns (delegated)', () => {
+  it('resets runs owned by a dead instance, leaves live-owned runs alone', async () => {
+    const store = new FakeStore();
+    store.instances = [inst('dead-1', 200), inst('live-1', 5)]; // 200s > 90s TTL
+    store.runs.set('r1', run('r1', 'dead-1'));
+    store.runs.set('r2', run('r2', 'live-1'));
+
+    const summary = await reclaimDeadInstanceRuns({ store });
+    expect(summary.deadInstanceIds).toEqual(['dead-1']);
+    expect(summary.reclaimedIds).toEqual(['r1']);
+    expect(summary.reclaimedCount).toBe(1);
+    expect(store.runs.get('r1')?.status).toBe('ready');
+    expect(store.runs.get('r1')?.retries).toBe(1);
+    expect(store.runs.get('r2')?.status).toBe('leased');
+  });
+
+  it('no dead instances = zero work', async () => {
+    const store = new FakeStore();
+    store.instances = [inst('live-1', 5)];
+    const summary = await reclaimDeadInstanceRuns({ store });
+    expect(summary.reclaimedCount).toBe(0);
+    expect(summary.deadInstanceIds).toEqual([]);
+  });
+});

--- a/src/lib/heart/liveness.ts
+++ b/src/lib/heart/liveness.ts
@@ -23,6 +23,11 @@ import type {
   InstanceStatus,
   DeadInstanceReclaimSummary,
 } from './types';
+import {
+  LivenessReclaimer,
+  type LivenessStore,
+  type AgentInstanceRow as PkgInstanceRow,
+} from '../../../packages/heart-fleet/src/index';
 
 // Lazy admin client, same pattern as lease-manager (tests never touch the DB).
 let _getSupabaseAdmin: (() => any) | null = null;
@@ -36,6 +41,53 @@ function getSupabaseAdmin() {
     throw new Error('Supabase admin client not initialized. Test-context only.');
   }
   return _getSupabaseAdmin();
+}
+
+/**
+ * SupabaseLivenessStore - adapts getSupabaseAdmin() to the shared package's
+ * LivenessStore, so reclaimDeadInstanceRuns delegates to the ONE ported
+ * LivenessReclaimer (doc 2149). The query shapes are identical to what this
+ * module did by hand; injectable for tests.
+ */
+class SupabaseLivenessStore implements LivenessStore {
+  now(): Date {
+    return new Date();
+  }
+  async liveInstances(): Promise<PkgInstanceRow[]> {
+    const { data, error } = await getSupabaseAdmin().from('agent_instances').select('*').neq('status', 'dead');
+    if (error) throw new Error(error.message);
+    return (data ?? []) as PkgInstanceRow[];
+  }
+  async markInstancesDead(ids: string[]): Promise<void> {
+    await getSupabaseAdmin().from('agent_instances').update({ status: 'dead' as InstanceStatus }).in('instance_id', ids);
+  }
+  async runsOwnedBy(ownerIds: string[], limit: number): Promise<AgentRunRow[]> {
+    const { data, error } = await getSupabaseAdmin()
+      .from('agent_runs')
+      .select('*')
+      .in('status', ['leased', 'running'] as RunStatus[])
+      .in('lease_owner', ownerIds)
+      .limit(limit);
+    if (error) throw new Error(error.message);
+    return (data ?? []) as AgentRunRow[];
+  }
+  async reclaimRun(runId: string, expectedOwner: string, retries: number): Promise<boolean> {
+    const { data, error } = await getSupabaseAdmin()
+      .from('agent_runs')
+      .update({
+        status: 'ready' as RunStatus,
+        lease_owner: null,
+        lease_expires_at: null,
+        retries,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', runId)
+      .eq('lease_owner', expectedOwner) // still owned by the dead instance
+      .select('id')
+      .single();
+    if (error || !data) return false;
+    return true;
+  }
 }
 
 /** Default liveness TTL: an instance silent this long is presumed dead. */
@@ -158,78 +210,23 @@ export async function drainInstance(instanceId: string): Promise<void> {
 export async function reclaimDeadInstanceRuns(options?: {
   ttlMs?: number;
   maxReclaimsPerCycle?: number;
+  store?: LivenessStore;
 }): Promise<DeadInstanceReclaimSummary> {
   const ttlMs = options?.ttlMs ?? DEFAULT_LIVENESS_TTL_MS;
   const maxReclaims = options?.maxReclaimsPerCycle ?? 200;
-  const db = getSupabaseAdmin();
-  const now = new Date();
-  const summary: DeadInstanceReclaimSummary = {
-    deadInstanceIds: [],
-    reclaimedCount: 0,
-    reclaimedIds: [],
-    errors: [],
-  };
 
   try {
-    const { data: instances, error: instErr } = await db
-      .from('agent_instances')
-      .select('*')
-      .neq('status', 'dead');
-    if (instErr) {
-      summary.errors.push({ id: 'instances', error: instErr.message });
-      return summary;
-    }
-
-    const dead = deadInstanceIds((instances ?? []) as AgentInstanceRow[], now, ttlMs);
-    if (dead.length === 0) return summary;
-    summary.deadInstanceIds = dead;
-
-    // Mark the dead instances dead (best-effort; reclaim proceeds regardless).
-    await db
-      .from('agent_instances')
-      .update({ status: 'dead' as InstanceStatus })
-      .in('instance_id', dead);
-
-    const { data: runs, error: runErr } = await db
-      .from('agent_runs')
-      .select('*')
-      .in('status', RECLAIMABLE_STATUSES as RunStatus[])
-      .in('lease_owner', dead)
-      .limit(maxReclaims);
-    if (runErr) {
-      summary.errors.push({ id: 'runs', error: runErr.message });
-      return summary;
-    }
-
-    for (const run of (runs ?? []) as AgentRunRow[]) {
-      try {
-        const { data: updated, error: updErr } = await db
-          .from('agent_runs')
-          .update({
-            status: 'ready' as RunStatus,
-            lease_owner: null,
-            lease_expires_at: null,
-            retries: (run.retries ?? 0) + 1,
-            updated_at: now.toISOString(),
-          })
-          .eq('id', run.id)
-          .eq('lease_owner', run.lease_owner) // still owned by the dead instance
-          .select('id')
-          .single();
-        if (updErr || !updated) {
-          summary.errors.push({ id: run.id, error: updErr?.message ?? 'no rows (re-leased)' });
-        } else {
-          summary.reclaimedIds.push(run.id);
-        }
-      } catch (err: unknown) {
-        summary.errors.push({ id: run.id, error: err instanceof Error ? err.message : String(err) });
-      }
-    }
-
-    summary.reclaimedCount = summary.reclaimedIds.length;
-    return summary;
+    // Delegate to the shared LivenessReclaimer (packages/heart-fleet) - the ONE
+    // dead-instance reclaim implementation. Same query shapes, same
+    // conditional-update guard (a run re-leased mid-reclaim is not clobbered).
+    const reclaimer = new LivenessReclaimer({ store: options?.store ?? new SupabaseLivenessStore(), ttlMs });
+    return await reclaimer.reclaimDeadInstanceRuns({ maxReclaimsPerCycle: maxReclaims });
   } catch (err: unknown) {
-    summary.errors.push({ id: 'exception', error: err instanceof Error ? err.message : String(err) });
-    return summary;
+    return {
+      deadInstanceIds: [],
+      reclaimedCount: 0,
+      reclaimedIds: [],
+      errors: [{ id: 'exception', error: err instanceof Error ? err.message : String(err) }],
+    };
   }
 }


### PR DESCRIPTION
## App liveness delegates to the shared LivenessReclaimer (completes Heart consolidation)

Follow-up to the liveness port (#2731) and the Option A shim (#2730). `reclaimDeadInstanceRuns` (the recovery cron's proactive-recovery path) now delegates to the ONE ported `LivenessReclaimer` via a `SupabaseLivenessStore` adapter - same query shapes, same conditional-update guard (a run re-leased mid-reclaim is never clobbered). registerInstance/heartbeat/drain + the pure helpers stay app-side.

**Full Heart consolidation is now done** on the reclaim paths: acquire, reclaimExpired, AND dead-instance reclaim all run through packages/heart-fleet.

### Proof (live recovery-cron code -> Vercel)
- App tsc: 0.
- Heart tests: 66/66 (the pre-existing stay green + 2 NEW happy-path tests via an injected LivenessStore, coverage the DB reclaim path never had).
- Production `npm run build`: GREEN (verified with real node_modules).

Behavior-identical, no flag.

Generated with [Claude Code](https://claude.com/claude-code)
