### PR TITLE
feat(zoe): surface cache-hit % in /budget breakdown

### DIFF
--- a/bot/src/zoe/__tests__/cost-governance.test.ts
+++ b/bot/src/zoe/__tests__/cost-governance.test.ts
@@ -342,6 +342,16 @@ describe('cost-governance', () => {
       expect(text).toContain('1 calls');
     });
 
+    it('shows cache-hit % in the breakdown when tokens were cached', () => {
+      vi.mocked(costLedger.todaySummary).mockReturnValue([
+        { model: 'sonnet', calls: 2, inputTokens: 1000, outputTokens: 200, cachedInputTokens: 750, costUsd: 0.02 },
+        { model: 'haiku', calls: 1, inputTokens: 400, outputTokens: 50, cachedInputTokens: 0, costUsd: 0.001 },
+      ]);
+      const text = formatSpendStatus(true);
+      expect(text).toContain('75% cached'); // sonnet: 750/1000
+      expect(text).not.toContain('0% cached'); // haiku: no cache -> no note
+    });
+
     it('handles empty ledger', () => {
       vi.mocked(costLedger.todaySummary).mockReturnValue([]);
 

--- a/bot/src/zoe/cost-governance.ts
+++ b/bot/src/zoe/cost-governance.ts
@@ -137,7 +137,13 @@ export function formatSpendStatus(detailed = false): string {
       main.push('\nBreakdown by model:');
       for (const row of summary) {
         const modelShort = row.model.length > 20 ? row.model.slice(0, 17) + '...' : row.model;
-        main.push(`  ${modelShort}: ${row.calls} calls, $${row.costUsd.toFixed(4)}`);
+        // Cache-hit % of input tokens (prompt-caching savings) - only shown when
+        // caching actually happened, so non-caching providers stay quiet.
+        const cached = row.cachedInputTokens ?? 0;
+        const cacheNote = cached > 0 && row.inputTokens > 0
+          ? `, ${Math.round((cached / row.inputTokens) * 100)}% cached`
+          : '';
+        main.push(`  ${modelShort}: ${row.calls} calls, $${row.costUsd.toFixed(4)}${cacheNote}`);
       }
     }
   }


### PR DESCRIPTION
Completes the prompt-caching thread: now that the ledger captures cache_read tokens (#68), the /budget detailed per-model breakdown shows the cache-hit % so Zaal actually SEES the savings (e.g. 'sonnet: 12 calls, $0.04, 75% cached'). Folded into the existing /budget surface (reuse over a new command); shown only when caching happened. tsc 40=baseline, cost-governance 20/20 (1 new), bundles clean.