### PR TITLE
fix(zoe): cache-hit % divides by total input, not fresh-only (caught by live test)

### DIFF
--- a/bot/src/zoe/__tests__/cost-governance.test.ts
+++ b/bot/src/zoe/__tests__/cost-governance.test.ts
@@ -342,14 +342,17 @@ describe('cost-governance', () => {
       expect(text).toContain('1 calls');
     });
 
-    it('shows cache-hit % in the breakdown when tokens were cached', () => {
+    it('shows cache-hit % over total input (fresh + cached), never over 100%', () => {
       vi.mocked(costLedger.todaySummary).mockReturnValue([
-        { model: 'sonnet', calls: 2, inputTokens: 1000, outputTokens: 200, cachedInputTokens: 750, costUsd: 0.02 },
-        { model: 'haiku', calls: 1, inputTokens: 400, outputTokens: 50, cachedInputTokens: 0, costUsd: 0.001 },
+        // fresh 250 + cached 750 = 1000 total => 75%
+        { model: 'sonnet', calls: 2, inputTokens: 250, outputTokens: 200, cachedInputTokens: 750, costUsd: 0.02 },
+        // real-shape: tiny fresh, huge cache_read => must be 100%, not 212410%
+        { model: 'haiku', calls: 1, inputTokens: 10, outputTokens: 50, cachedInputTokens: 21241, costUsd: 0.001 },
       ]);
       const text = formatSpendStatus(true);
-      expect(text).toContain('75% cached'); // sonnet: 750/1000
-      expect(text).not.toContain('0% cached'); // haiku: no cache -> no note
+      expect(text).toContain('75% cached'); // sonnet: 750/(250+750)
+      expect(text).toContain('100% cached'); // haiku: 21241/(10+21241) rounds to 100
+      expect(text).not.toMatch(/\d{4,}% cached/); // no absurd 4+-digit %
     });
 
     it('handles empty ledger', () => {

--- a/bot/src/zoe/__tests__/cost-ledger.test.ts
+++ b/bot/src/zoe/__tests__/cost-ledger.test.ts
@@ -144,12 +144,21 @@ describe('cache observability', () => {
     expect(todaySummary(TEST_DAY)[0].cachedInputTokens).toBe(0);
   });
 
-  it('summaryText shows a cache-hit percentage when cached tokens exist', () => {
-    // 800 of 1000 input tokens cached = 80%
-    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'sonnet', in: 1000, out: 100, cached: 800, usd: 0.01 }) + '\n');
+  it('summaryText shows a cache-hit % over TOTAL input (fresh + cached)', () => {
+    // in=250 fresh + cached=750 => total input 1000, hit-rate 750/1000 = 75%.
+    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'sonnet', in: 250, out: 100, cached: 750, usd: 0.01 }) + '\n');
     const text = summaryText(TEST_DAY);
-    expect(text).toContain('80% of input tokens served from cache');
-    expect(text).toContain('80% cached in');
+    expect(text).toContain('75% of input tokens served from cache');
+    expect(text).toContain('75% cached in');
+  });
+
+  it('summaryText never reports over 100% when cached dwarfs fresh input (the bug)', () => {
+    // Real shape: fresh input is tiny (10), cache_read is huge (21241). Dividing
+    // by fresh alone gave 212410%; correct is 21241/21251 = ~100%.
+    mockReadFileSync.mockReturnValue(JSON.stringify({ model: 'haiku', in: 10, out: 40, cached: 21241, usd: 0.01 }) + '\n');
+    const text = summaryText(TEST_DAY);
+    expect(text).toContain('100% cached in');
+    expect(text).not.toMatch(/\d{4,}% cached/); // no 4+-digit percentage
   });
 
   it('summaryText omits the cache line when nothing is cached', () => {

--- a/bot/src/zoe/cost-governance.ts
+++ b/bot/src/zoe/cost-governance.ts
@@ -140,8 +140,12 @@ export function formatSpendStatus(detailed = false): string {
         // Cache-hit % of input tokens (prompt-caching savings) - only shown when
         // caching actually happened, so non-caching providers stay quiet.
         const cached = row.cachedInputTokens ?? 0;
-        const cacheNote = cached > 0 && row.inputTokens > 0
-          ? `, ${Math.round((cached / row.inputTokens) * 100)}% cached`
+        // Denominator is total input (fresh + cached), not fresh alone - else
+        // cache_read dwarfing the tiny fresh input yields absurd >100% (see
+        // cost-ledger.summaryText).
+        const totalInput = row.inputTokens + cached;
+        const cacheNote = cached > 0 && totalInput > 0
+          ? `, ${Math.round((cached / totalInput) * 100)}% cached`
           : '';
         main.push(`  ${modelShort}: ${row.calls} calls, $${row.costUsd.toFixed(4)}${cacheNote}`);
       }

--- a/bot/src/zoe/cost-ledger.ts
+++ b/bot/src/zoe/cost-ledger.ts
@@ -104,15 +104,19 @@ export function summaryText(day = today()): string {
   const totalCalls = rows.reduce((s, r) => s + r.calls, 0);
   const lines = rows.map((r) => {
     const cached = r.cachedInputTokens ?? 0;
-    const cacheNote = cached > 0 && r.inputTokens > 0
-      ? ` (${Math.round((cached / r.inputTokens) * 100)}% cached in)`
+    // Cache-hit % = cached / total-input, where total input = fresh (inputTokens,
+    // the non-cached count) + cached. Dividing by inputTokens alone overstates it
+    // wildly (cache_read can dwarf the tiny fresh input -> >100%).
+    const totalInput = r.inputTokens + cached;
+    const cacheNote = cached > 0 && totalInput > 0
+      ? ` (${Math.round((cached / totalInput) * 100)}% cached in)`
       : '';
     return `- ${r.model}: ${r.calls} calls, ${(r.inputTokens + r.outputTokens).toLocaleString()} tok${cacheNote}, $${r.costUsd.toFixed(4)}`;
   });
   const totalIn = rows.reduce((s, r) => s + r.inputTokens, 0);
   const totalCached = rows.reduce((s, r) => s + (r.cachedInputTokens ?? 0), 0);
-  const cacheLine = totalCached > 0 && totalIn > 0
-    ? ` (${Math.round((totalCached / totalIn) * 100)}% of input tokens served from cache)`
+  const cacheLine = totalCached > 0 && totalIn + totalCached > 0
+    ? ` (${Math.round((totalCached / (totalIn + totalCached)) * 100)}% of input tokens served from cache)`
     : '';
   return [`ZOE spend ${day} - $${total.toFixed(4)} across ${totalCalls} calls${cacheLine}:`, ...lines].join('\n');
 }


### PR DESCRIPTION
Live testing showed '/budget' rendering 'haiku: 128400% cached'. input_tokens is the fresh (non-cached) count; cache_read is separate, so the denominator must be fresh+cached. Fixed in summaryText + formatSpendStatus, with regression tests. tsc 40=baseline, 38/38.