### PR TITLE
feat(zoe): per-brand mail identities - fleet runtime capability (doc 2155)

### DIFF
--- a/bot/src/zoe/__tests__/identities.test.ts
+++ b/bot/src/zoe/__tests__/identities.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  loadIdentities,
+  parseIdentity,
+  resolveEmail,
+  defaultIdentity,
+  DEFAULT_INBOX,
+  DEFAULT_KEY_ENV,
+} from '../identities';
+
+test('no registry path -> the single default ZOE identity', () => {
+  const ids = loadIdentities(
+    () => {
+      throw new Error('reader must not be called when path is undefined');
+    },
+    undefined,
+  );
+  assert.equal(ids.length, 1);
+  assert.equal(ids[0].brand, 'The ZAO');
+  assert.equal(ids[0].email.inbox, DEFAULT_INBOX);
+  assert.equal(ids[0].email.keyEnv, DEFAULT_KEY_ENV);
+});
+
+test('unreadable / bad-JSON registry -> default, never throws', () => {
+  const bad = loadIdentities(() => {
+    throw new Error('ENOENT');
+  }, '/nope/identities.json');
+  assert.equal(bad.length, 1);
+  assert.equal(bad[0].brand, 'The ZAO');
+
+  const notJson = loadIdentities(() => 'this is not json', '/x.json');
+  assert.equal(notJson[0].brand, 'The ZAO');
+});
+
+test('valid registry (object form) loads all well-formed identities', () => {
+  const json = JSON.stringify({
+    identities: [
+      { brand: 'The ZAO', agent: 'ZOE', email: { inbox: 'zoe-zao@agentmail.to', keyEnv: 'AGENTMAIL_API_KEY' }, icmBox: 'thezao' },
+      { brand: 'WaveWarZ', email: { inbox: 'wavewarz@agentmail.to', keyEnv: 'AGENTMAIL_KEY_WAVEWARZ' }, socials: { x: '@wavewarz' } },
+    ],
+  });
+  const ids = loadIdentities(() => json, '/reg.json');
+  assert.equal(ids.length, 2);
+  assert.equal(ids[1].brand, 'WaveWarZ');
+  assert.equal(ids[1].socials?.x, '@wavewarz');
+});
+
+test('array form is also accepted', () => {
+  const json = JSON.stringify([
+    { brand: 'Sparkz', email: { inbox: 'sparkz@agentmail.to', keyEnv: 'AGENTMAIL_KEY_SPARKZ' } },
+  ]);
+  const ids = loadIdentities(() => json, '/reg.json');
+  assert.equal(ids.length, 1);
+  assert.equal(ids[0].brand, 'Sparkz');
+});
+
+test('malformed entries are skipped; if none survive, falls back to default', () => {
+  const json = JSON.stringify({
+    identities: [
+      { brand: 'no-email' },
+      { email: { inbox: 'x@agentmail.to', keyEnv: 'K' } },
+      { brand: 'bad-email', email: { inbox: '', keyEnv: 'K' } },
+    ],
+  });
+  const ids = loadIdentities(() => json, '/reg.json');
+  assert.equal(ids.length, 1);
+  assert.equal(ids[0].brand, 'The ZAO', 'no valid entries -> default');
+});
+
+test('parseIdentity rejects missing required fields', () => {
+  assert.equal(parseIdentity(null), null);
+  assert.equal(parseIdentity({ brand: 'x' }), null, 'no email');
+  assert.equal(parseIdentity({ email: { inbox: 'a', keyEnv: 'b' } }), null, 'no brand');
+  assert.equal(parseIdentity({ brand: 'x', email: { inbox: 'a' } }), null, 'no keyEnv');
+  const ok = parseIdentity({ brand: 'x', email: { inbox: 'a@b.to', keyEnv: 'K' } });
+  assert.ok(ok);
+  assert.equal(ok?.brand, 'x');
+});
+
+test('resolveEmail reads the key from the env at call time, never stores it', () => {
+  const id = defaultIdentity();
+  const withKey = resolveEmail(id, { AGENTMAIL_API_KEY: 'secret-value' } as NodeJS.ProcessEnv);
+  assert.equal(withKey.inbox, DEFAULT_INBOX);
+  assert.equal(withKey.apiKey, 'secret-value');
+
+  const noKey = resolveEmail(id, {} as NodeJS.ProcessEnv);
+  assert.equal(noKey.apiKey, undefined, 'unset env -> undefined key, not a throw');
+});

--- a/bot/src/zoe/__tests__/inbox-ingest.test.ts
+++ b/bot/src/zoe/__tests__/inbox-ingest.test.ts
@@ -107,3 +107,22 @@ test('ingestInbox survives a non-ok fetch without throwing', async () => {
   const r = await ingest.ingestInbox(fakeFetch([], false, 500));
   assert.equal(r.ingested, 0);
 });
+
+test('ingestInbox source.apiKey works without AGENTMAIL_API_KEY in the env (per-brand)', async () => {
+  const prev = process.env.AGENTMAIL_API_KEY;
+  delete process.env.AGENTMAIL_API_KEY; // env has NO default key
+  const r = await ingest.ingestInbox(
+    fakeFetch([{ id: 'brand-1', from: 'x@thezao.com', subject: 'hi', preview: 'yo' }]),
+    { inbox: 'wavewarz@agentmail.to', apiKey: 'brand-key' },
+  );
+  assert.equal(r.ingested, 1, 'per-brand creds ingest even with no env key');
+  if (prev) process.env.AGENTMAIL_API_KEY = prev;
+});
+
+test('ingestInbox with no source still requires the env key (backward compatible)', async () => {
+  const prev = process.env.AGENTMAIL_API_KEY;
+  delete process.env.AGENTMAIL_API_KEY;
+  const r = await ingest.ingestInbox(fakeFetch([{ id: 'z', subject: 'x' }]));
+  assert.deepEqual(r, { ingested: 0, skipped: 0, scanned: 0 }, 'no env key + no source -> no-op');
+  if (prev) process.env.AGENTMAIL_API_KEY = prev;
+});

--- a/bot/src/zoe/identities.example.json
+++ b/bot/src/zoe/identities.example.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Per-brand Identity Kit registry (doc 2155). Copy to a real path and point ZOE_IDENTITIES_PATH at it. NEVER put a key VALUE here - only keyEnv, the NAME of the env var holding that brand's AgentMail key. Values live in the environment / ~/.zao/private. With no registry configured, the runtime uses only the built-in default (ZOE on zoe-zao@agentmail.to).",
+  "identities": [
+    {
+      "brand": "The ZAO",
+      "agent": "ZOE",
+      "email": { "inbox": "zoe-zao@agentmail.to", "keyEnv": "AGENTMAIL_API_KEY" },
+      "icmBox": "thezao",
+      "personaRef": "human.md"
+    },
+    {
+      "brand": "WaveWarZ",
+      "agent": "wavewarz-agent",
+      "email": { "inbox": "wavewarz@agentmail.to", "keyEnv": "AGENTMAIL_KEY_WAVEWARZ" },
+      "icmBox": "wavewarz",
+      "socials": { "farcaster": "@wavewarz", "x": "@wavewarz" }
+    }
+  ]
+}

--- a/bot/src/zoe/identities.ts
+++ b/bot/src/zoe/identities.ts
@@ -1,0 +1,134 @@
+/**
+ * identities.ts — the per-brand Identity Kit registry (doc 2155).
+ *
+ * A ZAO "fleet" is one shared runtime wearing many brand faces. Each brand
+ * identity is { brand, agent, email:{inbox,keyEnv}, socials, icmBox, personaRef }.
+ * This module loads that registry and resolves each identity's email creds at
+ * read time from the environment — credential VALUES never live in the registry
+ * file, only a reference to the env var that holds the key (secret-hygiene.md,
+ * agent-loops rule 15).
+ *
+ * Backward-compatible by design: with NO registry file configured, this returns
+ * exactly one identity — ZOE on zoe-zao@agentmail.to keyed by AGENTMAIL_API_KEY —
+ * which is the live behavior today. Adding brands is purely additive; nothing
+ * about the running bot changes until a registry is provided AND a caller opts
+ * into iterating it.
+ *
+ * The registry path comes from ZOE_IDENTITIES_PATH (a JSON file). Absent/unreadable/
+ * malformed -> the built-in default identity, never a throw.
+ */
+
+import { readFileSync } from 'node:fs';
+
+/** The canonical default: ZOE's own inbox, live today. */
+export const DEFAULT_INBOX = 'zoe-zao@agentmail.to';
+export const DEFAULT_KEY_ENV = 'AGENTMAIL_API_KEY';
+
+/** One brand's email config. `keyEnv` names the env var holding the API key. */
+export interface EmailConfig {
+  inbox: string;
+  keyEnv: string;
+}
+
+/** A brand identity in the fleet. Only `brand` + `email` are required. */
+export interface BrandIdentity {
+  brand: string;
+  agent?: string;
+  email: EmailConfig;
+  icmBox?: string;
+  socials?: Record<string, string>;
+  personaRef?: string;
+}
+
+/** Resolved email creds for a runtime call. `apiKey` is undefined if the env var is unset. */
+export interface ResolvedEmail {
+  brand: string;
+  inbox: string;
+  apiKey: string | undefined;
+}
+
+/** The identity that exists with zero configuration — ZOE today. */
+export function defaultIdentity(): BrandIdentity {
+  return {
+    brand: 'The ZAO',
+    agent: 'ZOE',
+    email: { inbox: DEFAULT_INBOX, keyEnv: DEFAULT_KEY_ENV },
+    icmBox: 'thezao',
+  };
+}
+
+/** True when a value is a usable non-empty string. */
+function nonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+/**
+ * Defensively coerce one raw registry entry into a BrandIdentity, or null if it
+ * lacks the required fields. Never throws.
+ */
+export function parseIdentity(raw: unknown): BrandIdentity | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const email = r.email as Record<string, unknown> | undefined;
+  if (!nonEmptyString(r.brand)) return null;
+  if (!email || !nonEmptyString(email.inbox) || !nonEmptyString(email.keyEnv)) return null;
+
+  const id: BrandIdentity = {
+    brand: r.brand.trim(),
+    email: { inbox: (email.inbox as string).trim(), keyEnv: (email.keyEnv as string).trim() },
+  };
+  if (nonEmptyString(r.agent)) id.agent = r.agent.trim();
+  if (nonEmptyString(r.icmBox)) id.icmBox = r.icmBox.trim();
+  if (nonEmptyString(r.personaRef)) id.personaRef = r.personaRef.trim();
+  if (r.socials && typeof r.socials === 'object') {
+    const socials: Record<string, string> = {};
+    for (const [k, v] of Object.entries(r.socials as Record<string, unknown>)) {
+      if (nonEmptyString(v)) socials[k] = v.trim();
+    }
+    if (Object.keys(socials).length > 0) id.socials = socials;
+  }
+  return id;
+}
+
+/**
+ * Load the fleet registry. Returns the default identity alone when no registry
+ * is configured or it cannot be parsed. Malformed individual entries are skipped;
+ * if none survive, falls back to the default. Never throws.
+ *
+ * @param readImpl injectable file reader for tests (defaults to fs.readFileSync).
+ * @param path override for the registry path (defaults to ZOE_IDENTITIES_PATH).
+ */
+export function loadIdentities(
+  readImpl: (p: string) => string = (p) => readFileSync(p, 'utf8'),
+  path: string | undefined = process.env.ZOE_IDENTITIES_PATH,
+): BrandIdentity[] {
+  if (!nonEmptyString(path)) return [defaultIdentity()];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readImpl(path));
+  } catch {
+    // Missing / unreadable / bad JSON -> safe default. Never break the bot.
+    return [defaultIdentity()];
+  }
+
+  const rawList = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { identities?: unknown[] })?.identities)
+      ? (parsed as { identities: unknown[] }).identities
+      : [];
+
+  const identities = rawList.map(parseIdentity).filter((x): x is BrandIdentity => x !== null);
+  return identities.length > 0 ? identities : [defaultIdentity()];
+}
+
+/**
+ * Resolve an identity's email creds from the environment at call time. The API
+ * key value is read from `process.env[keyEnv]` and never stored in the registry.
+ */
+export function resolveEmail(
+  id: BrandIdentity,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedEmail {
+  return { brand: id.brand, inbox: id.email.inbox, apiKey: env[id.email.keyEnv] };
+}

--- a/bot/src/zoe/inbox-ingest.ts
+++ b/bot/src/zoe/inbox-ingest.ts
@@ -54,6 +54,17 @@ export interface IngestResult {
   scanned: number;
 }
 
+/**
+ * Which inbox to ingest from. Both fields default to ZOE's own inbox +
+ * AGENTMAIL_API_KEY, so an existing call `ingestInbox()` / `ingestInbox(fetch)`
+ * behaves exactly as before. A per-brand caller (doc 2155 fleet) passes an
+ * identity's resolved inbox + apiKey to ingest that brand's mail instead.
+ */
+export interface InboxSource {
+  inbox?: string;
+  apiKey?: string;
+}
+
 /** Stable dedup key for a message. Falls back to from+subject when no id. */
 function sourceId(m: RawAgentMailMessage): string {
   return (
@@ -86,18 +97,22 @@ export function synthesizeSummary(m: RawAgentMailMessage): string {
 /**
  * Fetch + ingest new forwarded mail. Returns counts; never throws.
  * @param fetchImpl injectable for tests (defaults to global fetch).
+ * @param source which inbox + key to read (defaults to ZOE's own — backward
+ *   compatible; existing no-arg / fetch-only callers are unchanged).
  */
 export async function ingestInbox(
   fetchImpl: typeof fetch = fetch,
+  source: InboxSource = {},
 ): Promise<IngestResult> {
   const empty: IngestResult = { ingested: 0, skipped: 0, scanned: 0 };
-  const key = process.env.AGENTMAIL_API_KEY;
+  const inbox = source.inbox ?? AGENTMAIL_INBOX;
+  const key = source.apiKey ?? process.env.AGENTMAIL_API_KEY;
   if (!key) return empty;
 
   let messages: RawAgentMailMessage[];
   try {
     const res = await fetchImpl(
-      `https://api.agentmail.to/v0/inboxes/${AGENTMAIL_INBOX}/messages?limit=${FETCH_LIMIT}`,
+      `https://api.agentmail.to/v0/inboxes/${inbox}/messages?limit=${FETCH_LIMIT}`,
       { headers: { Authorization: `Bearer ${key}` }, signal: AbortSignal.timeout(8000) },
     );
     if (!res.ok) {
@@ -155,7 +170,9 @@ export async function ingestInbox(
   }
 
   if (ingested > 0) {
-    console.log(`[zoe/inbox-ingest] folded ${ingested} forwarded message(s) into ZOE context`);
+    console.log(
+      `[zoe/inbox-ingest] folded ${ingested} forwarded message(s) from ${inbox} into ZOE context`,
+    );
   }
   return { ingested, skipped, scanned: messages.length };
 }


### PR DESCRIPTION
## Fleet runtime capability - per-brand mail identities

Builds the first piece of code from doc 2155 (per-brand Identity Kit): the runtime can now wear any brand's mailbox. **Additive and backward-compatible - the live ZOE bot's behavior does not change** until a registry is configured AND a caller opts into iterating it.

### What's new
- **`bot/src/zoe/identities.ts`** - fleet registry loader: `loadIdentities` / `parseIdentity` / `resolveEmail`. Each identity = `{ brand, agent, email:{inbox, keyEnv}, socials, icmBox, personaRef }`. Credential **values never live in the registry** - only `keyEnv` (the env-var NAME), resolved from the environment at call time (secret-hygiene.md).
- **`identities.example.json`** - documented example (env-var names only, no secrets).
- **`ingestInbox` generalized** - optional `InboxSource {inbox?, apiKey?}`, defaulting to ZOE's own inbox + `AGENTMAIL_API_KEY`. Existing `ingestInbox()` / `ingestInbox(fetch)` callers are unchanged; the scheduler is untouched.

### Safety
- No registry configured (`ZOE_IDENTITIES_PATH` unset) -> exactly one identity (ZOE today). Unreadable/bad-JSON -> same default, never throws.
- The scheduler still calls `ingestInbox()` with no source -> identical live behavior.

### Verify
- `bot tsc --noEmit`: **0 errors in changed files** (pre-existing baseline errors in unrelated hermes/zai files are untouched).
- **15/15 tests pass** - 7 new `identities.test.ts` (default fallback, bad-JSON safety, malformed-entry skipping, env-resolved key) + 8 `inbox-ingest.test.ts` (incl. new per-brand-creds and backward-compat cases).

### Not in this PR (deliberately)
The scheduler is NOT wired to iterate the fleet - that changes live behavior and needs real brand inboxes (Zaal's gated account-creation). This PR is the capability; wiring happens when a brand is provisioned.

Code PR - **for your review, not auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYxDaBCuhpmPPvhSPFhpjG
