### PR TITLE
feat(zoe): fleet driver - ingestAllIdentities + loadPersona (doc 2155)

### DIFF
--- a/bot/src/zoe/__tests__/fleet.test.ts
+++ b/bot/src/zoe/__tests__/fleet.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { ingestAllIdentities, loadPersona } from '../fleet';
+import type { BrandIdentity } from '../identities';
+
+/** Fake fetch returning the given messages (shape ingestInbox expects). */
+function fakeFetch(messages: unknown[]): typeof fetch {
+  return (async () =>
+    ({ ok: true, status: 200, json: async () => ({ messages }) }) as unknown as Response) as unknown as typeof fetch;
+}
+
+const ID = (brand: string, keyEnv: string, personaRef?: string): BrandIdentity => ({
+  brand,
+  email: { inbox: `${brand.toLowerCase()}@agentmail.to`, keyEnv },
+  personaRef,
+});
+
+test('ingestAllIdentities skips brands whose key env var is unset', async () => {
+  const ids = [ID('WaveWarZ', 'AGENTMAIL_KEY_WAVEWARZ'), ID('Sparkz', 'AGENTMAIL_KEY_SPARKZ')];
+  const res = await ingestAllIdentities(fakeFetch([]), ids, {} as NodeJS.ProcessEnv);
+  assert.equal(res.length, 2);
+  assert.ok(res.every((r) => r.result === null && r.skipped?.includes('no key')));
+});
+
+test('ingestAllIdentities ingests a brand whose key IS set, using its inbox', async () => {
+  const ids = [ID('WaveWarZ', 'AGENTMAIL_KEY_WAVEWARZ')];
+  const env = { AGENTMAIL_KEY_WAVEWARZ: 'a-key', ZOE_HOME: '/tmp/zoe-fleet-test' } as NodeJS.ProcessEnv;
+  const res = await ingestAllIdentities(fakeFetch([]), ids, env);
+  assert.equal(res.length, 1);
+  assert.equal(res[0].brand, 'WaveWarZ');
+  assert.equal(res[0].inbox, 'wavewarz@agentmail.to');
+  assert.ok(res[0].result !== null, 'ingest ran (result not null)');
+});
+
+test('ingestAllIdentities never throws; a per-brand error is captured as skipped', async () => {
+  const throwingFetch = (async () => {
+    throw new Error('network down');
+  }) as unknown as typeof fetch;
+  const ids = [ID('WaveWarZ', 'AGENTMAIL_KEY_WAVEWARZ')];
+  const env = { AGENTMAIL_KEY_WAVEWARZ: 'a-key' } as NodeJS.ProcessEnv;
+  const res = await ingestAllIdentities(throwingFetch, ids, env);
+  // ingestInbox itself swallows fetch errors -> result with 0 counts, not a throw.
+  assert.equal(res.length, 1);
+  assert.ok(res[0].result !== null || res[0].skipped);
+});
+
+test('loadPersona returns the file text for a personaRef', () => {
+  const id = ID('WaveWarZ', 'K', 'research/identity/personas/wavewarz.persona.md');
+  const text = loadPersona(id, () => '# Persona: WaveWarZ\nvoice stuff');
+  assert.ok(text.includes('Persona: WaveWarZ'));
+});
+
+test('loadPersona returns empty string when no personaRef or file unreadable', () => {
+  assert.equal(loadPersona(ID('X', 'K')), '');
+  const withRef = ID('X', 'K', '/nope/persona.md');
+  assert.equal(
+    loadPersona(withRef, () => {
+      throw new Error('ENOENT');
+    }),
+    '',
+  );
+});

--- a/bot/src/zoe/fleet.ts
+++ b/bot/src/zoe/fleet.ts
@@ -1,0 +1,78 @@
+/**
+ * fleet.ts — the driver that puts the per-brand Identity Kit to work (doc 2155).
+ *
+ * `ingestAllIdentities` iterates the fleet registry (identities.ts) and ingests
+ * each brand's mailbox in turn, using that brand's resolved inbox + API key. A
+ * brand whose key env var is unset is SKIPPED (not an error) — so with no fleet
+ * configured, only the default ZOE identity runs, exactly as today.
+ *
+ * `loadPersona` reads a brand's persona block (research/identity/personas/*) so
+ * the runtime can speak in that brand's voice.
+ *
+ * IMPORTANT — this is a capability, NOT wired to the scheduler. The scheduler
+ * still calls `ingestInbox()` (ZOE's own inbox) directly. Wiring the fleet in is
+ * deliberate future work, because ingestInbox currently appends to ONE shared
+ * context log; per-brand context separation is the follow-up before the fleet
+ * ingest should run automatically (see doc 2155). Until then this is opt-in.
+ */
+
+import { readFileSync } from 'node:fs';
+import { loadIdentities, resolveEmail, type BrandIdentity } from './identities';
+import { ingestInbox, type IngestResult } from './inbox-ingest';
+
+/** Per-brand ingest outcome. `result` is null when the brand was skipped. */
+export interface FleetIngestResult {
+  brand: string;
+  inbox: string;
+  result: IngestResult | null;
+  skipped?: string;
+}
+
+/**
+ * Ingest every configured brand identity's inbox. Never throws — a brand with no
+ * resolvable key, or whose ingest errors, is recorded as skipped and the loop
+ * continues.
+ *
+ * @param fetchImpl injectable fetch (defaults to global fetch).
+ * @param ids the fleet registry (defaults to loadIdentities()).
+ * @param env environment for key resolution (defaults to process.env).
+ */
+export async function ingestAllIdentities(
+  fetchImpl: typeof fetch = fetch,
+  ids: BrandIdentity[] = loadIdentities(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<FleetIngestResult[]> {
+  const out: FleetIngestResult[] = [];
+  for (const id of ids) {
+    const { brand, inbox, apiKey } = resolveEmail(id, env);
+    if (!apiKey) {
+      out.push({ brand, inbox, result: null, skipped: `no key in ${id.email.keyEnv}` });
+      continue;
+    }
+    try {
+      const result = await ingestInbox(fetchImpl, { inbox, apiKey });
+      out.push({ brand, inbox, result });
+    } catch (err) {
+      out.push({ brand, inbox, result: null, skipped: (err as Error).message });
+    }
+  }
+  return out;
+}
+
+/**
+ * Load a brand's persona block text from its `personaRef` path. Returns '' when
+ * the identity has no personaRef or the file cannot be read — never throws.
+ *
+ * @param readImpl injectable reader for tests (defaults to fs.readFileSync).
+ */
+export function loadPersona(
+  id: BrandIdentity,
+  readImpl: (p: string) => string = (p) => readFileSync(p, 'utf8'),
+): string {
+  if (!id.personaRef) return '';
+  try {
+    return readImpl(id.personaRef);
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
The driver that puts the per-brand Identity Kit to work. `ingestAllIdentities()` iterates the fleet registry and ingests each brand's mailbox; a brand with no key is skipped (not an error), so with no fleet configured only ZOE runs - zero live change. `loadPersona()` reads a brand's persona block.

NOT wired to the scheduler (opt-in) - per-brand context separation is the documented follow-up before auto-running.

Verified: tsc clean on changed files; 5/5 tests. Code PR for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYxDaBCuhpmPPvhSPFhpjG