### PR TITLE
fix(bot): unbreak relay-bridge test - main CI red since #2773

### DIFF
--- a/bot/src/zoe/__tests__/relay-bridge.test.ts
+++ b/bot/src/zoe/__tests__/relay-bridge.test.ts
@@ -96,10 +96,15 @@ describe('tryInstantRelayReply', () => {
     process.env.COWORK_TRACKER_URL = 'https://x.test';
     process.env.COWORK_TRACKER_KEY = 'k';
     const hub = { id: 'h1', metadata: { relays: [] as RelayMsg[] } };
-    let patched: unknown;
-    const fetchMock = vi.fn(async (_url: string, init?: { method?: string; body?: string }) => {
-      if (init?.method === 'PATCH') {
-        patched = JSON.parse(init.body || '{}');
+    let merged: unknown;
+    let mergeUrl = '';
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      // The write goes through the atomic relay_hub_merge RPC (POST), NOT a
+      // whole-object PATCH - a PATCH of { metadata: { relays } } replaces the
+      // whole metadata column and wipes metadata.holds (doc 2170 R0).
+      if (init?.method === 'POST') {
+        mergeUrl = url;
+        merged = JSON.parse(init.body || '{}');
         return { ok: true, text: async () => '' } as unknown as Response;
       }
       return { ok: true, text: async () => JSON.stringify([hub]) } as unknown as Response;
@@ -107,9 +112,12 @@ describe('tryInstantRelayReply', () => {
     vi.stubGlobal('fetch', fetchMock);
     const ok = await tryInstantRelayReply('rl-cowork', 'on it', 'ts1');
     expect(ok).toBe(true);
+    // it hit the merge RPC, and the patch touches ONLY the relays key
+    expect(mergeUrl).toContain('/rest/v1/rpc/relay_hub_merge');
+    const patch = (merged as { p_patch: { relays: RelayMsg[] } }).p_patch;
+    expect(Object.keys(patch)).toEqual(['relays']);
     // the appended reply targets the cowork lane with from:zoe
-    const relays = (patched as { metadata: { relays: RelayMsg[] } }).metadata.relays;
-    expect(relays.at(-1)).toMatchObject({ from: 'zoe', to: 'cowork', msg: 'on it', read: false });
+    expect(patch.relays.at(-1)).toMatchObject({ from: 'zoe', to: 'cowork', msg: 'on it', read: false });
     vi.unstubAllGlobals();
     delete process.env.COWORK_TRACKER_URL;
     delete process.env.COWORK_TRACKER_KEY;


### PR DESCRIPTION
## What breaks without this

`main` CI is red and has been since 2026-08-01 00:40 UTC (PR #2773). The **Bot
Tests** job fails on every push:

```
FAIL src/zoe/__tests__/relay-bridge.test.ts > tryInstantRelayReply > routes a relay qid to its lane and returns true
TypeError: Cannot read properties of undefined (reading 'metadata')
 -> src/zoe/__tests__/relay-bridge.test.ts:111:70
Test Files  1 failed | 137 passed (138)
```

(run 30699715716, job 91368467562 - the same failure reproduces locally.)

Knock-on effect: `.github/workflows/ci.yml` declares `build: needs: [lint-typecheck, test, bot-test]`,
so the **Build** job has been *skipped* on every run since. Nothing has verified
`npm run build` on main for the last ~10 hours of merges, and every new PR opens
against an already-red baseline, so a genuine regression in the bot suite would
be invisible.

## Root cause

PR #2773 (`fix(zoe): relay-bridge stops wiping metadata.holds`) changed
`saveHubRelays` from a whole-object `PATCH` of `{ metadata: { relays } }` to the
atomic `relay_hub_merge(p_patch)` RPC (a `POST`). The source change is correct -
it is what stops a relay write from destroying `metadata.holds`. But the test was
not updated: it still branches on `init?.method === 'PATCH'`, so with the new code
no branch ever fires, `patched` stays `undefined`, and line 111 dereferences it.

## The fix

Test-only, 14 insertions. The mock now captures the `POST`, and the assertions
check the invariant #2773 actually shipped:

- the write hits `/rest/v1/rpc/relay_hub_merge` (not a whole-object PATCH)
- `Object.keys(p_patch)` is exactly `['relays']` - so the merge can never clobber
  `metadata.holds`
- the appended relay is still `{ from: 'zoe', to: 'cowork', msg: 'on it', read: false }`

This makes the test guard the regression that #2773 fixed, instead of asserting
the shape that caused it.

## Verification

```
$ npx vitest run src/zoe/__tests__/relay-bridge.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
exit 0
```

Before: 1 failed / 11 passed, exit 1. No source files touched.

## Other things the audit noticed (NOT fixed here - one PR only)

1. **No migration for `relay_hub_merge`.** `bot/src/zoe/relay-bridge.ts` calls
   `rpc/relay_hub_merge`, but the only definition anywhere in the repo is prose in
   research docs 2157/2170/2171 - `bot/migrations/` contains just `hermes_runs.sql`
   and `team_bots.sql`. #2773 says the RPC was "verified live", so this is likely a
   documentation/reproducibility gap rather than a live break. Worth confirming,
   because if the function is ever absent, `fetchJson` returns `null` -> 
   `saveHubRelays` returns `false` -> every relay write is silently dropped AND
   `pushInboundRelays` never marks messages pushed, so the same relay re-DMs Zaal
   on every tick. Nothing surfaces the failure.
2. **`bot/src/zoe/__tests__/transcribe.test.ts` is not Windows-safe** - it asserts
   `dest` contains `/tmp/zoe-files` while `path.join` yields `\tmp\zoe-files`. Green
   on the Linux runner, fails for anyone running the bot suite locally on Windows.
   Cosmetic to CI, so left alone.
3. **`bot/` typecheck has a pre-existing baseline of ~46 errors** (implicit `any`
   on grammy `ctx` params, plus `Cannot find module 'grammy'` when `bot/node_modules`
   is absent). Known/acknowledged in recent commit messages; not touched.

Automated audit run. No merge, no deploy, nothing external - repo only.
