### PR TITLE
fix(api): /api/tasks/list leaked the whole cowork task board to anonymous callers

### DIFF
--- a/src/app/api/tasks/list/route.ts
+++ b/src/app/api/tasks/list/route.ts
@@ -1,5 +1,6 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { getSessionData } from "@/lib/auth/session";
 import { logger } from "@/lib/logger";
 
 interface CoworkTask {
@@ -26,12 +27,26 @@ interface TasksResponse {
  * Queries the COWORK_TRACKER Supabase project for tasks.
  * Returns gracefully if the tracker is not configured (env vars missing).
  *
+ * Session required. The tracker is queried with its SERVICE ROLE key, which
+ * bypasses RLS and returns every row of the internal task board (titles,
+ * owners, sources). Without this guard the whole board is readable by any
+ * anonymous caller on the internet - middleware only rate-limits, it does not
+ * authenticate, and /api/tasks has no rate-limit entry either.
+ *
  * Response:
  * - If configured: { configured: true, tasks: [...] }
  * - If not configured: { configured: false, message: "..." }
  */
 export async function GET(): Promise<NextResponse<TasksResponse>> {
   try {
+    const session = await getSessionData();
+    if (!session) {
+      return NextResponse.json(
+        { configured: false, message: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
     const trackerUrl = process.env.COWORK_TRACKER_URL;
     const trackerKey = process.env.COWORK_TRACKER_SERVICE_ROLE_KEY;
 


### PR DESCRIPTION
## Executive Summary

`GET /api/tasks/list` was readable by anyone on the internet, with no login. It
queries the separate COWORK_TRACKER Supabase project using that project's
**service role key** - the key that bypasses row-level security - and returns
every row of the `tasks` table: titles, owners, due dates, source tags, project
names. There is no session check, no admin check, and no rate limit. This PR adds
a session guard (401 when there is no session) to the route, matching how every
other internal route in the repo is gated. Nothing else changes.

## What breaks without the fix (concretely)

`curl https://<host>/api/tasks/list` from any machine, no cookie, returns
`{"configured":true,"tasks":[ ...every task... ]}`. The internal board - what
Zaal and the loops are working on, who owns what, what is overdue - is a public
JSON endpoint. Two separate layers that normally catch this both miss it:

- `src/middleware.ts:141` only rate-limits and sets headers. It does **not**
  authenticate. Anything under `/api/` is open unless the route itself checks.
- `src/middleware.ts:13` (`RATE_LIMITS`) has no `/api/tasks` prefix, so the route
  is not even throttled - it is an unauthenticated, unbounded read amplified into
  a service-role query on every hit.

The `/overview` page that consumes it lives under the `(auth)` layout
(`src/app/(auth)/layout.tsx:23` redirects when there is no session), which is
almost certainly why this read as "gated" - but the page's gate does not extend
to the API route it fetches.

## The fix

`src/app/api/tasks/list/route.ts`

```
const session = await getSessionData();
if (!session) {
  return NextResponse.json({ configured: false, message: "Unauthorized" }, { status: 401 });
}
```

Placed inside the existing `try`, so a session/Supabase failure still returns the
route's sanitized 500 rather than throwing. The 401 body fits the declared
`TasksResponse` type, so the route's return type is unchanged. Also drops the
now-unused `type NextRequest` import (the handler takes no argument).

BEFORE: anonymous -> 200 + full board.
AFTER:  anonymous -> 401. Logged-in member -> unchanged 200 + full board.

## Evidence

- **Proven by reading the source:** no auth call existed anywhere in
  `src/app/api/tasks/list/route.ts` before this change (the whole file is 90
  lines); `src/middleware.ts` contains no auth logic and no `/api/tasks` entry.
  Compare `src/app/api/admin/quick-stats/route.ts:11-14`, which does
  `getSessionData()` then 403 - the pattern this route was missing.
- **Not run in this environment:** `npm run typecheck`, `npm test`, and
  `biome check` were NOT executed - this audit runs on a bare checkout with no
  `node_modules`, and installing them was out of scope for a one-file guard. CI
  (lint-typecheck / test / bot-test / build) will verify on this PR. The change
  uses an import and a response shape already used elsewhere in the repo, so it
  is type-compatible by construction, but treat CI as the receipt, not this note.
- No test was added for the same reason - an unrunnable test is worse than none.
  A `__tests__/route.test.ts` asserting 401-without-session is the obvious
  follow-up once someone can run vitest locally.

## Decision for you (not made here)

I gated on **any session**, which is the zero-regression choice: `/overview` is
in `BottomNav` MORE_ITEMS for every logged-in member, so an admin-only gate would
take the page away from members who can reach it today. But the data is your
private ops board. If members should not see it, change `!session` to
`!session.isAdmin` and return 403 - one-line follow-up, your call.

## Other things this audit pass noticed (NOT fixed here, one-PR rule)

- `/api/tasks` has no `RATE_LIMITS` entry in `src/middleware.ts`. Same for
  `/api/events` - and `POST /api/events/verify-ticket` is deliberately public and
  fans out to Neynar plus an on-chain read per call, so it is an unauthenticated
  paid-API amplifier. Worth a prefix entry each.
- `src/lib/agents/runner.ts:120` claims the daily budget atomically *before* the
  trade, and the later `skipped` paths (price API down, price above ceiling) never
  release the claim - so a run of API outages silently burns the daily budget with
  zero trades. May be intentional; flagging, not changing.
- `src/lib/agents/swap.ts:88` divides the 0x `price` field by 1,000,000, while
  `getEthPrice` in `runner.ts:39` treats the same field as a direct unit price.
  One of the two is wrong; if it is `getZabalPrice`, `buy_price_ceiling` is
  effectively never enforced. Needs someone to confirm 0x v1 response semantics
  before touching a money path - I did not.

Everything else I swept came back clean: no unresolved `@/` or relative imports
in `src/` or `bot/src/`, no `.only`/`.skip` in the suites, cron routes all check
`CRON_SECRET`, `rateLimit()` fails closed in production, and the heart-fleet
lease/outbox/reconcile paths hold up on read.

Found by the unattended hourly repo auditor. PR-only, no merge - yours to land.
