### PR TITLE
fix(zoe): a negated approval verb approved the plan ("no, don't do it" dispatched it)

### DIFF
--- a/bot/src/zoe/__tests__/approvals.test.ts
+++ b/bot/src/zoe/__tests__/approvals.test.ts
@@ -159,6 +159,38 @@ test('an approval verb anywhere overrides a leading reject ("no but go ahead")',
   assert.equal(parseApprovalReply('no but go ahead').decision, 'approve-all');
 });
 
+test('a NEGATED approval verb never approves ("no, don\'t do it")', () => {
+  // The approve-anywhere override used to fire on the verb inside a negation,
+  // so a rejection containing "do it"/"ship it"/"go ahead" was parsed as
+  // approve-all and the plan dispatched.
+  for (const t of [
+    "no, don't do it",
+    "don't do it",
+    "do not ship it",
+    "no, don't go ahead",
+    "nope, don't send it",
+    "no do it",
+    "never do it",
+    "can't ship it",
+  ]) {
+    assert.notEqual(parseApprovalReply(t).decision, 'approve-all', `"${t}" must not approve`);
+    assert.notEqual(parseApprovalReply(t).decision, 'approve-ids', `"${t}" must not approve`);
+  }
+});
+
+test('leading "don\'t" / "do not" resolve to reject', () => {
+  for (const t of ["don't do it", "don't", 'do not ship it', "no, don't do it"]) {
+    assert.equal(parseApprovalReply(t).decision, 'reject', `"${t}" should reject`);
+  }
+});
+
+test('negation detection does not swallow real approvals', () => {
+  assert.equal(parseApprovalReply('no but go ahead').decision, 'approve-all');
+  assert.equal(parseApprovalReply('change nothing, ship it').decision, 'approve-all');
+  assert.equal(parseApprovalReply('actually yes do it').decision, 'approve-all');
+  assert.equal(parseApprovalReply("don't wait, ship it").decision, 'approve-all');
+});
+
 test('a bare edit keyword with no content is NOT an edit (leaves pending)', () => {
   // "wait" alone used to become edit with empty text → empty re-decompose.
   assert.equal(parseApprovalReply('wait').decision, 'not-an-approval');

--- a/bot/src/zoe/approvals.ts
+++ b/bot/src/zoe/approvals.ts
@@ -180,14 +180,20 @@ const PENDING_FILE = join(ZOE_PATHS.home, 'pending-approvals.json');
 // In-memory store, one pending item per chat scope. Mirror of disk.
 const pendingByScope = new Map<string, PendingApproval>();
 
-const REJECT_RE = /^\s*(n|no|nope|cancel|stop|abort|skip|nah|nvm|never\s*mind)\b/i;
+const REJECT_RE = /^\s*(n|no|nope|cancel|stop|abort|skip|nah|nvm|never\s*mind|don'?t|do\s+not)\b/i;
 const APPROVE_RE = /^\s*(y|yes|yep|yeah|yup|approve|approved|go|go ahead|ship it|ship|send it|do it|lgtm|sounds good)\b/i;
 const EDIT_RE = /^\s*(edit|revise|change|tweak|adjust|instead|actually|no but|wait)\b[:,]?\s*(.*)/i;
 // An explicit approval verb appearing ANYWHERE (not just at the start). Used to
 // override a leading edit/reject prefix (doc 770 MED): "actually yes do it" and
 // "no but go ahead" are approvals, not edits/rejects. Conservative — omits the
 // bare "y"/"go"/"ship" forms that would false-positive mid-sentence.
-const APPROVE_ANYWHERE_RE = /\b(yes|yep|yeah|yup|approved?|go ahead|ship it|send it|do it|lgtm|sounds good)\b/i;
+const APPROVE_ANYWHERE_RE = /\b(yes|yep|yeah|yup|approved?|go ahead|ship it|send it|do it|lgtm|sounds good)\b/gi;
+// A negation ADJACENT to the approval verb inverts it: "no, don't do it" and
+// "do not ship it" are rejections, not approvals. Only an immediately-preceding
+// negator (plus at most two filler words) counts, so the contrastive
+// "no but go ahead" / "change nothing, ship it" stay approvals.
+const NEGATED_APPROVE_TAIL_RE =
+  /\b(?:do\s*not|don'?t|does\s*not|doesn'?t|did\s*not|didn'?t|cannot|can'?t|won'?t|wouldn'?t|shouldn'?t|never|not|no|hold\s+off(?:\s+on)?)\s*[,:-]?\s+(?:(?:really|just|please|actually|ever|yet|still|you|i|we|to|go|maybe)\s+){0,2}$/i;
 // Subtask / patch / proposal ids: st-1, patch-2, lp-3, etc.
 const ID_RE = /\b((?:st|patch|lp|sq|task)-[a-z0-9]+)\b/gi;
 
@@ -206,7 +212,7 @@ export function parseApprovalReply(text: string): ApprovalReply {
   const trimmed = text.trim();
   if (!trimmed) return { decision: 'not-an-approval', ids: [] };
 
-  const containsApprove = APPROVE_ANYWHERE_RE.test(trimmed);
+  const containsApprove = hasUnnegatedApproval(trimmed);
 
   if (REJECT_RE.test(trimmed) && !containsApprove) {
     return { decision: 'reject', ids: [] };
@@ -228,6 +234,18 @@ export function parseApprovalReply(text: string): ApprovalReply {
   }
 
   return { decision: 'not-an-approval', ids: [] };
+}
+
+/**
+ * True when an approval verb appears WITHOUT an adjacent negation. Used for the
+ * approve-anywhere override, so "no but go ahead" still approves while
+ * "no, don't do it" does not.
+ */
+function hasUnnegatedApproval(text: string): boolean {
+  for (const m of text.matchAll(APPROVE_ANYWHERE_RE)) {
+    if (!NEGATED_APPROVE_TAIL_RE.test(text.slice(0, m.index))) return true;
+  }
+  return false;
 }
 
 function extractIds(text: string): string[] {


### PR DESCRIPTION
## Executive summary

ZOE's human approval gate could read a rejection as a full approval. In
`bot/src/zoe/approvals.ts`, `parseApprovalReply` treats an approval verb appearing
ANYWHERE in the reply as an override that beats the reject branch (doc 770 MED, so
that "no but go ahead" approves). That check did not care whether the verb sat
inside a negation - so "no, don't do it" contains "do it", the reject branch was
suppressed, and the message resolved to `approve-all`.

## What breaks without this fix, concretely

`bot/src/zoe/index.ts:1821` runs every DM against `parseApprovalReply` while a
pending approval is armed, and any non-`not-an-approval` decision goes straight to
`resolvePendingApproval` (`index.ts:2485`). `approve-all` there means:

- `plan` / `plan-gate` -> `runApprovedPlan(...)` - dispatches the worker agents
- `reflexion` -> `applyReflexionPatches(...)` - writes the proposed memory patches
- `learn` -> `applyLearnProposals(...)` - applies the self-improvement proposals
- `bonfire-submission` -> promotes the submission into the knowledge graph

So Zaal typing the most natural refusal - "no, don't do it", "do not ship it",
"nope, don't send it", "never do it" - dispatched the thing he was declining. The
gate inverted on exactly the phrasing a human uses to say no. Verified against
the live parser, not inferred: the new tests fail on `main` (2 failing assertions)
and pass with the fix.

## The fix (2 files, 53 insertions)

- The approve-anywhere override now requires an UNNEGATED approval verb. A negator
  immediately before the verb (allowing at most two filler words) disqualifies that
  match; a message with no unnegated approval verb falls through to reject.
- Adjacency is what keeps the earlier fix intact: "but" and "nothing," are not
  adjacent negators, so `no but go ahead`, `change nothing, ship it` and
  `actually yes do it` still approve (covered by tests).
- `REJECT_RE` also learns the leading `don't` / `do not` forms, so
  "don't do it" cancels cleanly instead of passing through as a normal turn.

No behavior change to arming, TTL, persistence, or the clobber guard.

## Evidence

- 3 new tests, RED before the fix (`"no, don't do it" must not approve`,
  `"don't do it" should reject`), GREEN after.
- `npx vitest run src/zoe/__tests__/approvals.test.ts`: 21 -> 24 passing.
- Full bot suite: 1766 passing before, 1769 after, no new failures.
- `npx tsc --noEmit` in `bot/`: 40 errors before AND after - all pre-existing,
  none in `approvals.ts`.
- One pre-existing bot test failure, unchanged by this PR:
  `src/zoe/__tests__/transcribe.test.ts > downloadTelegramFile` fails identically
  on clean `main` (Windows path-separator assertion on `photo.jpg`).

## Other things this audit pass saw (NOT fixed here - one PR only)

- `bot/src/zoe/cost-ledger.ts:60` - `recordCall` swallows every write error, and
  `todaySummary` returns `[]` on any read error. `cost-governance.ts` computes the
  95% hard stop from that ledger, so a silently unwritable `~/.zao/zoe/cost/` reads
  as $0 spend and the spend guard never trips. Fail-open on a cost control.
- `bot/src/zoe/mcp/farcaster-client.ts:16` resolves the server path from
  `import.meta.url` and spawns bare `tsx`. Fine today (no caller yet), but it will
  not resolve from a bundled/`dist` boot - worth pinning before ZOE calls it.
- "Research index (CI-owned)" is still red on `main`; that is already covered by
  the open PR #2786, so nothing new opened for it.

Not merged, not pushed to main - branch + PR only.
