### PR TITLE
fix(test): add .on to stdin mocks - main red after #2873+#2876

### DIFF
--- a/bot/src/hermes/__tests__/codex-cli.test.ts
+++ b/bot/src/hermes/__tests__/codex-cli.test.ts
@@ -32,7 +32,7 @@ function makeSpawn(stdout: string, stderr: string, exitCode: number | null) {
         if (ev === 'data' && stderr) process.nextTick(() => cb(Buffer.from(stderr)));
       }),
     },
-    stdin: { write: vi.fn(), end: vi.fn() },
+    stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
     on: vi.fn((ev: string, cb: (code: number | null) => void) => {
       if (ev === 'close') setTimeout(() => cb(exitCode), 10);
     }),

--- a/bot/src/zoe/safety/__tests__/klearu.test.ts
+++ b/bot/src/zoe/safety/__tests__/klearu.test.ts
@@ -21,7 +21,7 @@ const { makeSpawn } = vi.hoisted(() => {
       stderr: {
         on: (_event: string, _cb: unknown) => {},
       },
-      stdin: { write: vi.fn(), end: vi.fn() },
+      stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
       on: (event: string, cb: (code: number) => void) => {
         if (event === 'close') setImmediate(() => cb(exitCode));
       },


### PR DESCRIPTION
#2876's stdin.on('error') crash fix broke the test mocks (no .on method) -> 11 klearu tests failed closed once #2873+#2876 merged together. Fix: give mocked stdin an .on. tsc 40=baseline, full suite 1885/1885.