### PR TITLE
fix(zoe): unbreak main - seen-events prune dropped the key it just wrote (wall-clock vs injected now)

### DIFF
--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -50,9 +50,11 @@ async function readSeen(): Promise<Record<string, number>> {
   }
 }
 
-async function writeSeen(seen: Record<string, number>): Promise<void> {
-  // prune old keys so the file stays small
-  const cutoff = Date.now() - SEEN_TTL_MS;
+async function writeSeen(seen: Record<string, number>, now: number = Date.now()): Promise<void> {
+  // Prune old keys so the file stays small. Pruned against the SAME injected
+  // clock the callers key their entries with - reading Date.now() here instead
+  // would drop a key the caller just wrote whenever the two clocks disagree.
+  const cutoff = now - SEEN_TTL_MS;
   const pruned: Record<string, number> = {};
   for (const [k, ts] of Object.entries(seen)) if (ts >= cutoff) pruned[k] = ts;
   await fs.mkdir(ZOE_PATHS.home, { recursive: true });
@@ -130,7 +132,7 @@ export async function gatherEventCandidates(now: number = Date.now()): Promise<C
     });
   }
 
-  if (out.length > 0) await writeSeen(seen);
+  if (out.length > 0) await writeSeen(seen, now);
   return out;
 }
 
@@ -190,7 +192,7 @@ export async function gatherGraphCandidates(now: number = Date.now()): Promise<C
   }
 
   seen[`graphcheck:${today}`] = now; // mark the sweep done for today regardless
-  await writeSeen(seen);
+  await writeSeen(seen, now);
 
   if (!coldest) return [];
   return [
@@ -245,7 +247,7 @@ export async function gatherInactivityCandidates(now: number = Date.now()): Prom
   const key = `inactivity:${today}`;
   if (seen[key]) return [];
   seen[key] = now;
-  await writeSeen(seen);
+  await writeSeen(seen, now);
 
   const hrs = Math.floor(silentHrs);
   return [
@@ -355,6 +357,6 @@ export async function gatherCalendarCandidates(now: number = Date.now()): Promis
     console.warn('[zoe/events] ZOE calendar check failed (nbd):', (err as Error).message);
   }
 
-  if (out.length > 0) await writeSeen(seen);
+  if (out.length > 0) await writeSeen(seen, now);
   return out;
 }


### PR DESCRIPTION
## Executive Summary

`main` CI has been red since 2026-08-05 14:00 UTC and will stay red on every future run. One bot test fails: `bot/src/zoe/__tests__/events.test.ts` > `gatherGraphCandidates` > "marks the daily gate as done even when no stale topics found".

The root cause is not the test. It is a clock inconsistency in `bot/src/zoe/events.ts`: `writeSeen()` prunes old dedup keys against real wall-clock `Date.now()`, while all four of its callers key their entries with the injected `now` parameter. When those two clocks disagree, the prune throws away the key the caller wrote a microsecond earlier.

This PR threads the caller's `now` into `writeSeen()` so the write and the prune share one clock. 5 changed lines, one file.

## What breaks without the fix, concretely

**1. CI stays permanently red.** Not a flake - a one-way time bomb.

`SEEN_TTL_MS = 14 days`. The test's fixture is `NOW = 2026-07-22T14:00:00Z`. `writeSeen` computes `cutoff = Date.now() - 14d`. Verified arithmetic at the time of this audit:

```
NOW    1784728800000   (2026-07-22T14:00:00Z)
cutoff 1784732864063   (real now 2026-08-05T15:07:44Z, minus 14d)
NOW < cutoff -> true -> key pruned on write
```

The test wrote `graphcheck:2026-07-22`, `writeSeen` immediately deleted it, and the assertion read `undefined`. The gap only widens each hour, so no future run recovers.

Matches the observed CI history exactly - the 2026-08-05 10:22Z failure was a different cause (fixed by #2842); the 14:26Z and 14:36Z failures are this.

**2. The production bug this exposes.** `events.ts` injects `now` everywhere specifically so the tick has one consistent clock. `writeSeen` was the one place that reached past the injection to wall-clock. In prod the drift is small (callers pass `Date.now()` at tick start), so the practical impact today is near zero - graded accordingly, this is a correctness/determinism defect, not a live outage. But it is the actual defect: patching the test fixture would leave the inconsistent clock in place and just reset the timer on the same failure.

## The change

```diff
-async function writeSeen(seen: Record<string, number>): Promise<void> {
-  // prune old keys so the file stays small
-  const cutoff = Date.now() - SEEN_TTL_MS;
+async function writeSeen(seen: Record<string, number>, now: number = Date.now()): Promise<void> {
+  // Prune old keys so the file stays small. Pruned against the SAME injected
+  // clock the callers key their entries with - reading Date.now() here instead
+  // would drop a key the caller just wrote whenever the two clocks disagree.
+  const cutoff = now - SEEN_TTL_MS;
```

Plus `writeSeen(seen)` -> `writeSeen(seen, now)` at all four call sites (lines 135, 195, 250, 360 - `now` is already in scope at each). The parameter defaults to `Date.now()`, so prod behaviour is unchanged.

## Evidence

**Proven:**

- Failure reproduced locally before the fix: `1 failed | 29 passed (30)`, same assertion, same line 350.
- After the fix, that file: `30 passed (30)`.
- Full bot suite after the fix: `141 passed | 1 failed (142)` files, `1792 passed | 1 failed (1793)` tests. The one remaining failure is `transcribe.test.ts` > "downloads the file and writes it to destDir", asserting `'\tmp\zoe-files\photo.jpg'` contains `'/tmp/zoe-files'` - a Windows-only `path.join` separator artifact on the auditor's machine, pre-existing, unrelated to this diff, and passing on CI's ubuntu runner (it passed in run 31016045466 where only `events.test.ts` failed).
- `bot` tsc error count: 40 before the change, 40 after (stashed and re-ran to confirm). Zero of them in `events.ts`. These are pre-existing and not CI-gated - root `npm run typecheck` covers `src/`, not `bot/`.
- Secret scan on the staged diff (private key / `sk-ant-` / `ghp_` / 64-hex / PEM): no matches.

**Not run:** biome on the touched file. The root `node_modules` was not installed in this audit checkout and `npx biome` resolves to an unrelated `biome@0.3.3` package. CI's biome step is `continue-on-error: true` and scoped to changed files, so this cannot gate the merge; the diff is 5 lines matching the surrounding style.

## Other findings from this audit (NOT fixed here - one PR per the audit contract)

1. **`src/app/api/wavewarz/sync/route.ts:16` - cron auth fails open when `CRON_SECRET` is unset.** `if (authHeader !== \`Bearer ${process.env.CRON_SECRET}\`)` interpolates to the literal string `Bearer undefined` when the env var is missing, so anyone sending exactly that header passes auth and triggers the sync (Supabase writes + proposal creation). Worth a separate look, including whether other cron routes share the pattern. Graded moderate, not critical: it requires the env var to actually be absent in the deployed environment, which I did not verify and cannot verify from the repo.

2. **`bot` has 40 pre-existing tsc errors**, mostly vitest `Mock<...>` generic mismatches in test files plus `scheduler.ts:505` (`Promise<TextMessage>` assigned to `Promise<void>`). Not CI-gated today. Only #2 (`scheduler.ts`) is non-test code and worth a look.

## Founder-lens translation

- **Engineer:** one function read the wall clock while its callers used an injected clock; they now share one.
- **Architect:** ZOE's proactive tick is designed around an injectable clock so a tick is deterministic and replayable. `writeSeen` was the leak in that boundary. Sealing it makes the whole tick honest about time.
- **Founder:** main's build is green again, and it stays green - this class of failure was set to recur silently every hour.
- **Investor:** a test that rots into permanent failure trains a team to ignore red CI. Fixing the cause rather than the fixture is what keeps the signal trustworthy.

Biological analogy: ZOE's seen-events file is short-term memory, and the TTL prune is the forgetting curve. The bug had her forgetting an event in the same instant she recorded it, because the "how long ago was that" question was answered by a different clock than the one that stamped it.

Zaal merges. Nothing outbound, nothing gated, no deploy touched.
