### PR TITLE
fix(ci): auto-merge classifier only saw the first 100 PR files

### DIFF
--- a/.github/workflows/docs-automerge.yml
+++ b/.github/workflows/docs-automerge.yml
@@ -36,8 +36,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Read "status<TAB>filename" pairs so we can require additive-only scripts.
-          pairs=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" --jq '.[] | "\(.status)\t\(.filename)"')
+          #
+          # --paginate is load-bearing: without it this returns only the FIRST page
+          # (100 files) and every file past that is invisible to the classifier. A
+          # PR whose 101st file is runtime code would be classified off its first
+          # 100 (docs) and auto-merged unreviewed. GitHub still hard-caps this
+          # endpoint at 3000 files, so the count assertion below fails closed on
+          # any remaining truncation (silent-failure-guard rules 1-3).
+          pairs=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" --jq '.[] | "\(.status)\t\(.filename)"')
           echo "$pairs"
+
+          # Fail closed unless we saw EVERY changed file. A short list can only
+          # under-report unsafe files, so anything incomplete waits for Zaal.
+          seen=$(printf '%s\n' "$pairs" | grep -c . || true)
+          expected='${{ github.event.pull_request.changed_files }}'
+          if [ "$seen" != "$expected" ]; then
+            echo "::warning title=PR file list incomplete::classified $seen of $expected changed files - holding for review"
+            echo "category=unsafe" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           has_docs=0; has_tests=0; has_scripts=0; has_unsafe=0
           while IFS=$'\t' read -r status f; do
             [ -z "$f" ] && continue
@@ -97,7 +115,9 @@ jobs:
           # e.g. 363 exists as both community/363-... and agents/363-...) would
           # otherwise be falsely held forever - which blocked real green docs PRs
           # (#1650/#1654/#1661/#1613) on edits they did not author. (Fixed 2026-07-17.)
-          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" --jq '.[] | select(.status=="added") | .filename')
+          # --paginate for the same reason as the classifier: an added doc dir past
+          # the first page would otherwise never be collision-checked.
+          files=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" --jq '.[] | select(.status=="added") | .filename')
           newdirs=$(echo "$files" | grep -oE '^research/[a-z_-]+/[0-9]+-[^/]+' | sort -u || true)
           if [ -z "$newdirs" ]; then echo "collision=false" >> "$GITHUB_OUTPUT"; exit 0; fi
           main_dirs=$(gh api "repos/${{ github.repository }}/git/trees/main?recursive=1" --paginate --jq '.tree[].path' | grep -oE '^research/[a-z_-]+/[0-9]+-[^/]+' | sort -u)


### PR DESCRIPTION
## What breaks without this

`.github/workflows/docs-automerge.yml` auto-merges "safe" PRs (docs / tests / additive scripts) to `main` on green CI. Its `Classify PR files` step decided the category from:

```
gh api "repos/.../pulls/N/files?per_page=100" --jq '...'
```

No `--paginate`, so it read **page 1 only**. Files 101+ never reached the `case` statement, and a file the classifier never sees cannot set `has_unsafe=1`.

Concrete failure: a PR with 100+ changed files where the unsafe one is not in the first page. The endpoint returns files in path order, and `research/**` sorts before `src/**`, so a PR bundling 100+ research docs with one edit to e.g. `src/lib/auth/session.ts` classifies as `docs`, passes the collision guard, and gets `gh pr merge --auto`. Runtime code lands on `main` with no human review - the exact thing the `unsafe` category exists to prevent. The workflow holds `contents: write`.

The collision-guard step used the same unpaginated call, so an added `research/<topic>/NNN-slug/` past file 100 was never checked for a doc-number collision either.

This has not fired yet - the largest of the last 60 PRs was 5 files - but it is a gate that silently stops inspecting its input, which is why it is worth closing before a big docs sweep hits it.

## The fix

- `--paginate` on both file-list calls (the tree call on line 121 already had it).
- Assert `seen == github.event.pull_request.changed_files`; on mismatch emit a warning, set `category=unsafe`, and hold for review.

The assertion is not redundant with `--paginate`: GitHub hard-caps this endpoint at 3000 files even when paginated, and a failed or partial fetch yields an empty/short list. A short list can only ever *under*-report unsafe files, so incomplete must fail closed (`silent-failure-guard.md` rules 1-3).

## Verification

- YAML parses (`yaml.load`, 3 steps).
- The count assertion was run against four inputs - full list, short list, empty-on-API-failure, zero files. Only the full-list case proceeds to classification; the rest hold.
- Not exercisable end-to-end without a >100-file PR; the logic change is the assertion above.
- This PR touches `.github/**`, so it classifies `unsafe` and will not auto-merge itself. Zaal merges.

## Also seen this pass, not fixed (one PR per run)

- `bot/src/zoe/scheduler.ts:428` - the daily-note rollover cron is commented "Loud-fail on DB error (exits non-zero to page)", but `rolloverNotes()` catches everything internally and returns an `"error: ..."` **string**, which the scheduler prints via `console.log` at info level and keeps its `claimFire` sentinel. A DB outage during rollover is therefore neither loud nor paged. Comment and behavior disagree.
- `bot/src/zoe/__tests__/transcribe.test.ts:187` - asserts `toContain('/tmp/zoe-files')` against a `path.join` result, so it fails on Windows (`\tmp\zoe-files\photo.jpg`). Green on Linux CI, red on the Windows desktop.
- `bot/` has `grammy` in `package.json` but it is not installed in the local `bot/node_modules`, so 2 local test files fail to collect. Local install gap, not a repo defect - `npm ci` in `bot/` fixes it.
- No `.github/workflows/*` script uses `set -o pipefail`.

## Prior audit PR still open

#2786 (research-index symlink pathspec) is from an earlier run and is unrelated to this one.

