### PR TITLE
fix(zoe): verify-replan judge must not use bare (bare stripped OAuth -> gate always fail-opened)

### DIFF
--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -220,7 +220,12 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
             model: 'haiku',
             prompt,
             cwd: ctx.workspace_dir,
-            bare: true,
+            // NOTE: do NOT pass `bare: true` here. `--bare` skips config
+            // auto-discovery, which is where the CLI's OAuth login lives - so
+            // bare returns "Not logged in", the judge always throws, and
+            // verify-replan silently fail-opens (rubber-stamps every result
+            // instead of verifying). Proven via A/B on the VPS 2026-08-05;
+            // see feedback_no_bare_with_oauth. Keep the judge authenticated.
             maxBudgetUsd: 0.15,
             timeoutMs: 120000,
           });


### PR DESCRIPTION
## What changed

Removed `bare: true` from the verify-replan **judge** call in `bot/src/zoe/work-loop.ts`.

## Why this matters (the bug this fixes)

verify-replan (PR #2853) was shipped so autonomous research docs get *verified* before commit - a judge scores the result, and on a graded-incomplete verdict ZOE re-researches with the missing aspects fed back. The judge call passed `bare: true`.

`--bare` skips the CLI's config auto-discovery - and that config is **where the CLI's OAuth login lives**. So the judge ran un-authenticated, returned `Not logged in - Please run /login`, threw, and verify-replan **silently fail-opened** - accepting every result without ever verifying it. The gate was a rubber stamp.

This is the known `feedback_no_bare_with_oauth` lesson ("bare strips oauth"), which the judge call violated.

## Evidence (proven, not assumed)

Caught by a live manual work-loop self-test on the VPS (2026-08-05):

- The research **worker** (non-bare) authenticated fine - real span in `~/.zao/zoe/traces/2026-08-05.jsonl`: `worker:research-worker` -> `llm.call` (sonnet, 93 in / 2362 out, $0.388) -> `critic` (score 32).
- The **judge** (bare) logged: `verify-replan: judge failed, accepting - claude CLI exited 1 ... "Not logged in - Please run /login"`.
- A/B on the VPS with the exact CLI invocation:
  - without `--bare` -> `OK` (authenticated)
  - with `--bare` -> `Not logged in - Please run /login`

## Verification (loop-evals gate A)

- `tsc --noEmit`: 40 errors = pre-existing baseline, **0 added** by this change.
- `esbuild` bundle of the `work-loop.ts` boot graph: OK (115kb).
- Non-entrypoint import of `verify-replan.ts`: loads clean.

## Scope

One line removed (plus an explanatory comment so it is never re-added). No behavior change beyond making the judge authenticate. The intentional `bare: true` in the claude-cli **health-check** probe (which catches `CliAuthError` on purpose) is left untouched.
