### PR TITLE
fix(ci): research-index backfill dies on a symlink pathspec - 53 straight failures on main

### DIFF
--- a/.github/workflows/research-index.yml
+++ b/.github/workflows/research-index.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - 'research/**'
       - 'scripts/backfill-research-index.sh'
+      - '.github/workflows/research-index.yml'
 permissions:
   contents: write
 jobs:
@@ -33,7 +34,17 @@ jobs:
           if ! git diff --quiet -- research; then
             git config user.name "zao-index-bot"
             git config user.email "zao-index-bot@users.noreply.github.com"
-            git add research/*/README.md
+            # `git add research/*/README.md` died here: the shell glob expands
+            # to research/314-music-metadata-isrc-ai-distribution/README.md,
+            # which sits behind a TRACKED SYMLINK (research/314-... ->
+            # music/314-...), and git refuses a pathspec that traverses a
+            # symlink ("fatal: ... is beyond a symbolic link", exit 128). The
+            # step is `bash -e`, so the job died and the backfill was thrown
+            # away on every run that actually had rows to commit.
+            # `-u` stages modifications to already-tracked files under
+            # research/ (all this script ever does is append to an existing
+            # topic README), and a directory pathspec never walks the symlink.
+            git add -u -- research
             git commit -m "chore(research): CI backfill folder index rows [skip ci]"
             git push || echo "::warning::index backfill could not push (branch protection?) - nightly backfill will catch it"
           else


### PR DESCRIPTION
## What breaks without this

The `Research index (CI-owned)` workflow has failed **53 consecutive times on main**
(every run since 2026-07-25; 0 successes since). It fails on its commit step:

```
fatal: pathspec 'research/314-music-metadata-isrc-ai-distribution/README.md' is beyond a symbolic link
##[error]Process completed with exit code 128
```

`research/314-music-metadata-isrc-ai-distribution` is a **tracked symlink**
(mode `120000`, target `music/314-music-metadata-isrc-ai-distribution`, landed in
`705f7296d`, 2026-04-11). The shell glob in `git add research/*/README.md` expands
through it, and git refuses any pathspec that traverses a symlink. The step runs
under `bash -e`, so the job exits 128 and **the backfilled index rows are thrown
away**.

The nasty part is the shape of the failure: the job only goes green when it has
nothing to do. Verified on the last successful run (`30161411627`): 0 `backfilled
doc` lines, took the `else` branch, printed "index already complete". Every run
that actually had rows to write has died. So the workflow that exists to keep
`research/<topic>/README.md` self-healing has never once succeeded at doing it.

Concrete drift on main right now - running `scripts/backfill-research-index.sh`
against `2ea609368` produces:

```
+| 2147 | [Overnight run 2026-07-30: morning brief + your decision queue](./2147-overnight-run-jul30-brief/) | STANDALONE | Research doc 2147. |
```

Doc 2147 merged 2026-07-30 and is still absent from `research/events/README.md`,
because the run that would have added it exited 128.

## The fix

```diff
-  git add research/*/README.md
+  git add -u -- research
```

`backfill-research-index.sh` only ever appends to an **already-tracked** topic
README (it `continue`s unless `[ -f "$topic_readme" ]`), so `-u` stages exactly
its output and nothing else. A directory pathspec plus `-u` walks index entries,
so it never constructs a path through the symlink.

Also adds `.github/workflows/research-index.yml` to the push trigger paths - the
workflow's push trigger is scoped to `research/**` and the script, so a fix to
the workflow alone would not run until the next unrelated research commit. With
this, merging this PR is itself the verification.

## Verification

- YAML parses; the commit step's bash body passes `bash -n`.
- `git add -u -- research` stages only the modified tracked README (checked in a
  scratch repo with a tracked `120000` entry).
- The symlink failure path itself **cannot be reproduced on this Windows box**
  (`core.symlinks` is off; `ln -s` returns `Operation not permitted`), so the
  proof of the failure is the CI logs above, and the proof of the fix will be the
  first post-merge run. Expect it to print `backfilled doc 2147 -> events/README.md`
  and push a `chore(research): CI backfill folder index rows [skip ci]` commit.

## Deliberately not fixed here (one-PR rule)

- `bot/` typecheck has pre-existing errors in test files - `src/hermes/__tests__/commands.test.ts`
  (`TeamMember` fixtures missing `id` / `scope` / `telegram_username`),
  `src/hermes/__tests__/critic.test.ts` (`CritiqueInput` missing `branchName`,
  plus `Cannot find name 'beforeEach'`). CI runs `npm test` for the bot, not
  `tsc`, so these are invisible to CI. Real but lower value than a job that has
  been red for a week.
- Root `npm run typecheck` is clean; the only errors come from a stale local
  `.next/types/validator.ts` build artifact, not from source.
