### PR TITLE
feat(outbox): the reconciler - closes the crash window (doc 2145, last piece)

### DIFF
--- a/bot/src/zoe/__tests__/outbox-reconcile.test.ts
+++ b/bot/src/zoe/__tests__/outbox-reconcile.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DurableEffectLedger,
+  reconcileOutbox,
+  type OutboxClient,
+  type IntentRow,
+  type ChannelProbe,
+} from '../../../../packages/heart-fleet/src/index';
+
+/**
+ * Outbox reconciler (doc 2145, the crash-window closer). Proves the three
+ * probe outcomes on a fake effect_intents store:
+ *  - 'sent'      -> the stale row is committed with the recovered evidence
+ *  - 'not-sent'  -> reopened for retry
+ *  - 'unknown'   -> NEVER resent; abandoned only past the attempt ceiling
+ */
+
+interface Row {
+  run_id: string; effect_key: string; state: string; channel: string; payload_digest: string;
+  fence_owner: string | null; fence_expires_at: string | null; external_ref: Record<string, unknown> | null;
+  attempts: number; last_error: string | null; created_at: string; committed_at: string | null;
+}
+
+class FakeOutboxClient implements OutboxClient {
+  rows = new Map<string, Row>();
+  private key(r: string, e: string) { return `${r}::${e}`; }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  from(table: string): any {
+    const self = this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const q: any = {
+      _table: table, _op: null, _values: {}, _eq: {}, _in: {}, _lt: {},
+      insert(v: Record<string, unknown>) { q._op = 'insert'; q._values = v; return q; },
+      update(v: Record<string, unknown>) { q._op = 'update'; q._values = v; return q; },
+      select() { return q; },
+      eq(f: string, v: unknown) { q._eq[f] = v; return q; },
+      in(f: string, v: unknown[]) { q._in[f] = v; return q; },
+      lt(f: string, v: string) { q._lt[f] = v; return q; },
+      limit() { return Promise.resolve(self._runSelect(q)); },
+      async maybeSingle() { return self._run(q); },
+    };
+    return q;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _match(row: Row, q: any): boolean {
+    for (const [f, v] of Object.entries(q._eq)) if ((row as unknown as Record<string, unknown>)[f] !== v) return false;
+    for (const [f, vs] of Object.entries(q._in)) if (!(vs as unknown[]).includes((row as unknown as Record<string, unknown>)[f])) return false;
+    for (const [f, b] of Object.entries(q._lt)) {
+      const a = (row as unknown as Record<string, unknown>)[f];
+      if (typeof a !== 'string' || new Date(a) >= new Date(b as string)) return false;
+    }
+    return true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _runSelect(q: any) {
+    if (q._table === 'outbox_dispatch_log') return { data: [], error: null };
+    return { data: [...this.rows.values()].filter((r) => this._match(r, q)), error: null };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _run(q: any) {
+    if (q._table === 'outbox_dispatch_log') return { data: { id: 'log' }, error: null };
+    if (q._op === 'insert') {
+      const k = this.key(String(q._values.run_id), String(q._values.effect_key));
+      if (this.rows.has(k)) return { data: null, error: { code: '23505', message: 'dup' } };
+      this.rows.set(k, { fence_owner: null, fence_expires_at: null, external_ref: null, attempts: 0, last_error: null, committed_at: null, ...(q._values as Partial<Row>) } as Row);
+      return { data: { run_id: q._values.run_id }, error: null };
+    }
+    for (const [k, row] of this.rows) {
+      if (row.run_id === q._eq.run_id && row.effect_key === q._eq.effect_key) {
+        if (!this._match(row, q)) return { data: null, error: null };
+        this.rows.set(k, { ...row, ...(q._values as Partial<Row>) });
+        return { data: { run_id: row.run_id }, error: null };
+      }
+    }
+    return { data: null, error: null };
+  }
+  seedDispatched(effectKey: string, channel: string, attempts: number) {
+    const runId = 'run-1';
+    this.rows.set(this.key(runId, effectKey), {
+      run_id: runId, effect_key: effectKey, state: 'dispatched', channel, payload_digest: 'd',
+      fence_owner: 'dead-worker', fence_expires_at: '2026-07-30T09:00:00.000Z', external_ref: null,
+      attempts, last_error: null, created_at: '2026-07-30T08:00:00.000Z', committed_at: null,
+    });
+  }
+}
+
+const NOW = () => new Date('2026-07-30T10:00:00.000Z'); // past the seeded fence expiry
+
+let client: FakeOutboxClient;
+let ledger: DurableEffectLedger;
+
+beforeEach(() => {
+  client = new FakeOutboxClient();
+  ledger = new DurableEffectLedger({ client, now: NOW });
+});
+
+describe('reconcileOutbox', () => {
+  it("commits a stale row the probe proves was 'sent'", async () => {
+    client.seedDispatched('e-sent', 'farcaster', 1);
+    const probe: ChannelProbe = async () => ({ status: 'sent', externalRef: { cast_hash: '0xabc' } });
+    const s = await reconcileOutbox(ledger, { probes: { farcaster: probe }, now: NOW });
+    expect(s.committed).toBe(1);
+    const row = [...client.rows.values()][0];
+    expect(row.state).toBe('committed');
+    expect(row.external_ref).toEqual({ cast_hash: '0xabc' });
+  });
+
+  it("reopens a stale row the probe proves was 'not-sent'", async () => {
+    client.seedDispatched('e-notsent', 'farcaster', 1);
+    const probe: ChannelProbe = async () => ({ status: 'not-sent' });
+    const s = await reconcileOutbox(ledger, { probes: { farcaster: probe }, now: NOW });
+    expect(s.reopened).toBe(1);
+    expect([...client.rows.values()][0].state).toBe('intent');
+  });
+
+  it("NEVER resends an 'unknown' row under the ceiling - leaves it dispatched", async () => {
+    client.seedDispatched('e-unknown', 'telegram', 2); // no probe -> unknown, attempts < 5
+    const s = await reconcileOutbox(ledger, { now: NOW }); // telegram has no probe
+    expect(s.left).toBe(1);
+    expect(s.abandoned).toBe(0);
+    expect([...client.rows.values()][0].state).toBe('dispatched'); // untouched, revisited next run
+  });
+
+  it("abandons an 'unknown' row past the ceiling (at-most-once: never resent)", async () => {
+    client.seedDispatched('e-old', 'telegram', 5); // attempts >= maxAttempts
+    const s = await reconcileOutbox(ledger, { maxAttempts: 5, now: NOW });
+    expect(s.abandoned).toBe(1);
+    const row = [...client.rows.values()][0];
+    expect(row.state).toBe('abandoned');
+    expect(row.last_error).toContain('at-most-once');
+  });
+
+  it('scans nothing when there are no stale dispatched rows', async () => {
+    const s = await reconcileOutbox(ledger, { now: NOW });
+    expect(s.scanned).toBe(0);
+  });
+});

--- a/bot/src/zoe/heart-canary.ts
+++ b/bot/src/zoe/heart-canary.ts
@@ -23,6 +23,7 @@ import {
   DurableEffectLedger,
   executeWithLease,
   sendOnce,
+  reconcileOutbox,
   effectKey,
   deterministicResourceId,
   type SupabaseLikeClient,
@@ -82,6 +83,15 @@ async function runOutboxDemo(
       toExternalRef: (r) => ({ message_id: r.message_id ?? null }),
     });
     console.log(`[zoe/heart-canary] outbox demo: ${JSON.stringify(outcome.sent ? { sent: true } : outcome)}`);
+    // Defensive reconcile: resolve any dispatched-but-uncommitted rows left by a
+    // prior crash. No probes wired for telegram (it has no 'did I send X' query),
+    // so unknown rows are left/abandoned - never resent (at-most-once). Doc 2145.
+    try {
+      const rec = await reconcileOutbox(ledger());
+      if (rec.scanned > 0) console.log(`[zoe/heart-canary] outbox reconcile: ${JSON.stringify(rec)}`);
+    } catch (e) {
+      console.warn('[zoe/heart-canary] outbox reconcile skipped:', (e as Error)?.message);
+    }
     return outcome.sent ? 'sent' : outcome.reason;
   } catch (err) {
     const msg = (err as Error)?.message ?? String(err);

--- a/packages/heart-fleet/src/index.ts
+++ b/packages/heart-fleet/src/index.ts
@@ -44,3 +44,10 @@ export {
   type InstanceStatus,
   type DeadInstanceReclaimSummary,
 } from './liveness';
+export {
+  reconcileOutbox,
+  type ChannelProbe,
+  type ProbeResult,
+  type ReconcileOptions,
+  type ReconcileSummary,
+} from './reconcile';

--- a/packages/heart-fleet/src/reconcile.ts
+++ b/packages/heart-fleet/src/reconcile.ts
@@ -1,0 +1,101 @@
+/**
+ * reconcileOutbox - closes the crash window in the transactional outbox
+ * (design doc 2145, the last piece). A row stuck in `dispatched` with an
+ * expired fence means: the process claimed the send and MAY have performed it,
+ * but crashed before recording the commit. The reconciler resolves each such
+ * row, biased HARD toward at-most-once (never resend without proof).
+ *
+ * Per-channel PROBE decides:
+ *   - 'sent' (+ external ref) -> markCommitted. The send did happen; record it.
+ *   - 'not-sent'              -> reopen for ONE bounded retry (safe: proven not sent).
+ *   - 'unknown'               -> the channel can't tell (e.g. Telegram has no
+ *                                "did I send X" query). Do NOT resend - that
+ *                                would risk a duplicate, breaking the whole
+ *                                at-most-once promise. Past the attempt ceiling,
+ *                                ABANDON with a clear reason so the caller sees
+ *                                it (a distinct terminal state, not silent loss).
+ *
+ * The reconciler is meant to run under a lease (the recovery cron / canary), so
+ * only one instance reconciles at a time.
+ */
+import type { DurableEffectLedger, IntentRow } from './durable-effect-ledger';
+
+export type ProbeResult =
+  | { status: 'sent'; externalRef: Record<string, unknown> }
+  | { status: 'not-sent' }
+  | { status: 'unknown' };
+
+/** A per-channel probe: did this dispatched-but-uncommitted effect actually happen? */
+export type ChannelProbe = (intent: IntentRow) => Promise<ProbeResult>;
+
+export interface ReconcileOptions {
+  /** Probes by channel. A channel with no probe is treated as 'unknown'. */
+  probes?: Partial<Record<string, ChannelProbe>>;
+  /** Beyond this attempt count, an unresolved 'unknown' row is abandoned. */
+  maxAttempts?: number;
+  /** How many stale rows to process per run. */
+  limit?: number;
+  /** Injectable clock. */
+  now?: () => Date;
+}
+
+export interface ReconcileSummary {
+  scanned: number;
+  committed: number;
+  reopened: number;
+  abandoned: number;
+  left: number; // still dispatched (unknown, under the ceiling) - revisited next run
+  errors: Array<{ effectKey: string; error: string }>;
+}
+
+export async function reconcileOutbox(
+  ledger: DurableEffectLedger,
+  options?: ReconcileOptions,
+): Promise<ReconcileSummary> {
+  const probes = options?.probes ?? {};
+  const maxAttempts = options?.maxAttempts ?? 5;
+  const limit = options?.limit ?? 50;
+  const nowFn = options?.now ?? (() => new Date());
+
+  const summary: ReconcileSummary = { scanned: 0, committed: 0, reopened: 0, abandoned: 0, left: 0, errors: [] };
+
+  let stale: IntentRow[];
+  try {
+    stale = await ledger.findStaleDispatched(nowFn().toISOString(), limit);
+  } catch (err: unknown) {
+    summary.errors.push({ effectKey: 'scan', error: err instanceof Error ? err.message : String(err) });
+    return summary;
+  }
+  summary.scanned = stale.length;
+
+  for (const intent of stale) {
+    try {
+      const probe = probes[intent.channel];
+      const result: ProbeResult = probe ? await probe(intent) : { status: 'unknown' };
+
+      if (result.status === 'sent') {
+        await ledger.markCommitted({ runId: intent.run_id, effectKey: intent.effect_key, externalRef: result.externalRef });
+        summary.committed++;
+      } else if (result.status === 'not-sent') {
+        await ledger.reopen(intent.run_id, intent.effect_key, 'reconciler: provably not sent, reopened for retry');
+        summary.reopened++;
+      } else {
+        // unknown - never resend (at-most-once). Abandon past the ceiling.
+        if (intent.attempts >= maxAttempts) {
+          await ledger.abandon(
+            intent.run_id,
+            intent.effect_key,
+            `reconciler: unverifiable send on '${intent.channel}' past ${maxAttempts} attempts - abandoned (not resent, at-most-once)`,
+          );
+          summary.abandoned++;
+        } else {
+          summary.left++;
+        }
+      }
+    } catch (err: unknown) {
+      summary.errors.push({ effectKey: intent.effect_key, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return summary;
+}


### PR DESCRIPTION
The final piece of the transactional outbox. A dispatched-but-uncommitted row with an expired fence = the send maybe happened, the commit didn't (crash). reconcileOutbox resolves each via a per-channel probe, biased hard to at-most-once: 'sent' -> commit with recovered evidence, 'not-sent' -> reopen for retry, 'unknown' (no probe, e.g. Telegram) -> NEVER resend, abandon past the ceiling with a clear reason. Wired defensively into the canary beat (flag-gated, graceful). 5 tests cover all three outcomes + ceiling + empty. bot tsc = baseline 46, esbuild clean. The outbox protocol is now complete end to end (claim -> fence -> dispatch -> send -> commit, + crash recovery).

Generated with [Claude Code](https://claude.com/claude-code)