### PR TITLE
docs(identity): draft ICM box content for coc-concertz + poidh (empty boxes)

### DIFF
--- a/research/identity/icm-boxes/drafts/README.md
+++ b/research/identity/icm-boxes/drafts/README.md
@@ -1,0 +1,11 @@
+# ICM Box Content Drafts (NOT published)
+
+Drafts for ICM boxes that are currently EMPTY on useicm.com. Each `*.draft.llm.txt`
+is generated from confirmed ZAO facts (memory + research + public docs) for Zaal to
+review, edit, and publish via the `/icm` skill. **Publishing to a live box is gated
+to Zaal** (public content); these repo drafts are safe artifacts, not published.
+
+- `coc-concertz.draft.llm.txt` - needs Thy Revolution sign-off too (partnership framing).
+- `poidh.draft.llm.txt` - confirm box scope (ZAO's-use-of-POIDH vs the platform) + the canonical URL.
+
+Written in the overnight build loop 2026-07-30. Source lines are in each draft.

--- a/research/identity/icm-boxes/drafts/coc-concertz.draft.llm.txt
+++ b/research/identity/icm-boxes/drafts/coc-concertz.draft.llm.txt
@@ -1,0 +1,28 @@
+# ICM: COC Concertz (DRAFT - needs Zaal + ideally Thy Revolution sign-off before publishing)
+
+> DRAFT for the empty coc-concertz ICM box (id icm_PmXTIAro8llyOv9LCJ-LZw). Generated 2026-07-30 from confirmed ZAO facts (memory `project_coc_concertz_framing`, doc 866). GATED: publishing to the live box is Zaal's action - and because COC Concertz is a partnership, the partnership framing below should be confirmed with Thy Revolution before it goes live (Fellenz brand challenge 4, doc 839, was exactly this framing being wrong).
+
+COC Concertz is a concert series - a **50/50 joint venture between The ZAO and the COC**, led by **Thy Revolution**. It sits in the middle of both brands: the COC owns its piece, Thy Revolution leads it, and **The ZAO does not own it.** Part of the ZAO Festivals family, run to stand independent.
+
+## What it is
+- A partnership concert series, not a ZAO-owned property. Frame it publicly as "ZAO Festivals + COC Concertz," never "The ZAO's COC."
+- Thy Revolution leads; the COC owns its share. The ZAO is the partner, not the owner.
+- Built to run independent - "a place in the ZAO that you own, separate, so you don't need Zaal to succeed."
+
+## In the ZAO ecosystem
+- One of the ZAO Festivals lanes alongside ZAOstock and the other festivals.
+- The ZAO currently covers the streaming portion only (Thy Revolution lacks a laptop; a crowdfund is in motion). This is a support role, not ownership.
+
+## Framing rules (important - this brand has been miswritten before)
+- ALWAYS a partnership: The ZAO + the COC, Thy Revolution lead.
+- NEVER "The ZAO owns COC" or "COC is a ZAO project." It is a 50/50 JV.
+- Do not add "(pending COC confirmation)" - the partnership itself is confirmed (2026-06-17 call). What still needs confirmation is THIS box's exact wording, with Thy Revolution.
+
+## Find it
+- (Fill: official COC Concertz link / channel - Zaal to provide before publishing.)
+
+## Related boxes
+- The ZAO (thezao), ZAO Festivals (zao-festivals), ZAOstock (zaostock).
+
+## Source
+Confirmed framing: memory `project_coc_concertz_framing` (Thy Rev call 2026-06-17, doc 866), doc 839 (Fellenz brand challenge 4). Draft written in the overnight loop; NOT published.

--- a/research/identity/icm-boxes/drafts/poidh.draft.llm.txt
+++ b/research/identity/icm-boxes/drafts/poidh.draft.llm.txt
@@ -1,0 +1,29 @@
+# ICM: POIDH (The ZAO's POIDH bounty program) - DRAFT, needs Zaal sign-off before publishing
+
+> DRAFT for the empty poidh ICM box (id icm_1CRn7Oyvee1jDSK9kje7dw). Generated 2026-07-30 from the poidh dev docs + ZAO's zpoidh repo + memory. GATED: publishing to the live box is Zaal's action. Confirm scope: is this box "The ZAO's use of POIDH" (assumed here) or POIDH-the-platform? Adjust before publishing.
+
+The ZAO runs **POIDH bounties** - "pics or it didn't happen" - as a core part of ZABAL Games and community engagement. POIDH itself is a decentralized bounty platform (founder: Kenny / @poidhbot): users create tasks, submit image proof of completion, and the community votes on valid submissions. The ZAO's program (run by BetterCallZaal) issues bounty rounds and judges them.
+
+## What POIDH is (the platform)
+- A decentralized "pics or it didn't happen" bounty platform. Create a bounty, submit a picture as proof, community votes, winner is paid; a proof-of-completion NFT is minted.
+- POIDH v3 contracts are immutable, deployed on Ethereum, Arbitrum, Base, and Degen Chain.
+- Data via the indexer API (indexer.poidh.xyz) + direct JSON bounty endpoints. NOT a ZAO product - it is Kenny's platform; The ZAO is a heavy user + partner.
+
+## The ZAO's POIDH program (BCZ-run)
+- Bounty rounds tied to ZABAL Games: e.g. Round 3 (best ZABAL Gamez ad, resolved + paid on-chain, winner @femmie), Round 4 (the ZABAL Gamez open pot, live on Base bounty 1249, July open-build month), Round 5 in draft (POIDH x Unlock Protocol clipping bounty).
+- Each round: cast the bounty, collect image-proof claims, judge with a rubric (floor checks + pick-score 0-10), pay the winner on-chain, cast the winner. Judging pages + brand kits live in the zpoidh repo.
+- Source of truth for BCZ POIDH ops: the zpoidh repo (rounds, judging pages, brand kits, leaderboard).
+
+## In the ZAO ecosystem
+- A production/engagement lane feeding ZABAL Games - bounties get real community builds shipped with real on-chain payouts.
+- Partnership with Kenny/POIDH (co-amplification; Kenny is a high-signal Farcaster relationship, 106k).
+
+## Find it
+- POIDH: poidh.xyz | indexer: indexer.poidh.xyz | founder: Kenny (@poidhbot)
+- ZAO/BCZ POIDH hub: (Zaal to confirm the canonical public URL before publishing.)
+
+## Related boxes
+- ZABAL Games (zabalgamez), The ZAO (thezao), WaveWarZ (wavewarz).
+
+## Source
+poidh dev docs (docs.poidh.xyz/developers), the zpoidh repo README, memory `project_poidh_bounty_live` / `project_poidh_judging_arch`. Draft written in the overnight loop; NOT published.


### PR DESCRIPTION
Both boxes are empty on useicm.com (found during fleet work - blocks their personas). Drafts from confirmed ZAO facts for Zaal to review + publish via /icm (publishing is gated - these are repo drafts, NOT published).

- **coc-concertz**: confirmed partnership framing (50/50 JV, Thy Rev leads, ZAO does NOT own - doc 866/839); flags Thy Rev sign-off.
- **poidh**: ZAO's BCZ-run bounty program on Kenny's 'pics or it didn't happen' platform; flags box-scope + URL confirmation.

Once published, their personas can be generated (completing the persona set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYxDaBCuhpmPPvhSPFhpjG