### PR TITLE
feat(zoe): golden-eval regression harness (catch prompt regressions)

### DIFF
--- a/bot/src/zoe/__tests__/golden-eval.test.ts
+++ b/bot/src/zoe/__tests__/golden-eval.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  gradeOutput,
+  runGoldenSet,
+  formatGoldenReport,
+  SEED_GOLDEN_SET,
+  type GoldenCase,
+} from '../golden-eval';
+
+describe('gradeOutput', () => {
+  it('passes when all deterministic checks hold', () => {
+    const r = gradeOutput('The ZAO is a decentralized music network. Here is a long enough answer.', {
+      contains: ['zao'],
+      notContains: ['as an ai language model'],
+      minLength: 20,
+      matches: ['network|community'],
+    });
+    expect(r.pass).toBe(true);
+    expect(r.failures).toEqual([]);
+  });
+
+  it('fails on missing text, forbidden text, short length, and no-match', () => {
+    const r = gradeOutput('short', {
+      contains: ['zao'],
+      notContains: ['short'],
+      minLength: 100,
+      matches: ['network'],
+    });
+    expect(r.pass).toBe(false);
+    expect(r.failures.length).toBe(4); // missing / forbidden / too-short / no-match
+  });
+
+  it('checks jsonParseable (block inside prose counts)', () => {
+    expect(gradeOutput('here: {"a":1}', { jsonParseable: true }).pass).toBe(true);
+    expect(gradeOutput('no json here', { jsonParseable: true }).pass).toBe(false);
+  });
+});
+
+describe('runGoldenSet', () => {
+  const cases: GoldenCase[] = [
+    { id: 'a', input: 'x', expect: { contains: ['good'] } },
+    { id: 'b', input: 'y', expect: { contains: ['nope'] } },
+  ];
+
+  it('replays each case and reports pass/fail counts', async () => {
+    const run = vi.fn(async (input: string) => (input === 'x' ? 'this is good' : 'this is bad'));
+    const report = await runGoldenSet(cases, run);
+    expect(report).toMatchObject({ total: 2, passed: 1, failed: 1 });
+    expect(report.results.find((r) => r.id === 'a')?.pass).toBe(true);
+    expect(report.results.find((r) => r.id === 'b')?.pass).toBe(false);
+  });
+
+  it('a runner that THROWS is a fail-closed FAIL, never a silent pass', async () => {
+    const run = vi.fn(async () => { throw new Error('cli down'); });
+    const report = await runGoldenSet([cases[0]], run);
+    expect(report.failed).toBe(1);
+    expect(report.results[0].failures[0]).toMatch(/runner threw/);
+  });
+});
+
+describe('formatGoldenReport + seed set', () => {
+  it('formats a clean pass and a failure list', () => {
+    expect(formatGoldenReport({ total: 2, passed: 2, failed: 0, results: [] })).toBe('Golden eval: 2/2 passed');
+    const withFail = formatGoldenReport({
+      total: 2,
+      passed: 1,
+      failed: 1,
+      results: [{ id: 'b', pass: false, failures: ['missing required text: "nope"'] }],
+    });
+    expect(withFail).toContain('1 FAILED');
+    expect(withFail).toContain('b: missing required text');
+  });
+
+  it('the seed set is non-empty and well-formed', () => {
+    expect(SEED_GOLDEN_SET.length).toBeGreaterThan(0);
+    for (const c of SEED_GOLDEN_SET) {
+      expect(c.id).toBeTruthy();
+      expect(c.input).toBeTruthy();
+      expect(c.expect).toBeTruthy();
+    }
+  });
+});

--- a/bot/src/zoe/golden-eval.ts
+++ b/bot/src/zoe/golden-eval.ts
@@ -1,0 +1,144 @@
+/**
+ * golden-eval.ts - a golden-set regression harness for ZOE (doc 2200).
+ *
+ * ZOE has a per-change gate (loop-evals.md) but no standing REGRESSION SET: a
+ * fixed list of tasks you replay whenever a persona / worker-spec / learning
+ * changes, so "this prompt edit made ZOE worse" is caught BEFORE it ships. This
+ * is the "evaluation harness" doc 2200 named the winning teams invested in.
+ *
+ * Two-tier, per Langfuse/Sonar (doc 2198/2200): the grader here is the
+ * DETERMINISTIC tier - a real command that returns pass/fail identically every
+ * run (output contains X, matches a regex, parses as JSON, meets a length floor).
+ * A probabilistic LLM-judge tier can layer on top later (reuse verify-replan's
+ * judge), but the hard halt is deterministic - "a failing check is a fact."
+ *
+ * No new dependency. gradeOutput is pure + unit-tested; runGoldenSet takes an
+ * injected `run` fn (the ZOE task runner) so tests never call the CLI, and CI
+ * wiring (replay on a persona/spec change) is a thin script on top.
+ */
+
+export interface GoldenExpect {
+  /** output must contain each string (case-insensitive). */
+  contains?: string[];
+  /** output must NOT contain any of these (case-insensitive). */
+  notContains?: string[];
+  /** output must match each regex (given as source strings, matched case-insensitively). */
+  matches?: string[];
+  /** output length floor (chars) - guards against a truncated/empty regression. */
+  minLength?: number;
+  /** output (or a {...} block inside it) must JSON-parse. */
+  jsonParseable?: boolean;
+}
+
+export interface GoldenCase {
+  id: string;
+  input: string;
+  expect: GoldenExpect;
+}
+
+export interface CaseResult {
+  id: string;
+  pass: boolean;
+  failures: string[];
+}
+
+export interface GoldenReport {
+  total: number;
+  passed: number;
+  failed: number;
+  results: CaseResult[];
+}
+
+/** Deterministic grader: returns pass + the list of failed checks (empty if pass). */
+export function gradeOutput(output: string, expect: GoldenExpect): { pass: boolean; failures: string[] } {
+  const failures: string[] = [];
+  const lower = output.toLowerCase();
+
+  if (typeof expect.minLength === 'number' && output.trim().length < expect.minLength) {
+    failures.push(`too short (${output.trim().length} < ${expect.minLength})`);
+  }
+  for (const s of expect.contains ?? []) {
+    if (!lower.includes(s.toLowerCase())) failures.push(`missing required text: "${s}"`);
+  }
+  for (const s of expect.notContains ?? []) {
+    if (lower.includes(s.toLowerCase())) failures.push(`contains forbidden text: "${s}"`);
+  }
+  for (const src of expect.matches ?? []) {
+    let re: RegExp;
+    try {
+      re = new RegExp(src, 'i');
+    } catch {
+      failures.push(`bad regex in expectation: "${src}"`);
+      continue;
+    }
+    if (!re.test(output)) failures.push(`did not match /${src}/i`);
+  }
+  if (expect.jsonParseable) {
+    const m = output.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
+    let ok = false;
+    if (m) {
+      try {
+        JSON.parse(m[0]);
+        ok = true;
+      } catch {
+        ok = false;
+      }
+    }
+    if (!ok) failures.push('no parseable JSON found in output');
+  }
+
+  return { pass: failures.length === 0, failures };
+}
+
+/**
+ * Replay every golden case through `run` (the ZOE task runner) and grade the
+ * output. `run` is injected so this is testable + reusable for any runner. A
+ * case whose `run` throws is a FAIL (fail-closed - a runner that crashed is not
+ * a pass; loop-evals rule). Never throws.
+ */
+export async function runGoldenSet(
+  cases: GoldenCase[],
+  run: (input: string) => Promise<string>,
+): Promise<GoldenReport> {
+  const results: CaseResult[] = [];
+  for (const c of cases) {
+    try {
+      const output = await run(c.input);
+      const { pass, failures } = gradeOutput(output, c.expect);
+      results.push({ id: c.id, pass, failures });
+    } catch (e) {
+      results.push({ id: c.id, pass: false, failures: [`runner threw: ${(e as Error)?.message ?? 'unknown'}`] });
+    }
+  }
+  const passed = results.filter((r) => r.pass).length;
+  return { total: cases.length, passed, failed: cases.length - passed, results };
+}
+
+/** Render a compact report for CI logs / the loop self-report. */
+export function formatGoldenReport(report: GoldenReport): string {
+  const head = `Golden eval: ${report.passed}/${report.total} passed` + (report.failed ? `, ${report.failed} FAILED` : '');
+  const fails = report.results
+    .filter((r) => !r.pass)
+    .map((r) => `- ${r.id}: ${r.failures.join('; ')}`)
+    .join('\n');
+  return fails ? `${head}\n${fails}` : head;
+}
+
+/**
+ * A small SEED golden set - deterministic expectations that a healthy ZOE should
+ * always satisfy. Grow this as regressions are found (promote a real failing
+ * case into a golden case, per Langfuse's golden-dataset flow). Kept tiny + real
+ * on purpose - a golden set is only as good as its cases being genuinely golden.
+ */
+export const SEED_GOLDEN_SET: GoldenCase[] = [
+  {
+    id: 'research-has-substance',
+    input: 'Research: what is the ZAO in one paragraph',
+    expect: { minLength: 120, contains: ['zao'], notContains: ['as an ai language model'] },
+  },
+  {
+    id: 'decompose-returns-json-plan',
+    input: 'Plan: build a new feature with three steps and a review gate',
+    expect: { jsonParseable: true, matches: ['subtask|step|plan'] },
+  },
+];


### PR DESCRIPTION
ZOE upgrade 3 of 3. Confirmed-missing (doc 2200): ZOE has the loop-evals gate but no standing regression SET. New golden-eval.ts = a deterministic grader (contains/matches/minLength/jsonParseable - a real pass/fail) + runGoldenSet (injected runner, fail-closed if the runner throws) + a seed set. No new dep; pure + injected-dep tested. CI wiring (replay on persona/spec change) is a thin follow-up script. 7/7 tests, zero new tsc errors, esbuild clean. PR-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)