### PR TITLE
fix(zoe): research pipeline operational - doc collisions + command mis-parse

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Union-merge append-only research prose so concurrent doc-index appends don't
+# conflict. When two research docs land at once, each appends a row to a topic
+# README.md; without a union driver git can't auto-merge the two appends and the
+# branch conflicts on every landing. See .claude/rules/agent-loops.md rule 29.
+#
+# SCOPED TO RESEARCH MARKDOWN ONLY. Union merge is safe for append-only prose
+# (it dedupes/concatenates lines); it is NEVER safe on code, where it duplicates
+# blocks and drops braces. Do NOT extend this to *.ts / source files.
+research/**/*.md merge=union

--- a/bot/src/zoe/__tests__/research-dedupe.test.ts
+++ b/bot/src/zoe/__tests__/research-dedupe.test.ts
@@ -1,7 +1,43 @@
 import { describe, it, expect, vi } from 'vitest';
-import { extractFirstUrl, normalizeUrl, wasResearched } from '../research-dedupe';
+import {
+  extractFirstUrl,
+  isFollowUpNotResearch,
+  normalizeUrl,
+  wasResearched,
+} from '../research-dedupe';
 
 describe('research-dedupe', () => {
+  describe('isFollowUpNotResearch', () => {
+    it('reroutes conversational commands aimed at ZOE (the audit bug)', () => {
+      // The exact phrase that got queued as a research task (audit afaa850).
+      expect(isFollowUpNotResearch('can u share it with me')).toBe(true);
+      expect(isFollowUpNotResearch('can you send it to me')).toBe(true);
+      expect(isFollowUpNotResearch('share the doc')).toBe(true);
+      expect(isFollowUpNotResearch('resend it')).toBe(true);
+      expect(isFollowUpNotResearch('pls send me that doc')).toBe(true);
+    });
+
+    it('reroutes short replies / acknowledgements', () => {
+      expect(isFollowUpNotResearch('thanks')).toBe(true);
+      expect(isFollowUpNotResearch('yes please')).toBe(true);
+      expect(isFollowUpNotResearch('ok cool')).toBe(true);
+      expect(isFollowUpNotResearch('')).toBe(true);
+      expect(isFollowUpNotResearch('nvm')).toBe(true);
+    });
+
+    it('keeps genuine research subjects as research', () => {
+      expect(isFollowUpNotResearch('vector database options for RAG')).toBe(false);
+      expect(isFollowUpNotResearch('research the Audos platform summer camp')).toBe(false);
+      expect(isFollowUpNotResearch('deep dive on Farcaster mini apps')).toBe(false);
+      expect(isFollowUpNotResearch('how do rollups handle data availability now')).toBe(false);
+    });
+
+    it('always treats a URL as a research subject even with command words', () => {
+      expect(isFollowUpNotResearch('can u look at https://example.com/x')).toBe(false);
+      expect(isFollowUpNotResearch('share https://example.com/y')).toBe(false);
+    });
+  });
+
   describe('extractFirstUrl', () => {
     it('extracts a URL from text', () => {
       expect(extractFirstUrl('research this https://example.com/page')).toBe(

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -110,7 +110,7 @@ import { recordMessageContext, getMessageContext, clearMessageContext } from './
 import { takePendingAnswer } from './pending-answers';
 import { tryInstantRelayReply } from './relay-bridge';
 import { commitResearchDoc } from './research-doc';
-import { extractFirstUrl, wasResearched } from './research-dedupe';
+import { extractFirstUrl, isFollowUpNotResearch, wasResearched } from './research-dedupe';
 import { enqueueTurn } from './turn-queue';
 import {
   getPending,
@@ -1507,6 +1507,14 @@ bot.on('message:text', async (ctx) => {
         // Override the draft routing to chat routing when we have brand context.
         action = { kind: 'chat' };
       }
+    }
+
+    // Research topic reroute: a plain topic or URL is a research subject, but a
+    // conversational follow-up/command ("can u share it with me", "thanks") is
+    // NOT - queuing it spins a worker to "research" that phrase (audit afaa850).
+    // Reroute those to chat so ZOE answers instead of producing a junk doc.
+    if (action.kind === 'research' && !extractFirstUrl(text) && isFollowUpNotResearch(text)) {
+      action = { kind: 'chat' };
     }
 
     // Bridge log: record EVERY ZAAL BOTZ turn (all topics, incl auto-act ones)

--- a/bot/src/zoe/research-dedupe.ts
+++ b/bot/src/zoe/research-dedupe.ts
@@ -18,6 +18,40 @@ export function extractFirstUrl(text: string): string | null {
 }
 
 /**
+ * Decide whether a message dropped in the Research topic is a conversational
+ * follow-up / command TO ZOE ("can u share it with me", "thanks", "send it")
+ * rather than an actual research subject. The Research topic auto-enqueues every
+ * plain message as a research task (topic = intent), so without this guard a
+ * reply like "can u share it with me" gets queued as a research goal and ZOE
+ * spins up a worker to "research" that phrase (audit afaa850, 2026-08-04).
+ *
+ * Bias: a URL or an explicit research verb is ALWAYS a research subject. Only the
+ * obvious command/reply family is rerouted; a genuine multi-word topic with no
+ * command markers still researches. A false skip just makes ZOE answer in chat
+ * (recoverable); a false research produces a junk doc (the bug we're fixing).
+ *
+ * Returns true when the message should be treated as chat, not research.
+ */
+export function isFollowUpNotResearch(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (!t) return true; // empty is not a research subject
+  if (/https?:\/\//.test(t)) return false; // a URL is always a research subject
+  // Explicit research intent always wins over the command heuristics below.
+  if (/^(research|look into|deep dive|dig into|find out|study|investigate|explore|analyz|analys|compare|summari)/.test(t)) {
+    return false;
+  }
+  // Conversational command/question aimed at ZOE about prior work, not a topic.
+  if (/^(can|could|would|will)\s+(you|u|ya)\b/.test(t)) return true; // "can u share it with me"
+  if (/^(pls|plz|please|share|send|show|give|resend|forward|link|thanks|thank|ty|ok|okay|cool|nice|great|yes|yep|no|nope|sure|nvm)\b/.test(t)) {
+    return true;
+  }
+  if (/\b(share it|send it|show me|link me|with me|to me|that doc|the doc|resend it)\b/.test(t)) return true;
+  // Very short with no research verb: a reply/aside ("thanks!", "yes please").
+  if (t.split(/\s+/).filter(Boolean).length <= 2) return true;
+  return false;
+}
+
+/**
  * Normalize a URL for robust matching: lowercase host, strip protocol,
  * trailing slash, query, and fragment.
  *

--- a/bot/src/zoe/research-doc.ts
+++ b/bot/src/zoe/research-doc.ts
@@ -28,7 +28,7 @@ async function git(args: string[]): Promise<string> {
   return stdout.trim();
 }
 
-/** Highest doc number across merged dirs + open PR titles, +1. */
+/** Highest doc number across merged dirs + open PR titles + in-flight branches, +1. */
 async function nextDocNum(): Promise<number> {
   let max = 0;
   for (const t of TOPICS) {
@@ -40,6 +40,14 @@ async function nextDocNum(): Promise<number> {
     const { stdout } = await exec('gh', ['api', 'repos/bettercallzaal/ZAOOS/pulls?state=open&per_page=80', '--jq', '.[].title'], { maxBuffer: 1024 * 1024 });
     for (const line of stdout.split('\n')) { const m = line.match(/doc[ #]?(\d{3,})/i); if (m) max = Math.max(max, Number(m[1])); }
   } catch { /* gh optional */ }
+  // In-flight branches: a doc branched (ws/zoe-research-N) but not yet merged or
+  // PR'd collides otherwise (audit afaa850, 2026-08-04). Bound to 3-4 digits so a
+  // slug's stray digits/SHA can't poison the max into the trillions (the loose-regex
+  // bug the /zao-research skill already learned, 2026-07-22).
+  try {
+    const { stdout } = await exec('git', ['-C', REPO, 'ls-remote', '--heads', 'origin', 'ws/zoe-research-*'], { maxBuffer: 1024 * 1024 });
+    for (const line of stdout.split('\n')) { const m = line.match(/ws\/zoe-research-(\d{3,4})\b/); if (m) max = Math.max(max, Number(m[1])); }
+  } catch { /* git optional */ }
   return max + 1;
 }
 


### PR DESCRIPTION
## Make the research pipeline operational

Audit `afaa850` (2026-08-04) traced three symptoms Zaal saw: doc-number collision PRs, README index conflicts, and ZOE queuing a reply ("can u share it with me") as a research task. Roots verified against live code before any edit (file:line confirmed).

### Fixes
1. **`.gitattributes` (new file)** - `research/**/*.md merge=union`. The file was entirely absent, so every concurrent topic-README append conflicted (rule 29 gap). Scoped to research markdown ONLY - never `.ts`.
2. **`research-doc.ts` `nextDocNum()`** - now also scans in-flight `ws/zoe-research-N` branches, not just merged dirs + open PR titles. A branched-but-unmerged doc no longer collides. Bounded to 3-4 digits so slug noise can't poison the max (the loose-regex bug `/zao-research` already learned).
3. **`index.ts` + `research-dedupe.ts`** - new pure helper `isFollowUpNotResearch()`. A conversational follow-up/command in the Research topic reroutes to chat instead of being enqueued as a research subject. A URL or an explicit research verb always stays research.

### Verification
- `29/29` dedupe tests pass (4 new guard tests, incl. the exact audit-bug phrase)
- `tsc --noEmit`: zero new errors (40 pre-existing baseline in unrelated test files, untouched)
- `esbuild` bundles the full ZOE boot graph clean (679kb, exit 0) - poller never booted (rule 21)

### Not included (deliberate, code-restraint)
The audit also proposed a `getResearchDocLink()` recall feature (return the prior doc when asked to share). The command guard already gives the operational behavior - ZOE answers in chat instead of queuing junk - so recall is a follow-up enhancement, not shipped here.

PR-only. A human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
