### PR TITLE
feat(zoe): complexity-gate the critic panel (doc 2215 #4)

### DIFF
--- a/bot/src/hermes/__tests__/critic-complexity-gate.test.ts
+++ b/bot/src/hermes/__tests__/critic-complexity-gate.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const m = vi.hoisted(() => ({
+  callClaudeCliCapAware: vi.fn(),
+  hasCodexCli: vi.fn(),
+  callCodexCli: vi.fn(),
+  hasCapFallbackProvider: vi.fn(),
+  callCapFallback: vi.fn(),
+  runCmd: vi.fn(),
+}));
+
+vi.mock('../../zoe/models/cli-cap-aware', () => ({ callClaudeCliCapAware: m.callClaudeCliCapAware }));
+vi.mock('../codex-cli', () => ({ hasCodexCli: m.hasCodexCli, callCodexCli: m.callCodexCli }));
+vi.mock('../../zoe/models/router', () => ({ hasCapFallbackProvider: m.hasCapFallbackProvider, callCapFallback: m.callCapFallback }));
+vi.mock('../git', () => ({ runCmd: m.runCmd }));
+
+import { runCritic } from '../critic';
+
+const cli = (text: string) => ({ text, isError: false, inputTokens: 10, outputTokens: 5, model: 'sonnet' });
+const SIMPLE_DIFF = 'diff --git a/README.md b/README.md\n+a docs line';
+const COMPLEX_DIFF = 'diff --git a/a.ts b/a.ts\n+  const r = eval(userInput);';
+
+function setDiff(diff: string) {
+  m.runCmd.mockResolvedValue({ exitCode: 0, stdout: diff, stderr: '' });
+}
+
+beforeEach(() => {
+  process.env.ZOE_CRITIC_PANEL = '1';
+  delete process.env.ZOE_CRITIC_PANEL_ALL_DIFFS;
+  m.runCmd.mockReset();
+  m.hasCodexCli.mockReset().mockReturnValue(false);
+  m.hasCapFallbackProvider.mockReset().mockReturnValue(true);
+  m.callCodexCli.mockReset();
+  m.callCapFallback.mockReset().mockResolvedValue({ result: cli('{"score":80,"feedback":"panel"}'), provider: 'openrouter' });
+  m.callClaudeCliCapAware.mockReset().mockResolvedValue(cli('{"score":85,"feedback":"single or claude"}'));
+});
+afterEach(() => {
+  delete process.env.ZOE_CRITIC_PANEL;
+  delete process.env.ZOE_CRITIC_PANEL_ALL_DIFFS;
+});
+
+describe('complexity gate', () => {
+  it('SKIPS the panel on a simple (docs-only) diff even with the flag on', async () => {
+    setDiff(SIMPLE_DIFF);
+    input: void 0;
+    await runCritic({ workTreePath: '/tmp', branchName: 'b', filesChanged: ['README.md'], issueText: 'doc' });
+    expect(m.callCapFallback).not.toHaveBeenCalled(); // panel did NOT run
+    expect(m.callClaudeCliCapAware).toHaveBeenCalledTimes(1); // single critic only
+  });
+
+  it('RUNS the panel on a complex (risky code) diff', async () => {
+    setDiff(COMPLEX_DIFF);
+    await runCritic({ workTreePath: '/tmp', branchName: 'b', filesChanged: ['a.ts'], issueText: 'code' });
+    expect(m.callCapFallback).toHaveBeenCalled(); // panel ran (DeepSeek voter)
+  });
+
+  it('ZOE_CRITIC_PANEL_ALL_DIFFS=1 forces the panel even on a simple diff', async () => {
+    process.env.ZOE_CRITIC_PANEL_ALL_DIFFS = '1';
+    setDiff(SIMPLE_DIFF);
+    await runCritic({ workTreePath: '/tmp', branchName: 'b', filesChanged: ['README.md'], issueText: 'doc' });
+    expect(m.callCapFallback).toHaveBeenCalled();
+  });
+});

--- a/bot/src/hermes/__tests__/critic-panel-verify.test.ts
+++ b/bot/src/hermes/__tests__/critic-panel-verify.test.ts
@@ -21,6 +21,7 @@ const input = { workTreePath: '/tmp/wt', branchName: 'b', filesChanged: ['a.ts']
 
 beforeEach(() => {
   process.env.ZOE_CRITIC_PANEL = '1';
+  process.env.ZOE_CRITIC_PANEL_ALL_DIFFS = '1'; // these tests exercise panel logic, not the complexity gate
   delete process.env.ZOE_CRITIC_PANEL_VERIFY;
   m.runCmd.mockReset().mockResolvedValue({ exitCode: 0, stdout: 'diff --git a/a.ts b/a.ts\n+x', stderr: '' });
   m.hasCodexCli.mockReset().mockReturnValue(true);
@@ -30,6 +31,7 @@ beforeEach(() => {
   m.callClaudeCliCapAware.mockReset();
 });
 afterEach(() => {
+  delete process.env.ZOE_CRITIC_PANEL_ALL_DIFFS;
   delete process.env.ZOE_CRITIC_PANEL;
   delete process.env.ZOE_CRITIC_PANEL_VERIFY;
 });

--- a/bot/src/hermes/__tests__/critic-shadow.test.ts
+++ b/bot/src/hermes/__tests__/critic-shadow.test.ts
@@ -26,6 +26,7 @@ const input = { workTreePath: '/tmp/wt', branchName: 'ws/x', filesChanged: ['a.t
 beforeEach(() => {
   delete process.env.ZOE_CRITIC_PANEL;
   process.env.ZOE_CRITIC_PANEL_SHADOW = '1';
+  process.env.ZOE_CRITIC_PANEL_ALL_DIFFS = '1'; // these tests exercise panel logic, not the complexity gate
   m.runCmd.mockReset().mockResolvedValue({ exitCode: 0, stdout: 'diff --git a/a.ts b/a.ts\n+x', stderr: '' });
   m.hasCodexCli.mockReset().mockReturnValue(false);
   m.hasCapFallbackProvider.mockReset().mockReturnValue(true);
@@ -37,6 +38,7 @@ beforeEach(() => {
   m.readFileSync.mockReset();
 });
 afterEach(() => {
+  delete process.env.ZOE_CRITIC_PANEL_ALL_DIFFS;
   delete process.env.ZOE_CRITIC_PANEL_SHADOW;
 });
 

--- a/bot/src/hermes/critic.ts
+++ b/bot/src/hermes/critic.ts
@@ -106,10 +106,18 @@ export async function runCritic(input: CritiqueInput): Promise<CritiqueOutput> {
 
   const userPrompt = buildCriticUserPrompt(input, diff);
   const crossFamilyAvailable = hasCodexCli() || hasCapFallbackProvider();
+  // Complexity gate (doc 2215 #4): the 2-3 model panel is 2-3x the cost/latency,
+  // so only spend it where a second opinion can catch something - 'complex'
+  // diffs (logic/security/large). Docs + trivial low-risk edits stay single-critic
+  // even with the panel/shadow flag on. Override with ZOE_CRITIC_PANEL_ALL_DIFFS=1.
+  const worthPanel =
+    crossFamilyAvailable &&
+    (process.env.ZOE_CRITIC_PANEL_ALL_DIFFS === '1' ||
+      classifyDiffComplexity({ diff, filesChanged: input.filesChanged }) === 'complex');
 
-  // Multi-family panel GATES the PR when ZOE_CRITIC_PANEL=1 and a cross-family
-  // reviewer is available (doc 2214). Otherwise the single critic gates.
-  if (panelEnabled() && crossFamilyAvailable) {
+  // Multi-family panel GATES the PR when ZOE_CRITIC_PANEL=1 and the diff is worth
+  // a panel (doc 2214). Otherwise the single critic gates.
+  if (panelEnabled() && worthPanel) {
     return runCriticPanel(input, diff, userPrompt);
   }
 
@@ -117,7 +125,7 @@ export async function runCritic(input: CritiqueInput): Promise<CritiqueOutput> {
   // ALSO run the panel in parallel and log the delta - pure measurement, zero
   // risk to the gate. This is how we PROVE the panel beats the single critic
   // before ever turning it on by default.
-  if (shadowEnabled() && crossFamilyAvailable) {
+  if (shadowEnabled() && worthPanel) {
     const [single, panel] = await Promise.all([
       runSingleCritic(input, diff, userPrompt),
       runCriticPanel(input, diff, userPrompt).catch(() => null),


### PR DESCRIPTION
Only run the 2-3 model panel on complex diffs (logic/security/>=30 LOC); docs + trivial edits stay single-critic. Makes shadow-mode measurement affordable. ZOE_CRITIC_PANEL_ALL_DIFFS=1 to override. tsc 40=baseline, full suite 1875/1875.