### PR TITLE
feat(zoe): per-task complexity model routing (#60)

### DIFF
--- a/bot/src/zoe/__tests__/decompose.test.ts
+++ b/bot/src/zoe/__tests__/decompose.test.ts
@@ -143,3 +143,33 @@ test('renderPlanForApproval handles single-step plan cleanly', () => {
   assert.match(out, /Steps \(1\):/);
   assert.match(out, /st-1\. Look up the answer inline -> task-dispatcher/);
 });
+
+// --- modelForCostClass: per-task complexity routing (opt-in) ---
+import { modelForCostClass } from '../decompose.ts';
+
+test('modelForCostClass: routing OFF returns the worker default unchanged', () => {
+  const prev = process.env.ZOE_TASK_COMPLEXITY_ROUTING;
+  delete process.env.ZOE_TASK_COMPLEXITY_ROUTING;
+  try {
+    assert.equal(modelForCostClass('sonnet', 'small'), 'sonnet');
+    assert.equal(modelForCostClass('haiku', 'large'), 'haiku');
+    assert.equal(modelForCostClass('sonnet', undefined), 'sonnet');
+  } finally {
+    if (prev === undefined) delete process.env.ZOE_TASK_COMPLEXITY_ROUTING;
+    else process.env.ZOE_TASK_COMPLEXITY_ROUTING = prev;
+  }
+});
+
+test('modelForCostClass: routing ON maps cost class to model tier', () => {
+  const prev = process.env.ZOE_TASK_COMPLEXITY_ROUTING;
+  process.env.ZOE_TASK_COMPLEXITY_ROUTING = '1';
+  try {
+    assert.equal(modelForCostClass('sonnet', 'small'), 'haiku'); // ZOE_QUICK_MODEL
+    assert.equal(modelForCostClass('haiku', 'medium'), 'sonnet'); // ZOE_DEFAULT_MODEL
+    assert.equal(modelForCostClass('haiku', 'large'), 'opus'); // ZOE_HARD_MODEL
+    assert.equal(modelForCostClass('sonnet', undefined), 'sonnet'); // default -> medium tier
+  } finally {
+    if (prev === undefined) delete process.env.ZOE_TASK_COMPLEXITY_ROUTING;
+    else process.env.ZOE_TASK_COMPLEXITY_ROUTING = prev;
+  }
+});

--- a/bot/src/zoe/decompose.ts
+++ b/bot/src/zoe/decompose.ts
@@ -22,7 +22,7 @@
  */
 
 import { callClaudeCli } from '../hermes/claude-cli';
-import { ZOE_DEFAULT_MODEL, ZOE_HARD_MODEL } from './types';
+import { ZOE_DEFAULT_MODEL, ZOE_HARD_MODEL, ZOE_QUICK_MODEL } from './types';
 import type { ZoeContext } from './types';
 
 export type WorkerKind =
@@ -219,6 +219,32 @@ function findLastJsonObject(text: string): string | null {
  * via ZOE_MAX_SUBTASKS.
  */
 export const MAX_SUBTASKS = Math.max(1, Number(process.env.ZOE_MAX_SUBTASKS ?? 12));
+
+/**
+ * Pick a model for one subtask from its decomposer-rated `estimated_cost_class`
+ * (schema: 'small' = haiku-sized, 'medium' = sonnet, 'large' = opus). The
+ * decomposer already rates this per-subtask AS a model tier - this wires that
+ * rating to the actual model, so a boilerplate subtask drops to the quick tier
+ * and a genuinely-hard one gets the strong tier, instead of every subtask
+ * running the worker-kind's fixed default.
+ *
+ * OPT-IN: returns `defaultModel` unchanged unless ZOE_TASK_COMPLEXITY_ROUTING=1,
+ * so the current worker-kind behavior is preserved until Zaal enables it. The
+ * strong (opus) tier is only reached for a 'large' subtask, which the decomposer
+ * is prompted to mark sparingly (decompose prompt: "Default to lower cost class").
+ */
+export function modelForCostClass(defaultModel: string, costClass?: CostClass): string {
+  if (process.env.ZOE_TASK_COMPLEXITY_ROUTING !== '1') return defaultModel;
+  switch (costClass) {
+    case 'small':
+      return ZOE_QUICK_MODEL;
+    case 'large':
+      return ZOE_HARD_MODEL;
+    case 'medium':
+    default:
+      return ZOE_DEFAULT_MODEL;
+  }
+}
 
 /**
  * Validate + narrow the parsed JSON into a DecompositionPlan. Throws on

--- a/bot/src/zoe/workers.ts
+++ b/bot/src/zoe/workers.ts
@@ -24,6 +24,7 @@ import { recordCall } from './cost-ledger';
 import { Trace, writeTrace } from './trace';
 import { ZOE_DEFAULT_MODEL, ZOE_QUICK_MODEL } from './types';
 import type { ZoeContext } from './types';
+import { modelForCostClass } from './decompose';
 import type { Subtask, WorkerKind } from './decompose';
 import { CRITIQUE_PASS_THRESHOLD, type CritiqueOutput } from './critics/types';
 import { runResearchCritic } from './critics/research-critic';
@@ -314,10 +315,14 @@ async function runCriticFor(
 export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult> {
   const worker = args.subtask.worker as ClaudeWorkerKind;
   const cfg = WORKER_CONFIG[worker];
+  // Per-task complexity routing (opt-in via ZOE_TASK_COMPLEXITY_ROUTING): map the
+  // subtask's decomposer-rated cost class to a model tier; falls back to the
+  // worker-kind default when routing is off. See decompose.modelForCostClass.
+  const model = modelForCostClass(cfg.model, args.subtask.estimated_cost_class);
   const base: Omit<WorkerResult, 'status' | 'output' | 'critique' | 'revised'> = {
     subtaskId: args.subtask.id,
     worker,
-    model: cfg.model,
+    model,
     inputTokens: 0,
     outputTokens: 0,
     costUsd: 0,
@@ -327,7 +332,7 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
   // Step-level trace (best-effort; doc 2200). Records the worker run as a span
   // tree - each model call + critic as a child span - so we can see WHERE a run
   // failed, not just that it did. All best-effort: never breaks the worker.
-  const trace = new Trace(`worker:${worker}`, Date.now(), { 'gen_ai.request.model': cfg.model });
+  const trace = new Trace(`worker:${worker}`, Date.now(), { 'gen_ai.request.model': model });
   const flushTrace = (status: 'ok' | 'error', attrs: Record<string, unknown> = {}): void => {
     try {
       trace.finish(Date.now(), status, attrs);
@@ -351,10 +356,10 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
   }
 
   const call = async (criticFeedback?: string, budgetUsd: number = cfg.maxBudgetUsd) => {
-    trace.begin('llm.call', 'generation', Date.now(), { 'gen_ai.request.model': cfg.model });
+    trace.begin('llm.call', 'generation', Date.now(), { 'gen_ai.request.model': model });
     try {
       const r = await callClaudeCli({
-        model: cfg.model,
+        model,
         prompt: buildWorkerPrompt(args, criticFeedback),
         cwd: args.context.workspace_dir,
         appendSystemPrompt: spec,


### PR DESCRIPTION
Wires the decomposer's already-rated per-subtask estimated_cost_class (small=haiku, medium=sonnet, large=opus) to actual model selection in runClaudeWorker. The rating existed but was ignored - every subtask ran the worker-kind's fixed default. Now a boilerplate subtask drops to the quick tier and a hard one gets the strong tier. Opt-in via ZOE_TASK_COMPLEXITY_ROUTING=1 (default OFF = no behavior change). tsc 40=baseline, 9/9 decompose tests (2 new), workers+scheduler bundle clean.