### PR TITLE
feat(zoe): shadow-mode eval harness for the critic panel (doc 2215 M2)

### DIFF
--- a/bot/src/hermes/__tests__/critic-shadow.test.ts
+++ b/bot/src/hermes/__tests__/critic-shadow.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const m = vi.hoisted(() => ({
+  callClaudeCliCapAware: vi.fn(),
+  hasCodexCli: vi.fn(),
+  callCodexCli: vi.fn(),
+  hasCapFallbackProvider: vi.fn(),
+  callCapFallback: vi.fn(),
+  runCmd: vi.fn(),
+  appendFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('../../zoe/models/cli-cap-aware', () => ({ callClaudeCliCapAware: m.callClaudeCliCapAware }));
+vi.mock('../codex-cli', () => ({ hasCodexCli: m.hasCodexCli, callCodexCli: m.callCodexCli }));
+vi.mock('../../zoe/models/router', () => ({ hasCapFallbackProvider: m.hasCapFallbackProvider, callCapFallback: m.callCapFallback }));
+vi.mock('../git', () => ({ runCmd: m.runCmd }));
+vi.mock('node:fs', () => ({ appendFileSync: m.appendFileSync, mkdirSync: m.mkdirSync, readFileSync: m.readFileSync }));
+
+import { runCritic, shadowSummary } from '../critic';
+
+const cli = (text: string) => ({ text, isError: false, inputTokens: 10, outputTokens: 5, model: 'sonnet' });
+const input = { workTreePath: '/tmp/wt', branchName: 'ws/x', filesChanged: ['a.ts'], issueText: 'fix a' };
+
+beforeEach(() => {
+  delete process.env.ZOE_CRITIC_PANEL;
+  process.env.ZOE_CRITIC_PANEL_SHADOW = '1';
+  m.runCmd.mockReset().mockResolvedValue({ exitCode: 0, stdout: 'diff --git a/a.ts b/a.ts\n+x', stderr: '' });
+  m.hasCodexCli.mockReset().mockReturnValue(false);
+  m.hasCapFallbackProvider.mockReset().mockReturnValue(true);
+  m.callCodexCli.mockReset();
+  m.callCapFallback.mockReset();
+  m.callClaudeCliCapAware.mockReset();
+  m.appendFileSync.mockReset();
+  m.mkdirSync.mockReset();
+  m.readFileSync.mockReset();
+});
+afterEach(() => {
+  delete process.env.ZOE_CRITIC_PANEL_SHADOW;
+});
+
+describe('shadow mode dispatch', () => {
+  it('single critic GATES; panel runs alongside and the delta is logged', async () => {
+    // single review + panel(claude) review both via callClaudeCliCapAware; deepseek via callCapFallback
+    m.callClaudeCliCapAware
+      .mockResolvedValueOnce(cli('{"score":88,"feedback":"single: ok"}')) // single gate
+      .mockResolvedValueOnce(cli('{"score":55,"feedback":"panel-claude: concern"}')); // panel claude
+    m.callCapFallback.mockResolvedValue({ result: cli('{"score":60,"feedback":"deepseek advisory"}'), provider: 'openrouter' });
+
+    const out = await runCritic(input);
+    expect(out.score).toBe(88); // the SINGLE critic gates, unaffected by the panel
+    expect(out.feedback).toContain('single: ok');
+    expect(m.appendFileSync).toHaveBeenCalledOnce(); // the comparison was logged
+    const logged = JSON.parse((m.appendFileSync.mock.calls[0][1] as string).trim());
+    expect(logged.single_score).toBe(88);
+    expect(logged.single_pass).toBe(true);
+    expect(typeof logged.panel_score).toBe('number');
+  });
+
+  it('records panel_failed_to_run without breaking the gate when the panel throws', async () => {
+    m.callClaudeCliCapAware.mockResolvedValueOnce(cli('{"score":90,"feedback":"single ok"}'));
+    // panel: claude review fails to parse AND deepseek throws -> panel returns score 0 (all failed) or null
+    m.callCapFallback.mockRejectedValue(new Error('openrouter down'));
+    // panel's claude reviewer: second call returns garbage -> dropped; no cross-family -> panel all-failed
+    m.callClaudeCliCapAware.mockResolvedValueOnce({ text: 'garbage', isError: false, inputTokens: 1, outputTokens: 1, model: 'sonnet' });
+
+    const out = await runCritic(input);
+    expect(out.score).toBe(90); // single still gates
+    expect(m.appendFileSync).toHaveBeenCalledOnce();
+  });
+
+  it('a logging failure never breaks the critic run', async () => {
+    m.mkdirSync.mockImplementation(() => { throw new Error('disk full'); });
+    m.callClaudeCliCapAware
+      .mockResolvedValueOnce(cli('{"score":80,"feedback":"ok"}'))
+      .mockResolvedValueOnce(cli('{"score":75,"feedback":"panel"}'));
+    m.callCapFallback.mockResolvedValue({ result: cli('{"score":78,"feedback":"ds"}'), provider: 'openrouter' });
+
+    const out = await runCritic(input);
+    expect(out.score).toBe(80); // survived the logging failure
+  });
+});
+
+describe('shadowSummary', () => {
+  it('classifies agreements and disagreements at the pass threshold', () => {
+    const rows = [
+      { single_pass: true, panel_pass: true, agree: true },        // agree
+      { single_pass: false, panel_pass: false, agree: true },       // agree
+      { single_pass: true, panel_pass: false, agree: false },       // panel stricter (extra catch candidate)
+      { single_pass: false, panel_pass: true, agree: false },       // single stricter (panel too lenient)
+      { single_pass: true, panel_pass: null, agree: null },         // panel failed to run
+    ].map((r) => JSON.stringify(r)).join('\n');
+    m.readFileSync.mockReturnValue(rows);
+
+    const s = shadowSummary('2026-08-06');
+    expect(s.total).toBe(5);
+    expect(s.bothRan).toBe(4);
+    expect(s.agree).toBe(2);
+    expect(s.disagree).toBe(2);
+    expect(s.panelStricterFails).toBe(1);
+    expect(s.singleStricterFails).toBe(1);
+    expect(s.panelFailedToRun).toBe(1);
+  });
+
+  it('returns zeros when there is no log', () => {
+    m.readFileSync.mockImplementation(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); });
+    expect(shadowSummary('2026-08-06').total).toBe(0);
+  });
+});

--- a/bot/src/hermes/critic.ts
+++ b/bot/src/hermes/critic.ts
@@ -8,6 +8,9 @@ import { hasCodexCli, callCodexCli } from './codex-cli';
 import { hasCapFallbackProvider, callCapFallback } from '../zoe/models/router';
 import { runCmd } from './git';
 import { classifyDiffComplexity, HERMES_PASS_THRESHOLD, type CritiqueInput, type CritiqueOutput } from './types';
+import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 
 /**
  * Sprint 1 cost-routing (per doc 541): when HERMES_ROUTING=on, classify
@@ -102,15 +105,32 @@ export async function runCritic(input: CritiqueInput): Promise<CritiqueOutput> {
   }
 
   const userPrompt = buildCriticUserPrompt(input, diff);
+  const crossFamilyAvailable = hasCodexCli() || hasCapFallbackProvider();
 
-  // Multi-family review panel (doc 2214, DEEP): when ZOE_CRITIC_PANEL=1 AND a
-  // cross-family reviewer is actually available, run 2-3 disjoint families
-  // INDEPENDENTLY and aggregate (vote, never debate). Otherwise fall through to
-  // the single-critic path below, byte-for-byte unchanged.
-  if (panelEnabled() && (hasCodexCli() || hasCapFallbackProvider())) {
+  // Multi-family panel GATES the PR when ZOE_CRITIC_PANEL=1 and a cross-family
+  // reviewer is available (doc 2214). Otherwise the single critic gates.
+  if (panelEnabled() && crossFamilyAvailable) {
     return runCriticPanel(input, diff, userPrompt);
   }
 
+  // SHADOW mode (doc 2215, milestone 2): the single critic still GATES, but we
+  // ALSO run the panel in parallel and log the delta - pure measurement, zero
+  // risk to the gate. This is how we PROVE the panel beats the single critic
+  // before ever turning it on by default.
+  if (shadowEnabled() && crossFamilyAvailable) {
+    const [single, panel] = await Promise.all([
+      runSingleCritic(input, diff, userPrompt),
+      runCriticPanel(input, diff, userPrompt).catch(() => null),
+    ]);
+    logShadowComparison(input, single, panel);
+    return single;
+  }
+
+  return runSingleCritic(input, diff, userPrompt);
+}
+
+/** The single-family Claude critic (the historical path). Gates unless the panel is on. */
+async function runSingleCritic(input: CritiqueInput, diff: string, userPrompt: string): Promise<CritiqueOutput> {
   const criticModel = selectCriticModel(diff, input.filesChanged);
   const result = await callClaudeCliCapAware({
     model: criticModel,
@@ -454,4 +474,109 @@ async function verifyDisagreement(
   } catch {
     return null;
   }
+}
+
+// ─── Shadow-mode eval harness (doc 2215, milestone 2) ────────────────────────
+// PROVE-then-enable: with ZOE_CRITIC_PANEL_SHADOW=1 the single critic still GATES
+// the PR, but we run the panel alongside it and log both verdicts + the delta.
+// Reading the log tells us whether the panel would catch more real blockers (or
+// just add noise) BEFORE we ever flip ZOE_CRITIC_PANEL on by default. Fully
+// fail-safe: logging never affects the gate and never throws.
+
+const SHADOW_DIR = process.env.ZOE_HOME
+  ? join(process.env.ZOE_HOME, 'critic-shadow')
+  : join(homedir(), '.zao', 'zoe', 'critic-shadow');
+
+/** Shadow measurement is opt-in and independent of the gating panel. */
+function shadowEnabled(): boolean {
+  return process.env.ZOE_CRITIC_PANEL_SHADOW === '1';
+}
+
+function shadowDay(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Append one panel-vs-single comparison to the shadow log. `panel` is null if
+ * the panel run failed - recorded as such, never silently dropped. Best-effort:
+ * a logging failure must never break a critic run.
+ */
+function logShadowComparison(input: CritiqueInput, single: CritiqueOutput, panel: CritiqueOutput | null): void {
+  try {
+    mkdirSync(SHADOW_DIR, { recursive: true });
+    const singlePass = single.score >= HERMES_PASS_THRESHOLD;
+    const panelPass = panel ? panel.score >= HERMES_PASS_THRESHOLD : null;
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      branch: input.branchName,
+      files: input.filesChanged.length,
+      single_score: single.score,
+      single_pass: singlePass,
+      panel_score: panel?.score ?? null,
+      panel_model: panel?.modelUsed ?? null,
+      panel_pass: panelPass,
+      // agree = did they reach the SAME pass/fail decision at the threshold?
+      agree: panelPass === null ? null : singlePass === panelPass,
+      // delta > 0 = panel stricter (scored lower); the disagreements are what we read.
+      delta: panel ? single.score - panel.score : null,
+      panel_feedback: panel?.feedback?.slice(0, 300) ?? null,
+    });
+    appendFileSync(join(SHADOW_DIR, `${shadowDay()}.jsonl`), `${line}\n`);
+  } catch {
+    /* shadow logging is measurement only - never break a critic run over it */
+  }
+}
+
+export interface ShadowSummary {
+  total: number;
+  bothRan: number;
+  agree: number;
+  disagree: number;
+  panelStricterFails: number; // panel FAILED where single PASSED (candidate extra catches)
+  singleStricterFails: number; // single FAILED where panel PASSED (panel too lenient?)
+  panelFailedToRun: number;
+}
+
+/** Aggregate a day's shadow log so the enable-decision is readable. Returns zeros on error. */
+export function shadowSummary(day = shadowDay()): ShadowSummary {
+  const s: ShadowSummary = {
+    total: 0,
+    bothRan: 0,
+    agree: 0,
+    disagree: 0,
+    panelStricterFails: 0,
+    singleStricterFails: 0,
+    panelFailedToRun: 0,
+  };
+  try {
+    const raw = readFileSync(join(SHADOW_DIR, `${day}.jsonl`), 'utf8');
+    for (const l of raw.split('\n')) {
+      if (!l.trim()) continue;
+      let rec: {
+        single_pass?: boolean;
+        panel_pass?: boolean | null;
+        agree?: boolean | null;
+      };
+      try {
+        rec = JSON.parse(l) as typeof rec;
+      } catch {
+        continue;
+      }
+      s.total += 1;
+      if (rec.panel_pass === null || rec.panel_pass === undefined) {
+        s.panelFailedToRun += 1;
+        continue;
+      }
+      s.bothRan += 1;
+      if (rec.agree) s.agree += 1;
+      else {
+        s.disagree += 1;
+        if (rec.single_pass === true && rec.panel_pass === false) s.panelStricterFails += 1;
+        if (rec.single_pass === false && rec.panel_pass === true) s.singleStricterFails += 1;
+      }
+    }
+  } catch {
+    /* no log yet / unreadable -> zeros */
+  }
+  return s;
 }


### PR DESCRIPTION
Milestone 2 foundation: ZOE_CRITIC_PANEL_SHADOW=1 runs the panel alongside the single critic (which still gates) and logs the delta to ~/.zao/zoe/critic-shadow/. This is how we PROVE the panel beats single-critic before default-ON. shadowSummary() aggregates agree/disagree/panel-stricter-fails. Zero risk, fail-safe. tsc 40=baseline, shadow 5/5, full suite 1872/1872.