### PR TITLE
feat(zoe): multi-family code-review panel for the Hermes critic (doc 2214)

### DIFF
--- a/bot/src/hermes/__tests__/critic-panel.test.ts
+++ b/bot/src/hermes/__tests__/critic-panel.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { parseCriticReview, aggregatePanel, type PanelReview } from '../critic';
+
+const R = (family: PanelReview['family'], score: number, feedback = 'fb'): PanelReview => ({
+  family,
+  model: family,
+  score,
+  feedback,
+  inputTokens: 10,
+  outputTokens: 5,
+});
+
+describe('parseCriticReview - tolerant cross-family parse', () => {
+  it('parses clean JSON', () => {
+    expect(parseCriticReview('{"score":80,"feedback":"ok"}')).toEqual({ score: 80, feedback: 'ok' });
+  });
+  it('parses JSON wrapped in a code fence', () => {
+    expect(parseCriticReview('```json\n{"score":55,"feedback":"meh"}\n```')).toEqual({ score: 55, feedback: 'meh' });
+  });
+  it('extracts the last score object from prose (Codex/DeepSeek style)', () => {
+    const text = 'Let me review.\nThe diff looks fine overall.\n{"score":90,"feedback":"clean"}';
+    expect(parseCriticReview(text)).toEqual({ score: 90, feedback: 'clean' });
+  });
+  it('returns null on unusable output', () => {
+    expect(parseCriticReview('I could not review this')).toBeNull();
+  });
+  it('rejects an out-of-range score', () => {
+    expect(parseCriticReview('{"score":150,"feedback":"x"}')).toBeNull();
+  });
+});
+
+describe('aggregatePanel - safety-biased weighted vote', () => {
+  it('gates on the MIN of full-weight families (the pessimist wins)', () => {
+    const out = aggregatePanel([R('claude', 85), R('codex', 60)], 20, 10);
+    expect(out.score).toBe(60); // codex is the pessimist
+    expect(out.modelUsed).toContain('panel:[claude,codex]');
+    expect(out.modelUsed).not.toContain('degraded');
+  });
+
+  it('treats DeepSeek/openrouter as ADVISORY - it never lowers the gate on its own', () => {
+    const out = aggregatePanel([R('claude', 85), R('codex', 90), R('openrouter', 40, 'looks risky')], 30, 15);
+    expect(out.score).toBe(85); // min(claude,codex) - openrouter 40 does NOT gate
+    expect(out.feedback).toContain('advisory openrouter flagged (40)');
+  });
+
+  it('does NOT surface an advisory family that agrees with the gate', () => {
+    const out = aggregatePanel([R('claude', 80), R('codex', 82), R('openrouter', 78)], 30, 15);
+    expect(out.score).toBe(80);
+    expect(out.feedback).not.toContain('advisory');
+  });
+
+  it('flags DEGRADED when only one family reviewed', () => {
+    const out = aggregatePanel([R('claude', 75)], 10, 5);
+    expect(out.score).toBe(75);
+    expect(out.modelUsed).toContain('(degraded)');
+    expect(out.feedback).toContain('degraded');
+  });
+
+  it('flags DEGRADED when only same-family Claude reviewers ran (no cross-family)', () => {
+    // two claude reviews but zero cross-family voters -> still degraded
+    const out = aggregatePanel([R('claude', 88), R('claude', 70)], 20, 10);
+    expect(out.feedback).toContain('degraded');
+  });
+
+  it('is NOT degraded with claude + one cross-family voter', () => {
+    const out = aggregatePanel([R('claude', 80), R('openrouter', 76)], 20, 10);
+    expect(out.feedback).not.toContain('degraded');
+    // openrouter is the only cross-family voter and it is advisory; gate rests on claude
+    expect(out.score).toBe(80);
+  });
+
+  it('falls back to the advisory score when NO full-weight family survived (degraded)', () => {
+    const out = aggregatePanel([R('openrouter', 65)], 10, 5);
+    expect(out.score).toBe(65);
+    expect(out.feedback).toContain('degraded');
+  });
+
+  it('caps feedback length', () => {
+    const long = 'x'.repeat(800);
+    const out = aggregatePanel([R('claude', 50, long), R('codex', 45, long)], 20, 10);
+    expect(out.feedback.length).toBeLessThanOrEqual(500);
+  });
+});

--- a/bot/src/hermes/critic.ts
+++ b/bot/src/hermes/critic.ts
@@ -4,6 +4,8 @@ import {
   HERMES_ROUTING_ENABLED,
 } from './claude-cli';
 import { callClaudeCliCapAware } from '../zoe/models/cli-cap-aware';
+import { hasCodexCli, callCodexCli } from './codex-cli';
+import { hasCapFallbackProvider, callCapFallback } from '../zoe/models/router';
 import { runCmd } from './git';
 import { classifyDiffComplexity, type CritiqueInput, type CritiqueOutput } from './types';
 
@@ -67,6 +69,23 @@ const CRITIC_OUTPUT_SCHEMA = {
   },
 } as const;
 
+function buildCriticUserPrompt(input: CritiqueInput, diff: string): string {
+  return [
+    `[EXTERNAL_SOURCE: original_issue]`,
+    input.issueText,
+    `[END_EXTERNAL_SOURCE]`,
+    '',
+    `# Files Changed (${input.filesChanged.length})`,
+    input.filesChanged.join('\n'),
+    '',
+    `[EXTERNAL_SOURCE: stock_coder_diff]`,
+    diff.slice(0, 16000),
+    `[END_EXTERNAL_SOURCE]`,
+    '',
+    'Score this diff per your system prompt rules. Output JSON only.',
+  ].join('\n');
+}
+
 export async function runCritic(input: CritiqueInput): Promise<CritiqueOutput> {
   const diffOutput = await runCmd('git', ['diff', 'origin/main'], input.workTreePath);
   if (diffOutput.exitCode !== 0) {
@@ -82,20 +101,15 @@ export async function runCritic(input: CritiqueInput): Promise<CritiqueOutput> {
     };
   }
 
-  const userPrompt = [
-    `[EXTERNAL_SOURCE: original_issue]`,
-    input.issueText,
-    `[END_EXTERNAL_SOURCE]`,
-    '',
-    `# Files Changed (${input.filesChanged.length})`,
-    input.filesChanged.join('\n'),
-    '',
-    `[EXTERNAL_SOURCE: stock_coder_diff]`,
-    diff.slice(0, 16000),
-    `[END_EXTERNAL_SOURCE]`,
-    '',
-    'Score this diff per your system prompt rules. Output JSON only.',
-  ].join('\n');
+  const userPrompt = buildCriticUserPrompt(input, diff);
+
+  // Multi-family review panel (doc 2214, DEEP): when ZOE_CRITIC_PANEL=1 AND a
+  // cross-family reviewer is actually available, run 2-3 disjoint families
+  // INDEPENDENTLY and aggregate (vote, never debate). Otherwise fall through to
+  // the single-critic path below, byte-for-byte unchanged.
+  if (panelEnabled() && (hasCodexCli() || hasCapFallbackProvider())) {
+    return runCriticPanel(input, diff, userPrompt);
+  }
 
   const criticModel = selectCriticModel(diff, input.filesChanged);
   const result = await callClaudeCliCapAware({
@@ -151,4 +165,172 @@ function parseJsonStrict<T>(text: string): T {
       `Critic returned non-JSON output. First 200 chars: ${cleaned.slice(0, 200)}. Parse error: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+// ─── Multi-family review panel (doc 2214, DEEP) ──────────────────────────────
+// Independent reviewers from disjoint model families vote on the same diff; the
+// gate is safety-biased (the pessimist among full-weight families wins) and a
+// cheap cross-family voter (DeepSeek) is advisory, never a sole blocker. We VOTE,
+// never DEBATE: the deep research (Debate-or-Vote NeurIPS'25; arXiv 2509.05396)
+// found debate does not reliably beat a vote and can lower accuracy. Opt-in via
+// ZOE_CRITIC_PANEL=1; falls back to same-family Claude when only one family runs.
+
+/** Cross-family review panel is opt-in. Default OFF = the single-critic path. */
+function panelEnabled(): boolean {
+  return process.env.ZOE_CRITIC_PANEL === '1';
+}
+
+/** One family's independent review. */
+export interface PanelReview {
+  family: 'claude' | 'codex' | 'openrouter';
+  model: string;
+  score: number;
+  feedback: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * Tolerant parse of a critic response into {score, feedback}. Cross-family
+ * models (Codex, DeepSeek) may wrap the JSON in prose or fences, so we extract
+ * the last score-bearing object rather than requiring strict JSON. Returns null
+ * on an unusable response (that family is then dropped from the panel).
+ */
+export function parseCriticReview(text: string): { score: number; feedback: string } | null {
+  const cleaned = text.replace(/```(?:json)?/gi, '').trim();
+  const candidates: string[] = [];
+  const objs = cleaned.match(/\{[^{}]*"score"[^{}]*\}/g);
+  if (objs) candidates.push(objs[objs.length - 1]);
+  candidates.push(cleaned);
+  for (const c of candidates) {
+    try {
+      const o = JSON.parse(c) as { score?: unknown; feedback?: unknown };
+      if (typeof o.score === 'number' && o.score >= 0 && o.score <= 100) {
+        return { score: o.score, feedback: typeof o.feedback === 'string' ? o.feedback : '' };
+      }
+    } catch {
+      /* try next candidate */
+    }
+  }
+  return null;
+}
+
+async function reviewWithClaude(
+  input: CritiqueInput,
+  diff: string,
+  userPrompt: string,
+): Promise<PanelReview | null> {
+  const model = selectCriticModel(diff, input.filesChanged);
+  try {
+    const result = await callClaudeCliCapAware({
+      model,
+      prompt: userPrompt,
+      cwd: input.workTreePath,
+      appendSystemPrompt: CRITIC_SYSTEM,
+      permissionMode: 'bypassPermissions',
+      allowedTools: ['Read', 'Grep', 'Glob', 'Bash(git diff*)', 'Bash(cat *)', 'Bash(ls*)'],
+      disallowedTools: ['Edit', 'Write', 'Bash(git commit*)', 'Bash(git push*)', 'Bash(rm *)', 'Bash(curl *)'],
+      outputFormat: 'json',
+      jsonSchema: CRITIC_OUTPUT_SCHEMA,
+      timeoutMs: 4 * 60 * 1000,
+      maxBudgetUsd: Number(process.env.HERMES_CRITIC_BUDGET_USD ?? '1'),
+    });
+    if (result.isError) return null;
+    const p = parseCriticReview(result.text);
+    if (!p) return null;
+    return { family: 'claude', model, score: p.score, feedback: p.feedback, inputTokens: result.inputTokens, outputTokens: result.outputTokens };
+  } catch {
+    return null;
+  }
+}
+
+async function reviewWithCodex(input: CritiqueInput, userPrompt: string): Promise<PanelReview | null> {
+  if (!hasCodexCli()) return null;
+  try {
+    const r = await callCodexCli({ system: CRITIC_SYSTEM, user: userPrompt, cwd: input.workTreePath, timeoutMs: 4 * 60 * 1000 });
+    const p = parseCriticReview(r.text);
+    if (!p) return null;
+    return { family: 'codex', model: r.model, score: p.score, feedback: p.feedback, inputTokens: r.inputTokens, outputTokens: r.outputTokens };
+  } catch {
+    return null;
+  }
+}
+
+async function reviewWithOpenRouter(input: CritiqueInput, userPrompt: string): Promise<PanelReview | null> {
+  if (!hasCapFallbackProvider()) return null;
+  try {
+    const { result } = await callCapFallback(CRITIC_SYSTEM, userPrompt);
+    const p = parseCriticReview(result.text);
+    if (!p) return null;
+    return { family: 'openrouter', model: result.model, score: p.score, feedback: p.feedback, inputTokens: result.inputTokens, outputTokens: result.outputTokens };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Aggregate the surviving reviews into one gated verdict. Safety-biased: the
+ * gate score is the MIN across full-weight families (Claude, Codex); an
+ * OpenRouter/DeepSeek voter is advisory (surfaced when it scores materially
+ * lower, but never lowers the gate on its own). `degraded` = fewer than two
+ * families, or no cross-family voter (effectively single-family - reported, not
+ * silently passed).
+ */
+export function aggregatePanel(reviews: PanelReview[], inputTokens: number, outputTokens: number): CritiqueOutput {
+  const fullWeight = reviews.filter((r) => r.family === 'claude' || r.family === 'codex');
+  const advisory = reviews.filter((r) => r.family === 'openrouter');
+  const gatePool = fullWeight.length > 0 ? fullWeight : advisory;
+  const gate = gatePool.reduce((lowest, r) => (r.score < lowest.score ? r : lowest), gatePool[0]);
+
+  const crossFamily = reviews.filter((r) => r.family !== 'claude').length;
+  const degraded = reviews.length < 2 || crossFamily === 0;
+
+  const scoreLine = reviews.map((r) => `${r.family} ${r.score}`).join(', ');
+  const parts = [`[panel ${scoreLine}] ${gate.feedback}`];
+  for (const a of advisory) {
+    if (a.score + 15 < gate.score) parts.push(`advisory ${a.family} flagged (${a.score}): ${a.feedback}`);
+  }
+  if (degraded) parts.push('[degraded: <2 cross-family reviewers - treat as single-family]');
+
+  let feedback = parts.join(' | ');
+  if (feedback.length > 500) feedback = `${feedback.slice(0, 497)}...`;
+
+  return {
+    score: gate.score,
+    feedback,
+    inputTokens,
+    outputTokens,
+    modelUsed: `panel:[${reviews.map((r) => r.family).join(',')}]${degraded ? '(degraded)' : ''}`,
+  };
+}
+
+/**
+ * Run the review panel: fan out to every available family INDEPENDENTLY
+ * (Promise.allSettled - one family failing never fails the panel), drop any
+ * family that errored or returned an unusable response, then aggregate. Never
+ * throws.
+ */
+async function runCriticPanel(input: CritiqueInput, diff: string, userPrompt: string): Promise<CritiqueOutput> {
+  const settled = await Promise.allSettled([
+    reviewWithClaude(input, diff, userPrompt),
+    reviewWithCodex(input, userPrompt),
+    reviewWithOpenRouter(input, userPrompt),
+  ]);
+  const reviews = settled
+    .map((s) => (s.status === 'fulfilled' ? s.value : null))
+    .filter((r): r is PanelReview => r !== null);
+
+  const inputTokens = reviews.reduce((s, r) => s + r.inputTokens, 0);
+  const outputTokens = reviews.reduce((s, r) => s + r.outputTokens, 0);
+
+  if (reviews.length === 0) {
+    return {
+      score: 0,
+      feedback: 'critic panel: all reviewers failed to produce a valid review',
+      inputTokens,
+      outputTokens,
+      modelUsed: 'panel:none',
+    };
+  }
+  return aggregatePanel(reviews, inputTokens, outputTokens);
 }


### PR DESCRIPTION
Takes the code-review gate from a single Claude-family critic to a disjoint-family PANEL (doc 2214 DEEP design). Independent fan-out to Claude+Codex+DeepSeek, VOTE not debate, safety-biased min-gate with DeepSeek advisory, honest degradation. Opt-in ZOE_CRITIC_PANEL=1, default OFF = single path unchanged. tsc 40=baseline, panel 9/9, full suite 1862/1862.