### PR TITLE
feat(zoe): per-brand context separation + wire fleet ingest (doc 2159)

### DIFF
--- a/bot/src/zoe/__tests__/context-namespace.test.ts
+++ b/bot/src/zoe/__tests__/context-namespace.test.ts
@@ -1,0 +1,60 @@
+import { test, beforeAll, beforeEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Isolate ZOE_HOME before the app modules load (same pattern as inbox-ingest.test).
+const TMP = join(tmpdir(), `zoe-ns-test-${process.pid}-${Date.now()}`);
+process.env.ZOE_HOME = TMP;
+
+type MemMod = typeof import('../memory');
+let mem: MemMod;
+
+beforeAll(async () => {
+  await fs.mkdir(TMP, { recursive: true });
+  mem = await import('../memory');
+});
+
+beforeEach(async () => {
+  // Clear all inbox_context logs between tests.
+  for (const f of ['inbox_context.jsonl', 'inbox_context.wavewarz.jsonl', 'inbox_context.sparkz.jsonl']) {
+    await fs.rm(join(TMP, f), { force: true });
+  }
+});
+
+test('no namespace writes/reads the shared ZOE log (unchanged)', async () => {
+  await mem.appendInboxContext({ source_id: 'z1', summary: 'zoe mail' });
+  const rows = await mem.readInboxContext(10);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].source_id, 'z1');
+  // the shared file exists
+  const shared = await fs.readFile(join(TMP, 'inbox_context.jsonl'), 'utf8');
+  assert.ok(shared.includes('z1'));
+});
+
+test('two namespaces do NOT cross-contaminate (the doc 2159 guarantee)', async () => {
+  await mem.appendInboxContext({ source_id: 'w1', summary: 'wavewarz mail' }, 'wavewarz');
+  await mem.appendInboxContext({ source_id: 's1', summary: 'sparkz mail' }, 'sparkz');
+  await mem.appendInboxContext({ source_id: 'z1', summary: 'zoe mail' }); // shared
+
+  const ww = await mem.readInboxContext(10, 'wavewarz');
+  const sp = await mem.readInboxContext(10, 'sparkz');
+  const zoe = await mem.readInboxContext(10);
+
+  assert.deepEqual(ww.map((r) => r.source_id), ['w1'], 'wavewarz sees only its own');
+  assert.deepEqual(sp.map((r) => r.source_id), ['s1'], 'sparkz sees only its own');
+  assert.deepEqual(zoe.map((r) => r.source_id), ['z1'], 'ZOE shared log has only ZOE mail, not the brands');
+
+  // separate files on disk
+  assert.ok(await fs.readFile(join(TMP, 'inbox_context.wavewarz.jsonl'), 'utf8'));
+  assert.ok(await fs.readFile(join(TMP, 'inbox_context.sparkz.jsonl'), 'utf8'));
+});
+
+test('dedup is per-namespace', async () => {
+  await mem.appendInboxContext({ source_id: 'x1', summary: 'a' }, 'wavewarz');
+  const wwIds = await mem.readIngestedSourceIds('wavewarz');
+  const zoeIds = await mem.readIngestedSourceIds();
+  assert.ok(wwIds.has('x1'), 'wavewarz dedup set has its id');
+  assert.ok(!zoeIds.has('x1'), 'ZOE dedup set does NOT see the wavewarz id');
+});

--- a/bot/src/zoe/fleet.ts
+++ b/bot/src/zoe/fleet.ts
@@ -17,7 +17,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { loadIdentities, resolveEmail, type BrandIdentity } from './identities';
+import { loadIdentities, resolveEmail, DEFAULT_INBOX, type BrandIdentity } from './identities';
 import { ingestInbox, type IngestResult } from './inbox-ingest';
 
 /** Per-brand ingest outcome. `result` is null when the brand was skipped. */
@@ -50,7 +50,10 @@ export async function ingestAllIdentities(
       continue;
     }
     try {
-      const result = await ingestInbox(fetchImpl, { inbox, apiKey });
+      // ZOE's own inbox keeps the shared context log (no namespace); every other
+      // brand gets its own namespaced logs so mail never cross-contaminates (doc 2159).
+      const namespace = inbox === DEFAULT_INBOX ? undefined : brand;
+      const result = await ingestInbox(fetchImpl, { inbox, apiKey, namespace });
       out.push({ brand, inbox, result });
     } catch (err) {
       out.push({ brand, inbox, result: null, skipped: (err as Error).message });

--- a/bot/src/zoe/inbox-ingest.ts
+++ b/bot/src/zoe/inbox-ingest.ts
@@ -63,6 +63,12 @@ export interface IngestResult {
 export interface InboxSource {
   inbox?: string;
   apiKey?: string;
+  /**
+   * Brand namespace for the context logs (doc 2159). Omitted -> ZOE's shared
+   * logs (unchanged). A brand slug -> that brand's own inbox_context.<slug>.jsonl
+   * + triage log + dedup set, so a brand's mail never mixes into ZOE's context.
+   */
+  namespace?: string;
 }
 
 /** Stable dedup key for a message. Falls back to from+subject when no id. */
@@ -126,7 +132,8 @@ export async function ingestInbox(
     return empty;
   }
 
-  const seen = await readIngestedSourceIds();
+  const ns = source.namespace;
+  const seen = await readIngestedSourceIds(ns);
   let ingested = 0;
   let skipped = 0;
 
@@ -146,7 +153,7 @@ export async function ingestInbox(
         source_id: sourceId_,
         summary,
         received_at: m.timestamp ?? m.created_at ?? m.date,
-      });
+      }, ns);
 
       // Triage the item
       const bucket = classifyBucket(m, summary);
@@ -160,7 +167,7 @@ export async function ingestInbox(
         bucket,
         connected_project: connectedProject,
         next_step: nextStep,
-      });
+      }, ns);
 
       ingested++;
     } catch (err) {

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -35,6 +35,19 @@ const BUILD_STATE_PATH = join(ZOE_HOME, 'build_state.jsonl');
 const INBOX_CONTEXT_PATH = join(ZOE_HOME, 'inbox_context.jsonl');
 const TRIAGE_CONTEXT_PATH = join(ZOE_HOME, 'triage_context.jsonl');
 
+/**
+ * Resolve a context-log path, optionally namespaced by brand (doc 2159 - the
+ * per-brand fleet). No namespace -> the shared ZOE log (unchanged behavior).
+ * A brand slug -> a separate log, e.g. inbox_context.wavewarz.jsonl, so a brand
+ * agent's mail never mixes into ZOE's context.
+ */
+function nsPath(fullPath: string, namespace?: string): string {
+  if (!namespace) return fullPath;
+  const slug = namespace.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!slug) return fullPath;
+  return fullPath.replace(/\.jsonl$/, `.${slug}.jsonl`);
+}
+
 const RECENT_MAX = 8;
 
 export type ChatScope = 'private' | string;
@@ -637,10 +650,10 @@ export async function appendBuildState(record: Omit<BuildStateRecord, 'id' | 'cr
  * mail) from the append-only inbox_context.jsonl log. Returns last N records
  * (most recent first) for concierge-prompt injection.
  */
-export async function readInboxContext(limit = 6): Promise<InboxContextRecord[]> {
+export async function readInboxContext(limit = 6, namespace?: string): Promise<InboxContextRecord[]> {
   await ensureZoeHome();
   try {
-    const raw = await fs.readFile(INBOX_CONTEXT_PATH, 'utf8');
+    const raw = await fs.readFile(nsPath(INBOX_CONTEXT_PATH, namespace), 'utf8');
     const lines = raw.trim().split('\n').filter((line) => line.trim());
     return lines
       .slice(-limit)
@@ -656,10 +669,10 @@ export async function readInboxContext(limit = 6): Promise<InboxContextRecord[]>
  * skip mail it has already summarized, so each forwarded message lands in ZOE's
  * context exactly once. Reads the whole log (small; one line per ingested mail).
  */
-export async function readIngestedSourceIds(): Promise<Set<string>> {
+export async function readIngestedSourceIds(namespace?: string): Promise<Set<string>> {
   await ensureZoeHome();
   try {
-    const raw = await fs.readFile(INBOX_CONTEXT_PATH, 'utf8');
+    const raw = await fs.readFile(nsPath(INBOX_CONTEXT_PATH, namespace), 'utf8');
     const ids = raw
       .trim()
       .split('\n')
@@ -677,7 +690,10 @@ export async function readIngestedSourceIds(): Promise<Set<string>> {
  * already run the summary through pii.ts redaction - this function does not
  * scrub, it only persists.
  */
-export async function appendInboxContext(record: Omit<InboxContextRecord, 'id' | 'created_at'>): Promise<void> {
+export async function appendInboxContext(
+  record: Omit<InboxContextRecord, 'id' | 'created_at'>,
+  namespace?: string,
+): Promise<void> {
   await ensureZoeHome();
   const doc: InboxContextRecord = {
     id: `inbox-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -686,7 +702,7 @@ export async function appendInboxContext(record: Omit<InboxContextRecord, 'id' |
     received_at: record.received_at,
     created_at: new Date().toISOString(),
   };
-  await fs.appendFile(INBOX_CONTEXT_PATH, JSON.stringify(doc) + '\n', 'utf8');
+  await fs.appendFile(nsPath(INBOX_CONTEXT_PATH, namespace), JSON.stringify(doc) + '\n', 'utf8');
 }
 
 /**
@@ -741,6 +757,7 @@ export async function readTriageContext(limit = 5): Promise<string> {
  */
 export async function appendTriageContext(
   record: Omit<import('./types').TriageRecord, 'id' | 'created_at'>,
+  namespace?: string,
 ): Promise<void> {
   await ensureZoeHome();
   const doc: import('./types').TriageRecord = {
@@ -753,7 +770,7 @@ export async function appendTriageContext(
     capture_id: record.capture_id,
     created_at: new Date().toISOString(),
   };
-  await fs.appendFile(TRIAGE_CONTEXT_PATH, JSON.stringify(doc) + '\n', 'utf8');
+  await fs.appendFile(nsPath(TRIAGE_CONTEXT_PATH, namespace), JSON.stringify(doc) + '\n', 'utf8');
 }
 
 /**

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -49,7 +49,7 @@ import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
 import { checkAndResend, readLastUserReplyAt } from './escalation';
 import { reconcileUntaggedTasks, getTaskStatusByIds } from './team-tracker';
-import { ingestInbox } from './inbox-ingest';
+import { ingestAllIdentities } from './fleet';
 import { runTaskCommentReplies } from './task-comment-replies';
 import { runMentionNotify } from './task-mention-notify';
 import { runTaskTeammateAck, readPendingReplies, removePendingReply } from './task-teammate-ack';
@@ -389,16 +389,24 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           console.warn('[zoe/scheduler] emit-queue flush failed (nbd):', (err as Error).message);
         }
 
-        // Fold any mail Zaal forwarded to zoe-zao@agentmail.to into ZOE's
-        // standing context (PII-scrubbed one-liners, deduped). Best-effort -
-        // a no-op when AGENTMAIL_API_KEY is unset.
+        // Fold any mail forwarded to the fleet's inboxes into standing context
+        // (PII-scrubbed one-liners, deduped, per-brand namespaced). With no
+        // ZOE_IDENTITIES_PATH configured this is exactly ZOE's own inbox as
+        // before (loadIdentities returns just the default identity); with a fleet
+        // registry it also ingests each brand's inbox into its own log (doc 2159).
+        // Best-effort - a no-op when the keys are unset.
         try {
-          const ing = await ingestInbox();
-          if (ing.ingested > 0) {
-            console.log(`[zoe/scheduler] inbox-ingest: folded ${ing.ingested} forwarded message(s)`);
+          const fleet = await ingestAllIdentities();
+          const total = fleet.reduce((n, r) => n + (r.result?.ingested ?? 0), 0);
+          if (total > 0) {
+            const per = fleet
+              .filter((r) => (r.result?.ingested ?? 0) > 0)
+              .map((r) => `${r.brand}:${r.result?.ingested}`)
+              .join(', ');
+            console.log(`[zoe/scheduler] fleet-ingest: folded ${total} forwarded message(s) (${per})`);
           }
         } catch (err) {
-          console.warn('[zoe/scheduler] inbox-ingest failed (nbd):', (err as Error).message);
+          console.warn('[zoe/scheduler] fleet-ingest failed (nbd):', (err as Error).message);
         }
 
         // Reply to any @zoe comments left on board tasks (thezao.xyz/board).


### PR DESCRIPTION
Implements doc 2159 and wires the scheduler to the fleet driver, so each brand's mail auto-ingests into its OWN log instead of mixing into ZOE's context. **This makes ZABAL auto-ingest live.**

Backward-compatible: with no ZOE_IDENTITIES_PATH set, the scheduler behaves identically to today (loadIdentities returns just ZOE). With the registry, it also polls ZABAL into inbox_context.zabal-games.jsonl.

Verified: tsc clean on changed files (scheduler:341 is pre-existing baseline), esbuild bundles clean, **1450/1450 zoe tests pass** incl. 3 new namespace tests (no cross-contamination + per-namespace dedup).

Final activation is a deploy env: set ZOE_IDENTITIES_PATH=bot/identities.json on the deployed ZOE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYxDaBCuhpmPPvhSPFhpjG