### PR TITLE
fix(bot): unbreak research-doc tests - main CI red since #2830

### DIFF
--- a/bot/src/zoe/__tests__/research-doc.test.ts
+++ b/bot/src/zoe/__tests__/research-doc.test.ts
@@ -31,9 +31,16 @@ function execOk(stdout = ''): { stdout: string; stderr: string } {
 /**
  * Set up mocks for the full happy path.
  * nextDocNum: readdir returns no matching files → max=0 → num=1
- *             gh api for PR titles → stdout '' → no PR numbers → num stays 1+1=2 actually 0+1=1
+ *             gh api for PR titles → stdout '' → no PR numbers → num stays 0+1=1
+ *             git ls-remote for in-flight ws/zoe-research-N branches → stdout ''
  * commitResearchDoc git calls: checkout main, pull, checkout -B branch, add, commit, push, checkout main
  * commitResearchDoc gh call for PR: returns URL
+ *
+ * Dispatch on the COMMAND, not on call order. A positional
+ * mockResolvedValueOnce queue silently breaks whenever the source adds another
+ * probe: #2830 inserted a `git ls-remote` in nextDocNum(), which shifted every
+ * later slot by one, ran the queue dry mid-run and made `exec` resolve
+ * undefined — so all three happy-path tests failed on `r.ok`.
  */
 function setupHappyPath(num = 1, prUrl = 'https://github.com/org/repo/pull/501') {
   // readdir: ENOENT for all topic dirs (no existing docs)
@@ -42,26 +49,11 @@ function setupHappyPath(num = 1, prUrl = 'https://github.com/org/repo/pull/501')
   mockWriteFile.mockResolvedValue(undefined);
   mockAppendFile.mockResolvedValue(undefined);
 
-  // exec calls in order:
-  // 1. gh api for open PR titles (nextDocNum)
-  // 2. git checkout main
-  // 3. git pull --quiet
-  // 4. git checkout -B branch
-  // 5. git add ...
-  // 6. git commit ...
-  // 7. git push ...
-  // 8. gh api POST create PR → returns URL
-  // 9. git checkout main
-  mockExec
-    .mockResolvedValueOnce(execOk(''))             // gh api PR titles
-    .mockResolvedValueOnce(execOk(''))             // git checkout main
-    .mockResolvedValueOnce(execOk(''))             // git pull
-    .mockResolvedValueOnce(execOk(''))             // git checkout -B branch
-    .mockResolvedValueOnce(execOk(''))             // git add
-    .mockResolvedValueOnce(execOk(''))             // git commit
-    .mockResolvedValueOnce(execOk(''))             // git push
-    .mockResolvedValueOnce(execOk(`${prUrl}\n`))   // gh api POST PR
-    .mockResolvedValueOnce(execOk(''));            // git checkout main (final)
+  // Only the PR-create call (`gh api -X POST .../pulls`) needs a distinct
+  // stdout; every other git/gh call is an empty success.
+  mockExec.mockImplementation(async (cmd: string, args: string[]) =>
+    cmd === 'gh' && args.includes('-X') ? execOk(`${prUrl}\n`) : execOk(''),
+  );
 }
 
 // ── commitResearchDoc ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Executive summary

Main's CI has been red since #2830 landed (run 30963160387, commit becb14ce, 2026-08-05 00:25 UTC). The `Bot Tests` job fails with 3 assertion errors in `bot/src/zoe/__tests__/research-doc.test.ts`. The production code is fine; the test's mock of `exec` was written against a fixed call ORDER, and #2830 added one more call. This PR makes the mock order-proof. Test-only change, no `src` change.

## What breaks without the fix

`nextDocNum()` in `bot/src/zoe/research-doc.ts` gained a fourth probe in #2830:

```ts
const { stdout } = await exec('git', ['-C', REPO, 'ls-remote', '--heads', 'origin', 'ws/zoe-research-*'], ...)
```

`setupHappyPath()` in the test queued exactly 9 ordered results via `mockResolvedValueOnce`. The new `ls-remote` call consumed slot 2 (which was meant for `git checkout main`), shifting every later slot by one. The 10th call then got `undefined` back, `const { stdout } = await exec(...)` threw on the destructure, and because `commitResearchDoc()` catches every error and returns `{ ok: false }`, the three happy-path tests failed on `expect(r.ok).toBe(true)` at lines 73, 81 and 89.

Concretely, this means:

- Every push to main reports a red CI check, so a genuinely broken bot change cannot be distinguished from this stale mock. This is the same failure shape as #2784 ("unbreak relay-bridge test - main CI has been red since #2773").
- The `Build` job is skipped when `Bot Tests` fails, so main currently has no build verification either.

## The fix

`setupHappyPath()` now dispatches on the command instead of the call order:

```ts
mockExec.mockImplementation(async (cmd: string, args: string[]) =>
  cmd === 'gh' && args.includes('-X') ? execOk(`${prUrl}\n`) : execOk(''),
);
```

Only the PR-create call (`gh api -X POST .../pulls`) needs a distinct stdout; everything else is an empty success. The next probe added to `nextDocNum()` or `commitResearchDoc()` will not turn the suite red again.

## Evidence (proven, run locally on this branch)

- `npx vitest run src/zoe/__tests__/research-doc.test.ts` in `bot/`: 7/7 pass. Before the fix on the same checkout: 4 pass, 3 fail, identical to CI.
- `npx vitest run` in `bot/`: 1780 passed of 1781. Test count is unchanged at 1781 (nothing dropped).
- `npx tsc --noEmit` in `bot/`: 40 errors before the change and 40 after, none in `research-doc.test.ts`. All 40 are pre-existing and untouched here.
- `biome check` does not apply: `bot/` is ignored by `biome.json`.

## Also seen this run, NOT fixed here (one PR per audit run)

1. `bot/src/zoe/__tests__/transcribe.test.ts > downloadTelegramFile` fails on this Windows checkout on the `expect(dest).toContain('photo.jpg')` assertion. It does NOT fail in CI (the failing run reported exactly 3 failures, all in research-doc), so this looks like a path-separator assumption in the test rather than a product bug. Unverified beyond that; worth a look but not urgent.
2. The unauthenticated `/api/tasks/list` exposure is already covered by the open PR #2839 - not duplicated here.
3. `bot/` currently carries 40 pre-existing `tsc --noEmit` errors (mostly `vi.fn()` typing in test files, plus `src/zoe/scheduler.ts:471` returning `Promise<TextMessage>` where `Promise<void>` is declared). Out of scope for this PR; flagging so the count is known.

Opened by the unattended hourly ZAOOS repo auditor. PR-only, no merge.
