### PR TITLE
feat(zoe): cache-aware cost observability (#68)

### DIFF
--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -4,6 +4,13 @@ export interface ClaudeCliResult {
   text: string;
   inputTokens: number;
   outputTokens: number;
+  /**
+   * Input tokens served from the prompt cache (Claude: usage.cache_read_input_tokens).
+   * These are ~10x cheaper than fresh input tokens, so this is the number that
+   * proves caching is actually saving money. Optional: providers without a cache
+   * (e.g. DeepSeek via OpenRouter) leave it 0. See cost-ledger for the rollup.
+   */
+  cachedInputTokens?: number;
   totalCostUsd: number;
   model: string;
   durationMs: number;
@@ -207,7 +214,7 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
             result?: string;
             session_id?: string;
             total_cost_usd?: number;
-            usage?: { input_tokens?: number; output_tokens?: number };
+            usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number };
             modelUsage?: Record<string, { inputTokens: number; outputTokens: number; costUSD: number }>;
           };
           if (parsed.is_error) {
@@ -237,6 +244,7 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
             text: parsed.result ?? '',
             inputTokens: usage.input_tokens ?? 0,
             outputTokens: usage.output_tokens ?? 0,
+            cachedInputTokens: usage.cache_read_input_tokens ?? 0,
             totalCostUsd: parsed.total_cost_usd ?? 0,
             model: opts.model,
             durationMs: parsed.duration_ms ?? 0,

--- a/bot/src/zoe/__tests__/cost-ledger.test.ts
+++ b/bot/src/zoe/__tests__/cost-ledger.test.ts
@@ -125,3 +125,45 @@ describe('recordCall', () => {
     expect(() => recordCall('test', { model: 'haiku', inputTokens: 0, outputTokens: 0, totalCostUsd: 0 })).not.toThrow();
   });
 });
+
+// ── cache-aware observability (cachedInputTokens) ───────────────────────────────
+
+describe('cache observability', () => {
+  it('aggregates cachedInputTokens per model', () => {
+    const l1 = JSON.stringify({ model: 'sonnet', in: 1000, out: 100, cached: 800, usd: 0.01 });
+    const l2 = JSON.stringify({ model: 'sonnet', in: 500, out: 50, cached: 400, usd: 0.005 });
+    mockReadFileSync.mockReturnValue(`${l1}\n${l2}\n`);
+    const rows = todaySummary(TEST_DAY);
+    const sonnet = rows.find((r) => r.model === 'sonnet');
+    expect(sonnet!.cachedInputTokens).toBe(1200);
+    expect(sonnet!.inputTokens).toBe(1500);
+  });
+
+  it('defaults cachedInputTokens to 0 for records without the field (old logs)', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'haiku', in: 100, out: 20, usd: 0.001 }) + '\n');
+    expect(todaySummary(TEST_DAY)[0].cachedInputTokens).toBe(0);
+  });
+
+  it('summaryText shows a cache-hit percentage when cached tokens exist', () => {
+    // 800 of 1000 input tokens cached = 80%
+    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'sonnet', in: 1000, out: 100, cached: 800, usd: 0.01 }) + '\n');
+    const text = summaryText(TEST_DAY);
+    expect(text).toContain('80% of input tokens served from cache');
+    expect(text).toContain('80% cached in');
+  });
+
+  it('summaryText omits the cache line when nothing is cached', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'haiku', in: 100, out: 20, cached: 0, usd: 0.001 }) + '\n');
+    const text = summaryText(TEST_DAY);
+    expect(text).not.toContain('cached');
+  });
+
+  it('recordCall persists the cached field', () => {
+    mockMkdirSync.mockImplementation(() => {}); // reset the throwing impl bled from an earlier test
+    mockWriteFileSync.mockImplementation(() => {});
+    mockReadFileSync.mockReturnValue('');
+    recordCall('worker', { model: 'sonnet', inputTokens: 1000, outputTokens: 100, cachedInputTokens: 700, totalCostUsd: 0.01 });
+    const parsed = JSON.parse((mockAppendFileSync.mock.calls[0][1] as string).trim());
+    expect(parsed.cached).toBe(700);
+  });
+});

--- a/bot/src/zoe/cost-ledger.ts
+++ b/bot/src/zoe/cost-ledger.ts
@@ -25,6 +25,8 @@ export interface CallCost {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  /** Input tokens served from the prompt cache (Claude cache_read_input_tokens). */
+  cachedInputTokens?: number;
   totalCostUsd: number;
 }
 
@@ -33,6 +35,9 @@ export interface ModelRollup {
   calls: number;
   inputTokens: number;
   outputTokens: number;
+  /** Of inputTokens, how many were served from cache. Optional: rollups from
+   * pre-cache-observability logs have no value. */
+  cachedInputTokens?: number;
   costUsd: number;
 }
 
@@ -53,6 +58,7 @@ export function recordCall(caller: string, r: CallCost): void {
       model: r.model,
       in: r.inputTokens ?? 0,
       out: r.outputTokens ?? 0,
+      cached: r.cachedInputTokens ?? 0,
       usd: r.totalCostUsd ?? 0,
     });
     appendFileSync(join(COST_DIR, `${today()}.jsonl`), `${line}\n`);
@@ -69,17 +75,18 @@ export function todaySummary(day = today()): ModelRollup[] {
     const byModel = new Map<string, ModelRollup>();
     for (const l of raw.split('\n')) {
       if (!l.trim()) continue;
-      let rec: { model?: string; in?: number; out?: number; usd?: number };
+      let rec: { model?: string; in?: number; out?: number; cached?: number; usd?: number };
       try {
         rec = JSON.parse(l) as typeof rec;
       } catch {
         continue;
       }
       const model = rec.model ?? 'unknown';
-      const m = byModel.get(model) ?? { model, calls: 0, inputTokens: 0, outputTokens: 0, costUsd: 0 };
+      const m = byModel.get(model) ?? { model, calls: 0, inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, costUsd: 0 };
       m.calls += 1;
       m.inputTokens += rec.in ?? 0;
       m.outputTokens += rec.out ?? 0;
+      m.cachedInputTokens = (m.cachedInputTokens ?? 0) + (rec.cached ?? 0);
       m.costUsd += rec.usd ?? 0;
       byModel.set(model, m);
     }
@@ -95,10 +102,19 @@ export function summaryText(day = today()): string {
   if (rows.length === 0) return `No ZOE model calls logged for ${day}.`;
   const total = rows.reduce((s, r) => s + r.costUsd, 0);
   const totalCalls = rows.reduce((s, r) => s + r.calls, 0);
-  const lines = rows.map(
-    (r) => `- ${r.model}: ${r.calls} calls, ${(r.inputTokens + r.outputTokens).toLocaleString()} tok, $${r.costUsd.toFixed(4)}`,
-  );
-  return [`ZOE spend ${day} - $${total.toFixed(4)} across ${totalCalls} calls:`, ...lines].join('\n');
+  const lines = rows.map((r) => {
+    const cached = r.cachedInputTokens ?? 0;
+    const cacheNote = cached > 0 && r.inputTokens > 0
+      ? ` (${Math.round((cached / r.inputTokens) * 100)}% cached in)`
+      : '';
+    return `- ${r.model}: ${r.calls} calls, ${(r.inputTokens + r.outputTokens).toLocaleString()} tok${cacheNote}, $${r.costUsd.toFixed(4)}`;
+  });
+  const totalIn = rows.reduce((s, r) => s + r.inputTokens, 0);
+  const totalCached = rows.reduce((s, r) => s + (r.cachedInputTokens ?? 0), 0);
+  const cacheLine = totalCached > 0 && totalIn > 0
+    ? ` (${Math.round((totalCached / totalIn) * 100)}% of input tokens served from cache)`
+    : '';
+  return [`ZOE spend ${day} - $${total.toFixed(4)} across ${totalCalls} calls${cacheLine}:`, ...lines].join('\n');
 }
 
 function writeDailySummary(): void {


### PR DESCRIPTION
The cost ledger was blind to caching - callClaudeCli dropped usage.cache_read_input_tokens at the source, so the spend view couldn't show whether prompt caching was saving money. Now captured end-to-end: the daily summary shows cache-hit % per model and overall (e.g. '80% of input tokens served from cache'). Additive + fail-safe (optional field, old logs and non-caching providers read 0, no new deps/keys/flags, no caller edits). tsc 40=baseline, cost-ledger 17/17 (5 new), cost-governance 19/19, hermes+router 149/149.