### PR TITLE
feat(zoe): step-level execution tracing - see WHERE a run failed (no new dep)

### DIFF
--- a/bot/src/zoe/__tests__/trace.test.ts
+++ b/bot/src/zoe/__tests__/trace.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { startSpan, endSpan, appendChild, summarizeTrace, Trace, writeTrace } from '../trace';
+
+describe('span builders', () => {
+  it('starts, ends, and nests spans', () => {
+    const root = startSpan('run', 'run', 0);
+    const child = endSpan(startSpan('llm', 'generation', 1, { 'gen_ai.request.model': 'haiku' }), 5, 'ok', {
+      'gen_ai.usage.output_tokens': 42,
+    });
+    appendChild(root, child);
+    endSpan(root, 6);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].endMs).toBe(5);
+    expect(root.children[0].attrs['gen_ai.usage.output_tokens']).toBe(42);
+    expect(root.endMs).toBe(6);
+  });
+});
+
+describe('summarizeTrace', () => {
+  it('counts spans, computes duration, and finds the FIRST failed span', () => {
+    const root = startSpan('worker:x', 'run', 0);
+    appendChild(root, endSpan(startSpan('llm.call', 'generation', 1), 3, 'ok'));
+    appendChild(root, endSpan(startSpan('critic', 'critic', 4), 7, 'error', { error: 'critic blew up' }));
+    endSpan(root, 8);
+    const s = summarizeTrace(root);
+    expect(s.spanCount).toBe(3);
+    expect(s.durationMs).toBe(8);
+    expect(s.failedSpan).toBe('critic'); // the "where did it fail" answer
+    expect(s.ok).toBe(false);
+  });
+  it('reports ok when nothing errored', () => {
+    const root = endSpan(startSpan('run', 'run', 0), 10);
+    expect(summarizeTrace(root)).toMatchObject({ ok: true, failedSpan: null, spanCount: 1 });
+  });
+});
+
+describe('Trace (stack tracer)', () => {
+  it('builds a nested tree via begin/end and finish', () => {
+    const t = new Trace('worker:research', 0, { 'gen_ai.request.model': 'sonnet' });
+    t.begin('llm.call', 'generation', 1);
+    t.end(4, 'ok', { 'gen_ai.usage.input_tokens': 100 });
+    t.begin('critic', 'critic', 5);
+    t.end(9, 'error', { error: 'low score' });
+    t.finish(10, 'error');
+    const s = summarizeTrace(t.root);
+    expect(s.spanCount).toBe(3);
+    expect(t.root.children.map((c) => c.name)).toEqual(['llm.call', 'critic']);
+    expect(t.root.children[0].attrs['gen_ai.usage.input_tokens']).toBe(100);
+    expect(s.failedSpan).toBe('critic');
+  });
+});
+
+describe('writeTrace', () => {
+  it('serializes the trace + a summary as one JSONL line to the day file', async () => {
+    const root = endSpan(startSpan('worker:x', 'run', 0), 5);
+    const write = vi.fn(async (_path: string, _line: string) => {});
+    await writeTrace(root, '2026-08-05T12:00:00Z', write);
+    expect(write).toHaveBeenCalledTimes(1);
+    const [path, line] = write.mock.calls[0] as [string, string];
+    expect(path).toContain('/traces/2026-08-05.jsonl');
+    const parsed = JSON.parse(line.trim());
+    expect(parsed.name).toBe('worker:x');
+    expect(parsed._summary.spanCount).toBe(1);
+    expect(line.endsWith('\n')).toBe(true);
+  });
+  it('never throws (best-effort) when the writer fails', async () => {
+    const root = startSpan('x', 'run', 0);
+    await expect(writeTrace(root, '2026-08-05', async () => { throw new Error('disk full'); })).resolves.toBeUndefined();
+  });
+});

--- a/bot/src/zoe/trace.ts
+++ b/bot/src/zoe/trace.ts
@@ -1,0 +1,145 @@
+/**
+ * trace.ts - step-level execution tracing for ZOE's worker runs, WITHOUT a new
+ * dependency. runs.ts records one line per RUN (did it pass/fail); this records
+ * the TREE of steps inside a run (worker -> each model call -> critic), so ZOE
+ * can answer "WHERE did this run fail", not just "it failed" - the gap doc 2200
+ * named. A trace is a nested span tree written to ~/.zao/zoe/traces/DATE.jsonl.
+ *
+ * Shaped to the OpenTelemetry GenAI semantic conventions (gen_ai.request.model,
+ * gen_ai.usage.input_tokens, ...) so a real @opentelemetry exporter can be bolted
+ * on later WITHOUT reshaping - that exporter is a follow-up (it needs a new dep,
+ * which is "ask first"). For now this is pure local telemetry, no dependency.
+ *
+ * Pure builders (startSpan/endSpan/appendChild/summarizeTrace) are unit-tested;
+ * Trace is a thin stack wrapper for instrumentation; writeTrace is best-effort +
+ * never throws (telemetry must never break a live run - runs.ts's rule).
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from './memory';
+
+export type SpanKind = 'run' | 'worker' | 'generation' | 'tool' | 'critic';
+export type SpanStatus = 'ok' | 'error';
+
+export interface SpanAttrs {
+  'gen_ai.request.model'?: string;
+  'gen_ai.usage.input_tokens'?: number;
+  'gen_ai.usage.output_tokens'?: number;
+  'gen_ai.cost_usd'?: number;
+  error?: string;
+  [k: string]: unknown;
+}
+
+export interface Span {
+  name: string;
+  kind: SpanKind;
+  startMs: number;
+  endMs?: number;
+  status: SpanStatus;
+  attrs: SpanAttrs;
+  children: Span[];
+}
+
+/** Begin a span (status defaults ok; caller flips to error on failure). */
+export function startSpan(name: string, kind: SpanKind, nowMs: number, attrs: SpanAttrs = {}): Span {
+  return { name, kind, startMs: nowMs, status: 'ok', attrs: { ...attrs }, children: [] };
+}
+
+/** Close a span: set endMs, optionally the status + extra attributes. */
+export function endSpan(span: Span, nowMs: number, status: SpanStatus = 'ok', attrs: SpanAttrs = {}): Span {
+  span.endMs = nowMs;
+  span.status = status;
+  span.attrs = { ...span.attrs, ...attrs };
+  return span;
+}
+
+export function appendChild(parent: Span, child: Span): Span {
+  parent.children.push(child);
+  return parent;
+}
+
+export interface TraceSummary {
+  durationMs: number | null;
+  spanCount: number;
+  /** name of the FIRST span (depth-first) whose status is error - the "where it failed" answer. */
+  failedSpan: string | null;
+  ok: boolean;
+}
+
+/** Flatten + summarize a trace: total spans, duration, and where the first failure was. */
+export function summarizeTrace(root: Span): TraceSummary {
+  let count = 0;
+  let failed: string | null = null;
+  // POST-order (children first) so the deepest/actual failing STEP is reported,
+  // not the root's rollup-error. "where did it fail" wants the leaf, not the run.
+  const walk = (s: Span) => {
+    count += 1;
+    for (const c of s.children) walk(c);
+    if (failed === null && s.status === 'error') failed = s.name;
+  };
+  walk(root);
+  const durationMs = root.endMs != null ? root.endMs - root.startMs : null;
+  return { durationMs, spanCount: count, failedSpan: failed, ok: failed === null };
+}
+
+/**
+ * A thin stack-based tracer for instrumenting a run. begin() pushes a child span
+ * under the current one; end() closes the current span and pops. The root is a
+ * 'run' span. Kept minimal on purpose - the smarts live in the pure fns above.
+ */
+export class Trace {
+  readonly root: Span;
+  private stack: Span[];
+  constructor(rootName: string, nowMs: number, attrs: SpanAttrs = {}) {
+    this.root = startSpan(rootName, 'run', nowMs, attrs);
+    this.stack = [this.root];
+  }
+  private get current(): Span {
+    return this.stack[this.stack.length - 1];
+  }
+  begin(name: string, kind: SpanKind, nowMs: number, attrs: SpanAttrs = {}): Span {
+    const s = startSpan(name, kind, nowMs, attrs);
+    appendChild(this.current, s);
+    this.stack.push(s);
+    return s;
+  }
+  end(nowMs: number, status: SpanStatus = 'ok', attrs: SpanAttrs = {}): void {
+    if (this.stack.length <= 1) {
+      endSpan(this.root, nowMs, status, attrs);
+      return;
+    }
+    endSpan(this.current, nowMs, status, attrs);
+    this.stack.pop();
+  }
+  finish(nowMs: number, status: SpanStatus = 'ok', attrs: SpanAttrs = {}): void {
+    endSpan(this.root, nowMs, status, attrs);
+  }
+}
+
+function tracesDir(): string {
+  return join(ZOE_PATHS.home, 'traces');
+}
+
+/**
+ * Append a finished trace to ~/.zao/zoe/traces/DATE.jsonl (one JSON line per
+ * trace). Best-effort: any failure is swallowed - telemetry must never break a
+ * run (mirrors runs.ts). Injected writeImpl for testing.
+ */
+export async function writeTrace(
+  root: Span,
+  dateIso: string,
+  writeImpl?: (path: string, line: string) => Promise<void>,
+): Promise<void> {
+  try {
+    const summary = summarizeTrace(root);
+    const line = JSON.stringify({ ...root, _summary: summary }) + '\n';
+    if (writeImpl) {
+      await writeImpl(join(tracesDir(), `${dateIso.slice(0, 10)}.jsonl`), line);
+      return;
+    }
+    await fs.mkdir(tracesDir(), { recursive: true });
+    await fs.appendFile(join(tracesDir(), `${dateIso.slice(0, 10)}.jsonl`), line, 'utf8');
+  } catch (e) {
+    console.error('[zoe/trace] writeTrace failed (non-fatal):', (e as Error)?.message);
+  }
+}

--- a/bot/src/zoe/workers.ts
+++ b/bot/src/zoe/workers.ts
@@ -21,6 +21,7 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { callClaudeCli, CliAuthError, CliError } from '../hermes/claude-cli';
 import { recordCall } from './cost-ledger';
+import { Trace, writeTrace } from './trace';
 import { ZOE_DEFAULT_MODEL, ZOE_QUICK_MODEL } from './types';
 import type { ZoeContext } from './types';
 import type { Subtask, WorkerKind } from './decompose';
@@ -323,10 +324,22 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     durationMs: 0,
   };
 
+  // Step-level trace (best-effort; doc 2200). Records the worker run as a span
+  // tree - each model call + critic as a child span - so we can see WHERE a run
+  // failed, not just that it did. All best-effort: never breaks the worker.
+  const trace = new Trace(`worker:${worker}`, Date.now(), { 'gen_ai.request.model': cfg.model });
+  const flushTrace = (status: 'ok' | 'error', attrs: Record<string, unknown> = {}): void => {
+    try {
+      trace.finish(Date.now(), status, attrs);
+      void writeTrace(trace.root, new Date().toISOString());
+    } catch { /* telemetry must never break a run */ }
+  };
+
   let spec: string;
   try {
     spec = await loadSpec(worker, args.context);
   } catch (err) {
+    flushTrace('error', { error: 'spec load failed' });
     return {
       ...base,
       status: 'failed',
@@ -338,20 +351,31 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
   }
 
   const call = async (criticFeedback?: string, budgetUsd: number = cfg.maxBudgetUsd) => {
-    const r = await callClaudeCli({
-      model: cfg.model,
-      prompt: buildWorkerPrompt(args, criticFeedback),
-      cwd: args.context.workspace_dir,
-      appendSystemPrompt: spec,
-      allowedTools: cfg.allowedTools,
-      disallowedTools: cfg.disallowedTools,
-      permissionMode: 'default',
-      outputFormat: 'json',
-      maxBudgetUsd: budgetUsd,
-      bare: false,
-    });
-    recordCall('worker:' + worker, r);
-    return r;
+    trace.begin('llm.call', 'generation', Date.now(), { 'gen_ai.request.model': cfg.model });
+    try {
+      const r = await callClaudeCli({
+        model: cfg.model,
+        prompt: buildWorkerPrompt(args, criticFeedback),
+        cwd: args.context.workspace_dir,
+        appendSystemPrompt: spec,
+        allowedTools: cfg.allowedTools,
+        disallowedTools: cfg.disallowedTools,
+        permissionMode: 'default',
+        outputFormat: 'json',
+        maxBudgetUsd: budgetUsd,
+        bare: false,
+      });
+      recordCall('worker:' + worker, r);
+      trace.end(Date.now(), 'ok', {
+        'gen_ai.usage.input_tokens': r.inputTokens,
+        'gen_ai.usage.output_tokens': r.outputTokens,
+        'gen_ai.cost_usd': r.totalCostUsd,
+      });
+      return r;
+    } catch (e) {
+      trace.end(Date.now(), 'error', { error: (e as Error)?.message });
+      throw e;
+    }
   };
 
   try {
@@ -362,7 +386,9 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     let cost = first.totalCostUsd;
     let dur = first.durationMs;
 
+    trace.begin('critic', 'critic', Date.now());
     let critique = await runCriticFor(cfg.critic, args, output);
+    trace.end(Date.now(), 'ok', { score: critique?.score });
     let revised = false;
 
     if (critique && critique.score < CRITIQUE_PASS_THRESHOLD) {
@@ -383,7 +409,9 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
         outTok += second.outputTokens;
         cost += second.totalCostUsd;
         dur += second.durationMs;
+        trace.begin('critic', 'critic', Date.now());
         critique = await runCriticFor(cfg.critic, args, output);
+        trace.end(Date.now(), 'ok', { score: critique?.score });
       }
     }
 
@@ -391,6 +419,7 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     if (critique) cost += critique.costUsd;
 
     const passed = !critique || critique.score >= CRITIQUE_PASS_THRESHOLD;
+    flushTrace(passed ? 'ok' : 'error', { 'gen_ai.cost_usd': cost });
     return {
       ...base,
       status: passed ? 'completed' : 'needs-revision',
@@ -407,6 +436,7 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     if (isAuthError) {
       console.error(`[zoe/workers] auth error in ${worker}:`, (err as Error).message);
     }
+    flushTrace('error', { error: (err as Error).message });
     return {
       ...base,
       status: 'failed',


### PR DESCRIPTION
ZOE upgrade 2 of 3. Confirmed-missing (doc 2200): runs.ts is run-level, so ZOE couldn't see WHERE inside a run it failed. New trace.ts records a nested span tree (worker -> model calls -> critic) to JSONL, OTel-GenAI-convention-shaped so a real exporter can be bolted on later. IMPORTANT: full OpenTelemetry needs the @opentelemetry deps which are 'ask first', so this ships the capability with ZERO new dependency. summarizeTrace answers 'where did it fail' (deepest failing step). runClaudeWorker instrumented, all best-effort. 6/6 trace + 2/2 workers tests, zero new tsc errors, esbuild clean. PR-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)