### PR TITLE
fix(ci): doc-collision guard failed every docs PR against its own just-merged doc

### DIFF
--- a/.github/workflows/doc-collision-guard.yml
+++ b/.github/workflows/doc-collision-guard.yml
@@ -61,23 +61,34 @@ jobs:
             exit 0
           fi
 
-          # Every doc number that already exists on the base branch.
+          # Every doc DIRECTORY that already exists on the base branch. Compare
+          # directories, not bare numbers, so a doc can never collide with
+          # ITSELF: `$base` is re-fetched at job start and points at LIVE main,
+          # and auto-merge routinely lands a docs PR while this job is still
+          # running (PRs #2840/#2843/#2844 all merged 9-15s after their guard job
+          # started). The number-only comparison then found the PR's own,
+          # just-merged directory on main and failed the PR against itself - so
+          # the guard red-flagged every clean docs PR and a REAL collision became
+          # indistinguishable from the routine false alarm. Excluding the exact
+          # same path keeps a genuine same-number/different-slug collision failing,
+          # including one that landed on main after this branch was cut.
           basetree=$(git ls-tree -r --name-only "$base") \
             || { echo "::error title=doc-guard git ls-tree failed::cannot read base tree - failing closed"; exit 1; }
-          existing=$(printf '%s\n' "$basetree" \
+          existingdirs=$(printf '%s\n' "$basetree" \
             | grep -oE '^research/[^_/][^/]*/[0-9]{3,4}-[^/]+/' \
-            | sed -E 's|^research/[^/]+/([0-9]{3,4})-.*|\1|' \
             | sort -u || true)
 
           fail=0
           while read -r d; do
             [ -z "$d" ] && continue
             num=$(echo "$d" | sed -E 's|^research/[^/]+/([0-9]{3,4})-.*|\1|')
-            if echo "$existing" | grep -qx "$num"; then
+            hits=$(printf '%s\n' "$existingdirs" \
+              | grep -E "^research/[^/]+/${num}-" \
+              | grep -vxF "$d" || true)
+            if [ -n "$hits" ]; then
               echo "::error title=Doc number $num already exists::$d collides with an existing doc number on ${{ github.base_ref }}."
               echo "  existing doc(s) with number $num:"
-              git ls-tree -r --name-only "$base" \
-                | grep -oE "^research/[^/]+/${num}-[^/]+/" | sed 's/^/    /' | sort -u
+              printf '%s\n' "$hits" | sed 's/^/    /'
               fail=1
             fi
           done <<< "$newdirs"


### PR DESCRIPTION
## Executive Summary

The "Doc number collision guard" CI job has been failing on essentially every research-doc PR for at least the last 5 docs (2197, 2198, 2199, 2200, 2201) - and every one of those failures was a false alarm. The guard was failing each PR against **its own doc**, which auto-merge had already landed on `main` seconds earlier while the guard job was still running.

Net effect: the one server-side gate that is supposed to stop doc-number collisions is currently a permanent red X that everyone merges past. A real collision would look exactly like the routine noise.

One-line fix: compare doc **directories** and exclude the exact same path, instead of comparing bare numbers.

## What breaks without the fix, concretely

`doc-collision-guard.yml` computes added doc dirs against the merge base, but computes the set of already-existing doc numbers from `origin/main`, which it **re-fetches at job start** (line 43). `docs-automerge.yml` merges a docs PR as soon as the required checks pass - the collision guard is not one of them - so main moves under the guard mid-run:

| PR | doc | guard job started | merge landed on main | guard result |
|----|-----|-------------------|----------------------|--------------|
| #2844 | 2201 | 10:40:04Z | 10:40:16Z | failure at 10:40:22Z |
| #2843 | 2200 | 10:26:44Z | 10:26:58Z | failure |
| #2840 | 2199 | 09:50:20Z | 09:50:29Z | failure |

Guard log for #2844 (run 30998336311), verbatim:

```
##[error]research/agents/2201-zoe-bonfire-memory-board-understanding/ collides with an existing doc number on main.
  existing doc(s) with number 2201:
    research/agents/2201-zoe-bonfire-memory-board-understanding/
```

The "existing" doc it collides with is itself - same path. `git log` on that directory shows exactly one commit: `50932f389`, the merge of #2844 itself.

Two consequences:

1. **False-alarm floor.** Every clean docs PR goes red. A genuine collision produces an identical-looking red X, so the guard no longer carries information - the exact "collision count went 30 -> 169" failure mode this workflow was written to stop (see its own header comment).
2. **The number-only comparison was over-broad anyway.** `docs-automerge.yml` already excludes the same slug (`grep -v "/${slug}$"`, line 128); the standalone guard never did.

## The fix

- Build `existingdirs` (full doc directory paths) instead of a bare number set.
- For each added dir, match existing dirs with the same number and exclude the identical path with `grep -vxF "$d"`.
- Report the actual `$hits` rather than re-running `git ls-tree`.

A same-number/different-slug collision still fails, including one that landed on `main` after the branch was cut - the live-`main` comparison is deliberately kept, since narrowing to the merge base would let that case through.

## Evidence

**Proven:** logic simulated against the real repo tree (`git ls-tree -r --name-only HEAD`):

| case | added dir | result |
|------|-----------|--------|
| self (the #2844 case) | `research/agents/2201-zoe-bonfire-memory-board-understanding/` | `fail=0` - PASS (was `fail=1` under the old logic, verified) |
| real collision | `research/agents/2201-some-other-slug/` | `fail=1`, reports the colliding dir - still caught |
| fresh number | `research/agents/2202-brand-new/` | `fail=0` |

The old number-only comparison was run against the same tree and did produce `fail=1` on the self case, confirming the diagnosis rather than assuming it.

**Not verified:** the workflow was not executed on GitHub (it only runs on `pull_request`); this PR's own run does not exercise the guard, since it touches no `research/**` paths. No YAML linter was available in this checkout - the change is confined to the existing `run: |` block literal, indentation unchanged, no tabs.

## Scope

One file, one job, `.github/workflows/doc-collision-guard.yml`. Classified `unsafe` by `docs-automerge.yml` (it is a CI file), so it waits for you - it will not self-merge.

## Also seen this run, NOT fixed here (one-PR rule)

- **`main` CI is red at `ae9f9a30`** ("Bot Tests": 3 failures in `bot/src/zoe/__tests__/research-doc.test.ts`). This looks already fixed by #2842 (`760529b51`), but **no CI run exists on `main` for `760529b51` or anything after it**, so main's last recorded state is still failure. Worth confirming the main-branch CI trigger is actually firing on merges.
- The doc-numbering race itself is upstream of all this: several loops reserve a number, then land it minutes later. `agent-loops.md` rule 19 already names ranges-per-agent as the real fix. Not attempted here.
