### PR TITLE
feat(zoe): high-tier cross-family escalation (GPT-5.5) for high-stakes review

### DIFF
--- a/bot/src/zoe/critics/types.ts
+++ b/bot/src/zoe/critics/types.ts
@@ -249,7 +249,13 @@ export async function runCritiqueModel(opts: {
   // what keeps cross-family alive while Codex is capped.
   const openRouterCross = async (): Promise<CritiqueModelResult | null> => {
     try {
-      const { result, provider } = await callCapFallback(opts.system, opts.user);
+      // High-stakes review: opt into the frontier cross-family model
+      // (OPENROUTER_HIGH_MODEL = GPT-5.5) instead of cheap DeepSeek, which the
+      // panel simulation found too lenient to be a useful second reviewer. This
+      // is a real per-review cost, so it is gated OFF by default - flip
+      // ZOE_CRITIC_HIGH_TIER=1 to use frontier for cross-family critique.
+      const tier = process.env.ZOE_CRITIC_HIGH_TIER === '1' ? 'high' : 'cheap';
+      const { result, provider } = await callCapFallback(opts.system, opts.user, { tier });
       if (opts.validate && !opts.validate(result.text)) {
         console.warn(
           `[zoe/critic] ${provider} cross-family returned an invalid response - falling back to same-family`,

--- a/bot/src/zoe/models/__tests__/router-failover.test.ts
+++ b/bot/src/zoe/models/__tests__/router-failover.test.ts
@@ -4,6 +4,7 @@ import {
   hasCapFallbackProvider,
   callCapFallback,
   routeAndCall,
+  OPENROUTER_HIGH_MODEL,
 } from '../router';
 
 /**
@@ -16,7 +17,7 @@ import {
  * (openrouter fails -> grok succeeds) without hitting any provider.
  */
 
-const KEYS = ['XAI_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'MODEL_ROUTING_ENABLED'];
+const KEYS = ['XAI_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'MODEL_ROUTING_ENABLED', 'OPENROUTER_MODEL', 'OPENROUTER_HIGH_MODEL'];
 const saved: Record<string, string | undefined> = {};
 const realFetch = globalThis.fetch;
 
@@ -139,5 +140,37 @@ describe('routeAndCall', () => {
     await expect(
       routeAndCall('sys', 'msg', { model: 'claude', provider: 'claude', rationale: 'x' }),
     ).rejects.toThrow(/fall back to Claude/);
+  });
+});
+
+describe('callCapFallback tier routing (high-tier escalation, doc 2217)', () => {
+  function bodyModelOf(fetchMock: ReturnType<typeof vi.fn>): string {
+    const init = fetchMock.mock.calls[0][1] as { body: string };
+    return (JSON.parse(init.body) as { model: string }).model;
+  }
+
+  it("default tier uses the cheap OpenRouter model (deepseek)", async () => {
+    setEnv({ OPENROUTER_API_KEY: 'or' });
+    const fetchMock = vi.fn(async () => okResponse('ok'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    await callCapFallback('sys', 'msg');
+    expect(bodyModelOf(fetchMock)).toBe('deepseek/deepseek-chat');
+  });
+
+  it("tier 'high' escalates to the frontier cross-family model (OPENROUTER_HIGH_MODEL)", async () => {
+    setEnv({ OPENROUTER_API_KEY: 'or' });
+    const fetchMock = vi.fn(async () => okResponse('ok'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    await callCapFallback('sys', 'msg', { tier: 'high' });
+    expect(bodyModelOf(fetchMock)).toBe(OPENROUTER_HIGH_MODEL);
+    expect(OPENROUTER_HIGH_MODEL).toContain('gpt-5.5'); // evidence-based default
+  });
+
+  it('OPENROUTER_MODEL still overrides the cheap default', async () => {
+    setEnv({ OPENROUTER_API_KEY: 'or', OPENROUTER_MODEL: 'meta-llama/llama-4' });
+    const fetchMock = vi.fn(async () => okResponse('ok'));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    await callCapFallback('sys', 'msg');
+    expect(bodyModelOf(fetchMock)).toBe('meta-llama/llama-4');
   });
 });

--- a/bot/src/zoe/models/router.ts
+++ b/bot/src/zoe/models/router.ts
@@ -255,15 +255,30 @@ async function callGpt(systemPrompt: string, userMessage: string): Promise<Claud
  * cheap-AI stack. This is the primary CAP FALLBACK provider: when the Claude CLI
  * is rate-limited or over its weekly cap, ZOE drops here instead of failing.
  */
-async function callOpenRouter(systemPrompt: string, userMessage: string): Promise<ClaudeCliResult> {
+/**
+ * High-tier cross-family model for HIGH-STAKES escalations (e.g. a code-review
+ * critic when we want the best non-Claude reviewer, not the cheap one). Chosen
+ * from Aug-2026 community benchmarks: GPT-5.5 is the strongest NON-Claude agentic
+ * coder (Gemini 3.1 Pro clearly trails on multi-file/tool-call work). Opus 4.8 is
+ * the best coder overall but is Claude-family, so it's not the cross-family pick.
+ * Override via OPENROUTER_HIGH_MODEL. See research doc 2217.
+ */
+export const OPENROUTER_HIGH_MODEL = process.env.OPENROUTER_HIGH_MODEL ?? 'openai/gpt-5.5';
+
+async function callOpenRouter(
+  systemPrompt: string,
+  userMessage: string,
+  modelOverride?: string,
+): Promise<ClaudeCliResult> {
   if (!hasOpenRouterApiKey()) {
     throw new Error('OPENROUTER_API_KEY not set');
   }
 
   const baseUrl = 'https://openrouter.ai/api/v1';
   // Default to a cheap, capable non-Anthropic model so a fallback never re-hits
-  // the same Anthropic cap that triggered it. Override via OPENROUTER_MODEL.
-  const model = process.env.OPENROUTER_MODEL ?? 'deepseek/deepseek-chat';
+  // the same Anthropic cap that triggered it. Override via OPENROUTER_MODEL, or
+  // pass modelOverride for a high-stakes escalation (OPENROUTER_HIGH_MODEL).
+  const model = modelOverride ?? process.env.OPENROUTER_MODEL ?? 'deepseek/deepseek-chat';
   const apiKey = process.env.OPENROUTER_API_KEY;
 
   const request: OpenAiRequest = {
@@ -332,9 +347,15 @@ export function hasCapFallbackProvider(): boolean {
 export async function callCapFallback(
   systemPrompt: string,
   userMessage: string,
+  opts?: { tier?: 'cheap' | 'high' },
 ): Promise<{ result: ClaudeCliResult; provider: string }> {
+  // tier 'high' (default 'cheap'): route the OpenRouter attempt to the frontier
+  // cross-family model (OPENROUTER_HIGH_MODEL) instead of the cheap default -
+  // for high-stakes calls where we WANT the best non-Claude model, not the
+  // cheapest. Grok/GPT direct paths are unchanged.
+  const orModel = opts?.tier === 'high' ? OPENROUTER_HIGH_MODEL : undefined;
   const attempts: Array<{ name: string; fn: () => Promise<ClaudeCliResult> }> = [];
-  if (hasOpenRouterApiKey()) attempts.push({ name: 'openrouter', fn: () => callOpenRouter(systemPrompt, userMessage) });
+  if (hasOpenRouterApiKey()) attempts.push({ name: 'openrouter', fn: () => callOpenRouter(systemPrompt, userMessage, orModel) });
   if (hasGrokApiKey()) attempts.push({ name: 'grok', fn: () => callGrok(systemPrompt, userMessage) });
   if (hasGptApiKey()) attempts.push({ name: 'gpt', fn: () => callGpt(systemPrompt, userMessage) });
 


### PR DESCRIPTION
Leverage the highest-tier OpenRouter model when needed, not always. OPENROUTER_HIGH_MODEL (default openai/gpt-5.5, the best non-Claude agentic coder per Aug-2026 benchmarks) + a tier param on callCapFallback. The cross-family critic uses it only when ZOE_CRITIC_HIGH_TIER=1 (money stays Zaal's flip); cheap fleet path unchanged. Fixes the sim finding that DeepSeek was too lenient. tsc 40=baseline, full suite 1878/1878.