### PR TITLE
fix(zoe): codex cap-detection matched the critique's own words, killing cross-family review

### DIFF
--- a/bot/src/hermes/__tests__/codex-cli.test.ts
+++ b/bot/src/hermes/__tests__/codex-cli.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  existsSync: vi.fn(() => true),
+  readFile: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({ spawn: mocks.spawn }));
+vi.mock('node:fs', () => ({ existsSync: mocks.existsSync }));
+vi.mock('node:fs/promises', () => ({
+  mkdtemp: vi.fn(async () => '/tmp/zoe-codex-test'),
+  readFile: mocks.readFile,
+  rm: vi.fn(async () => undefined),
+}));
+
+import { CodexUnavailableError, callCodexCli, detectCodexUnavailable } from '../codex-cli';
+
+afterEach(() => vi.clearAllMocks());
+
+/** Minimal ChildProcess double: streams the given stdout/stderr then closes. */
+function makeSpawn(stdout: string, stderr: string, exitCode: number | null) {
+  return {
+    stdout: {
+      on: vi.fn((ev: string, cb: (b: Buffer) => void) => {
+        if (ev === 'data' && stdout) process.nextTick(() => cb(Buffer.from(stdout)));
+      }),
+    },
+    stderr: {
+      on: vi.fn((ev: string, cb: (b: Buffer) => void) => {
+        if (ev === 'data' && stderr) process.nextTick(() => cb(Buffer.from(stderr)));
+      }),
+    },
+    stdin: { write: vi.fn(), end: vi.fn() },
+    on: vi.fn((ev: string, cb: (code: number | null) => void) => {
+      if (ev === 'close') setTimeout(() => cb(exitCode), 10);
+    }),
+    kill: vi.fn(),
+  };
+}
+
+const OPTS = { system: 'sys', user: 'usr', cwd: '/tmp/repo' };
+
+describe('detectCodexUnavailable', () => {
+  it('treats a clean run as success even when the critique text matches a cap marker', () => {
+    // A research-critic answer legitimately contains "insufficient" / "429".
+    const critique = '{"score":40,"summary":"insufficient sources; quota of 429 words","issues":[]}';
+    expect(
+      detectCodexUnavailable({ code: 0, finalMessage: critique, combined: critique }),
+    ).toBeNull();
+  });
+
+  it('flags a genuine cap: non-zero exit, no final message', () => {
+    expect(
+      detectCodexUnavailable({
+        code: 1,
+        finalMessage: '',
+        combined: 'You have hit your usage limit. Try again later.',
+      }),
+    ).toMatch(/usage limit/i);
+  });
+
+  it('flags a cap that exits 0 but writes no final message', () => {
+    expect(
+      detectCodexUnavailable({ code: 0, finalMessage: '   ', combined: 'not logged in' }),
+    ).toMatch(/not logged in/i);
+  });
+
+  it('returns null for a failed run with no cap marker (caller handles empty output)', () => {
+    expect(detectCodexUnavailable({ code: 2, finalMessage: '', combined: 'boom' })).toBeNull();
+  });
+});
+
+describe('callCodexCli', () => {
+  it('returns the critique when the transcript happens to contain cap words', async () => {
+    // Regression: the cap scan used to run over stdout (which carries the
+    // agent's own answer), so a valid critique saying "insufficient" was
+    // rejected as a usage cap and the review silently degraded to same-family.
+    const critique = '{"score":45,"summary":"insufficient sources","issues":[]}';
+    mocks.readFile.mockResolvedValue(critique);
+    mocks.spawn.mockReturnValue(makeSpawn(critique, '', 0));
+
+    const result = await callCodexCli(OPTS);
+    expect(result.text).toBe(critique);
+    expect(result.model).toBe('codex');
+    expect(result.totalCostUsd).toBe(0);
+  });
+
+  it('throws CodexUnavailableError when codex is actually usage-capped', async () => {
+    mocks.readFile.mockRejectedValue(new Error('ENOENT'));
+    mocks.spawn.mockReturnValue(makeSpawn('', 'error: you have hit your usage limit', 1));
+
+    await expect(callCodexCli(OPTS)).rejects.toBeInstanceOf(CodexUnavailableError);
+  });
+
+  it('throws CodexUnavailableError when the binary is missing', async () => {
+    mocks.existsSync.mockReturnValueOnce(false);
+    await expect(callCodexCli(OPTS)).rejects.toBeInstanceOf(CodexUnavailableError);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/hermes/codex-cli.ts
+++ b/bot/src/hermes/codex-cli.ts
@@ -52,6 +52,33 @@ export function hasCodexCli(): boolean {
 const CAP_OR_AUTH = /usage limit|hit your usage limit|not logged in|please run .*login|quota|insufficient|\b401\b|\b403\b|\b429\b/i;
 
 /**
+ * Decide whether a FINISHED codex run means "codex is unavailable" (capped /
+ * not logged in) rather than "codex answered". Returns the matched marker, or
+ * null when the run succeeded.
+ *
+ * The cap markers may only be matched against a run that FAILED, because the
+ * text we scan (`combined` = the agent's own stdout + stderr) contains the
+ * critique itself - a critic reviewing a research doc routinely writes
+ * "insufficient sources", "quota", or a bare "429". Matching those in a
+ * successful run threw away a valid cross-family critique and silently
+ * downgraded the review to same-family Claude - and an untrusted input could
+ * trigger it on purpose just by containing the word "insufficient".
+ *
+ * A clean run - exit 0 AND a non-empty final-message file - is a success no
+ * matter what the transcript says. Anything else falls back to the marker scan,
+ * which is where a genuine cap/auth failure lands (codex writes no final
+ * message when it refuses to run).
+ */
+export function detectCodexUnavailable(opts: {
+  code: number | null;
+  finalMessage: string;
+  combined: string;
+}): string | null {
+  if (opts.code === 0 && opts.finalMessage.trim()) return null;
+  return opts.combined.match(CAP_OR_AUTH)?.[0] ?? null;
+}
+
+/**
  * Run one headless Codex critique. Returns the agent's final message text.
  * Throws CodexUnavailableError on cap / auth / spawn / timeout so the caller
  * can fall back to same-family review.
@@ -105,13 +132,6 @@ export async function callCodexCli(opts: {
     });
     child.on('close', async (code) => {
       clearTimeout(timer);
-      const combined = `${stdout}\n${stderr}`;
-      if (CAP_OR_AUTH.test(combined)) {
-        cleanup();
-        const hit = combined.match(CAP_OR_AUTH)?.[0] ?? 'cap/auth';
-        reject(new CodexUnavailableError(`codex unavailable (${hit})`));
-        return;
-      }
       let last = '';
       try {
         last = await readFile(outFile, 'utf8');
@@ -119,6 +139,12 @@ export async function callCodexCli(opts: {
         /* no last-message file written */
       }
       cleanup();
+      const combined = `${stdout}\n${stderr}`;
+      const hit = detectCodexUnavailable({ code, finalMessage: last, combined });
+      if (hit) {
+        reject(new CodexUnavailableError(`codex unavailable (${hit})`));
+        return;
+      }
       const text = last.trim() || stdout.trim();
       if (!text) {
         reject(new CodexUnavailableError(`codex produced no output (exit ${code})`));


### PR DESCRIPTION
## Executive summary

ZOE's cross-family critic (PR #2862 / #2863) routes a critique to Codex so a
different model family reviews Claude's work. It was being switched off at
runtime by its own success case: the "is Codex capped?" check scanned Codex's
own output, and a normal critique containing the word "insufficient" (or
"quota", or a bare "429") looked exactly like a usage-limit message. The
critique was thrown away and the review silently fell back to same-family
Claude. One-line-ish fix plus the missing test file.

## What breaks without the fix, concretely

`callCodexCli` decided cap/auth BEFORE deciding success:

```ts
child.on('close', async (code) => {
  const combined = `${stdout}\n${stderr}`;
  if (CAP_OR_AUTH.test(combined)) { reject(new CodexUnavailableError(...)); return; }
  ...
  const text = last.trim() || stdout.trim();   // <- stdout IS the critique
```

`CAP_OR_AUTH` is `/usage limit|...|quota|insufficient|\b401\b|\b403\b|\b429\b/i`
(`bot/src/hermes/codex-cli.ts:52`), and `combined` includes stdout - which the
next line itself treats as the critique text. So:

1. A `research-critic` run scores a doc and writes
   `{"score":45,"summary":"insufficient sources",...}`. Codex exits 0 and writes
   a clean final message.
2. `CAP_OR_AUTH` matches `insufficient` in the transcript.
3. `callCodexCli` throws `CodexUnavailableError("codex unavailable (insufficient)")`.
4. `runCritiqueModel` logs "codex cross-family unavailable" and re-runs the whole
   critique on Claude, returning `reviewerFamily: 'same'`.

Net effect: cross-family verification is defeated precisely when the reviewer
found something wrong (low-scoring critiques are the ones that use words like
"insufficient"), plus a wasted duplicate Claude call each time. "insufficient"
and "429" are ordinary vocabulary for a critic that scores source coverage
against the /zao-research Hard Reqs, so this is the common path, not an edge
case. The reviewed content is explicitly `TRUST=UNTRUSTED_DATA`, so an input can
also force the downgrade just by containing one of those words.

`reviewerFamily` is reported honestly as `'same'`, so this degrades loudly
rather than silently - but the capability is still gone.

## Fix

Read the final-message file first, then only apply the cap markers to a run that
did NOT cleanly succeed:

```ts
export function detectCodexUnavailable(opts: {
  code: number | null; finalMessage: string; combined: string;
}): string | null {
  if (opts.code === 0 && opts.finalMessage.trim()) return null;
  return opts.combined.match(CAP_OR_AUTH)?.[0] ?? null;
}
```

Exit 0 + a non-empty final message is a success regardless of transcript wording.
A genuine cap still lands in the marker scan, because Codex writes no final
message when it refuses to run. Extracted as an exported pure function so the
decision is unit-testable without spawning a process. No behavior change to the
timeout, spawn-error, or missing-binary paths.

## Evidence

Proven:
- `bot/src/hermes/codex-cli.ts` had **zero tests** - `cross-family.test.ts` mocks
  the whole module out. Added `bot/src/hermes/__tests__/codex-cli.test.ts`, 7 tests.
- Red before green: with the exit-0 guard removed, 2 of the new tests fail with
  `CodexUnavailableError: codex unavailable (insufficient)`. With the fix, all 7 pass.
- Full bot suite: `1827 passed, 2 failed (147 files)`. Both failures are
  pre-existing and unrelated - `trace.test.ts` and `transcribe.test.ts` assert
  POSIX `/tmp/...` paths and fail on a Windows checkout. Confirmed identical on a
  stashed (clean) tree. CI runs ubuntu, where they pass.
- `npx tsc --noEmit` in `bot/`: 40 errors before, 40 after, none in the touched
  files. That 40 is the repo's existing baseline (see #2863 "tsc baseline").
- Secret/PII scan on the diff: clean. `bot/` is outside biome's include set.

Not tested: no live `codex` binary in this environment, so the real CLI's exit
code and `-o` file behavior on a genuine cap were not observed. The fix is
conservative about this - if Codex exits 0 with no final message, the old
marker scan still applies.

## Also found, not fixed here (one-PR rule)

`bot/src/hermes/codex-cli.ts:163` - `child.stdin.write(prompt)` runs with no
`error` listener on `child.stdin`. If the binary exists but cannot be spawned
(permission denied, wrong arch, corrupted install), the write hits a destroyed
stream and the resulting unhandled `'error'` event would crash the ZOE process
rather than resolving via the `child.on('error')` fallback. A 2-line
`child.stdin.on('error', ...)` guard would close it. Left out to keep this PR to
one issue.

Audit run: unattended, PR-only. Not merged.
