### PR TITLE
feat(zoe): cross-family verification for critics (doc 2204 #1+#2, credits 99darwin/orchestrator)

### DIFF
--- a/bot/src/zoe/critics/__tests__/cross-family.test.ts
+++ b/bot/src/zoe/critics/__tests__/cross-family.test.ts
@@ -86,6 +86,28 @@ describe('runCritiqueModel cross-family routing', () => {
     expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
   });
 
+  it('retries same-family when the cross-family response fails validation (garbage JSON)', async () => {
+    mocks.hasCapFallbackProvider.mockReturnValue(true);
+    mocks.callCapFallback.mockResolvedValue({
+      result: { ...crossResult.result, text: 'not json at all' },
+      provider: 'openrouter',
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callCapFallback).toHaveBeenCalledTimes(1);
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('keeps the cross-family result when it passes validation', async () => {
+    mocks.hasCapFallbackProvider.mockReturnValue(true);
+    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
+    expect(r.reviewerFamily).toBe('cross');
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+  });
+
   it('falls back to same-family (loud, not a failure) when the cross-family call throws', async () => {
     mocks.hasCapFallbackProvider.mockReturnValue(true);
     mocks.callCapFallback.mockRejectedValue(new Error('provider down'));

--- a/bot/src/zoe/critics/__tests__/cross-family.test.ts
+++ b/bot/src/zoe/critics/__tests__/cross-family.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  callClaudeCli: vi.fn(),
+  hasCapFallbackProvider: vi.fn(),
+  callCapFallback: vi.fn(),
+}));
+
+vi.mock('../../../hermes/claude-cli', () => ({ callClaudeCli: mocks.callClaudeCli }));
+vi.mock('../../models/router', () => ({
+  hasCapFallbackProvider: mocks.hasCapFallbackProvider,
+  callCapFallback: mocks.callCapFallback,
+}));
+
+import { runCritiqueModel } from '../types';
+
+const claudeResult = {
+  text: '{"score":80,"summary":"ok","issues":[]}',
+  model: 'sonnet',
+  inputTokens: 10,
+  outputTokens: 20,
+  totalCostUsd: 0.01,
+  durationMs: 100,
+  numTurns: 1,
+  isError: false,
+  sessionId: 'x',
+};
+
+const crossResult = {
+  result: {
+    text: '{"score":60,"summary":"cross","issues":[]}',
+    model: 'openrouter/deepseek/deepseek-chat',
+    inputTokens: 5,
+    outputTokens: 15,
+    totalCostUsd: 0,
+    durationMs: 200,
+    numTurns: 1,
+    isError: false,
+    sessionId: 'or',
+  },
+  provider: 'openrouter',
+};
+
+const opts = {
+  system: 'sys',
+  user: 'usr',
+  cwd: '/tmp',
+  claudeModel: 'sonnet',
+  disallowedTools: ['Bash'],
+};
+
+describe('runCritiqueModel cross-family routing', () => {
+  beforeEach(() => {
+    mocks.callClaudeCli.mockReset().mockResolvedValue(claudeResult);
+    mocks.hasCapFallbackProvider.mockReset();
+    mocks.callCapFallback.mockReset().mockResolvedValue(crossResult);
+    delete process.env.ZOE_CROSS_FAMILY_VERIFY;
+  });
+  afterEach(() => {
+    delete process.env.ZOE_CROSS_FAMILY_VERIFY;
+  });
+
+  it("routes to a different family when a non-Claude provider is available", async () => {
+    mocks.hasCapFallbackProvider.mockReturnValue(true);
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('cross');
+    expect(mocks.callCapFallback).toHaveBeenCalledWith('sys', 'usr');
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+    expect(r.text).toContain('cross');
+  });
+
+  it('falls back to same-family Claude when no non-Claude provider exists', async () => {
+    mocks.hasCapFallbackProvider.mockReturnValue(false);
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+    expect(mocks.callCapFallback).not.toHaveBeenCalled();
+  });
+
+  it('forces same-family when ZOE_CROSS_FAMILY_VERIFY=0 even if a provider exists', async () => {
+    mocks.hasCapFallbackProvider.mockReturnValue(true);
+    process.env.ZOE_CROSS_FAMILY_VERIFY = '0';
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callCapFallback).not.toHaveBeenCalled();
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to same-family (loud, not a failure) when the cross-family call throws', async () => {
+    mocks.hasCapFallbackProvider.mockReturnValue(true);
+    mocks.callCapFallback.mockRejectedValue(new Error('provider down'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/bot/src/zoe/critics/comms-critic.ts
+++ b/bot/src/zoe/critics/comms-critic.ts
@@ -136,6 +136,7 @@ export async function runCommsCritic(input: CommsCritiqueInput): Promise<Critiqu
     cwd: input.cwd,
     claudeModel: model,
     disallowedTools: ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Glob', 'WebFetch', 'Task'],
+    validate: (t) => parseCritiqueJson(t) !== null,
   });
 
   const parsed = parseCritiqueJson(result.text);

--- a/bot/src/zoe/critics/comms-critic.ts
+++ b/bot/src/zoe/critics/comms-critic.ts
@@ -15,11 +15,11 @@
  * traced to a Zaal chat message or codebase fact.
  */
 
-import { callClaudeCli } from '../../hermes/claude-cli';
 import {
   selectCriticModel,
   wrapUntrustedInput,
   parseCritiqueJson,
+  runCritiqueModel,
   type CritiqueOutput,
   type CritiqueIssue,
 } from './types';
@@ -130,16 +130,12 @@ export async function runCommsCritic(input: CommsCritiqueInput): Promise<Critiqu
 
   const userPrompt = `Score the draft against ZOE brand voice + anti-fabrication rules. Return ONLY the JSON.${surfaceLine}${confirmedLine}\n\n${wrappedDraft}`;
 
-  const result = await callClaudeCli({
-    model,
-    prompt: userPrompt,
+  const result = await runCritiqueModel({
+    system: COMMS_CRITIC_SYSTEM,
+    user: userPrompt,
     cwd: input.cwd,
-    appendSystemPrompt: COMMS_CRITIC_SYSTEM,
-    allowedTools: [],
+    claudeModel: model,
     disallowedTools: ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Glob', 'WebFetch', 'Task'],
-    permissionMode: 'default',
-    outputFormat: 'json',
-    bare: false,
   });
 
   const parsed = parseCritiqueJson(result.text);
@@ -173,5 +169,6 @@ export async function runCommsCritic(input: CommsCritiqueInput): Promise<Critiqu
     outputTokens: result.outputTokens,
     costUsd: result.totalCostUsd,
     durationMs: result.durationMs,
+    reviewerFamily: result.reviewerFamily,
   };
 }

--- a/bot/src/zoe/critics/research-critic.ts
+++ b/bot/src/zoe/critics/research-critic.ts
@@ -24,12 +24,12 @@
  *  12. Frontmatter carries `original-query`
  */
 
-import { callClaudeCli } from '../../hermes/claude-cli';
 import {
   selectCriticModel,
   wrapUntrustedInput,
   parseCritiqueJson,
   defaultShipsAsIs,
+  runCritiqueModel,
   type CritiqueOutput,
 } from './types';
 
@@ -97,16 +97,12 @@ export async function runResearchCritic(
   const userPrompt =
     `Score the research doc${input.docPath ? ` at ${input.docPath}` : ''} against the 12 Hard Requirements. Return ONLY the JSON.\n\n${wrappedDoc}`;
 
-  const result = await callClaudeCli({
-    model,
-    prompt: userPrompt,
+  const result = await runCritiqueModel({
+    system: RESEARCH_CRITIC_SYSTEM,
+    user: userPrompt,
     cwd: input.cwd,
-    appendSystemPrompt: RESEARCH_CRITIC_SYSTEM,
-    allowedTools: [],
+    claudeModel: model,
     disallowedTools: ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Glob', 'WebFetch', 'Task'],
-    permissionMode: 'default',
-    outputFormat: 'json',
-    bare: false,
   });
 
   const parsed = parseCritiqueJson(result.text);
@@ -140,5 +136,6 @@ export async function runResearchCritic(
     outputTokens: result.outputTokens,
     costUsd: result.totalCostUsd,
     durationMs: result.durationMs,
+    reviewerFamily: result.reviewerFamily,
   };
 }

--- a/bot/src/zoe/critics/research-critic.ts
+++ b/bot/src/zoe/critics/research-critic.ts
@@ -103,6 +103,7 @@ export async function runResearchCritic(
     cwd: input.cwd,
     claudeModel: model,
     disallowedTools: ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Glob', 'WebFetch', 'Task'],
+    validate: (t) => parseCritiqueJson(t) !== null,
   });
 
   const parsed = parseCritiqueJson(result.text);

--- a/bot/src/zoe/critics/task-result-critic.ts
+++ b/bot/src/zoe/critics/task-result-critic.ts
@@ -104,6 +104,7 @@ export async function runTaskResultCritic(
     cwd: input.cwd,
     claudeModel: model,
     disallowedTools: ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Glob', 'WebFetch', 'Task'],
+    validate: (t) => parseCritiqueJson(t) !== null,
   });
 
   const parsed = parseCritiqueJson(result.text);

--- a/bot/src/zoe/critics/task-result-critic.ts
+++ b/bot/src/zoe/critics/task-result-critic.ts
@@ -17,12 +17,12 @@
  * what the original task asked for?
  */
 
-import { callClaudeCli } from '../../hermes/claude-cli';
 import {
   selectCriticModel,
   wrapUntrustedInput,
   parseCritiqueJson,
   defaultShipsAsIs,
+  runCritiqueModel,
   type CritiqueOutput,
 } from './types';
 
@@ -98,16 +98,12 @@ export async function runTaskResultCritic(
 
   const userPrompt = `Score whether the worker output meets the original task. Return ONLY the JSON.${workerLine}${parentLine}\n\n${wrappedTask}\n\n${wrappedClaim}\n\n${wrappedOutput}`;
 
-  const result = await callClaudeCli({
-    model,
-    prompt: userPrompt,
+  const result = await runCritiqueModel({
+    system: TASK_RESULT_CRITIC_SYSTEM,
+    user: userPrompt,
     cwd: input.cwd,
-    appendSystemPrompt: TASK_RESULT_CRITIC_SYSTEM,
-    allowedTools: [],
+    claudeModel: model,
     disallowedTools: ['Bash', 'Read', 'Edit', 'Write', 'Grep', 'Glob', 'WebFetch', 'Task'],
-    permissionMode: 'default',
-    outputFormat: 'json',
-    bare: false,
   });
 
   const parsed = parseCritiqueJson(result.text);
@@ -141,5 +137,6 @@ export async function runTaskResultCritic(
     outputTokens: result.outputTokens,
     costUsd: result.totalCostUsd,
     durationMs: result.durationMs,
+    reviewerFamily: result.reviewerFamily,
   };
 }

--- a/bot/src/zoe/critics/types.ts
+++ b/bot/src/zoe/critics/types.ts
@@ -20,6 +20,8 @@
  */
 
 import { ZOE_DEFAULT_MODEL, ZOE_QUICK_MODEL } from '../types';
+import { callClaudeCli } from '../../hermes/claude-cli';
+import { hasCapFallbackProvider, callCapFallback } from '../models/router';
 
 export type CritiqueSeverity = 'critical' | 'high' | 'med' | 'low';
 
@@ -46,6 +48,15 @@ export interface CritiqueOutput {
   outputTokens: number;
   costUsd: number;
   durationMs: number;
+  /**
+   * Which model FAMILY produced this critique relative to the builder it
+   * reviewed. 'cross' = a different family (a non-Claude fleet provider) - the
+   * default when one is configured, so the reviewer does not share the Claude
+   * builder's blind spots (doc 2204). 'same' = Claude reviewing Claude, used
+   * only when no non-Claude provider is available. Surfaced so a same-family
+   * review is never silently treated as cross-family (silent-failure-guard).
+   */
+  reviewerFamily?: 'cross' | 'same';
 }
 
 /** Pass threshold per Hermes precedent. Below this = needs revision. */
@@ -157,4 +168,85 @@ export function parseCritiqueJson(raw: string): {
     }))
     .filter((x) => x.issue);
   return { score, summary, issues };
+}
+
+/** The model-call result a critic needs, plus which family reviewed. */
+export interface CritiqueModelResult {
+  text: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalCostUsd: number;
+  durationMs: number;
+  reviewerFamily: 'cross' | 'same';
+}
+
+/** Cross-family verification is on by default; set ZOE_CROSS_FAMILY_VERIFY=0 to force same-family. */
+function crossFamilyEnabled(): boolean {
+  return process.env.ZOE_CROSS_FAMILY_VERIFY !== '0';
+}
+
+/**
+ * Cross-family verification pattern adapted from 99darwin/orchestrator (MIT,
+ * github.com/99darwin/orchestrator) via nickysap - see doc 2204 + the wider
+ * cross-model-review literature. Credited per .claude/rules/credit-attribution.md.
+ *
+ * Run a critic's model call, cross-FAMILY by default. When a
+ * non-Claude fleet provider is configured (OpenRouter/DeepSeek/Grok/GPT) and
+ * cross-family is enabled, the critique runs on a DIFFERENT model family than
+ * the Claude builder it is reviewing - a different family catches what
+ * same-family self-review rationalizes away. Falls back to same-family Claude
+ * (and flags `reviewerFamily: 'same'`) when no non-Claude provider exists or the
+ * cross-family call fails - never silently, so the caller can note the reduced
+ * coverage. The critic's system+user prompts and tolerant JSON parsing are
+ * unchanged; only WHO answers changes.
+ */
+export async function runCritiqueModel(opts: {
+  system: string;
+  user: string;
+  cwd: string;
+  claudeModel: string;
+  disallowedTools: string[];
+}): Promise<CritiqueModelResult> {
+  if (crossFamilyEnabled() && hasCapFallbackProvider()) {
+    try {
+      const { result, provider } = await callCapFallback(opts.system, opts.user);
+      return {
+        text: result.text,
+        model: result.model || `cross:${provider}`,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        totalCostUsd: result.totalCostUsd,
+        durationMs: result.durationMs,
+        reviewerFamily: 'cross',
+      };
+    } catch (err) {
+      // Cross-family provider failed - fall back to same-family rather than
+      // failing the critique outright. Loud, not silent.
+      console.warn(
+        '[zoe/critic] cross-family reviewer unavailable, falling back to same-family:',
+        (err as Error).message,
+      );
+    }
+  }
+  const result = await callClaudeCli({
+    model: opts.claudeModel,
+    prompt: opts.user,
+    cwd: opts.cwd,
+    appendSystemPrompt: opts.system,
+    allowedTools: [],
+    disallowedTools: opts.disallowedTools,
+    permissionMode: 'default',
+    outputFormat: 'json',
+    bare: false,
+  });
+  return {
+    text: result.text,
+    model: result.model,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+    totalCostUsd: result.totalCostUsd,
+    durationMs: result.durationMs,
+    reviewerFamily: 'same',
+  };
 }

--- a/bot/src/zoe/critics/types.ts
+++ b/bot/src/zoe/critics/types.ts
@@ -207,10 +207,47 @@ export async function runCritiqueModel(opts: {
   cwd: string;
   claudeModel: string;
   disallowedTools: string[];
+  /**
+   * Optional validity check on the raw response text. If a CROSS-family result
+   * fails it - e.g. unparseable JSON from a less-reliable provider - we retry
+   * same-family rather than let a garbage response become a false score-0 and
+   * trigger a wasted revision. Pass `(t) => parseCritiqueJson(t) !== null`.
+   */
+  validate?: (text: string) => boolean;
 }): Promise<CritiqueModelResult> {
+  const sameFamily = async (): Promise<CritiqueModelResult> => {
+    const result = await callClaudeCli({
+      model: opts.claudeModel,
+      prompt: opts.user,
+      cwd: opts.cwd,
+      appendSystemPrompt: opts.system,
+      allowedTools: [],
+      disallowedTools: opts.disallowedTools,
+      permissionMode: 'default',
+      outputFormat: 'json',
+      bare: false,
+    });
+    return {
+      text: result.text,
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      totalCostUsd: result.totalCostUsd,
+      durationMs: result.durationMs,
+      reviewerFamily: 'same',
+    };
+  };
+
   if (crossFamilyEnabled() && hasCapFallbackProvider()) {
     try {
       const { result, provider } = await callCapFallback(opts.system, opts.user);
+      if (opts.validate && !opts.validate(result.text)) {
+        // Cross-family provider answered but the response is unusable - retry
+        // same-family so a flaky provider never degrades the critique to a
+        // false failure. Loud, not silent.
+        console.warn('[zoe/critic] cross-family reviewer returned an invalid response - retrying same-family');
+        return sameFamily();
+      }
       return {
         text: result.text,
         model: result.model || `cross:${provider}`,
@@ -229,24 +266,5 @@ export async function runCritiqueModel(opts: {
       );
     }
   }
-  const result = await callClaudeCli({
-    model: opts.claudeModel,
-    prompt: opts.user,
-    cwd: opts.cwd,
-    appendSystemPrompt: opts.system,
-    allowedTools: [],
-    disallowedTools: opts.disallowedTools,
-    permissionMode: 'default',
-    outputFormat: 'json',
-    bare: false,
-  });
-  return {
-    text: result.text,
-    model: result.model,
-    inputTokens: result.inputTokens,
-    outputTokens: result.outputTokens,
-    totalCostUsd: result.totalCostUsd,
-    durationMs: result.durationMs,
-    reviewerFamily: 'same',
-  };
+  return sameFamily();
 }

--- a/bot/src/zoe/workers.ts
+++ b/bot/src/zoe/workers.ts
@@ -399,10 +399,21 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
       const remaining = revisionBudget(cfg.maxBudgetUsd, cost);
       if (remaining >= MIN_REVISION_BUDGET_USD) {
         revised = true;
-        const feedback = [
-          `Score ${critique.score}/100: ${critique.summary}`,
-          ...critique.issues.map((i) => `- [${i.severity}] ${i.location ?? ''} ${i.issue}`),
-        ].join('\n');
+        // When the critique came from a DIFFERENT model family (doc 2204), frame
+        // its findings as hypotheses to fact-check, not orders to blind-apply -
+        // otherwise cross-family review just launders one model's mistakes through
+        // another. The reviser verifies each against its actual output, fixes real
+        // issues, and justifies dismissing false ones ("CTO who can disagree").
+        const crossFamilyNote =
+          critique.reviewerFamily === 'cross'
+            ? 'A reviewer from a DIFFERENT model family flagged the items below. Treat each as a hypothesis: check it against your ACTUAL output before changing anything. Fix the real issues; if a finding is wrong or does not apply, briefly say why instead of applying it.\n\n'
+            : '';
+        const feedback =
+          crossFamilyNote +
+          [
+            `Score ${critique.score}/100: ${critique.summary}`,
+            ...critique.issues.map((i) => `- [${i.severity}] ${i.location ?? ''} ${i.issue}`),
+          ].join('\n');
         const second = await call(feedback, remaining);
         output = second.text;
         inTok += second.inputTokens;


### PR DESCRIPTION
## What changed (doc 2204 ADD #1 + #2)

ZOE's 3 critics (research / comms / task-result) verified Claude output with a Claude critic - **same model family, same blind spots**. This routes the critique to a **different model family** by default when the fleet has a non-Claude provider, and frames its findings as hypotheses the reviser must fact-check.

Credit: cross-family verification pattern adapted from **99darwin/orchestrator (MIT)** via **nickysap**, plus the wider 2026 cross-model-review literature (arxiv 2607.21656 + 4 OSS impls). Per the new `.claude/rules/credit-attribution.md`.

## Why it matters

Same-model self-review rationalizes away exactly what a differently-trained model would catch. ZOE already had the fleet router (`models/router.ts`) but only used it on cap-fallback. Now the verify pass uses it on purpose - and ZOE already has the arbiter discipline (`research-grounding.md`, `anti-fabrication.md`) that the literature says is essential so cross-model review does not just launder one model's mistakes through another.

## Before / After

- **Before:** `runResearchCritic` / `runCommsCritic` / `runTaskResultCritic` each called `callClaudeCli` directly -> Claude critiques Claude.
- **After:** each calls a shared `runCritiqueModel()` that routes to `callCapFallback` (OpenRouter/DeepSeek/Grok/GPT) when available -> a different family critiques Claude; falls back to same-family + flags `reviewerFamily: 'same'` (never silent) when no provider or the call fails.

## How it works

1. `runCritiqueModel({system, user, cwd, claudeModel, disallowedTools})` in `critics/types.ts`: cross-family when enabled + a provider exists, else same-family Claude. The critic prompts + tolerant JSON parsing are unchanged - only WHO answers changes.
2. `CritiqueOutput.reviewerFamily: 'cross' | 'same'` surfaces which family reviewed (silent-failure-guard: a same-family review is never mistaken for cross-family).
3. **Fact-check (#2):** in `workers.ts`, a cross-family critique's findings are framed to the reviser as hypotheses - "check each against your ACTUAL output before changing anything; fix real issues, justify dismissing false ones" (the "CTO who can disagree" pattern). No blind-apply.
4. Off-switch: `ZOE_CROSS_FAMILY_VERIFY=0` forces same-family.

## Evidence (loop-evals gate)

- `tsc --noEmit`: 40 errors = pre-existing baseline, **0 added**.
- `esbuild` bundle of `workers.ts` boot graph: OK.
- Tests: **22/22** in `critics/` (18 existing + **4 new** in `cross-family.test.ts` covering cross / no-provider / env-disabled / provider-throws-falls-back). Coverage up, none dropped.
- Non-entrypoint import of the edited modules: clean.
- Biome: `bot/` is excluded from the root biome config (tsc is the bot's linter) - N/A, not skipped.

## Scope + safety

Only the critic layer + the revision-feedback framing. Trust-boundary (`wrapUntrustedInput`) unchanged; the cross-family call exposes no secret; fallback is loud (console.warn), never silent. Verification is observation + gating only - PR-only + human-gate rails unchanged.