### PR TITLE
fix(zoe): relay bridge marked relays pushed to Telegram even when every send failed

### DIFF
--- a/bot/src/zoe/__tests__/relay-bridge.test.ts
+++ b/bot/src/zoe/__tests__/relay-bridge.test.ts
@@ -161,4 +161,30 @@ describe('pushInboundRelays', () => {
     delete process.env.COWORK_TRACKER_URL;
     delete process.env.COWORK_TRACKER_KEY;
   });
+
+  it('does NOT mark pushed (or arm the reply path) when every Telegram send fails', async () => {
+    process.env.COWORK_TRACKER_URL = 'https://x.test';
+    process.env.COWORK_TRACKER_KEY = 'k';
+    const hub = { id: 'h1', metadata: { relays: [rel({ from: 'cowork', to: 'zoe', ts: 'a', tg_pushed: false })] } };
+    const writes: string[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      if (init?.method === 'POST') writes.push(url);
+      return { ok: true, text: async () => JSON.stringify([hub]) } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const sendMessage = vi.fn(async () => {
+      throw new Error('telegram 429');
+    });
+    const recordContext = vi.fn(async () => {});
+    const armPending = vi.fn();
+    const n = await pushInboundRelays({ chatId: 999, sendMessage, now: () => 't', recordContext, armPending });
+    // the relay stays pending so the next tick retries it - not silently dropped
+    expect(n).toBe(0);
+    expect(writes).toEqual([]);
+    expect(recordContext).not.toHaveBeenCalled();
+    expect(armPending).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+    delete process.env.COWORK_TRACKER_URL;
+    delete process.env.COWORK_TRACKER_KEY;
+  });
 });

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -232,6 +232,13 @@ export async function pushInboundRelays(deps: RelayBridgeDeps): Promise<number> 
         formatInboundDm(r),
         { replyMarkup: replyKeyboard(r.from), markupOn: 'last' },
       );
+      // sendChunkedToTelegram swallows per-chunk send errors and returns null
+      // ONLY when every chunk failed - so the catch below never fires on a send
+      // failure. Marking tg_pushed there would permanently drop the relay (it is
+      // the only dedup gate and is never re-evaluated), and would also arm the
+      // gesture-free reply path for a message Zaal never saw. Leave it unpushed
+      // so the next tick retries. (silent-failure-guard rules 1 + 6.)
+      if (sent == null) continue;
       pushedTs.add(r.ts);
       // Register message_id -> rl-<lane> so a plain reply to THIS message routes
       // back to the lane (no button tap). Best-effort - never blocks the push.


### PR DESCRIPTION
## Executive summary

The ZOE relay bridge (Telegram side of the fleet relay) could permanently lose a
relay message. When a relay was pushed to Zaal's DM and every Telegram send
attempt failed, the bridge still recorded it as delivered. The message is never
retried and never surfaces again. This PR makes the bridge only mark a relay
delivered when a send actually succeeded, plus a regression test.

Scope: 2 files, 33 added lines, no deletions. Behaviour change is one guard.

## Why this matters

`tg_pushed` is the bridge's ONLY dedup gate (deliberately separate from the
terminal's `read` flag - see the module header). Once it flips true, the relay is
filtered out of `pendingInbound` forever. So a failed delivery is not a delayed
delivery, it is a lost message: a terminal relays something to the `zoe` lane,
Telegram 429s / times out, and Zaal never sees it - with no error visible
anywhere, because the send path swallows its own errors.

## What breaks without the fix, concretely

`bot/src/zoe/relay-bridge.ts` `pushInboundRelays`:

```ts
const sent = await sendChunkedToTelegram(...);
pushedTs.add(r.ts);            // <- unconditional
...
} catch {
  // one send failure does not block the others; leave it unpushed to retry next tick
}
```

`sendChunkedToTelegram` (`bot/src/zoe/tg-chunk.ts:66-76`) wraps every chunk send
in its own `try {} catch {}` and returns `markupResult ?? last`, i.e. `null` when
every chunk failed. It never throws. So:

1. The `catch` block above is unreachable on a send failure, and its
   "leave it unpushed to retry next tick" comment never applies.
2. `pushedTs.add(r.ts)` runs anyway -> `saveHubRelays` writes `tg_pushed: true`
   -> `pendingInbound` skips it forever. Message lost.
3. Same path then calls `armPending(chatId, 'rl-<lane>')`, arming the
   gesture-free reply state for a message Zaal never received. His next plain
   message in General gets relayed to that lane as the answer to an invisible
   question.

Trigger conditions are ordinary Telegram failures: 429 rate limit, 5xx, network
timeout, a chat/permission error.

## The fix

```ts
if (sent == null) continue;   // every chunk failed - leave unpushed, retry next tick
pushedTs.add(r.ts);
```

`null` is returned only when ALL chunks failed (a partial failure still returns
the last successful message), so this does not regress the partial-send case.

## Evidence (proven)

- New test `does NOT mark pushed (or arm the reply path) when every Telegram send fails`.
- Proven to catch the bug: with the guard line temporarily removed, that test
  FAILS with `AssertionError: expected 1 to be +0` (the relay got marked pushed).
  With the guard in place it passes.
- `vitest run` on `bot/src/zoe/__tests__/relay-bridge.test.ts` +
  `tg-chunk.test.ts`: **24 passed / 24** (relay-bridge 12 -> 13 tests, no
  coverage regression).
- The `sent == null` narrowing on an `unknown` compiles under `tsc --strict`
  (checked in isolation).

## Not verified

- Full `npm run typecheck` and `npm run test` were NOT run: this audit checkout
  has no `node_modules` installed (root and `bot/`), so the suites could not run
  here. Tests above were run with a standalone `vitest@3.2.4` against the two
  dependency-free test files. CI should confirm the full suites.

## Other things seen this pass (NOT fixed here, one-PR limit)

- `bot/src/zoe/relay-bridge.ts:243` - `deps.armPending?.(...)` is called once per
  relay inside the loop, so when several relays arrive in one tick only the LAST
  lane stays armed; Zaal's next typed message answers that one. Arguably
  intended, flagged rather than changed.
- The `catch {}` at the end of that loop is now dead for send failures (it only
  covers `recordContext` throwing, which is already `.catch`ed). Left alone to
  keep the diff minimal.
