### PR TITLE
feat(zoe): /board <person> - per-teammate coordination view

### DIFF
--- a/bot/src/zoe/__tests__/team-tracker.test.ts
+++ b/bot/src/zoe/__tests__/team-tracker.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, capturePriority, formatTeamDigest, buildPrioritiesEpisode, buildTeamContextBlock, type TeamTask } from '../team-tracker';
+import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, capturePriority, formatTeamDigest, buildPrioritiesEpisode, buildTeamContextBlock, formatOwnerDigest, type TeamTask } from '../team-tracker';
+
+describe('formatOwnerDigest', () => {
+  const members = new Map([['u1', 'zaal'], ['u2', 'iman']]);
+  const tk = (o: Partial<TeamTask>): TeamTask => ({
+    title: 'x', status: 'todo', priority: null, due: null, project: null, legacy_id: null, ...o,
+  });
+
+  it('filters to one person by name (case-insensitive), in-progress first', () => {
+    const tasks = [
+      tk({ title: 'iman UI work', status: 'in_progress', owner_id: 'u2' }),
+      tk({ title: 'iman todo', status: 'todo', priority: 'P1', owner_id: 'u2' }),
+      tk({ title: 'zaal thing', status: 'in_progress', owner_id: 'u1' }),
+    ];
+    const out = formatOwnerDigest(tasks, members, 'IMAN');
+    expect(out).toContain('iman - 2 open, 1 in progress');
+    expect(out).toContain('iman UI work [doing]');
+    expect(out).not.toContain('zaal thing');
+    expect(out.indexOf('iman UI work')).toBeLessThan(out.indexOf('iman todo'));
+  });
+
+  it('handles no-match and empty query', () => {
+    expect(formatOwnerDigest([], members, '')).toMatch(/Usage/);
+    expect(formatOwnerDigest([tk({ owner_id: 'u1' })], members, 'nobody')).toMatch(/No open tasks found/);
+  });
+});
 
 describe('buildTeamContextBlock', () => {
   const members = new Map([['u1', 'zaal'], ['u2', 'iman']]);

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -47,7 +47,7 @@ import { readFleetStatus, formatLoopsStatus, formatLoopDetail } from './loops-st
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
 import { runCrmOps, summarizeCrmResults } from './crm';
-import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured, addTeamTask, mirrorCapturesToTracker, runTeamDigest } from './team-tracker';
+import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured, addTeamTask, mirrorCapturesToTracker, runTeamDigest, getTeamMemberMap, formatOwnerDigest } from './team-tracker';
 import { decomposeGoal, renderPlanForApproval, shouldDecompose } from './decompose';
 import {
   buildMemoryBlocks,
@@ -867,6 +867,13 @@ bot.command('board', async (ctx) => {
     await ctx.reply(
       'Team tracker not wired up yet - set COWORK_TRACKER_URL + COWORK_TRACKER_KEY in bot/.env to read the team board.',
     );
+    return;
+  }
+  // "/board iman" -> that person's view; "/board" -> the full per-owner digest.
+  const person = (ctx.match ?? '').toString().trim();
+  if (person) {
+    const [tasks, members] = await Promise.all([getOpenTeamTasks(), getTeamMemberMap()]);
+    await replyChunked(ctx, formatOwnerDigest(tasks, members, person));
     return;
   }
   const { digest } = await runTeamDigest({ mirrorToBonfire: false });

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -474,6 +474,49 @@ export function formatTeamDigest(tasks: TeamTask[], members: Map<string, string>
 }
 
 /**
+ * Per-person board view: "/board iman" -> what that one teammate is on right now
+ * (in-progress first, then their open todos by priority). `query` is matched
+ * case-insensitively against the member display names AND their raw owner_id.
+ * Pure + exported for testing. Returns a not-found message when no one matches.
+ */
+export function formatOwnerDigest(
+  tasks: TeamTask[],
+  members: Map<string, string>,
+  query: string,
+): string {
+  const q = query.trim().toLowerCase();
+  if (!q) return 'Usage: /board <person> - e.g. /board iman';
+  // resolve matching owner_ids: display name contains q, or the id equals q
+  const matchIds = new Set<string>();
+  for (const [id, name] of members) {
+    if (name.toLowerCase().includes(q) || id.toLowerCase() === q) matchIds.add(id);
+  }
+  const theirs = tasks.filter(
+    (t) => !isRecurring(t.title) && t.owner_id != null && matchIds.has(t.owner_id),
+  );
+  // resolve the display name for the header (first match), fall back to the query
+  const displayName =
+    [...matchIds].map((id) => members.get(id)).find(Boolean) ?? query.trim();
+  if (theirs.length === 0) {
+    return `No open tasks found for "${query.trim()}" (they may have nothing assigned, or the name didn't match a teammate).`;
+  }
+  const sorted = [...theirs].sort((a, b) => {
+    const ia = isInProgress(a.status) ? 0 : 1;
+    const ib = isInProgress(b.status) ? 0 : 1;
+    if (ia !== ib) return ia - ib;
+    return priorityRank(a.priority) - priorityRank(b.priority);
+  });
+  const lines = sorted.map((t) => {
+    const doing = isInProgress(t.status) ? ' [doing]' : '';
+    const pri = priorityRank(t.priority) <= 2 ? `[${t.priority!.toUpperCase()}] ` : '';
+    const over = isOverdue(t.due) ? ' (overdue)' : '';
+    return `- ${pri}${t.title}${doing}${over}`;
+  });
+  const doingN = theirs.filter((t) => isInProgress(t.status)).length;
+  return `${displayName} - ${theirs.length} open, ${doingN} in progress:\n\n${lines.join('\n')}`;
+}
+
+/**
  * A rich "current team priorities" episode for Bonfire (doc 2201 gap: the graph
  * was full of shallow doc-title stubs, not current state). Body is prose so a
  * /delve for "what are we doing now" returns substance, not just titles. Pure.


### PR DESCRIPTION
'/board iman' -> what that teammate is on right now (in-progress first, then todos by priority). Confirmed net-new. Reuses the board read + member map from #2845. 24/24 tests, zero new tsc errors, esbuild clean. PR-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)