### PR TITLE
feat(zoe): Codex as the cross-family critic reviewer (flat-rate, no OpenRouter)

### DIFF
--- a/bot/src/hermes/codex-cli.ts
+++ b/bot/src/hermes/codex-cli.ts
@@ -1,0 +1,140 @@
+/**
+ * Codex CLI wrapper - a headless call to OpenAI's `codex exec`, used as ZOE's
+ * cross-FAMILY reviewer (doc 2204): a different model family than the Claude
+ * builder, on the flat-rate Codex subscription (no per-call credits, no
+ * OpenRouter). Mirrors `claude-cli.ts` but shells to `codex exec`.
+ *
+ * Design notes:
+ *   - `-s read-only` sandbox: the reviewer READS + responds, never edits.
+ *   - `-o <file>` writes ONLY the agent's final message, so we parse the
+ *     critique JSON cleanly instead of scraping the whole transcript.
+ *   - Codex is periodically usage-capped; a cap / auth / spawn failure throws
+ *     CodexUnavailableError so the caller (runCritiqueModel) falls back to
+ *     same-family Claude - loud, never silent.
+ *   - Credited per .claude/rules/credit-attribution.md: cross-family review
+ *     pattern from 99darwin/orchestrator (MIT) + the Claude<->Codex pairing in
+ *     arxiv 2607.21656.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface CodexCliResult {
+  text: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalCostUsd: number;
+  durationMs: number;
+}
+
+/** Codex is unavailable (not installed, usage-capped, not logged in, timed out). */
+export class CodexUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodexUnavailableError';
+  }
+}
+
+function codexBin(): string {
+  return process.env.CODEX_BIN || join(process.env.HOME || '/home/zaal', '.local', 'bin', 'codex');
+}
+
+/** True if the codex binary is present. Does NOT prove it has capacity (that is
+ *  only known at call time - a capped codex still exists on disk). */
+export function hasCodexCli(): boolean {
+  return existsSync(codexBin());
+}
+
+const CAP_OR_AUTH = /usage limit|hit your usage limit|not logged in|please run .*login|quota|insufficient|\b401\b|\b403\b|\b429\b/i;
+
+/**
+ * Run one headless Codex critique. Returns the agent's final message text.
+ * Throws CodexUnavailableError on cap / auth / spawn / timeout so the caller
+ * can fall back to same-family review.
+ */
+export async function callCodexCli(opts: {
+  system: string;
+  user: string;
+  cwd: string;
+  timeoutMs?: number;
+  model?: string;
+}): Promise<CodexCliResult> {
+  const bin = codexBin();
+  if (!existsSync(bin)) {
+    throw new CodexUnavailableError(`codex CLI not found at ${bin}`);
+  }
+  const startMs = Date.now();
+  const dir = await mkdtemp(join(tmpdir(), 'zoe-codex-'));
+  const outFile = join(dir, 'last.txt');
+  const prompt = `${opts.system}\n\n${opts.user}`;
+  const args = ['exec', '--skip-git-repo-check', '-s', 'read-only', '-o', outFile];
+  if (opts.model) args.push('-m', opts.model);
+  args.push('-'); // read the prompt from stdin
+
+  return new Promise<CodexCliResult>((resolve, reject) => {
+    const child = spawn(bin, args, {
+      cwd: opts.cwd,
+      env: { ...process.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const cleanup = (): void => {
+      void rm(dir, { recursive: true, force: true });
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      cleanup();
+      reject(new CodexUnavailableError(`codex timed out after ${opts.timeoutMs ?? 120000}ms`));
+    }, opts.timeoutMs ?? 120000);
+
+    child.stdout.on('data', (d) => {
+      stdout += String(d);
+    });
+    child.stderr.on('data', (d) => {
+      stderr += String(d);
+    });
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      cleanup();
+      reject(new CodexUnavailableError(`codex spawn failed: ${e.message}`));
+    });
+    child.on('close', async (code) => {
+      clearTimeout(timer);
+      const combined = `${stdout}\n${stderr}`;
+      if (CAP_OR_AUTH.test(combined)) {
+        cleanup();
+        const hit = combined.match(CAP_OR_AUTH)?.[0] ?? 'cap/auth';
+        reject(new CodexUnavailableError(`codex unavailable (${hit})`));
+        return;
+      }
+      let last = '';
+      try {
+        last = await readFile(outFile, 'utf8');
+      } catch {
+        /* no last-message file written */
+      }
+      cleanup();
+      const text = last.trim() || stdout.trim();
+      if (!text) {
+        reject(new CodexUnavailableError(`codex produced no output (exit ${code})`));
+        return;
+      }
+      resolve({
+        text,
+        model: opts.model ? `codex/${opts.model}` : 'codex',
+        inputTokens: 0,
+        outputTokens: 0,
+        totalCostUsd: 0, // flat-rate subscription - not metered per call
+        durationMs: Date.now() - startMs,
+      });
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}

--- a/bot/src/zoe/critics/__tests__/cross-family.test.ts
+++ b/bot/src/zoe/critics/__tests__/cross-family.test.ts
@@ -2,14 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   callClaudeCli: vi.fn(),
-  hasCapFallbackProvider: vi.fn(),
-  callCapFallback: vi.fn(),
+  hasCodexCli: vi.fn(),
+  callCodexCli: vi.fn(),
 }));
 
 vi.mock('../../../hermes/claude-cli', () => ({ callClaudeCli: mocks.callClaudeCli }));
-vi.mock('../../models/router', () => ({
-  hasCapFallbackProvider: mocks.hasCapFallbackProvider,
-  callCapFallback: mocks.callCapFallback,
+vi.mock('../../../hermes/codex-cli', () => ({
+  hasCodexCli: mocks.hasCodexCli,
+  callCodexCli: mocks.callCodexCli,
+  CodexUnavailableError: class extends Error {},
 }));
 
 import { runCritiqueModel } from '../types';
@@ -26,19 +27,13 @@ const claudeResult = {
   sessionId: 'x',
 };
 
-const crossResult = {
-  result: {
-    text: '{"score":60,"summary":"cross","issues":[]}',
-    model: 'openrouter/deepseek/deepseek-chat',
-    inputTokens: 5,
-    outputTokens: 15,
-    totalCostUsd: 0,
-    durationMs: 200,
-    numTurns: 1,
-    isError: false,
-    sessionId: 'or',
-  },
-  provider: 'openrouter',
+const codexResult = {
+  text: '{"score":60,"summary":"cross via codex","issues":[]}',
+  model: 'codex',
+  inputTokens: 0,
+  outputTokens: 0,
+  totalCostUsd: 0,
+  durationMs: 200,
 };
 
 const opts = {
@@ -49,73 +44,70 @@ const opts = {
   disallowedTools: ['Bash'],
 };
 
-describe('runCritiqueModel cross-family routing', () => {
+describe('runCritiqueModel cross-family routing via Codex', () => {
   beforeEach(() => {
     mocks.callClaudeCli.mockReset().mockResolvedValue(claudeResult);
-    mocks.hasCapFallbackProvider.mockReset();
-    mocks.callCapFallback.mockReset().mockResolvedValue(crossResult);
+    mocks.hasCodexCli.mockReset();
+    mocks.callCodexCli.mockReset().mockResolvedValue(codexResult);
     delete process.env.ZOE_CROSS_FAMILY_VERIFY;
   });
   afterEach(() => {
     delete process.env.ZOE_CROSS_FAMILY_VERIFY;
   });
 
-  it("routes to a different family when a non-Claude provider is available", async () => {
-    mocks.hasCapFallbackProvider.mockReturnValue(true);
+  it('routes to Codex (different family) when the codex CLI is present', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
     const r = await runCritiqueModel(opts);
     expect(r.reviewerFamily).toBe('cross');
-    expect(mocks.callCapFallback).toHaveBeenCalledWith('sys', 'usr');
+    expect(r.model).toBe('codex');
+    expect(mocks.callCodexCli).toHaveBeenCalledTimes(1);
     expect(mocks.callClaudeCli).not.toHaveBeenCalled();
-    expect(r.text).toContain('cross');
   });
 
-  it('falls back to same-family Claude when no non-Claude provider exists', async () => {
-    mocks.hasCapFallbackProvider.mockReturnValue(false);
+  it('falls back to same-family Claude when the codex CLI is absent', async () => {
+    mocks.hasCodexCli.mockReturnValue(false);
     const r = await runCritiqueModel(opts);
     expect(r.reviewerFamily).toBe('same');
     expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
-    expect(mocks.callCapFallback).not.toHaveBeenCalled();
+    expect(mocks.callCodexCli).not.toHaveBeenCalled();
   });
 
-  it('forces same-family when ZOE_CROSS_FAMILY_VERIFY=0 even if a provider exists', async () => {
-    mocks.hasCapFallbackProvider.mockReturnValue(true);
+  it('forces same-family when ZOE_CROSS_FAMILY_VERIFY=0 even if codex is present', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
     process.env.ZOE_CROSS_FAMILY_VERIFY = '0';
     const r = await runCritiqueModel(opts);
     expect(r.reviewerFamily).toBe('same');
-    expect(mocks.callCapFallback).not.toHaveBeenCalled();
+    expect(mocks.callCodexCli).not.toHaveBeenCalled();
     expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
   });
 
-  it('retries same-family when the cross-family response fails validation (garbage JSON)', async () => {
-    mocks.hasCapFallbackProvider.mockReturnValue(true);
-    mocks.callCapFallback.mockResolvedValue({
-      result: { ...crossResult.result, text: 'not json at all' },
-      provider: 'openrouter',
-    });
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
-    expect(r.reviewerFamily).toBe('same');
-    expect(mocks.callCapFallback).toHaveBeenCalledTimes(1);
-    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalled();
-    warn.mockRestore();
-  });
-
-  it('keeps the cross-family result when it passes validation', async () => {
-    mocks.hasCapFallbackProvider.mockReturnValue(true);
-    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
-    expect(r.reviewerFamily).toBe('cross');
-    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
-  });
-
-  it('falls back to same-family (loud, not a failure) when the cross-family call throws', async () => {
-    mocks.hasCapFallbackProvider.mockReturnValue(true);
-    mocks.callCapFallback.mockRejectedValue(new Error('provider down'));
+  it('falls back to same-family (loud) when Codex is usage-capped / throws', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    mocks.callCodexCli.mockRejectedValue(new Error('codex unavailable (usage limit)'));
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const r = await runCritiqueModel(opts);
     expect(r.reviewerFamily).toBe('same');
     expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it('retries same-family when the Codex response fails validation (garbage)', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    mocks.callCodexCli.mockResolvedValue({ ...codexResult, text: 'not json at all' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callCodexCli).toHaveBeenCalledTimes(1);
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('keeps the Codex result when it passes validation', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
+    expect(r.reviewerFamily).toBe('cross');
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
   });
 });

--- a/bot/src/zoe/critics/types.ts
+++ b/bot/src/zoe/critics/types.ts
@@ -21,7 +21,7 @@
 
 import { ZOE_DEFAULT_MODEL, ZOE_QUICK_MODEL } from '../types';
 import { callClaudeCli } from '../../hermes/claude-cli';
-import { hasCapFallbackProvider, callCapFallback } from '../models/router';
+import { hasCodexCli, callCodexCli } from '../../hermes/codex-cli';
 
 export type CritiqueSeverity = 'critical' | 'high' | 'med' | 'low';
 
@@ -191,15 +191,15 @@ function crossFamilyEnabled(): boolean {
  * github.com/99darwin/orchestrator) via nickysap - see doc 2204 + the wider
  * cross-model-review literature. Credited per .claude/rules/credit-attribution.md.
  *
- * Run a critic's model call, cross-FAMILY by default. When a
- * non-Claude fleet provider is configured (OpenRouter/DeepSeek/Grok/GPT) and
- * cross-family is enabled, the critique runs on a DIFFERENT model family than
- * the Claude builder it is reviewing - a different family catches what
- * same-family self-review rationalizes away. Falls back to same-family Claude
- * (and flags `reviewerFamily: 'same'`) when no non-Claude provider exists or the
- * cross-family call fails - never silently, so the caller can note the reduced
- * coverage. The critic's system+user prompts and tolerant JSON parsing are
- * unchanged; only WHO answers changes.
+ * Run a critic's model call, cross-FAMILY by default. When cross-family is
+ * enabled and the Codex CLI is present, the critique runs on Codex (OpenAI) - a
+ * DIFFERENT model family than the Claude builder it is reviewing, on the flat-rate
+ * Codex subscription (no per-call credits, no OpenRouter). A different family
+ * catches what same-family self-review rationalizes away. Falls back to
+ * same-family Claude (and flags `reviewerFamily: 'same'`) when Codex is absent,
+ * usage-capped, or returns an unusable response - never silently, so the caller
+ * can note the reduced coverage. The critic's system+user prompts and tolerant
+ * JSON parsing are unchanged; only WHO answers changes.
  */
 export async function runCritiqueModel(opts: {
   system: string;
@@ -238,19 +238,24 @@ export async function runCritiqueModel(opts: {
     };
   };
 
-  if (crossFamilyEnabled() && hasCapFallbackProvider()) {
+  if (crossFamilyEnabled() && hasCodexCli()) {
     try {
-      const { result, provider } = await callCapFallback(opts.system, opts.user);
+      const result = await callCodexCli({
+        system: opts.system,
+        user: opts.user,
+        cwd: opts.cwd,
+        timeoutMs: 120000,
+      });
       if (opts.validate && !opts.validate(result.text)) {
-        // Cross-family provider answered but the response is unusable - retry
-        // same-family so a flaky provider never degrades the critique to a
-        // false failure. Loud, not silent.
-        console.warn('[zoe/critic] cross-family reviewer returned an invalid response - retrying same-family');
+        // Codex answered but the response is unusable - retry same-family so a
+        // flaky/agentic transcript never degrades the critique to a false
+        // failure. Loud, not silent.
+        console.warn('[zoe/critic] codex cross-family returned an invalid response - retrying same-family');
         return sameFamily();
       }
       return {
         text: result.text,
-        model: result.model || `cross:${provider}`,
+        model: result.model,
         inputTokens: result.inputTokens,
         outputTokens: result.outputTokens,
         totalCostUsd: result.totalCostUsd,
@@ -258,10 +263,10 @@ export async function runCritiqueModel(opts: {
         reviewerFamily: 'cross',
       };
     } catch (err) {
-      // Cross-family provider failed - fall back to same-family rather than
-      // failing the critique outright. Loud, not silent.
+      // Codex unavailable (usage-capped, not logged in, timed out) - fall back
+      // to same-family Claude rather than failing the critique. Loud, not silent.
       console.warn(
-        '[zoe/critic] cross-family reviewer unavailable, falling back to same-family:',
+        '[zoe/critic] codex cross-family unavailable, falling back to same-family:',
         (err as Error).message,
       );
     }


### PR DESCRIPTION
## What changed

Cross-family verification (doc 2204) now routes the critique to **Codex (OpenAI)** - a different model family than the Claude builder, on your flat-rate Codex subscription - instead of OpenRouter (which needs per-call credits and is currently out). New `bot/src/hermes/codex-cli.ts` wrapper; the 3 critics reach it via the existing `runCritiqueModel`.

Codex-when-available, Claude-when-not - your call from chat.

## Why

The point of cross-family review is a *different family* catching what same-family self-review rationalizes away. Claude Max is the same family (not cross-family); OpenRouter was out of credits. Codex is a genuinely different family, flat-rate, and is literally the Claude<->Codex pairing the research (arxiv 2607.21656) studied. Credited per `.claude/rules/credit-attribution.md` (99darwin/orchestrator MIT).

## How

- `callCodexCli` shells to `codex exec --skip-git-repo-check -s read-only -o <file> -` (read-only sandbox; `-o` writes only the agent's final message, so the critique JSON parses cleanly with no transcript scraping).
- On cap / auth / timeout / spawn failure it throws `CodexUnavailableError`; the critic falls back to same-family Claude - loud (`console.warn`), never silent, `reviewerFamily: 'same'`.
- The validate-retry from the prior PR still guards a garbage transcript.
- `hasCodexCli()` gates on the binary existing, so a machine without Codex just uses same-family. `ZOE_CROSS_FAMILY_VERIFY=0` kill switch unchanged.

## Evidence

- `tsc --noEmit`: 40 = pre-existing baseline, **0 added**.
- Tests: **24/24** in `critics/` (18 existing + 6 rewritten for the Codex path: routes-to-codex / no-codex / env-disabled / capped-throws / garbage-retries / valid-keeps).
- `esbuild` bundle of `workers.ts` boot graph: OK.
- **Live on the VPS**: ran the real critic against this branch. Codex is currently usage-capped, so the wrapper detected it (`codex unavailable (hit your usage limit)`) and fell back to same-family Claude (`reviewerFamily=same`, haiku, score 100) - the fallback path is proven end-to-end. Actual cross-family delivery validates when Codex resets (Aug 8).

## Note

Requires the `codex` CLI installed + logged in on the host (it is, on the VPS). No OpenRouter dependency in the critic path anymore.