### PR TITLE
doc 2181: ZABAL Gamez guest-stream recaps + media ingestor

### DIFF
--- a/research/media/2181-zabal-gamez-guest-stream-recaps/README.md
+++ b/research/media/2181-zabal-gamez-guest-stream-recaps/README.md
@@ -1,0 +1,133 @@
+---
+topic: media
+type: guide
+status: research-complete
+last-validated: 2026-08-02
+superseded-by:
+related-docs: 1453, 2153, 2179, 2141
+original-query: "Create a media ingestor and include the recent ZABAL Gamez livestreams in the repo + write about them. Ingest the recent Twitch VODs, transcribe, and produce a recap per stream."
+tier: STANDARD
+---
+
+# 2181 - ZABAL Gamez Guest-Stream Recaps (Aug 2026)
+
+> **Goal:** Get the recent ZABAL Gamez guest livestreams into the repo, written up. Four Twitch VODs ingested -> transcribed -> recapped. Also documents the media-ingestor pattern so this repeats.
+
+## The media-ingestor pattern (how these were made)
+
+- **Source -> transcript:** `~/bin/zao-ingest.sh` (universal source->transcript engine; whisper via `meeting/scripts/transcribe.sh`).
+- **The Twitch gotcha (fix noted):** `zao-ingest.sh` does NOT recognize `twitch.tv/videos/*` URLs - it treats them as a web page and fails. **Fix:** download audio with `yt-dlp -x --audio-format m4a` FIRST, then feed the local audio file to `zao-ingest.sh` (which handles local files). The clean follow-up is teaching `zao-ingest.sh` to route `twitch.tv` -> yt-dlp directly. Wrapper lives at `~/.zao/stream-ingest/run.sh`.
+- **Transcript -> recap:** one recap agent per transcript (grounded on the transcript only).
+- Raw transcripts stay off-repo (`~/.zao/stream-ingest/*.txt`); only the prose recaps land here. Recaps are from whisper auto-transcripts, so names/handles may be imperfect - flagged `[unclear]` where the transcript was garbled.
+
+## The streams (twitch.tv/bettercallzaal)
+
+| Stream | Length | VOD | Guest |
+|--------|--------|-----|-------|
+| w/Arun (DreamStarter) | 24:50 | [2835343130](https://www.twitch.tv/videos/2835343130) | Arun - AI marketing automation for creators |
+| w/Meta Mu (Gnome Pear Club) | 25:18 | [2834817913](https://www.twitch.tv/videos/2834817913) | Meta Mu - seed-saver community, live website build |
+| w/Danny (Unlock Protocol) | 34:31 | [2834431287](https://www.twitch.tv/videos/2834431287) | Danny Toms - on-chain ticketing / tournaments |
+| Brainstorm w/Nounish Prof | 39:03 | [2826447905](https://www.twitch.tv/videos/2826447905) | Nounish Prof - Sparkz / tokenless-empire brainstorm |
+
+(Not yet ingested - bigger lifts: ZAO-VILLE LIVE ~1h20, Solana TrencheZ ~3h18.)
+
+---
+
+## 1. Arun (DreamStarter)
+
+**What it was:** Zaal hosted Arun (8+yr web3, ex-Polygon/Matic CMO), founder of **DreamStarter** - an AI marketing-automation platform that frees creators (esp. musicians) from outreach/content/lead-gen busywork. Exploratory two-builders vibe.
+
+**Substance:**
+- DreamStarter "Dream Brief" ("dreamstorming"): enter an idea -> AI agents auto-generate a brief that drives all workflows.
+- Workflows demoed: market research agent, lead discovery + CRM (found ~600 scored leads), video clipper (YouTube -> captioned clips -> scheduled), AI explainer-video generator, Gmail drip sequences.
+- Real users: Arun's dad's etymology YouTube channel, Artisan Fam auto-clipping, India NGO/education orgs.
+
+**Quotes:** Arun - "Zabal is literally the only pillar holding up Web3 Music right now." Zaal - "I have a specific workflow I'd love to test... get one of our brands leveraging DreamStarter."
+
+**Follow-ups:** (1) Arun to add Zaal as co-dreamer on an open web3-music dream; (2) stand up a ZAO Fund project on DreamStarter; (3) test the video-clipper + email workflows with ZABAL Games brands for season 2.
+
+**Content angles:** "From idea to 600 relevant leads in 72 hours" · "Zabal + DreamStarter: automating the busywork so web3 artists can focus on their craft."
+
+---
+
+## 2. Meta Mu (Gnome Pear Club)
+
+**What it was:** Zaal live-built a community website with **Meta Mu** (founder of the Gnome Pear Club, a Frankie the Frog sub-community for seed savers) - deployed to Vercel in minutes with Claude Code + GitHub. Ties to the repo Zaal set up (`bettercallzaal/gnome-pear-club`).
+
+**Substance:**
+- Game loop: daily tree check-in -> earn pears -> redeem for rare seeds in a seed bank -> level up / craft -> marketplace.
+- Stack taught: GitHub (free) + Vercel (free, auto-deploy on main) + Claude Code ($20/mo).
+- Live demo: deployed the repo + added a dark-mode toggle on-stream, live in seconds. Meta Mu added as a repo collaborator.
+
+**Quotes:** Meta Mu - "I wanted to bring something tangible to Web3... from my life and my passions and my hobbies." On GitHub making sense: "Not really, but kind of." Zaal - "Don't get vendor locked in to any one thing, try things out."
+
+**Follow-ups:** custom domain (blocked on Zaal's domain skill); next session Meta Mu drives while Zaal narrates; use branches to test before merging.
+
+**Content angles:** "Non-technical founders ship a production site in 5 minutes with Claude Code + GitHub + Vercel" · "Building real-world community in Web3: seed-saving, gardening, camaraderie on-chain."
+
+---
+
+## 3. Danny Toms (Unlock Protocol) - doubles as Tuesday Unlock-DAO prep
+
+**What it was:** **Danny Toms** (Technology & Innovation Steward, Unlock Protocol) walked through using Unlock's smart contracts for ticketing, tournaments, escrow, and affiliate rewards - Unlock as an on-chain primitives layer, not just access control.
+
+**Substance:**
+- Danny's path: Buidl Guild / Speedrun ETH -> Gitcoin Moonshot -> Unlock (2022) -> Steward.
+- **T-Rex** (event ticketing): powers tournaments; event protection (auto-refund if min headcount unmet); on-chain escrow prize pools with a 30h dispute window; NFT tickets enable repeat-attendee discounts.
+- **P2E Inferno:** 3-level on-chain affiliate/referral (creator sets splits, unclaimed flows back); fiat card onramp mints NFTs (global cards, Venezuela/Nigeria examples).
+- **WaveWarZ x Unlock brainstorm:** NFT collectibles per daily battle, VIP ticket tiers for the October event, musician royalty/affiliate splits in-contract.
+
+**Follow-ups for the Tuesday Unlock DAO meeting:**
+1. **ZABAL Games collectible drops** - an Unlock lock per daily event (~11/week); test one week, maybe a cumulative meta-collectible.
+2. **WaveWarZ ticketing + royalty** - NFT battle tickets w/ repeat discounts; musician royalty splits auto-split via the affiliate contract; trader referral bonuses.
+3. **October event VIP tiers** - free tier + VIP via Unlock.
+4. **Fiat onramp** - Danny's card integration lowers friction for non-crypto musicians (WaveWarZ + artist-grant payouts).
+5. **Co-author a "musician use case" guide** - Unlock wants JS-framework + hooks tutorials; ZAO brings the creator angle.
+
+Contact (from transcript, verify): X @DannyToms; TG "Blackheart".
+
+**Content angles:** "Musicians winning with Unlock: NFT tickets + battle rewards" · "Build tournaments in an afternoon: Unlock powers on-chain events."
+
+---
+
+## 4. Nounish Prof - Sparkz / tokenless-empire brainstorm
+
+**What it was:** A 40-min brainstorm with **Nounish Prof** (Nouns educator/builder) on creator-coin fatigue and a build-first-tokenize-later model - mapping out **Sparkz** on Clanker V5. Directly feeds [doc 2179](../../business/2179-creator-organism-stack-sparkz/) (Sparkz as the creator-organism front door).
+
+**Ideas generated:**
+- **Sparkz** = a *tokenless* empire: start with a "Spark," progress via leaderboards/integrations, decide on a token *later* (or never). Counter to Base's "launch a token or die" push.
+- $25 no-code channel leaderboards (Empire Builder); Empire as a composable, white-label launchpad on Clanker with no vendor lock-in.
+- **Capsule** = a thematic collection (music drop + token idea + repo + content) under one umbrella.
+- AI-personality crowdsourcing: top holder/contributor adds a "line of soul code" daily.
+- Open-source PR tipping (Farcaster tipping culture -> GitHub PRs); Clanker Droids for agents (solve FID ownership + BYOK).
+- Teaching vibe-coding to non-technical creators (AI as debugger, not replacement; community as the real teacher).
+
+**Quotes:** Zaal - "I felt like the token was being pushed upon me to create." Prof (paraphrasing DWR) - "What would the token do? Until I have a good answer, I'm not launching a token."
+
+**Follow-ups:** Sparkz launching with Clanker V5 (~"one more week" from stream); release the open-source repo for community ideas before V5; a Farcaster space w/ Quazia + DiviFly + Berserker + Prof on V5; Nouns x ZAO teaching collab.
+
+**Content angles:** "Tokenless Empires - the tool that lets creators say 'not yet'" · "Vibe Coding - teaching musicians to code via AI + community."
+
+---
+
+## Also See
+
+- [Doc 2179](../../business/2179-creator-organism-stack-sparkz/) - Sparkz creator-organism stack (the Nounish Prof brainstorm feeds this).
+- [Doc 1453](../../agents/1453-summary-livestream-command-spec-jul2026/) - the `!summary` live-capture spec (complementary: live vs post-VOD).
+- [Doc 2153](../2153-zm-zao-media-aggregation-system/) - ZAO media aggregation.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Raise the 5 Unlock action items at the Tuesday Unlock DAO meeting | @Zaal | Meeting | 2026-08-04 |
+| Test DreamStarter with one ZAO brand (Arun to add Zaal as co-dreamer) | @Zaal | Follow-up | 2026-08-09 |
+| Next Gnome Pear Club session - Meta Mu drives, Zaal narrates | @Zaal | Stream | 2026-08-09 |
+| Fold the Nounish Prof Sparkz ideas into doc 2179's build path | @Zaal | Doc update | 2026-08-06 |
+| Teach `zao-ingest.sh` to route twitch.tv -> yt-dlp (so the ingestor is one-command) - PR | @Zaal | PR | 2026-08-09 |
+| Ingest the 2 bigger streams (ZAO-VILLE 1h20, Solana TrencheZ 3h18) | @Zaal | Ingest | when useful |
+
+## Sources
+
+- [FULL] Twitch VODs 2835343130 / 2834817913 / 2834431287 / 2826447905 (twitch.tv/bettercallzaal) - downloaded + transcribed via yt-dlp + whisper, 2026-08-02.
+- [FULL] Auto-transcripts at `~/.zao/stream-ingest/*.txt` (4319 / 4199 / 5247 / 7449 words) - each recap grounded on its transcript. Whisper auto-transcription; names/handles may be imperfect (flagged).


### PR DESCRIPTION
## Summary
Media-ingestor deliverable: the 4 recent ZABAL Gamez guest livestreams (Arun/DreamStarter, Meta Mu/Gnome Pear Club, Danny/Unlock, Nounish Prof/Sparkz brainstorm) ingested from Twitch VODs, transcribed, and recapped into the repo. Documents the ingestor pattern (yt-dlp -> zao-ingest.sh) + the Twitch-URL gotcha. Danny/Unlock recap doubles as Tuesday Unlock-DAO prep; Nounish Prof feeds doc 2179 (Sparkz).

## Tier
STANDARD

## Next Actions
See doc - 5 Unlock action items for Tue, DreamStarter test, Gnome Pear next session, teach zao-ingest.sh Twitch routing.