### PR TITLE
fix(zoe): daily-note rollover reports a DB outage as a successful roll

### DIFF
--- a/bot/src/zoe/__tests__/daily-note.test.ts
+++ b/bot/src/zoe/__tests__/daily-note.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { rolloverNotes } from '../daily-note';
+
+/**
+ * Tests for the daily-note rollover job. Database I/O is mocked; what is under
+ * test is the STATUS the job reports back to the scheduler.
+ *
+ * This matters because the scheduler logs an 'error' status at error level and
+ * releases the day's fire sentinel, while a 'silent' or 'success' status marks
+ * the day as rolled. A DB failure that reports anything other than 'error' is a
+ * green-while-broken outage (.claude/rules/silent-failure-guard.md), and it
+ * strands yesterday's unchecked items: tomorrow's run only looks at TODAY's
+ * note, so nothing ever picks them up again.
+ */
+
+const state = vi.hoisted(() => ({
+  // Result of an awaited select chain (the "notes due yesterday" query).
+  listResult: { data: [] as unknown[], error: null as { message: string } | null },
+  // Result of a select chain ending in .single() (get today's note).
+  selectSingleResult: { data: null as unknown, error: null as { message: string } | null },
+  // Result of an awaited update chain (write today's rolled items).
+  updateResult: { error: null as { message: string } | null },
+  // Result of an update chain ending in .select().single() (promotion save).
+  updateSelectResult: { data: null as unknown, error: null as { message: string } | null },
+  // Result of an insert chain ending in .select().single() (create promoted task).
+  insertResult: { data: null as unknown, error: null as { message: string } | null },
+}));
+
+vi.mock('../../supabase', () => ({
+  db: vi.fn(() => ({
+    from: () => {
+      // A chainable stub whose terminal value depends on which write verb was
+      // used, so one builder can stand in for select / insert / update chains.
+      const builder: Record<string, unknown> = { op: 'select' };
+      const chain = () => builder;
+      builder.select = chain;
+      builder.eq = chain;
+      builder.gte = chain;
+      builder.order = chain;
+      builder.limit = chain;
+      builder.insert = () => {
+        builder.op = 'insert';
+        return builder;
+      };
+      builder.update = () => {
+        builder.op = 'update';
+        return builder;
+      };
+      builder.single = () =>
+        Promise.resolve(
+          builder.op === 'insert'
+            ? state.insertResult
+            : builder.op === 'update'
+              ? state.updateSelectResult
+              : state.selectSingleResult,
+        );
+      builder.then = (onOk: (v: unknown) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(builder.op === 'update' ? state.updateResult : state.listResult).then(onOk, onErr);
+      return builder;
+    },
+  })),
+}));
+
+const ITEM = {
+  id: 'it-1',
+  text: 'ship the rollover fix',
+  done: false,
+  roll_count: 0,
+  created_at: '2026-08-01T12:00:00.000Z',
+  promoted_task_id: null,
+};
+
+const YESTERDAY_NOTE = {
+  id: 'note-yesterday',
+  owner_id: 'zaal',
+  metadata: { items: [ITEM], note_date: '2026-08-01' },
+};
+
+const TODAY_NOTE = {
+  id: 'note-today',
+  kind: 'daily_note',
+  owner_id: 'zaal',
+  metadata: { items: [], note_date: '2026-08-02' },
+};
+
+describe('rolloverNotes', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    state.listResult = { data: [YESTERDAY_NOTE], error: null };
+    state.selectSingleResult = { data: TODAY_NOTE, error: null };
+    state.updateResult = { error: null };
+    state.updateSelectResult = {
+      data: { ...TODAY_NOTE, metadata: { items: [{ ...ITEM, promoted_task_id: 'task-1' }], note_date: '2026-08-02' } },
+      error: null,
+    };
+    state.insertResult = { data: { id: 'task-1' }, error: null };
+  });
+
+  it('reports success when items roll', async () => {
+    const result = await rolloverNotes();
+    expect(result.status).toBe('success');
+    expect(result.summary).toContain('rolled 1 items');
+  });
+
+  it('reports silent when there are no notes to roll', async () => {
+    state.listResult = { data: [], error: null };
+    const result = await rolloverNotes();
+    expect(result.status).toBe('silent');
+  });
+
+  it('reports error (not silent) when the lookup query fails', async () => {
+    state.listResult = { data: [], error: { message: 'connection refused' } };
+    const result = await rolloverNotes();
+    expect(result.status).toBe('error');
+    expect(result.summary).toContain('connection refused');
+  });
+
+  it('reports error when an owner write fails, even though other work succeeded', async () => {
+    state.updateResult = { error: { message: 'permission denied for table tasks' } };
+    const result = await rolloverNotes();
+    expect(result.status).toBe('error');
+    expect(result.summary).toContain('1/1 owners failed');
+  });
+
+  it('reports error when today note creation fails for an owner', async () => {
+    state.selectSingleResult = { data: null, error: { message: 'no rows' } };
+    state.insertResult = { data: null, error: { message: 'insert rejected' } };
+    const result = await rolloverNotes();
+    expect(result.status).toBe('error');
+    expect(result.summary).toContain('owners failed');
+  });
+});

--- a/bot/src/zoe/daily-note.ts
+++ b/bot/src/zoe/daily-note.ts
@@ -367,15 +367,32 @@ async function promoteCarriedItems(note: DailyNoteRow): Promise<DailyNoteRow> {
 }
 
 /**
+ * What a rollover run reports back to the scheduler.
+ *
+ * The scheduler must be able to tell "there was nothing to roll" apart from
+ * "the database was down", because those need opposite handling: a silent run
+ * is normal, a failed run must log at error level and must NOT leave the day's
+ * fire sentinel claimed (.claude/rules/silent-failure-guard.md rule 6). This
+ * mirrors the discriminated status `persistDailyDigest` already returns.
+ */
+export type RolloverStatus = 'success' | 'silent' | 'error';
+
+export interface RolloverResult {
+  status: RolloverStatus;
+  summary: string;
+}
+
+/**
  * Rollover cron job — called daily at 00:00 EST.
  * For each owner with a yesterday note:
  *   1. Create today's note if not present (idempotent).
  *   2. Copy unchecked items to TOP of today, increment roll_count.
  *   3. Run promotion pass on carried items.
  *
- * Returns a summary of what was rolled (for logging).
+ * Returns the run status plus a summary of what was rolled (for logging).
+ * Never throws — a failure is reported as status 'error' so the caller decides.
  */
-export async function rolloverNotes(): Promise<string> {
+export async function rolloverNotes(): Promise<RolloverResult> {
   try {
     const client = db();
     const yesterday = yesterdayIso();
@@ -390,16 +407,17 @@ export async function rolloverNotes(): Promise<string> {
 
     if (error) {
       console.error('[zoe/daily-note] rollover query failed:', error.message);
-      return 'error: DB query failed';
+      return { status: 'error', summary: `DB query failed: ${error.message}` };
     }
 
     if (!yesterdayNotes || yesterdayNotes.length === 0) {
       console.log('[zoe/daily-note] rollover: no yesterday notes found (silent)');
-      return 'silent: no notes to roll';
+      return { status: 'silent', summary: 'no notes to roll' };
     }
 
     let totalRolled = 0;
     let totalPromoted = 0;
+    let failedOwners = 0;
 
     for (const yesterdayRow of yesterdayNotes) {
       const yesterdayMeta = (yesterdayRow.metadata as DailyNoteMetadata) ?? { items: [], note_date: yesterday };
@@ -414,7 +432,8 @@ export async function rolloverNotes(): Promise<string> {
       // Create today's note (idempotent by owner + date)
       const todayNote = await getOrCreateTodayNote(ownerId);
       if (!todayNote) {
-        console.warn(`[zoe/daily-note] failed to create today note for owner ${ownerId}`);
+        console.error(`[zoe/daily-note] failed to create today note for owner ${ownerId}`);
+        failedOwners++;
         continue;
       }
 
@@ -443,6 +462,7 @@ export async function rolloverNotes(): Promise<string> {
 
       if (updateError) {
         console.error(`[zoe/daily-note] rollover update failed for owner ${ownerId}:`, updateError.message);
+        failedOwners++;
         continue;
       }
 
@@ -462,11 +482,21 @@ export async function rolloverNotes(): Promise<string> {
     }
 
     const summary = `rolled ${totalRolled} items, promoted ${totalPromoted}`;
+
+    // A partial failure is still a failure: the owners that errored have items
+    // stranded on yesterday's note, and tomorrow's run only looks at TODAY's
+    // note, so they are never picked up again unless this run is retried.
+    if (failedOwners > 0) {
+      const detail = `${summary} (${failedOwners}/${yesterdayNotes.length} owners failed)`;
+      console.error(`[zoe/daily-note] rollover partially failed: ${detail}`);
+      return { status: 'error', summary: detail };
+    }
+
     console.log(`[zoe/daily-note] rollover complete: ${summary}`);
-    return summary;
+    return { status: 'success', summary };
   } catch (err) {
     console.error('[zoe/daily-note] rolloverNotes error:', (err as Error)?.message ?? err);
-    return `error: ${(err as Error)?.message ?? 'unknown'}`;
+    return { status: 'error', summary: (err as Error)?.message ?? 'unknown' };
   }
 }
 

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -425,8 +425,22 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       async () => {
         if (!(await claimFire('daily-note-rollover'))) return;
         try {
-          const summary = await rolloverNotes();
-          console.log(`[zoe/scheduler] daily note rollover: ${summary}`);
+          const result = await rolloverNotes();
+          if (result.status === 'error') {
+            // Loud-fail: rolloverNotes swallows its own exceptions and reports
+            // the failure as a status, so this branch (not the catch) is what
+            // actually fires on a DB outage. Release the claim so the day is not
+            // recorded as rolled, and log at error level.
+            await releaseFire('daily-note-rollover');
+            console.error('[zoe/scheduler] daily note rollover failed:', result.summary);
+            return;
+          }
+          if (result.status === 'silent') {
+            await releaseFire('daily-note-rollover');
+            console.log('[zoe/scheduler] daily note rollover: nothing to roll (silent)');
+            return;
+          }
+          console.log(`[zoe/scheduler] daily note rollover: ${result.summary}`);
         } catch (err) {
           await releaseFire('daily-note-rollover');
           console.error('[zoe/scheduler] daily note rollover failed:', (err as Error).message);


### PR DESCRIPTION
## Executive Summary

ZOE's daily-note rollover runs at midnight New York and is the only thing that
carries an unfinished item from yesterday's note onto today's. If the database
is unreachable when it runs, the job caught its own error, returned a plain
string, and the scheduler printed that string at info level and marked the day
as rolled. Nothing looked broken. Yesterday's unfinished items just quietly
stopped existing on the board, because the next night's run only looks at
*today's* note - it never goes back two days.

This makes the job report a real status (`success` / `silent` / `error`), makes
a partial failure count as a failure, and makes the scheduler log at error level
and release the day's sentinel when the roll actually failed. Adds the first
tests for `daily-note.ts`.

## What breaks without the fix, concretely

1. Supabase is down (or the key rotates, or RLS denies the write) at 00:00
   America/New_York on day N.
2. `rolloverNotes()` hits the `if (error)` branch, logs, and returns the string
   `'error: DB query failed'`.
3. `rolloverNotes()` never throws, so the scheduler's `catch` - the only place
   that called `releaseFire` - is dead code. The sentinel written by
   `claimFire('daily-note-rollover')` stays on disk, so the day is recorded as
   already fired.
4. The scheduler prints `console.log('[zoe/scheduler] daily note rollover: error: DB query failed')`.
   Info level. Nothing pages, nothing alerts.
5. On day N+1 the job queries notes with `due = N`. The items that were stranded
   on day N-1 are not in that query. They are orphaned permanently.

Net effect: a transient DB blip silently deletes a day of carried work items
from the board, and the logs say the rollover ran.

## Before vs After

BEFORE - `bot/src/zoe/scheduler.ts`:
```ts
const summary = await rolloverNotes();       // always a string, never throws
console.log(`[zoe/scheduler] daily note rollover: ${summary}`);
} catch (err) {                              // unreachable on a DB error
  await releaseFire('daily-note-rollover');
```

AFTER:
```ts
const result = await rolloverNotes();
if (result.status === 'error') {
  await releaseFire('daily-note-rollover'); // day not recorded as rolled
  console.error('[zoe/scheduler] daily note rollover failed:', result.summary);
  return;
}
```

Also changed: the two per-owner failure paths inside `rolloverNotes` used to
`continue` past a failed write and still return a success-shaped summary. They
now increment `failedOwners`, and a non-zero count makes the whole run report
`error`. One owner's items being stranded is still items being stranded.

The `console.warn` on a failed today-note creation is now `console.error`, since
that path loses data.

## Biological analogy

This is the Heart's afferent path. The rollover is the beat that carries
unfinished intent from one day into the next. A beat that fails but reports a
pulse anyway is worse than one that fails loudly - the organism keeps acting as
if the signal arrived. This change gives the beat a real pulse signal instead of
a shrug.

## Evidence

Proven:
- New test `bot/src/zoe/__tests__/daily-note.test.ts` - 5 tests, all pass
  (`npx vitest run src/zoe/__tests__/daily-note.test.ts`).
- The tests are non-vacuous: mutating the fix so the DB-error path returns
  `silent` and the partial-failure path returns `success` fails 3 of the 5 tests.
- Full bot suite on this branch: 1744 passed, 1 failed. The one failure is
  `transcribe.test.ts` asserting a POSIX path separator on a Windows checkout,
  pre-existing and unrelated. Two further suites fail to *collect* locally
  because `grammy` is not installed in this checkout's `bot/node_modules` - also
  pre-existing and unrelated.
- `bot` typecheck: 177 errors on this branch, 177 errors on `origin/main`
  (identical count; all of them are the missing-`grammy` and pre-existing
  implicit-any noise in this local checkout). Zero errors in the changed files.
- Root repo `npm run typecheck`: exit 0.

Not tested here:
- No esbuild bundle/boot verify was run. Neither `esbuild` nor `grammy` is
  installed in `bot/node_modules` on this machine, so per
  `.claude/rules/silent-failure-guard.md` rule 3 a missing verifier is reported
  as not-run, not as a pass. CI is the gate for that.
- The scheduler wiring itself is not unit-tested (it would need node-cron and
  grammy mocks). The tested contract is the status `rolloverNotes` returns.

## Risks

Low. `rolloverNotes` had exactly one caller (`scheduler.ts`), and it is changed
in the same commit. The behaviour on the happy path is identical. The one
behavioural change beyond logging is that `releaseFire` now runs on the silent
and error paths, which is the same pattern the afferent-digest handler directly
above already uses.

## Also found, NOT fixed here (one PR per run)

In `src/lib/spore/trust.ts`, merged today in #2792. Flag-gated behind
`SPORE_TRUST_ENABLED` (default OFF) and not imported by any live route, so
neither is currently exploitable - but both should be fixed before it is wired:

1. Crash path instead of fail-closed. The structure check at line 376 validates
   `kind`, `nonce`, and `audience`, but not `issuer`. Line 426 then does
   `envelope.issuer.id`, so an envelope with no `issuer` throws a TypeError and
   the promise rejects, rather than returning the `REJECTED` assessment the
   module documents as its fail-closed contract.
2. Replay store is mutated before verification passes. Line 487 calls
   `replayStore.claim(envelope.issuer.id, envelope.nonce, envelope.id)`
   unconditionally, after the hash and signature checks are *recorded* but with
   no early return on either failing. An unauthenticated attacker can therefore
   burn arbitrary nonces under a victim issuer's scope with forged envelopes,
   so the issuer's real envelopes later come back `CONFLICT`. State mutation
   should happen only after signature verification succeeds.

Both need a decision from you on whether to fix now or when the flag is wired.

## Remaining work

- Completed: rollover status contract, scheduler loud-fail, first daily-note tests.
- Next: `daily-note.ts` uses UTC dates (`toISOString().slice(0,10)`) while the
  cron runs on `America/New_York`. The cron itself lands on the right date, but
  `appendItem` called after 20:00 Eastern writes to *tomorrow's* note. Not
  currently reachable (nothing calls `appendItem` outside the migration helper),
  so it is noted rather than fixed.
- Blocked: nothing.

## Translation layer

- Engineer: `rolloverNotes` now returns a discriminated status instead of a
  string; the caller branches on it instead of relying on an exception that a
  top-level try/catch guaranteed would never arrive.
- Architect: another instance of the green-while-broken class the silent-failure
  guard was written for. The scheduler's handlers are converging on one shape:
  status in, release-and-shout on error.
- Founder: a day of carried work items can no longer disappear from the board
  because of a transient database blip, and if it does fail you will see it.
- Investor: the board is the system of record for what the team owes each other.
  Silent data loss in that record is the kind of defect that erodes trust in the
  whole product; catching it in an unattended audit pass is the loop working.

Found by the unattended hourly repo auditor. Not merged, not pushed to main.

Generated with [Claude Code](https://claude.com/claude-code)
