### PR TITLE
fix(zoe): nudge ladder persist-before-ping (re-apply #2879 onto v2)

### DIFF
--- a/bot/src/zoe/__tests__/nudge-ladder.test.ts
+++ b/bot/src/zoe/__tests__/nudge-ladder.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -102,5 +102,17 @@ describe('persistence + the kill switch', () => {
   });
   it('stopNudge on an unknown qid returns false', async () => {
     expect(await stopNudge('nope')).toBe(false);
+  });
+  it('markPinged reports whether the advance was persisted (#2879 runaway guard)', async () => {
+    expect(await markPinged('nope', 0)).toBe(false); // unknown qid -> false, never pinged
+    await startNudge('qZ', 'c', ['x'], 0);
+    expect(await markPinged('qZ', 3 * MIN)).toBe(true);
+    await stopNudge('qZ');
+  });
+  it('a corrupt (non-array) state file degrades to no tracks, not a throw', async () => {
+    const path = join(TMP, 'nudge-ladder.json');
+    writeFileSync(path, '{"oops":true}');
+    await expect(dueTracks(10 * MIN)).resolves.toEqual([]);
+    writeFileSync(path, '[]');
   });
 });

--- a/bot/src/zoe/nudge-ladder.ts
+++ b/bot/src/zoe/nudge-ladder.ts
@@ -95,18 +95,27 @@ export function isExhausted(track: NudgeTrack): boolean {
 
 async function load(): Promise<NudgeTrack[]> {
   try {
-    return JSON.parse(await fs.readFile(ladderPath(), 'utf8')) as NudgeTrack[];
+    const parsed = JSON.parse(await fs.readFile(ladderPath(), 'utf8')) as unknown;
+    // A hand-edited / truncated-then-repaired file can parse to a non-array
+    // ({} or null). Callers immediately .filter()/.find() the result, so a
+    // non-array would throw a TypeError out of dueTracks() and take the whole
+    // orchestrator tick down. Treat anything that is not an array as "no tracks".
+    return Array.isArray(parsed) ? (parsed as NudgeTrack[]) : [];
   } catch {
     return [];
   }
 }
 
-async function save(tracks: NudgeTrack[]): Promise<void> {
+/** Persist. Returns false (best-effort) when the write failed - callers that are
+ *  about to SEND a ping must treat false as "do not ping": an unrecorded ping
+ *  means the schedule never advances and MAX_PINGS never trips (runaway pings). */
+async function save(tracks: NudgeTrack[]): Promise<boolean> {
   try {
     await fs.mkdir(ladderHome(), { recursive: true });
     await fs.writeFile(ladderPath(), JSON.stringify(tracks, null, 2));
+    return true;
   } catch {
-    /* best-effort */
+    return false;
   }
 }
 
@@ -135,13 +144,15 @@ export async function stopNudge(qid: string): Promise<boolean> {
   return true;
 }
 
-/** Record that a re-ping was just sent for a qid (advances the schedule). */
-export async function markPinged(qid: string, nowMs: number): Promise<void> {
+/** Record that a re-ping was just sent for a qid (advances the schedule).
+ *  Returns true only if the advance was PERSISTED - a caller that pings-on-true
+ *  then never pings a track it could not advance (else it would ping forever). */
+export async function markPinged(qid: string, nowMs: number): Promise<boolean> {
   const tracks = await load();
   const t = tracks.find((x) => x.qid === qid);
-  if (!t) return;
+  if (!t) return false;
   t.pingMs.push(nowMs);
-  await save(tracks);
+  return save(tracks);
 }
 
 /** The open tracks that are due for a re-ping right now. */

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -468,11 +468,16 @@ export async function runNudgePing(deps: {
     // Re-ping the due, still-open questions.
     const nowMs = deps.now.getTime();
     for (const t of await dueTracks(nowMs)) {
+      // Advance the schedule FIRST and only ping if the advance PERSISTED. If the
+      // write fails and we ping anyway, the track stays due every tick -> pings
+      // forever and MAX_PINGS never trips (the runaway #2879 fixed). Missing one
+      // ping on a failed write is the safe trade.
+      const advanced = await markPinged(t.qid, nowMs);
+      if (!advanced) continue;
       try {
         await deps.bot.api.sendMessage(deps.groupId, `Still need your answer: ${t.label}`, {
           reply_markup: questionKeyboard(t.qid, t.options),
         });
-        await markPinged(t.qid, nowMs);
       } catch (err) {
         console.error('[zoe/nudge-ladder] re-ping failed:', (err as Error)?.message);
       }


### PR DESCRIPTION
Re-applies #2879's runaway-ping fix onto the current nudge v2 (which moved the ping to runNudgePing). save/markPinged return whether persisted; runNudgePing advances first, pings only if persisted; load guards a corrupt file. Supersedes #2879. Full suite 1887/1887.