### PR TITLE
feat(zoe): OpenRouter as a second cross-family critic reviewer

### DIFF
--- a/bot/src/zoe/critics/__tests__/cross-family.test.ts
+++ b/bot/src/zoe/critics/__tests__/cross-family.test.ts
@@ -4,6 +4,8 @@ const mocks = vi.hoisted(() => ({
   callClaudeCli: vi.fn(),
   hasCodexCli: vi.fn(),
   callCodexCli: vi.fn(),
+  hasCapFallbackProvider: vi.fn(),
+  callCapFallback: vi.fn(),
 }));
 
 vi.mock('../../../hermes/claude-cli', () => ({ callClaudeCli: mocks.callClaudeCli }));
@@ -11,6 +13,10 @@ vi.mock('../../../hermes/codex-cli', () => ({
   hasCodexCli: mocks.hasCodexCli,
   callCodexCli: mocks.callCodexCli,
   CodexUnavailableError: class extends Error {},
+}));
+vi.mock('../../models/router', () => ({
+  hasCapFallbackProvider: mocks.hasCapFallbackProvider,
+  callCapFallback: mocks.callCapFallback,
 }));
 
 import { runCritiqueModel } from '../types';
@@ -36,6 +42,18 @@ const codexResult = {
   durationMs: 200,
 };
 
+const openrouterResult = {
+  text: '{"score":55,"summary":"cross via openrouter","issues":[]}',
+  model: 'openrouter/deepseek-chat',
+  inputTokens: 5,
+  outputTokens: 10,
+  totalCostUsd: 0,
+  durationMs: 150,
+  numTurns: 1,
+  isError: false,
+  sessionId: 'or',
+};
+
 const opts = {
   system: 'sys',
   user: 'usr',
@@ -49,6 +67,10 @@ describe('runCritiqueModel cross-family routing via Codex', () => {
     mocks.callClaudeCli.mockReset().mockResolvedValue(claudeResult);
     mocks.hasCodexCli.mockReset();
     mocks.callCodexCli.mockReset().mockResolvedValue(codexResult);
+    // Default: no cap-fallback provider, so the existing codex-only tests keep
+    // their old behavior (codex fail -> same-family).
+    mocks.hasCapFallbackProvider.mockReset().mockReturnValue(false);
+    mocks.callCapFallback.mockReset().mockResolvedValue({ result: openrouterResult, provider: 'openrouter' });
     delete process.env.ZOE_CROSS_FAMILY_VERIFY;
   });
   afterEach(() => {
@@ -109,5 +131,78 @@ describe('runCritiqueModel cross-family routing via Codex', () => {
     const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
     expect(r.reviewerFamily).toBe('cross');
     expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+  });
+});
+
+describe('runCritiqueModel cross-family routing via OpenRouter (second reviewer)', () => {
+  beforeEach(() => {
+    mocks.callClaudeCli.mockReset().mockResolvedValue(claudeResult);
+    mocks.hasCodexCli.mockReset();
+    mocks.callCodexCli.mockReset().mockResolvedValue(codexResult);
+    mocks.hasCapFallbackProvider.mockReset().mockReturnValue(true);
+    mocks.callCapFallback.mockReset().mockResolvedValue({ result: openrouterResult, provider: 'openrouter' });
+    delete process.env.ZOE_CROSS_FAMILY_VERIFY;
+  });
+  afterEach(() => {
+    delete process.env.ZOE_CROSS_FAMILY_VERIFY;
+  });
+
+  it('THE KEY CASE: Codex capped -> OpenRouter still gives a cross-family review', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    mocks.callCodexCli.mockRejectedValue(new Error('codex unavailable (usage limit)'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('cross'); // NOT same - OpenRouter covered it
+    expect(r.model).toBe('openrouter/deepseek-chat');
+    expect(mocks.callCapFallback).toHaveBeenCalledTimes(1);
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('uses OpenRouter cross-family when Codex is absent entirely', async () => {
+    mocks.hasCodexCli.mockReturnValue(false);
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('cross');
+    expect(r.model).toBe('openrouter/deepseek-chat');
+    expect(mocks.callCodexCli).not.toHaveBeenCalled();
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+  });
+
+  it('prefers Codex over OpenRouter when both are available', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('cross');
+    expect(r.model).toBe('codex');
+    expect(mocks.callCapFallback).not.toHaveBeenCalled();
+  });
+
+  it('falls to same-family only when BOTH cross reviewers are unavailable', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    mocks.callCodexCli.mockRejectedValue(new Error('codex capped'));
+    mocks.callCapFallback.mockRejectedValue(new Error('all cap-fallback providers failed'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('falls to same-family when the OpenRouter response fails validation', async () => {
+    mocks.hasCodexCli.mockReturnValue(false);
+    mocks.callCapFallback.mockResolvedValue({ result: { ...openrouterResult, text: 'not json' }, provider: 'openrouter' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await runCritiqueModel({ ...opts, validate: (t) => t.trim().startsWith('{') });
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callClaudeCli).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('ZOE_CROSS_FAMILY_VERIFY=0 skips BOTH cross reviewers', async () => {
+    mocks.hasCodexCli.mockReturnValue(true);
+    process.env.ZOE_CROSS_FAMILY_VERIFY = '0';
+    const r = await runCritiqueModel(opts);
+    expect(r.reviewerFamily).toBe('same');
+    expect(mocks.callCodexCli).not.toHaveBeenCalled();
+    expect(mocks.callCapFallback).not.toHaveBeenCalled();
   });
 });

--- a/bot/src/zoe/critics/types.ts
+++ b/bot/src/zoe/critics/types.ts
@@ -22,6 +22,7 @@
 import { ZOE_DEFAULT_MODEL, ZOE_QUICK_MODEL } from '../types';
 import { callClaudeCli } from '../../hermes/claude-cli';
 import { hasCodexCli, callCodexCli } from '../../hermes/codex-cli';
+import { hasCapFallbackProvider, callCapFallback } from '../models/router';
 
 export type CritiqueSeverity = 'critical' | 'high' | 'med' | 'low';
 
@@ -192,14 +193,18 @@ function crossFamilyEnabled(): boolean {
  * cross-model-review literature. Credited per .claude/rules/credit-attribution.md.
  *
  * Run a critic's model call, cross-FAMILY by default. When cross-family is
- * enabled and the Codex CLI is present, the critique runs on Codex (OpenAI) - a
- * DIFFERENT model family than the Claude builder it is reviewing, on the flat-rate
- * Codex subscription (no per-call credits, no OpenRouter). A different family
- * catches what same-family self-review rationalizes away. Falls back to
- * same-family Claude (and flags `reviewerFamily: 'same'`) when Codex is absent,
- * usage-capped, or returns an unusable response - never silently, so the caller
- * can note the reduced coverage. The critic's system+user prompts and tolerant
- * JSON parsing are unchanged; only WHO answers changes.
+ * enabled the critique runs on a DIFFERENT model family than the Claude builder
+ * it is reviewing - a different family catches what same-family self-review
+ * rationalizes away. Two cross-family reviewers are tried in order:
+ *   1. Codex (OpenAI) - flat-rate subscription, no per-call credits. Preferred.
+ *   2. OpenRouter/DeepSeek (via callCapFallback) - cheap per-call, and crucially
+ *      still works while Codex is usage-capped (Codex caps periodically), so
+ *      cross-family coverage does not silently collapse to same-family.
+ * Only if BOTH cross-family reviewers are unavailable (absent, capped, or return
+ * an unusable response) does it fall back to same-family Claude and flag
+ * `reviewerFamily: 'same'` - never silently, so the caller can note the reduced
+ * coverage. The critic's system+user prompts and tolerant JSON parsing are
+ * unchanged; only WHO answers changes.
  */
 export async function runCritiqueModel(opts: {
   system: string;
@@ -238,20 +243,18 @@ export async function runCritiqueModel(opts: {
     };
   };
 
-  if (crossFamilyEnabled() && hasCodexCli()) {
+  // Second cross-family reviewer: OpenRouter/DeepSeek (or grok/gpt) via
+  // callCapFallback. Returns a 'cross' result, or null if it is unavailable or
+  // returns an unusable response (caller then continues to same-family). This is
+  // what keeps cross-family alive while Codex is capped.
+  const openRouterCross = async (): Promise<CritiqueModelResult | null> => {
     try {
-      const result = await callCodexCli({
-        system: opts.system,
-        user: opts.user,
-        cwd: opts.cwd,
-        timeoutMs: 120000,
-      });
+      const { result, provider } = await callCapFallback(opts.system, opts.user);
       if (opts.validate && !opts.validate(result.text)) {
-        // Codex answered but the response is unusable - retry same-family so a
-        // flaky/agentic transcript never degrades the critique to a false
-        // failure. Loud, not silent.
-        console.warn('[zoe/critic] codex cross-family returned an invalid response - retrying same-family');
-        return sameFamily();
+        console.warn(
+          `[zoe/critic] ${provider} cross-family returned an invalid response - falling back to same-family`,
+        );
+        return null;
       }
       return {
         text: result.text,
@@ -263,13 +266,55 @@ export async function runCritiqueModel(opts: {
         reviewerFamily: 'cross',
       };
     } catch (err) {
-      // Codex unavailable (usage-capped, not logged in, timed out) - fall back
-      // to same-family Claude rather than failing the critique. Loud, not silent.
       console.warn(
-        '[zoe/critic] codex cross-family unavailable, falling back to same-family:',
+        '[zoe/critic] openrouter cross-family unavailable, falling back to same-family:',
         (err as Error).message,
       );
+      return null;
+    }
+  };
+
+  if (crossFamilyEnabled()) {
+    // 1. Codex (preferred cross-family - flat-rate, no per-call credits).
+    if (hasCodexCli()) {
+      try {
+        const result = await callCodexCli({
+          system: opts.system,
+          user: opts.user,
+          cwd: opts.cwd,
+          timeoutMs: 120000,
+        });
+        if (opts.validate && !opts.validate(result.text)) {
+          // Codex answered but the response is unusable - fall through to the
+          // OpenRouter cross-family reviewer, not straight to same-family. Loud.
+          console.warn('[zoe/critic] codex cross-family returned an invalid response - trying openrouter');
+        } else {
+          return {
+            text: result.text,
+            model: result.model,
+            inputTokens: result.inputTokens,
+            outputTokens: result.outputTokens,
+            totalCostUsd: result.totalCostUsd,
+            durationMs: result.durationMs,
+            reviewerFamily: 'cross',
+          };
+        }
+      } catch (err) {
+        // Codex unavailable (usage-capped, not logged in, timed out) - fall
+        // through to the OpenRouter cross-family reviewer. Loud, not silent.
+        console.warn(
+          '[zoe/critic] codex cross-family unavailable, trying openrouter:',
+          (err as Error).message,
+        );
+      }
+    }
+
+    // 2. OpenRouter/DeepSeek cross-family (works while Codex is capped).
+    if (hasCapFallbackProvider()) {
+      const orResult = await openRouterCross();
+      if (orResult) return orResult;
     }
   }
+
   return sameFamily();
 }


### PR DESCRIPTION
Cross-family verification used Codex as the only different-family reviewer, so while Codex is capped (till Aug 8) the critic silently fell back to same-family. This adds OpenRouter/DeepSeek (via callCapFallback) as a second cross-family reviewer. Order: Codex -> OpenRouter -> same-family; a Codex cap now falls through to OpenRouter, not straight to same-family. Pattern credit: 99darwin/orchestrator (MIT) via nickysap. tsc 40=baseline, cross-family 12/12 (6 new), full suite 1849/1849.