### PR TITLE
feat(zoe): /shadow command to read the critic panel eval (doc 2215)

### DIFF
--- a/bot/src/zoe/button-bar.ts
+++ b/bot/src/zoe/button-bar.ts
@@ -44,6 +44,7 @@ export const ZOE_COMMANDS = [
   { command: 'focus', description: 'Toggle hyperfocus (queue non-urgent pings)' },
   { command: 'agenda', description: 'Show the board - all open items' },
   { command: 'budget', description: "Today's spend + headroom" },
+  { command: 'shadow', description: 'Critic panel vs single-critic eval' },
   { command: 'checkpoint', description: 'Save a breadcrumb note' },
   { command: 'audit', description: 'Scan for fallen tasks / captures' },
 ];

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -147,6 +147,7 @@ import { brandBoxFor, fetchIcmBrain, brandSystemPreamble } from './brand-brain';
 import { appendApproved } from './outbox';
 import { enqueueZolCast } from './zol-queue';
 import { dispatchHermesRun } from '../hermes/runner';
+import { shadowSummary } from '../hermes/critic';
 import { logTopicThreadId } from './curator';
 import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
 import { parseQuestionCallback } from './questions';
@@ -824,6 +825,31 @@ bot.command('loops', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const data = await readFleetStatus();
   await replyChunked(ctx, formatLoopsStatus(data, Date.now()));
+});
+
+// Critic-panel shadow eval (doc 2215): panel-vs-single-critic agreement on
+// today's Hermes reviews. Read-only, Zaal-only. /shadow [YYYY-MM-DD].
+bot.command('shadow', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const day = (ctx.match ?? '').toString().trim() || undefined;
+  const s = day ? shadowSummary(day) : shadowSummary();
+  if (s.total === 0) {
+    await ctx.reply(
+      `No critic-panel shadow data${day ? ` for ${day}` : ' today'} yet. Enable with ZOE_CRITIC_PANEL_SHADOW=1 + a few Hermes fix-PRs on complex diffs.`,
+    );
+    return;
+  }
+  const lines = [
+    `Critic panel shadow eval${day ? ` (${day})` : ' (today)'}:`,
+    `- reviews: ${s.total} (both ran: ${s.bothRan}, panel failed: ${s.panelFailedToRun})`,
+    `- AGREE with single critic: ${s.agree}/${s.bothRan}`,
+    `- disagree: ${s.disagree}`,
+    `  - panel stricter (would BLOCK where single passed): ${s.panelStricterFails}  <- candidate extra catches`,
+    `  - single stricter (panel too lenient): ${s.singleStricterFails}`,
+    '',
+    'Read: high panel-stricter with real bugs = the panel earns default-ON; high single-stricter or noise = keep it off. Raw log: ~/.zao/zoe/critic-shadow/.',
+  ];
+  await replyChunked(ctx, lines.join('\n'));
 });
 
 bot.command('loop', async (ctx) => {


### PR DESCRIPTION
Completes the shadow eval loop: /shadow surfaces panel-vs-single agreement + the two disagreement classes (panel-stricter = candidate extra catches, single-stricter = too lenient) so the default-ON decision is data-driven. tsc 40=baseline, full suite 1875/1875.