### PR TITLE
fix(config): remove retired partners Magnetiq + SongJam from /ecosystem page

### DIFF
--- a/community.config.ts
+++ b/community.config.ts
@@ -171,18 +171,6 @@ export const communityConfig = {
    *  Icons: 'magnet' | 'music' | 'castle' | 'rocket' | 'coin' | 'nouns' | 'battle' */
   partners: [
     {
-      name: 'MAGNETIQ',
-      description: 'Proof of Meet hub — verify real-world connections and earn attestations.',
-      url: 'https://app.magnetiq.xyz',
-      icon: 'magnet',
-    },
-    {
-      name: 'SongJam',
-      description: 'Live audio spaces & ZABAL mention leaderboard — host rooms, earn points.',
-      url: 'https://songjam.space/zabal',
-      icon: 'music',
-    },
-    {
       name: 'Empire Builder',
       description: 'Token empire rewards — stake and earn in the ZABAL ecosystem.',
       url: 'https://empirebuilder.world',


### PR DESCRIPTION
**Live public leak caught by the reaudit.** The earlier retirement scrub cleaned the zabalgames site + memory, but `community.config.ts` still listed **MAGNETIQ + SongJam** in `partners[]` - which `zaoos.com/ecosystem` renders. Both were showing as active partners on the live site despite being retired 2026-07-31 (entry ~4 months stale).

Removed both partner objects; Empire Builder / Incented / etc. remain. `community.config.ts` is ask-first per CLAUDE.md - this PR is the gate.

Generated with Claude Code
