### PR TITLE
fix(zoe): afferent digest reports a DB outage as "nothing to digest"

### DIFF
--- a/bot/src/zoe/__tests__/afferent-digest.test.ts
+++ b/bot/src/zoe/__tests__/afferent-digest.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { persistDailyDigest } from '../afferent-digest';
+
+/**
+ * Tests for the afferent digest job. Database I/O is mocked; what is under test is
+ * the STATUS the job reports back to the scheduler, because the scheduler logs an
+ * 'error' status at error level and a 'silent' status at info level. A DB failure
+ * reported as 'silent' is a green-while-broken outage
+ * (.claude/rules/silent-failure-guard.md).
+ */
+
+const state = vi.hoisted(() => ({
+  // Result of the last-24h receipts query (awaited after .order()).
+  receiptsQuery: { data: [] as unknown[], error: null as { message: string } | null },
+  // Result of the idempotency lookup (.single()).
+  idempotency: {
+    data: null as { id: string } | null,
+    error: null as { code?: string; message: string } | null,
+  },
+  emitReceiptResult: true,
+  emitReceiptCalls: 0,
+}));
+
+vi.mock('../../supabase', () => ({
+  db: vi.fn(() => ({
+    from: vi.fn(() => {
+      const builder: Record<string, unknown> = {};
+      builder.select = () => builder;
+      builder.eq = () => builder;
+      builder.gte = () => builder;
+      builder.limit = () => builder;
+      builder.order = () => Promise.resolve(state.receiptsQuery);
+      builder.single = () => Promise.resolve(state.idempotency);
+      return builder;
+    }),
+  })),
+}));
+
+vi.mock('../receipts', () => ({
+  emitReceipt: vi.fn(() => {
+    state.emitReceiptCalls++;
+    return Promise.resolve(state.emitReceiptResult);
+  }),
+}));
+
+vi.mock('../bonfire-queue', () => ({
+  queueConfigured: () => false,
+  promoteSubmission: vi.fn(() => Promise.resolve({ ok: true })),
+  buildEpisode: vi.fn(),
+}));
+
+const RECEIPT = {
+  agent_identity: 'zoe',
+  capability: 'post_github',
+  action: 'create_pull_request',
+  result_type: 'success',
+  created_at: '2026-08-02T00:00:00.000Z',
+};
+
+describe('persistDailyDigest', () => {
+  beforeEach(() => {
+    state.receiptsQuery = { data: [RECEIPT], error: null };
+    state.idempotency = { data: null, error: { code: 'PGRST116', message: 'not found' } };
+    state.emitReceiptResult = true;
+    state.emitReceiptCalls = 0;
+  });
+
+  it('reports success when there are receipts to digest', async () => {
+    const result = await persistDailyDigest();
+    expect(result.status).toBe('success');
+    expect(result.receiptCount).toBe(1);
+    expect(state.emitReceiptCalls).toBe(1);
+  });
+
+  it('reports silent when the day genuinely had no receipts', async () => {
+    state.receiptsQuery = { data: [], error: null };
+    const result = await persistDailyDigest();
+    expect(result.status).toBe('silent');
+    expect(state.emitReceiptCalls).toBe(0);
+  });
+
+  it('reports error - not silent - when the receipts query fails', async () => {
+    state.receiptsQuery = { data: [], error: { message: 'connection refused' } };
+    const result = await persistDailyDigest();
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('connection refused');
+    expect(state.emitReceiptCalls).toBe(0);
+  });
+
+  it('reports silent when today already has a digest receipt', async () => {
+    state.idempotency = { data: { id: 'receipt-1' }, error: null };
+    const result = await persistDailyDigest();
+    expect(result.status).toBe('silent');
+    expect(state.emitReceiptCalls).toBe(0);
+  });
+
+  it('does NOT emit when the idempotency check itself fails', async () => {
+    state.idempotency = { data: null, error: { code: '57014', message: 'statement timeout' } };
+    const result = await persistDailyDigest();
+    expect(result.status).toBe('error');
+    expect(state.emitReceiptCalls).toBe(0);
+  });
+});

--- a/bot/src/zoe/afferent-digest.ts
+++ b/bot/src/zoe/afferent-digest.ts
@@ -26,6 +26,24 @@ export interface DigestResult {
 }
 
 /**
+ * Result of a digest build. "nothing happened today" (empty) and "we could not find
+ * out what happened today" (error) are DIFFERENT outcomes and must not collapse into
+ * one silent status - a DB outage reported as "nothing to digest" is exactly the
+ * green-while-broken failure `.claude/rules/silent-failure-guard.md` bans.
+ */
+type DigestBuild =
+  | {
+      kind: 'ok';
+      digest: string;
+      receiptCount: number;
+      statsByAgent: Record<string, number>;
+      statsByCapability: Record<string, number>;
+      statsByResultType: Record<string, number>;
+    }
+  | { kind: 'empty' }
+  | { kind: 'error'; message: string };
+
+/**
  * Compose a concise prose digest of today's organism activity.
  *
  * Queries receipts from the last 24h, groups by agent + capability, and produces
@@ -33,13 +51,7 @@ export interface DigestResult {
  *   "Today the organism: 42 receipts across zoe(35), zol(7). Actions: 28 posts,
  *    8 repos, 4 fetches, 2 decisions. 1 error, rest success."
  */
-async function buildDailyDigest(): Promise<{
-  digest: string;
-  receiptCount: number;
-  statsByAgent: Record<string, number>;
-  statsByCapability: Record<string, number>;
-  statsByResultType: Record<string, number>;
-} | null> {
+async function buildDailyDigest(): Promise<DigestBuild> {
   try {
     const client = db();
 
@@ -53,7 +65,7 @@ async function buildDailyDigest(): Promise<{
 
     if (error) {
       console.error('[zoe/afferent-digest] receipts query failed:', error.message);
-      return null;
+      return { kind: 'error', message: `receipts query failed: ${error.message}` };
     }
 
     const receipts = (data ?? []) as Array<{
@@ -65,7 +77,7 @@ async function buildDailyDigest(): Promise<{
     }>;
 
     if (receipts.length === 0) {
-      return null; // Silent if nothing to report
+      return { kind: 'empty' }; // Silent if nothing to report
     }
 
     // Group by agent, capability, result type
@@ -101,18 +113,30 @@ async function buildDailyDigest(): Promise<{
     const date = new Date().toISOString().slice(0, 10);
     const digest = `[${date}] Organism daily digest: ${receipts.length} actions across ${agentsSummary}. ${capsSummary}. ${resultsSummary}.`;
 
-    return { digest, receiptCount: receipts.length, statsByAgent, statsByCapability, statsByResultType };
+    return {
+      kind: 'ok',
+      digest,
+      receiptCount: receipts.length,
+      statsByAgent,
+      statsByCapability,
+      statsByResultType,
+    };
   } catch (err) {
-    console.error('[zoe/afferent-digest] buildDailyDigest error:', (err as Error)?.message ?? err);
-    return null;
+    const message = (err as Error)?.message ?? String(err);
+    console.error('[zoe/afferent-digest] buildDailyDigest error:', message);
+    return { kind: 'error', message };
   }
 }
 
 /**
  * Check if a digest receipt already exists for today (idempotency check).
  * Uses a per-day key: `afferent-digest-YYYY-MM-DD`.
+ *
+ * Tri-state on purpose: 'unknown' means the check itself failed, which is NOT the
+ * same as "no digest exists". Collapsing 'unknown' into false would let a flaky
+ * check wave through a duplicate emit - the opposite of the safeguard.
  */
-async function digestExistsForToday(): Promise<boolean> {
+async function digestExistsForToday(): Promise<'yes' | 'no' | 'unknown'> {
   try {
     const client = db();
     const today = new Date().toISOString().slice(0, 10);
@@ -130,13 +154,13 @@ async function digestExistsForToday(): Promise<boolean> {
     if (error && error.code !== 'PGRST116') {
       // PGRST116 = not found (ok), any other error is loud-fail
       console.error('[zoe/afferent-digest] idempotency check failed:', error.message);
-      return false; // On check failure, don't emit (safeguard against double-fire)
+      return 'unknown'; // On check failure, don't emit (safeguard against double-fire)
     }
 
-    return !!data; // true if receipt found, false if not
+    return data ? 'yes' : 'no';
   } catch (err) {
     console.error('[zoe/afferent-digest] digestExistsForToday error:', (err as Error)?.message ?? err);
-    return false;
+    return 'unknown';
   }
 }
 
@@ -149,13 +173,21 @@ async function digestExistsForToday(): Promise<boolean> {
 export async function persistDailyDigest(): Promise<DigestResult> {
   try {
     // Idempotency: one digest per calendar day
-    if (await digestExistsForToday()) {
+    const existing = await digestExistsForToday();
+    if (existing === 'yes') {
       return { status: 'silent', message: 'digest already emitted today' };
+    }
+    if (existing === 'unknown') {
+      // The check failed, so we cannot prove this is not a re-run. Do NOT emit.
+      return { status: 'error', message: 'idempotency check failed - skipped emit' };
     }
 
     // Build the digest
     const digestData = await buildDailyDigest();
-    if (!digestData) {
+    if (digestData.kind === 'error') {
+      return { status: 'error', message: digestData.message };
+    }
+    if (digestData.kind === 'empty') {
       return { status: 'silent', message: 'no receipts to digest' };
     }
 


### PR DESCRIPTION
## What breaks without this

`bot/src/zoe/afferent-digest.ts` is the nightly receipts -> memory bridge (02:30 UTC,
the "keystone" of the afferent loop from #2774). It has two defects that both make a
failure look like a normal quiet night.

### 1. A DB outage is reported as "nothing to digest"

`buildDailyDigest()` returned `null` for two different things:

- the last 24h genuinely had no receipts (an empty day), and
- the receipts query errored, or `db()` threw because `SUPABASE_URL` /
  `SUPABASE_SERVICE_ROLE_KEY` were missing.

`persistDailyDigest()` only saw `null`, so both became
`{ status: 'silent', message: 'no receipts to digest' }`. The scheduler
(`scheduler.ts:394`) logs a `silent` status with `console.log`:

```
[zoe/scheduler] afferent digest: nothing to digest (silent)
```

So during a Supabase outage or an env regression, the organism stops recording what
it did and the operator sees an ordinary info line - no error, nothing to alert on.
The cron fires once a day, so a broken night is a lost day of self-knowledge. This is
the exact green-while-broken shape `.claude/rules/silent-failure-guard.md` rule 6
bans, and it contradicts the file's own header ("Loud-fail: if DB is unreachable,
logs at error level + returns failure result").

### 2. The idempotency guard was inverted

```ts
if (error && error.code !== 'PGRST116') {
  console.error('[zoe/afferent-digest] idempotency check failed:', error.message);
  return false; // On check failure, don't emit (safeguard against double-fire)
}
```

The comment says "don't emit", but the function's contract is
`true = a digest already exists`. Returning `false` means "no digest today", so the
caller went straight on to emit. A statement timeout or a transient error on the
lookup produced the duplicate the check exists to prevent: a second `daily_digest`
receipt and, when Bonfire is configured, a second graph episode for the same day.
The per-day `claimFire` sentinel does not cover this - it is a local file, so a
redeploy or a wiped sentinel dir lets the tick run again.

## The fix

No behavior change on the happy path.

- `buildDailyDigest()` returns a discriminated `{ kind: 'ok' | 'empty' | 'error' }`,
  so an error can no longer be read as an empty day. `error` -> `status: 'error'`,
  which the scheduler logs via `console.error`.
- `digestExistsForToday()` is tri-state (`'yes' | 'no' | 'unknown'`). `'unknown'`
  now actually skips the emit and returns `status: 'error'`, matching the comment.

## Proof

New `bot/src/zoe/__tests__/afferent-digest.test.ts` (5 cases, DB mocked with
`vi.mock` + `vi.hoisted` per `.claude/rules/tests.md`). Run against the **pre-fix**
source, the two bug cases fail exactly as described:

```
x reports error - not silent - when the receipts query fails
  AssertionError: expected 'silent' to be 'error'
x does NOT emit when the idempotency check itself fails
  AssertionError: expected 'success' to be 'error'
Tests  2 failed | 3 passed (5)
```

With the fix, 5/5 pass.

- `bot: tsc --noEmit` -> 40 errors, identical to the count on unmodified
  `origin/main` (0 new; the remaining 40 are pre-existing).
- `bot: vitest run` -> 1756 passed / 1 failed. The failure is
  `transcribe.test.ts > downloadTelegramFile`, which reproduces on unmodified
  `origin/main` on this Windows box (path handling) and is green on Linux CI. Not
  touched here.

## Also seen this pass, not fixed (one PR per run)

- `bot/src/zoe/daily-note.ts` `rolloverNotes()` has the same shape: it never throws,
  it returns a string like `error: DB query failed`, and `scheduler.ts:429` logs the
  return with `console.log`, so a failed rollover reads as a successful one. Worse,
  the `claimFire('daily-note-rollover')` sentinel is not released on that path, so the
  day's rollover is marked done and never retries. Same fix shape as this PR.
- `bot/src/zoe/daily-note.ts` `todayIso()` uses `toISOString()`, i.e. UTC, while the
  rollover cron is pinned to `America/New_York`. An item captured after 20:00 ET lands
  on the next day's note. The midnight cron itself is unaffected.
- `bot/src/zoe/daily-note.ts` `rolloverNotes()` sums `totalPromoted` from every item
  carrying a `promoted_task_id`, including ones promoted on earlier days, so the
  summary log over-counts. Log-only.
- `transcribe.test.ts > downloadTelegramFile` fails on Windows, passes on CI.
