### PR TITLE
feat(zoe): add Learn topic (absorb + apply)

### DIFF
--- a/bot/src/zoe/topic-router.ts
+++ b/bot/src/zoe/topic-router.ts
@@ -38,6 +38,11 @@ export function routeTopic(topicName: string | undefined): TopicAction {
       return { kind: 'coding' };
     case 'Ideas':
       return { kind: 'capture', project: 'ideas' };
+    case 'Learn':
+      // Things to absorb + apply: podcasts/talks/articles to transcribe, distill,
+      // and turn into personal action. Captured under the `learn` project so they
+      // funnel to the one board and can be triaged into concrete todos.
+      return { kind: 'capture', project: 'learn' };
     case 'Newsletter':
       return { kind: 'draft', draftKind: 'newsletter', label: 'Newsletter draft' };
     case 'Farcaster':

--- a/bot/src/zoe/topics.ts
+++ b/bot/src/zoe/topics.ts
@@ -21,6 +21,7 @@ export const STANDARD_TOPICS = [
   'Farcaster',
   'Coding',
   'Ideas',
+  'Learn',
   'Newsletter',
   'WaveWarZ',
   'ZABAL Games',


### PR DESCRIPTION
Adds a Learn topic to ZAAL BOTZ - for podcasts/talks/articles to transcribe, distill, and turn into personal action. Routes to a learn capture on the board, triaged into todos. Type-safe: a new topic literal + a router case returning the existing capture shape.

Note: the actual Telegram forum topic gets created on the next /inittopics run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9