### PR TITLE
docs(zabal): mentor evaluation-criteria template

### DIFF
--- a/research/business/2137-zabal-gamez-august-concept-options/MENTOR-CRITERIA-TEMPLATE.md
+++ b/research/business/2137-zabal-gamez-august-concept-options/MENTOR-CRITERIA-TEMPLATE.md
@@ -1,0 +1,50 @@
+# ZABAL August - mentor evaluation-criteria template
+
+> What a mentor shares with their pod in week 1 (the ICM-box promise: "criteria shared openly"). Hand a mentor this on their yes; they fill the [brackets] for their track + pod. Keep it to one screen - builders should know exactly what "good" looks like before they build. Grounds the qualifier scoring (daily updates + community votes -> top 2 per track) so mentor judgment is transparent, not a black box.
+
+## The one-pager a mentor sends their pod
+
+```
+Hey [pod] - here's how I'll be looking at your work this month, up front, so nothing's a surprise.
+
+WHAT I'M WEIGHTING (rough, not a rubric to game):
+- Shipping in public: are you posting a real daily update? Momentum > polish.
+- Progress over the month: where you START matters less than the slope.
+- [track-specific bar - see below].
+- Using the community: did you take feedback, collaborate, help others in the pod?
+
+WHAT I DON'T CARE ABOUT:
+- A perfect week 1. Rough drafts count - that's the whole point.
+- Working alone and quietly. Build in public or it doesn't count for the qualifier.
+
+HOW TO WIN MY POD SESSION TIME:
+- Come to the weekly 30-min with ONE specific blocker or decision. I unblock fastest when the ask is concrete.
+- DM me between sessions when you're stuck - don't wait a week.
+
+If you reach the head-to-head rounds (weeks 3-4), we go 1:1 and I help you sharpen for the battle.
+```
+
+## Track-specific bar (the one [bracket] per track)
+
+**Artist track** - "Does the work move someone? A finished loop, a played set, a piece that lands emotionally beats a polished-but-empty one. Show me you can make people FEEL it, and that you shared it where the community could hear it."
+
+**Builder track** - "Does it actually run, and does it help a real ZAO use case? A rough tool people can use beats a beautiful demo that does nothing. Ship something someone in the 100+ member community could touch this month."
+
+**Creator track** - "Does it travel? Content/docs/media that other people share, cite, or build on. Reach and reuse beat production value. Show me the thing got picked up, not just posted."
+
+## How this feeds the qualifier (transparency for builders)
+
+- The qualifier score is **daily-update points + Farcaster community votes** (top 2 per track advance) - see doc 2137 for the weighting knob (50/50 default; a 10-15% mentor carve-out in week 2 is a Zaal decision, not locked).
+- Mentor criteria here make the "quality" half legible: builders know what their mentor values, so a daily update can target it. The mentor is a coach + a transparent judge, not a hidden gate.
+- Anti-gaming (from doc 2137): community votes are 1-per-FID-per-project-per-week; mentor judgment is bounded to their own pod.
+
+## For the mentor (private notes, not shared with the pod)
+
+- Fill the track bar to YOUR voice - the wording above is a starting point, make it yours.
+- ~4-6 hours across the month: one 30-min pod session/week + async nudges + 1:1 with any finalist.
+- If a builder ghosts after week 1, that's fine - they self-select out of the qualifier; don't chase.
+- Flag any standout early to Zaal - a builder worth a Sparkz launch or a deeper ZAO role is the real prize, above the tournament.
+
+## Sources
+
+- Doc 2137 (August format, qualifier scoring, the knobs) + MENTOR-PAIRING-CORE.md (the pods decision) + zabalgamez ICM box ("evaluation criteria shared openly")


### PR DESCRIPTION
The one-pager a mentor shares with their pod in week 1 (fulfills the ICM-box 'criteria shared openly' promise). What they weight + don't + how to win session time, a per-track bar (artist/builder/creator), how it feeds the qualifier transparently, and private mentor notes. Hand it to a mentor on their yes - supports Saturday.

Generated with [Claude Code](https://claude.com/claude-code)