### PR TITLE
feat(zoe): activate ZABAL Games as the first fleet brand (identities.json)

### DIFF
--- a/bot/identities.json
+++ b/bot/identities.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "LIVE fleet registry (doc 2155). Point ZOE_IDENTITIES_PATH here. Secret VALUES never live here - keyEnv names the env var. AgentMail uses ONE account-level key (AGENTMAIL_API_KEY) for all inboxes; brands differ by inbox address.",
+  "identities": [
+    {
+      "brand": "The ZAO",
+      "agent": "ZOE",
+      "email": { "inbox": "zoe-zao@agentmail.to", "keyEnv": "AGENTMAIL_API_KEY" },
+      "icmBox": "thezao",
+      "personaRef": "bot/src/zoe/human.md"
+    },
+    {
+      "brand": "ZABAL Games",
+      "agent": "zabalgamez-agent",
+      "email": { "inbox": "zabalgamez@agentmail.to", "keyEnv": "AGENTMAIL_API_KEY" },
+      "icmBox": "zabalgamez",
+      "personaRef": "research/identity/personas/zabalgamez.persona.md"
+    }
+  ]
+}


### PR DESCRIPTION
ZABAL is the first brand online beyond ZOE. Created **zabalgamez@agentmail.to** (live, readable - HTTP 200) and adds `bot/identities.json` (the live fleet registry - point `ZOE_IDENTITIES_PATH` here).

AgentMail uses one account-level key for all inboxes, so brands differ by inbox address, not key. ZABAL wired to its persona + icmBox. Env-var names only, no secrets.

Inert until the scheduler is wired to `ingestAllIdentities` (gated on per-brand context separation, doc 2159, supervised). This is the ready state: inbox live, config resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYxDaBCuhpmPPvhSPFhpjG