### PR TITLE
docs: meeting recap 2186 - ZAO launchpad + ZM livestream sync

### DIFF
--- a/research/events/2186-zao-launchpad-livestream-sync-jose-jim/README.md
+++ b/research/events/2186-zao-launchpad-livestream-sync-jose-jim/README.md
@@ -1,0 +1,72 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-08-03
+related-docs: "743, 1286, 1326"
+original-query: "/meeting on the Craig recording craig-3JJlYvlHZhYg (Zaal x Jose x Jim, ZAO launchpad + ZM livestream sync)"
+tier: STANDARD
+---
+
+# 2186 - ZAO launchpad + ZM livestream sync (Zaal x Jose x Jim)
+
+> **Goal:** Recap the 2026-08-03 Craig call. ZAO-relevant decisions + actions only;
+> personal discussion from the call is kept private off-repo, not recorded here.
+
+## Meeting
+
+- **Date:** 2026-08-03
+- **Duration:** ~1 hour
+- **Attendees:** Zaal Panthaki, Jose Acabrera, Jim (Crypto Endowment Network / "CCC")
+- **Platform:** Discord / Craig (multitrack, per-speaker tracks)
+- **Project:** ZAO Devz / general
+
+## Context
+
+A ZAO ecosystem sync. Three threads: Zaal's new daily ZM livestream, Jose's Fractal
+posts + community work, and Jim's token launchpad ("factory") built for ZAO and tied to
+the Crypto Endowment Network. Jim's launchpad is the substantive new item.
+
+## Decisions
+
+| # | Decision | Owner | Confidence |
+|---|----------|-------|-----------|
+| 1 | ZM daily livestream = Mon-Fri 5pm ET, 1 hour, scheduled 1hr before the Fractal. Song of the day + ecosystem updates. To Twitch/YouTube/X (LinkedIn/TG/IG/TikTok via Restream, TBD). | zaal | high |
+| 2 | Launch strategy: use Clanker at launch, AND offer Jim's ZAO Artist launchpad as another option. Keep it gated - ZAO curates who launches (no public/permissionless shitcoin launches). | zaal | high |
+| 3 | Jim's launchpad model: each artist gets a community token under the ZAO flag, launched against Spark + 3 endowment assets (stablecoin/BTC/ETH-pegged), with a slow auto-buy for artists; a third of flows support the Crypto Endowment Network (non-art causes - kids, trees, ocean, schools). | jim | medium |
+
+## Actions
+
+| Action | Owner | Why | Done when |
+|--------|-------|-----|-----------|
+| Try Jim's ZAO Artist launchpad this week; consider first launch with zaalcaster | zaal | Wants a ZAO launcher option beyond Clanker; ties to the zaalcaster token config (#712) | A test launch is run from the ZAO wallet through Jim's launchpad |
+| Get the launchpad contract address from Jim, feed it to AI to understand it | zaal | Jim has no human-readable docs; the contract is on-chain verified ("ask the robots what the contract does") | Zaal can explain what the launchpad contract does |
+| Join the AI-workshop Slack + confirm the Monday session | zaal | Workshop runs Mon + Wed; Zaal only got the Wednesday invite | Zaal is in the Slack + knows the Monday time |
+| Fractal post #2 today, #3 tomorrow; get Iman feedback on the webpage | jose | Two feedback sessions done, useful so far | Posts #2 + #3 published, Iman feedback captured |
+| Share the launchpad + zaalcaster with Dylan | zaal | Jose knows Dylan well; good fit | Dylan has seen the launchpad + zaalcaster |
+
+## Key quotes
+
+- Jim, on the launchpad being gated: "only you guys can curate who launches from your launchpad who is directly connected to your community ... I thought that you didn't want people just coming in here and launching shitcoins because it's fun."
+- Jim, on the endowment flow: "a third of the money still goes to feeding kids and planting trees and cleaning up the ocean and building schools."
+- Zaal, on the launcher strategy: "my goal is to use the clanker launcher at launch, but then have other options for other places we can launch like the Zao Artist launcher."
+- Zaal, on zaalcaster: "basically a GitHub that's my personal client to use to interact with Farcaster ... anyone that wants to help out build this repo out ... can fork it and make it a Jose caster or a James caster."
+
+## Research seeds
+
+- Jim's launchpad contract - verify what it does on-chain, compare to Clanker/Empire for the ZAO Artist launcher option
+- Crypto Endowment Network - the endowment-asset model (Spark + 3 pegged assets, asymmetrical locked-principal -> artist flow)
+
+## Note
+
+Personal discussion from this call (not ZAO business) is intentionally excluded from this
+recap and stored privately off-repo. The full raw transcript is not committed.
+
+## Also See
+
+- [Doc 743](../../wavewarz/743-*/) - WaveWarZ canonical (launch context)
+- [Doc 1286](../../business/1286-*/) / [Doc 1326](../../business/1326-*/) - Sparkz + Culture Coins
+
+## Sources
+
+- Craig multitrack recording craig-3JJlYvlHZhYg, transcribed locally (mlx-whisper) + merged by timestamp, 2026-08-03 [FULL]

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-08-03 | ZAO launchpad + ZM livestream sync | ZAO Devz | Zaal, Jose, Jim | [2186](2186-zao-launchpad-livestream-sync-jose-jim/) | 5 |
 | 2026-07-28 | Heart of Ellsworth Promotion Committee - ZAO Stock @ Art of Ellsworth | ZAO/events | Zaal, Laurel, Joy, Chesnee, Leslie | [2134](2134-heart-of-ellsworth-promo-jul28/) | 4 |
 | 2026-07-22 | Yulia x Zaal - job search + build-a-thon + Maine event | ZAO/network | Zaal, Yulia | [2128](2128-yulia-zaal-jobsearch-buildathon/) | 4 |
 | 2026-07-29 | Matteo Tambussi x Zaal - decentralized tooling + Spaghetti radio x ZAO streams | ZAO/partnership | Zaal, Matteo | [2129](2129-matteo-tambussi-decentralized-tooling/) | 4 |


### PR DESCRIPTION
/meeting recap of the 2026-08-03 Craig call (Zaal x Jose x Jim). ZAO decisions/actions only - personal discussion kept private off-repo, not committed. Jim's gated ZAO Artist launchpad (tied to the Crypto Endowment Network) is the key new item. 5 actions on the board (legacy_source meeting:2186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9