### PR TITLE
fix(zoe): nudge-ladder pings forever when the ping counter fails to persist

### DIFF
--- a/bot/src/zoe/__tests__/nudge-ladder.test.ts
+++ b/bot/src/zoe/__tests__/nudge-ladder.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -102,5 +102,21 @@ describe('persistence + the kill switch', () => {
   });
   it('stopNudge on an unknown qid returns false', async () => {
     expect(await stopNudge('nope')).toBe(false);
+  });
+  it('markPinged reports whether the advance was persisted', async () => {
+    // Unknown qid -> false, so a caller that pings-on-true never pings a
+    // track that is not there.
+    expect(await markPinged('nope', 0)).toBe(false);
+    await startNudge('qZ', 'c', ['x'], 0);
+    expect(await markPinged('qZ', 3 * MIN)).toBe(true);
+    await stopNudge('qZ');
+  });
+  it('a corrupt (non-array) state file degrades to no tracks, not a throw', async () => {
+    const path = join(TMP, 'nudge-ladder.json');
+    // A hand-edit / repaired-truncation can leave valid JSON that is not an
+    // array; dueTracks() must not throw a TypeError out of the tick.
+    writeFileSync(path, '{"oops":true}');
+    await expect(dueTracks(10 * MIN)).resolves.toEqual([]);
+    writeFileSync(path, '[]');
   });
 });

--- a/bot/src/zoe/nudge-ladder.ts
+++ b/bot/src/zoe/nudge-ladder.ts
@@ -95,18 +95,28 @@ export function isExhausted(track: NudgeTrack): boolean {
 
 async function load(): Promise<NudgeTrack[]> {
   try {
-    return JSON.parse(await fs.readFile(ladderPath(), 'utf8')) as NudgeTrack[];
+    const parsed = JSON.parse(await fs.readFile(ladderPath(), 'utf8')) as unknown;
+    // A hand-edited / truncated-then-repaired file can parse to a non-array
+    // ({} or null). Callers immediately .filter()/.find() the result, so a
+    // non-array would throw a TypeError out of dueTracks() and take the whole
+    // orchestrator tick down. Treat anything that is not an array as "no tracks".
+    return Array.isArray(parsed) ? (parsed as NudgeTrack[]) : [];
   } catch {
     return [];
   }
 }
 
-async function save(tracks: NudgeTrack[]): Promise<void> {
+/** Persist. Returns false (and logs) when the write failed - callers that are
+ *  about to SEND a ping must treat a false here as "do not ping": an unrecorded
+ *  ping means the schedule never advances and MAX_PINGS never trips. */
+async function save(tracks: NudgeTrack[]): Promise<boolean> {
   try {
     await fs.mkdir(ladderHome(), { recursive: true });
     await fs.writeFile(ladderPath(), JSON.stringify(tracks, null, 2));
-  } catch {
-    /* best-effort */
+    return true;
+  } catch (err) {
+    console.error('[zoe/nudge-ladder] persist failed:', (err as Error)?.message);
+    return false;
   }
 }
 
@@ -135,13 +145,16 @@ export async function stopNudge(qid: string): Promise<boolean> {
   return true;
 }
 
-/** Record that a re-ping was just sent for a qid (advances the schedule). */
-export async function markPinged(qid: string, nowMs: number): Promise<void> {
+/** Reserve a ping slot for a qid (advances the schedule). Returns true only if
+ *  the advance was PERSISTED - call this BEFORE sending, and skip the send when
+ *  it returns false. Failing to record a ping is what turns the ladder into the
+ *  runaway spam it exists to prevent. */
+export async function markPinged(qid: string, nowMs: number): Promise<boolean> {
   const tracks = await load();
   const t = tracks.find((x) => x.qid === qid);
-  if (!t) return;
+  if (!t) return false;
   t.pingMs.push(nowMs);
-  await save(tracks);
+  return save(tracks);
 }
 
 /** The open tracks that are due for a re-ping right now. */

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -592,10 +592,17 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
       const nowMs = deps.now.getTime();
       for (const t of await dueTracks(nowMs)) {
         try {
+          // Record the ping BEFORE sending - fail CLOSED. If the counter cannot
+          // be persisted, the track's pingMs never grows, so it stays permanently
+          // DUE and MAX_PINGS never trips: ZOE would re-ping this one question
+          // every cron tick forever. Skipping a ping is the safe direction.
+          if (!(await markPinged(t.qid, nowMs))) {
+            console.error(`[zoe/nudge-ladder] could not record ping for ${t.qid}, skipping re-ping`);
+            continue;
+          }
           await deps.bot.api.sendMessage(deps.groupId, `Still need your answer: ${t.label}`, {
             reply_markup: questionKeyboard(t.qid, t.options),
           });
-          await markPinged(t.qid, nowMs);
         } catch (err) {
           console.error('[zoe/nudge-ladder] re-ping failed:', (err as Error)?.message);
         }


### PR DESCRIPTION
## Executive Summary

The nudge ladder shipped this morning (#2877) can turn into the exact Telegram spam it was built to prevent. Its runaway cap (`MAX_PINGS = 40`) counts how many pings it has recorded on disk. The function that records a ping swallowed every write error silently and returned nothing, so the orchestrator sent the ping regardless of whether the count actually got saved. If the save fails, the count never grows, the question stays permanently "due", the cap never trips, and ZOE re-pings that one question on every cron tick forever.

This PR makes the counter authoritative: record the ping first, only send if the record stuck, and log loudly when it does not.

## What breaks without this fix, concretely

`bot/src/zoe/nudge-ladder.ts` (pre-fix):

```ts
async function save(tracks: NudgeTrack[]): Promise<void> {
  try { ... } catch { /* best-effort */ }   // every write error swallowed, no log
}

export async function markPinged(qid: string, nowMs: number): Promise<void> {
  ...
  t.pingMs.push(nowMs);
  await save(tracks);                        // caller cannot tell success from loss
}
```

`bot/src/zoe/orchestrator-tick.ts` (pre-fix, line 593):

```ts
await deps.bot.api.sendMessage(...);         // send first
await markPinged(t.qid, nowMs);              // then try to record - failure is invisible
```

The cap that is supposed to stop this is `isPingDue`:

```ts
if (track.pingMs.length >= MAX_PINGS) return false;
```

So the moment a write to `$ZOE_HOME/nudge-ladder.json` fails - disk full, a permissions change on `~/.zao/zoe`, a read-only mount, a partial write from a concurrent writer that makes the file unparseable - `pingMs` stays at length 1. `lastPing` stays `startedMs`, elapsed keeps growing, `isPingDue` keeps returning true, and `pingMs.length >= 40` is never reached. Result: "Still need your answer: ..." to Zaal's phone every 5 minutes, indefinitely, with zero log output explaining why. The module header claims this cannot happen ("a broken ladder can never become the spam it is meant to prevent"); the swallowed error is the hole in that guarantee.

Second, smaller crash path in the same file: `load()` returned `JSON.parse(...)` unchecked. A state file that parses to a non-array (`{}`, `null` - a hand-edit, or a truncation someone repaired) makes `dueTracks()` throw a `TypeError` on `.filter`. `dueTracks()` is called at `orchestrator-tick.ts:593` **outside** the per-track try/catch, so that throw propagates and kills the entire orchestrator tick - relay push, refill, everything - not just the nudge.

## The fix

- `save()` returns `false` and logs at error level instead of swallowing (`silent-failure-guard.md` rule 6: a soft-fail must be loud).
- `markPinged()` returns whether the advance was actually persisted.
- `orchestrator-tick` records the ping **before** sending and `continue`s when the record failed - fail closed. Losing one ping is strictly better than infinite pings.
- `load()` guards with `Array.isArray`, degrading a corrupt file to "no tracks" instead of a tick-killing `TypeError`.

Behavior when everything works is unchanged. `startNudge` / `stopNudge` signatures are untouched on purpose - `stopNudge` is called at `orchestrator-tick.ts:490` outside a try/catch, so making it throw would have been a regression.

## Evidence (proven)

- `npm test` in `bot/`: **1834 passed** (was 1832 - 2 new tests). The 2 failures in `transcribe.test.ts` and `trace.test.ts` are pre-existing and Windows-path-separator-only - verified by stashing this diff and re-running on clean `origin/main`, which produces the identical 2 failures. CI runs ubuntu, where they pass.
- `npx tsc --noEmit`: 40 errors = the documented baseline from #2877's own commit message. `grep` for `nudge-ladder|orchestrator-tick` in the tsc output: no matches.
- `npx esbuild src/zoe/orchestrator-tick.ts --bundle`: exit 0.
- Secret/PII scan of the diff (case-insensitive, run as its own step): no matches.

New tests: `markPinged` returns false for an unknown qid and true on a persisted advance; a non-array state file makes `dueTracks()` resolve to `[]` rather than throw.

## Also seen this pass, not fixed here (one-PR rule)

- `bot/src/zoe/nudge-ladder.ts` - `isExhausted()` is exported but never called anywhere. Its docstring says the caller "should surface it as stuck", so a question that burns all 40 pings unanswered goes silent with nobody told, and its track stays in the state file forever. Needs a product decision, not a mechanical fix.
- `orchestrator-tick.ts:595` - the re-ping does not call `armPendingAnswer`, unlike every other question-push site (line 558). `pending-answers` is in-memory and resets on bot restart, so after a deploy a re-ping's buttons still work but a plain typed answer is dead. Degraded, not broken.
- `startNudge` does read-modify-write on the shared state file; if `load()` fails transiently it returns `[]` and the subsequent `save()` drops every other track. `always-open-topics.ts` already uses a temp-file+rename atomic write for the same class of state file; `nudge-ladder.ts` does not.
- `src/app/api/nexus/links/route.ts:15` - the comment says "RLS public read policy filters to `is_active=true`", but the route uses `supabaseAdmin` (service role), which bypasses RLS. No leak today because line 40 filters `is_active` explicitly, but the comment misstates where the safety comes from.

Nothing else in this pass rose above style/speculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
