### PR TITLE
fix(heart-fleet): outbox reconciler could never abandon an unverifiable effect (attempts never incremented)

### DIFF
--- a/bot/src/zoe/__tests__/outbox-reconcile.test.ts
+++ b/bot/src/zoe/__tests__/outbox-reconcile.test.ts
@@ -130,6 +130,25 @@ describe('reconcileOutbox', () => {
     expect(row.last_error).toContain('at-most-once');
   });
 
+  it("counts each unresolved pass so an 'unknown' row reaches the ceiling (production starts at attempts=0)", async () => {
+    // claimIntent inserts attempts=0 and nothing else ever writes the column, so
+    // a real stale row starts here. Without per-pass counting the ceiling is
+    // unreachable and the row is revisited forever, never reaching a terminal state.
+    client.seedDispatched('e-real', 'telegram', 0);
+
+    const first = await reconcileOutbox(ledger, { maxAttempts: 2, now: NOW });
+    expect(first.left).toBe(1);
+    expect([...client.rows.values()][0].attempts).toBe(1);
+
+    const second = await reconcileOutbox(ledger, { maxAttempts: 2, now: NOW });
+    expect(second.left).toBe(1);
+    expect([...client.rows.values()][0].attempts).toBe(2);
+
+    const third = await reconcileOutbox(ledger, { maxAttempts: 2, now: NOW });
+    expect(third.abandoned).toBe(1);
+    expect([...client.rows.values()][0].state).toBe('abandoned');
+  });
+
   it('scans nothing when there are no stale dispatched rows', async () => {
     const s = await reconcileOutbox(ledger, { now: NOW });
     expect(s.scanned).toBe(0);

--- a/packages/heart-fleet/src/durable-effect-ledger.ts
+++ b/packages/heart-fleet/src/durable-effect-ledger.ts
@@ -180,6 +180,28 @@ export class DurableEffectLedger implements EffectLedger {
     await this.logAttempt(runId, effectKey, 0, 'reconciled', { reopened: true });
   }
 
+  /**
+   * Reconciler bookkeeping: record ONE unresolved reconcile pass on a stale
+   * dispatched row. `attempts` is inserted as 0 by claimIntent and no other path
+   * writes it, so without this the reconciler's abandon ceiling can never be
+   * reached and an unverifiable row is revisited forever instead of reaching a
+   * terminal state. Conditional on state='dispatched' so a row that got resolved
+   * concurrently is not touched. Returns the recorded count.
+   */
+  async noteUnresolved(runId: string, effectKey: string, currentAttempts: number): Promise<number> {
+    const next = (Number.isFinite(currentAttempts) ? currentAttempts : 0) + 1;
+    const { error } = await this.client
+      .from(this.intents)
+      .update({ attempts: next })
+      .eq('run_id', runId)
+      .eq('effect_key', effectKey)
+      .eq('state', 'dispatched')
+      .select('run_id')
+      .maybeSingle();
+    if (error) throw new Error(`noteUnresolved failed: ${error.message}`);
+    return next;
+  }
+
   /** Reconciler outcome: give up past the attempt ceiling (terminal). */
   async abandon(runId: string, effectKey: string, reason: string): Promise<void> {
     await this.client

--- a/packages/heart-fleet/src/reconcile.ts
+++ b/packages/heart-fleet/src/reconcile.ts
@@ -80,7 +80,10 @@ export async function reconcileOutbox(
         await ledger.reopen(intent.run_id, intent.effect_key, 'reconciler: provably not sent, reopened for retry');
         summary.reopened++;
       } else {
-        // unknown - never resend (at-most-once). Abandon past the ceiling.
+        // unknown - never resend (at-most-once). Abandon past the ceiling. The
+        // count lives on the row and is bumped once per unresolved pass below;
+        // nothing else writes `attempts`, so skipping that bump would make this
+        // ceiling unreachable and leave the row dispatched forever.
         if (intent.attempts >= maxAttempts) {
           await ledger.abandon(
             intent.run_id,
@@ -89,6 +92,7 @@ export async function reconcileOutbox(
           );
           summary.abandoned++;
         } else {
+          await ledger.noteUnresolved(intent.run_id, intent.effect_key, intent.attempts);
           summary.left++;
         }
       }


### PR DESCRIPTION
# Executive Summary

The outbox reconciler had a counter nobody incremented, so its safety valve could never open.

When ZOE sends something outward (a Telegram message, a cast) it goes through the transactional outbox: claim the intent, verify the lease, mark dispatched, send, mark committed. If the process crashes between "send" and "mark committed", the row is stuck in `dispatched` and nobody knows whether the message actually went out. The reconciler resolves those rows. For a channel that cannot be probed - Telegram has no "did I send X?" query - the design says: never resend (that would risk a duplicate), and after N unresolved passes, mark the row `abandoned` so it lands in a visible terminal state instead of being silently lost.

That abandon branch was unreachable. It was gated on `intent.attempts >= maxAttempts`, but `attempts` is written exactly once - as `0`, by `claimIntent` - and no code path, trigger, or migration ever incremented it. So the comparison was permanently `0 >= 5 = false`. Every unverifiable row was counted as `left` and re-scanned on every reconcile pass, forever, and never reached the terminal state the design promises.

Fix: a `noteUnresolved()` ledger method records one unresolved pass on the stale row, and the reconciler calls it in the `left` branch. The ceiling is now reachable. 46 lines, no behavior change to any other path.

# What breaks without the fix, concretely

With `ZOE_HEART_FLEET_CANARY` + `ZOE_OUTBOX_DEMO` on (both currently default OFF, which is why this is not a live outage today):

1. ZOE claims a Telegram send, marks it `dispatched`, sends it, then the process dies before `markCommitted` - a restart, an OOM, a redeploy.
2. Next canary beat runs `reconcileOutbox`. No Telegram probe exists, so the probe result is `unknown`. Correct call: do not resend.
3. `intent.attempts` is `0`. `0 >= 5` is false, so the row is counted as `left`.
4. Nothing writes `attempts`. Step 3 repeats identically on every beat - forever.

Result: the row lives in `dispatched` permanently. It never becomes `abandoned`, so nothing ever surfaces it as a failed effect; it is re-probed and re-logged on every reconcile pass for the lifetime of the table; and every stuck row adds permanent per-pass work to `findStaleDispatched` (capped at 50/run, so enough of them starve real reconciliation of newer rows). This is precisely the failure mode `.claude/rules/silent-failure-guard.md` rule 6 names - a soft-fail that is silent instead of loud.

The existing test suite passed because the `attempts >= ceiling` case was covered by seeding `attempts: 5` into the fake store by hand. The fixture supplied a value production never produces - a green test over a dead code path.

# Before vs After

BEFORE
- `claimIntent` inserts `attempts: 0`. Nothing else ever writes the column.
- `reconcileOutbox` reads `intent.attempts` and compares to `maxAttempts`; the comparison can never be true.
- `unknown` rows: `left` forever. `abandon()` is dead code in production.

AFTER
- `DurableEffectLedger.noteUnresolved(runId, effectKey, currentAttempts)` writes `attempts = currentAttempts + 1`, conditional on `state = 'dispatched'` so a row resolved concurrently is untouched.
- `reconcileOutbox` calls it in the `left` branch. A row escalates `0 -> 1 -> ... -> maxAttempts`, then hits the abandon branch and reaches the terminal state with the existing "unverifiable send, not resent, at-most-once" reason.
- At-most-once is unchanged: nothing new is ever resent. The only new write is a counter.

# Biological analogy

Bloodstream / Heart. The outbox is how the organism's signals actually leave the body, and the reconciler is the immune response that cleans up a signal whose delivery is unconfirmed. It was told to give up after five failed identifications - but had no way to remember how many times it had already tried. So it re-examined the same unresolvable cell on every heartbeat, forever, and never quarantined it. This restores the memory of the count, so quarantine actually happens.

# Evidence

Proven:
- Bug confirmed by grep: `attempts` appears in `packages/heart-fleet/src/` exactly three times - the type declaration, the `attempts: 0` insert in `claimIntent`, and the read in `reconcile.ts:84`. No increment anywhere in the repo. `scripts/2148-transactional-outbox.sql` has only `attempts INT NOT NULL DEFAULT 0` - no trigger, no function.
- New test fails on the pre-fix code with the exact predicted symptom: `AssertionError: expected +0 to be 1` at `outbox-reconcile.test.ts:141`, and passes after the fix.
- Bot suite: 1762 passed -> 1763 passed (the one added test). No test dropped.
- `tsc --noEmit`: 40 errors before the change, 40 after - zero regression, and zero in any changed file (`grep -E "heart-fleet|reconcile|durable-effect|outbox"` over the tsc output returns nothing). Those 40 are a local artifact of installing `bot/` deps with `--no-save` rather than the lockfile; they are pre-existing and identical on unmodified `origin/main` (verified by `git stash`).
- Secret/PII scan over the diff (case-insensitive, run as its own step): clean.

Not fixed here, flagged instead (one-PR rule):
- `bot/src/zoe/__tests__/transcribe.test.ts` fails on Windows only - `path.join('/tmp/zoe-files', 'photo.jpg')` yields `\tmp\zoe-files\photo.jpg`, and the assertion is `toContain('/tmp/zoe-files')`. Pre-existing, verified failing on unmodified `origin/main`; passes on Linux CI. A one-line `path.join`-based assertion would fix it.
- `sendOnce` does not increment `attempts` on a real dispatch either. Left alone deliberately: it interacts with the reopen/re-dispatch cycle and needs its own decision about whether the ceiling counts physical sends or reconcile passes. This PR makes the counter mean "unresolved reconcile passes", which is what the reconciler's own comment describes.
- `hasClaudeApiKey()` in `bot/src/zoe/models/router.ts` is defined and never used. Style-level, skipped.

# Risks

- Low. One additional conditional UPDATE per unresolved row per reconcile pass, only on rows that were already being scanned. No new external call, no resend, no schema change (the column already exists).
- The counter now escalates, so rows that previously sat forever will start reaching `abandoned`. That is the intended behavior, and it will make previously-invisible stuck effects visible in `effect_intents` - expect some to appear the first time this runs against a table that already has stuck rows.
- Both consuming flags (`ZOE_HEART_FLEET_CANARY`, `ZOE_OUTBOX_DEMO`) are default OFF, so merging changes nothing in prod until they are flipped.

# Anti-bloat pass (loop-evals gate C)

- No duplicated block: `noteUnresolved` follows the exact shape of the neighbouring `reopen`/`abandon` methods on the same class.
- Not a variant of an existing function: `reopen`/`abandon` are state transitions; this is a counter bump on an unchanged state.
- No dead code, no unused imports, no commented-out blocks left behind.
- 46 lines added / 1 changed across 3 files for a bug + its regression test. Scope is only the reconciler ceiling; no drive-by edits.

# Translation layer

- Engineer: `effect_intents.attempts` was write-once-at-0, so `attempts >= maxAttempts` in `reconcile.ts` was unreachable; added a conditional increment and called it in the `left` branch.
- Architect: the Bloodstream's at-most-once guarantee kept its safety property (never resend) but lost its liveness property (always terminate). Terminal states are what make a durable ledger auditable; without them the ledger grows a permanent tail of undecidable rows.
- Founder: an outbound message whose delivery we could not confirm used to disappear into a state nobody was ever told about. Now it ends up in a state you can query and act on.
- Investor: exactly-once outbound delivery with an auditable terminal state for every effect is the hard part of an autonomous agent that spends money and talks to people. This closes the last hole in that ledger.

Found by the unattended hourly repo auditor. One PR per run, no merges - Zaal merges.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
