### PR TITLE
fix(bot): unhandled stdin EPIPE kills the ZOE process instead of falling back to same-family review

### DIFF
--- a/bot/src/hermes/codex-cli.ts
+++ b/bot/src/hermes/codex-cli.ts
@@ -103,6 +103,20 @@ export async function callCodexCli(opts: {
       cleanup();
       reject(new CodexUnavailableError(`codex spawn failed: ${e.message}`));
     });
+    // A capped / not-logged-in codex exits BEFORE it consumes the prompt, so the
+    // pending stdin write below fails (EPIPE on Linux, EOF on Windows). Without a
+    // listener that is an unhandled stream 'error' event -> uncaughtException ->
+    // the whole bot process dies, instead of the same-family fallback this module
+    // exists to provide. `child.on('error')` does NOT cover stdin stream errors.
+    child.stdin.on('error', (e: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      cleanup();
+      reject(
+        new CodexUnavailableError(
+          `codex closed stdin before reading the prompt (${e.code ?? e.message})`,
+        ),
+      );
+    });
     child.on('close', async (code) => {
       clearTimeout(timer);
       const combined = `${stdout}\n${stderr}`;

--- a/bot/src/zoe/safety/klearu.ts
+++ b/bot/src/zoe/safety/klearu.ts
@@ -108,6 +108,14 @@ function run(cmdTemplate: string, stdinText: string | null, timeoutMs: number): 
       clearTimeout(timer);
       reject(e);
     });
+    // If the classifier exits before reading the text, the stdin write below fails
+    // (EPIPE/EOF). An unhandled stream 'error' event is an uncaughtException that
+    // kills the process; `child.on('error')` does not cover it. Reject instead, so
+    // the caller returns failVerdict() and the gate fails CLOSED as designed.
+    child.stdin.on('error', (e: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      reject(new Error(`klearu closed stdin before reading input (${e.code ?? e.message})`));
+    });
     child.on('close', (code) => {
       clearTimeout(timer);
       if (code === 0) resolve(out);


### PR DESCRIPTION
## Executive Summary

Two subprocess wrappers in the bot write a prompt to a spawned child's stdin with no error listener on that stream. When the child exits before it reads the prompt, the write fails and Node turns it into an **uncaughtException that kills the whole bot process**. This PR adds the missing listener at both sites so each failure follows the fallback path it was already designed to take.

## What breaks without this fix, concretely

`bot/src/hermes/codex-cli.ts` shells to `codex exec` as ZOE's cross-family critic. Its own header comment names the expected failure: *"Codex is periodically usage-capped; a cap / auth / spawn failure throws CodexUnavailableError so the caller (runCritiqueModel) falls back to same-family Claude."*

A capped or not-logged-in `codex` exits **before** consuming the prompt on stdin. Line 137 then writes into a pipe whose reader is gone:

- Linux: `EPIPE`. Windows: `EOF`. Either way it is emitted as an `'error'` event **on `child.stdin`**.
- `child.on('error', ...)` (line 101) does **not** cover stream errors on stdin - it only fires on spawn failure.
- An unhandled `'error'` event on a stream is an uncaughtException. `bot/src/index.ts:611` alerts then calls `process.exit(1)`; ZOE's own entrypoint (`bot/src/zoe/index.ts`) has no handler at all, so Node exits by default.

Net effect: the one condition the fallback exists for - Codex being capped - kills the bot instead of degrading to same-family review.

Same defect, same shape, in `bot/src/zoe/safety/klearu.ts:118` (the operator-configured safety classifier). There the crash also bypasses the `failVerdict()` fail-closed gate: the process dies rather than returning `unverified-block`.

Timing note, stated honestly: a prompt smaller than the pipe buffer (~64 KB) is absorbed before the child dies and no error is raised. The crash needs a large prompt (a critique prompt carrying a diff or transcript) or a child that dies mid-read. That is a normal-size critique payload, not an exotic one.

## Evidence (proven)

Minimal repro on this machine, `node v24.1.0` - a child that exits while a large stdin write is pending:

```
# without a stdin 'error' listener
UNCAUGHT: EOF write EOF
EXIT=42          <- process died

# with the listener this PR adds
HANDLED stdin error: EOF -> would reject CodexUnavailableError
close 1
EXIT=0           <- rejection path, process alive
```

Code facts verified by reading the files: `child.stdin.write` with no `'error'` listener at `bot/src/hermes/codex-cli.ts:137` and `bot/src/zoe/safety/klearu.ts:118`; `NodeJS.ErrnoException` is safe to use (`NodeJS.ProcessEnv` is already used in `bot/src/hermes/claude-cli.ts:129`, `@types/node ^22.7.0` in `bot/package.json`).

## Not verified in this run

`npm run typecheck` and `vitest run` were **not** executed - this audit checkout has no `node_modules` (root or `bot/`) and no global `tsc`. The change is 22 added lines of error handling with no happy-path behavior change, but please let CI be the gate. No regression test was added for the same reason: an unverifiable test is how main went red in #2830 / #2842.

## Behavior change

| | Before | After |
|---|---|---|
| Codex capped mid-prompt | uncaughtException, process exits | `CodexUnavailableError` -> same-family Claude fallback (loud warn, as designed) |
| Klearu classifier exits early | uncaughtException, process exits | rejects -> `failVerdict()` -> fail-**closed** |

## Other things seen this pass, not fixed here (one-PR rule)

- `codex-cli.ts:52` - `CAP_OR_AUTH` is tested against `stdout + stderr` combined. A critique whose reviewed *content* contains "quota", "401", or "insufficient" is misread as a cap and falls back to same-family. Soft-fails in the safe direction, so not fixed here.
- `codex-cli.ts:89` - on timeout, `cleanup()` removes the temp dir while the later `'close'` handler still tries to `readFile` the last-message file. It is caught, so it is cosmetic, not a bug.

Audit run: unattended hourly repo auditor, `main` @ `decf1c86d`. No merge, no push to main.
