### PR TITLE
feat(zoe): tap-to-approve buttons for fleet BUILD candidates

### DIFF
--- a/bot/src/zoe/__tests__/build-candidate.test.ts
+++ b/bot/src/zoe/__tests__/build-candidate.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildCandidateKeyboard,
+  parseBuildCandidateCallback,
+  applyBuildCandidate,
+} from '../build-candidate';
+
+describe('build-candidate', () => {
+  describe('buildCandidateKeyboard', () => {
+    it('builds an Approve + Skip row with bc: callbacks', () => {
+      const kb = buildCandidateKeyboard('1234');
+      expect(kb.inline_keyboard).toHaveLength(1);
+      const [approve, skip] = kb.inline_keyboard[0];
+      expect(approve.callback_data).toBe('bc:approve:1234');
+      expect(skip.callback_data).toBe('bc:skip:1234');
+    });
+  });
+
+  describe('parseBuildCandidateCallback', () => {
+    it('parses approve and skip', () => {
+      expect(parseBuildCandidateCallback('bc:approve:99')).toEqual({ action: 'approve', id: '99' });
+      expect(parseBuildCandidateCallback('bc:skip:abc-1')).toEqual({ action: 'skip', id: 'abc-1' });
+    });
+    it('returns null for non-bc callbacks (falls through the router)', () => {
+      expect(parseBuildCandidateCallback('veto:5')).toBeNull();
+      expect(parseBuildCandidateCallback('bc:bogus:5')).toBeNull();
+      expect(parseBuildCandidateCallback('bc:approve:')).toBeNull();
+      expect(parseBuildCandidateCallback('')).toBeNull();
+    });
+  });
+
+  describe('applyBuildCandidate', () => {
+    it('approve merges build_approved into existing metadata (preserves why/tier)', async () => {
+      const read = vi.fn().mockResolvedValue({ why: 'worth it', tier: 'premium-build-candidate' });
+      const patch = vi.fn().mockResolvedValue(undefined);
+      const res = await applyBuildCandidate('approve', '7', read, patch, '2026-08-04T00:00:00Z');
+      expect(res.ok).toBe(true);
+      expect(res.already).toBeUndefined();
+      expect(patch).toHaveBeenCalledWith('7', {
+        why: 'worth it',
+        tier: 'premium-build-candidate',
+        build_approved: '2026-08-04T00:00:00Z',
+      });
+    });
+
+    it('skip sets build_skipped and clears any prior build_approved', async () => {
+      const read = vi.fn().mockResolvedValue({ why: 'x', build_approved: '2026-08-01T00:00:00Z' });
+      const patch = vi.fn().mockResolvedValue(undefined);
+      const res = await applyBuildCandidate('skip', '7', read, patch, '2026-08-04T00:00:00Z');
+      expect(res.ok).toBe(true);
+      expect(patch).toHaveBeenCalledWith('7', { why: 'x', build_skipped: '2026-08-04T00:00:00Z' });
+    });
+
+    it('is idempotent: re-approving an approved candidate is a no-op', async () => {
+      const read = vi.fn().mockResolvedValue({ build_approved: '2026-08-01T00:00:00Z' });
+      const patch = vi.fn().mockResolvedValue(undefined);
+      const res = await applyBuildCandidate('approve', '7', read, patch, '2026-08-04T00:00:00Z');
+      expect(res).toEqual({ ok: true, already: true });
+      expect(patch).not.toHaveBeenCalled();
+    });
+
+    it('returns not-found when the row is gone (never a false success)', async () => {
+      const read = vi.fn().mockResolvedValue(null);
+      const patch = vi.fn();
+      const res = await applyBuildCandidate('approve', 'gone', read, patch, '2026-08-04T00:00:00Z');
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/not found/);
+      expect(patch).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a patch failure loudly (no silent success)', async () => {
+      const read = vi.fn().mockResolvedValue({});
+      const patch = vi.fn().mockRejectedValue(new Error('Tracker PATCH failed (400)'));
+      const res = await applyBuildCandidate('approve', '7', read, patch, '2026-08-04T00:00:00Z');
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/400/);
+    });
+  });
+});

--- a/bot/src/zoe/build-candidate.ts
+++ b/bot/src/zoe/build-candidate.ts
@@ -1,0 +1,114 @@
+/**
+ * build-candidate.ts - tap-to-approve inline buttons for fleet BUILD candidates.
+ *
+ * The fleet escalates build candidates (a loop draft -> `zao-escalate` -> a
+ * project=BUILD row + a Telegram ping). The ping used to carry a COMMAND
+ * ("approve: ssh vps build-approve <id>"), not something Zaal could tap. This
+ * module gives it [Approve] / [Skip] buttons instead.
+ *
+ * Why a metadata flag and not status='approved': the tasks.status CHECK
+ * constraint only allows todo/in_progress/blocked/done. The old `build-approve`
+ * PATCHed status='approved' and silently 400'd every time (93 candidates stuck
+ * in todo, "1 done ever"). So approval is recorded as metadata.build_approved =
+ * <iso> (valid jsonb, no enum fight) - the same minimal/reversible pattern as
+ * brief-veto's metadata.morning_veto. build-queue reads the flag.
+ *
+ * Pure module - no network. Testable seams: buildCandidateKeyboard,
+ * parseBuildCandidateCallback, applyBuildCandidate (injected read + patch).
+ */
+
+export type BuildCandidateAction = 'approve' | 'skip';
+
+export interface BuildCandidateCallback {
+  action: BuildCandidateAction;
+  id: string;
+}
+
+/**
+ * Inline keyboard for a single build candidate: [Approve - build it] [Skip].
+ * callback_data: "bc:approve:<id>" / "bc:skip:<id>".
+ */
+export function buildCandidateKeyboard(
+  buildId: string,
+): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [
+      [
+        { text: 'Approve - build it', callback_data: `bc:approve:${buildId}` },
+        { text: 'Skip', callback_data: `bc:skip:${buildId}` },
+      ],
+    ],
+  };
+}
+
+/**
+ * Parse a build-candidate callback. Returns null if `data` is not a `bc:` tap
+ * (so the shared callback router can fall through to other handlers).
+ * "bc:approve:1234" -> { action: 'approve', id: '1234' }
+ */
+export function parseBuildCandidateCallback(data: string): BuildCandidateCallback | null {
+  const m = /^bc:(approve|skip):(.+)$/.exec(data);
+  if (!m) return null;
+  return { action: m[1] as BuildCandidateAction, id: m[2] };
+}
+
+export interface ApplyBuildCandidateResult {
+  ok: boolean;
+  /** true when the candidate was already in the requested state (idempotent no-op). */
+  already?: boolean;
+  error?: string;
+}
+
+/**
+ * Record an approve/skip decision on a BUILD-queue candidate as a metadata flag,
+ * MERGING into the existing metadata (never overwriting `why`/`tier` that
+ * build-queue displays).
+ *
+ * - approve: set metadata.build_approved = nowIso, clear any build_skipped.
+ * - skip:    set metadata.build_skipped  = nowIso, clear any build_approved.
+ *
+ * Idempotent: a double-tap of the same action is a no-op (returns already=true).
+ * Only sets a flag - it does NOT dispatch a build (build-queue polls the flag),
+ * so a double-tap can never double-dispatch.
+ *
+ * @param readMetadata  reads the row's current metadata (null if the row is gone)
+ * @param patchMetadata writes the merged metadata back
+ * @param nowIso        ISO timestamp of the decision
+ */
+export async function applyBuildCandidate(
+  action: BuildCandidateAction,
+  id: string,
+  readMetadata: (id: string) => Promise<Record<string, unknown> | null>,
+  patchMetadata: (id: string, metadata: Record<string, unknown>) => Promise<void>,
+  nowIso: string,
+): Promise<ApplyBuildCandidateResult> {
+  try {
+    const current = await readMetadata(id);
+    if (current === null) {
+      return { ok: false, error: 'candidate not found' };
+    }
+
+    const alreadyFlag = action === 'approve' ? 'build_approved' : 'build_skipped';
+    if (current[alreadyFlag]) {
+      return { ok: true, already: true };
+    }
+
+    const merged: Record<string, unknown> = { ...current };
+    if (action === 'approve') {
+      merged.build_approved = nowIso;
+      delete merged.build_skipped;
+    } else {
+      merged.build_skipped = nowIso;
+      delete merged.build_approved;
+    }
+
+    await patchMetadata(id, merged);
+    return { ok: true };
+  } catch (err) {
+    console.error(
+      '[zoe/build-candidate] applyBuildCandidate failed:',
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, error: err instanceof Error ? err.message : 'unknown' };
+  }
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -95,6 +95,10 @@ import {
   loadPending as loadPostsPending,
 } from './posts';
 import { parseVetoCallback, applyVeto } from './brief-veto';
+import {
+  parseBuildCandidateCallback,
+  applyBuildCandidate,
+} from './build-candidate';
 import { dispatchPlan } from './dispatch';
 import {
   handleVoiceAnswer,
@@ -643,6 +647,59 @@ bot.on('callback_query:data', async (ctx, next) => {
         .catch(() => {});
     } else {
       await ctx.answerCallbackQuery({ text: 'Veto failed — check logs.' });
+    }
+    return;
+  }
+
+  // Fleet BUILD candidate — "bc:approve:<id>" / "bc:skip:<id>". Records the
+  // decision as a metadata flag (build_approved/build_skipped) so build-queue
+  // picks it up; merges into existing metadata so `why`/`tier` survive.
+  const bc = parseBuildCandidateCallback(ctx.callbackQuery.data);
+  if (bc) {
+    const base = process.env.COWORK_TRACKER_URL;
+    const key = process.env.COWORK_TRACKER_KEY;
+    if (!base || !key) {
+      await ctx.answerCallbackQuery({ text: 'Tracker not configured.' });
+      return;
+    }
+    const root = base.replace(/\/$/, '');
+    const readMetadata = async (id: string): Promise<Record<string, unknown> | null> => {
+      const res = await fetch(
+        `${root}/rest/v1/tasks?legacy_id=eq.${id}&select=metadata`,
+        { headers: { apikey: key, Authorization: `Bearer ${key}` } },
+      );
+      if (!res.ok) throw new Error(`Tracker GET failed (${res.status})`);
+      const rows = (await res.json()) as Array<{ metadata: Record<string, unknown> | null }>;
+      if (!rows.length) return null;
+      return rows[0].metadata ?? {};
+    };
+    const patchMetadata = async (id: string, metadata: Record<string, unknown>): Promise<void> => {
+      const res = await fetch(`${root}/rest/v1/tasks?legacy_id=eq.${id}`, {
+        method: 'PATCH',
+        headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ metadata }),
+      });
+      if (!res.ok) throw new Error(`Tracker PATCH failed (${res.status})`);
+    };
+
+    const result = await applyBuildCandidate(
+      bc.action,
+      bc.id,
+      readMetadata,
+      patchMetadata,
+      new Date().toISOString(),
+    );
+    if (result.ok) {
+      const verb = bc.action === 'approve' ? 'Approved' : 'Skipped';
+      const note = result.already ? `Already ${verb.toLowerCase()}.` : `${verb}.`;
+      const toast =
+        bc.action === 'approve' && !result.already
+          ? 'Approved - a build session will pick it up.'
+          : note;
+      await ctx.answerCallbackQuery({ text: toast });
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+    } else {
+      await ctx.answerCallbackQuery({ text: `Failed - ${result.error ?? 'check logs'}.` });
     }
     return;
   }


### PR DESCRIPTION
## Tap-to-approve buttons for fleet BUILD candidates

**Zaal:** "I'm getting suggestions for build candidates, but nothing coming to me from ZOE has options to actually respond to."

The fleet escalates build candidates to Telegram, but the message carried a command (`ssh vps build-approve <id>`), not something tappable. This adds `[Approve - build it]` / `[Skip]` inline buttons.

### What's here (repo, tested)
- **`bot/src/zoe/build-candidate.ts`** - mirrors the proven `brief-veto.ts` pattern:
  - `buildCandidateKeyboard(id)` -> `bc:approve:<id>` / `bc:skip:<id>`
  - `parseBuildCandidateCallback(data)` -> `{action,id}` or null (falls through the router)
  - `applyBuildCandidate()` -> records the decision as a **merged** metadata flag, idempotent, never a false success
- **`index.ts`** - `bc:` branch wired into the `callback_query:data` router (Zaal-only, clears buttons on tap)

### The bug this surfaced
`build-approve` PATCHes `status='approved'`, but the `tasks.status` CHECK constraint only allows `todo/in_progress/blocked/done` - so **every approve has silently 400'd** (93 candidates stuck in `todo`, "1 done ever"). The buttons avoid that entirely by writing a `metadata.build_approved` flag (valid jsonb, merges without clobbering `why`/`tier`).

### Verify
- `8/8` build-candidate tests (keyboard, parse, merge-preserve, idempotency, not-found, loud-failure)
- `tsc --noEmit`: zero new errors (40 pre-existing baseline, untouched)
- `esbuild` bundles the full ZOE boot graph clean (681kb)

### Send side (separate, on the VPS - reported to Zaal)
The keyboard is attached to the escalation ping and `build-queue`/`build-approve` are switched to the metadata flag on the VPS (operator scripts, not in this repo). Those fix the silent-failure above so an Approve tap actually causes a build to be picked up.

PR-only. A human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
