### PR TITLE
docs: fix persona-file drift - runtime ~/.zao/zoe/ paths (Zaal-approved)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,6 @@ The `bot/` tree houses Telegram bots running on VPS 1 (Hostinger KVM 2). Hermes 
 Conventions inside `bot/`:
 - Letta-style memory blocks at `~/.zao/zoe/` (persona, human, recent, tasks, captures, facts, newsletters)
 - Brand voice rules at `bot/src/zoe/brand.md` (Year of the ZABAL: no emojis, no em dashes, fact-only)
-- Persona at `bot/src/zoe/persona.md` (deployed to VPS at `~/.zao/zoe/persona.md`)
+- Persona is a RUNTIME file at `~/.zao/zoe/persona.md` (+ `~/.zao/zoe/human.md`), seeded from `PERSONA_DEFAULT` in `bot/src/zoe/memory.ts` - there is no committed `bot/src/zoe/persona.md`
 - Hermes pattern documented in [research doc 613](./research/agents/613-hermes-canonical-agent-framework/)
 - No new bots without a numbered research doc + Zaal sign-off (CLAUDE.md "Primary Surfaces")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ ZAO operating surfaces collapsed from 12+ systems to 4. Hermes was adapted into 
 - Hermes as a SEPARATE bot (`@zoe_hermes_bot`) — adapted into ZOE 2026-06-29; the coder/critic/auto-PR code in `bot/src/hermes/` is reused BY ZOE, do not run it as its own Telegram bot
 - FISHBOWLZ (paused 2026-04-16, killed 2026-05-04 — Juke partnership stands)
 
-**Rule: no new bots without doc.** Before adding a new Telegram bot, agent process, or autonomous loop, write a numbered research doc + get explicit Zaal approval. New brand voices = persona block in `bot/src/zoe/` `human.md`, NOT a new bot. Reference `research/agents/601-agent-stack-cleanup-decision/`.
+**Rule: no new bots without doc.** Before adding a new Telegram bot, agent process, or autonomous loop, write a numbered research doc + get explicit Zaal approval. New brand voices = a persona block in ZOE's runtime memory at `~/.zao/zoe/persona.md` / `~/.zao/zoe/human.md` (seeded from `PERSONA_DEFAULT` in `bot/src/zoe/memory.ts`; content voice lives in `bot/src/zoe/brand.md`), NOT a new bot. Reference `research/agents/601-agent-stack-cleanup-decision/`.
 
 ## ICM Context Boxes (AI-readable ZAO context)
 


### PR DESCRIPTION
The real drift zoe-drift (#2916) caught, fixed per Zaal's morning-grill call (point docs at runtime paths).

- CLAUDE.md:176: `bot/src/zoe/ human.md` -> runtime `~/.zao/zoe/persona.md` / `human.md` (seeded from PERSONA_DEFAULT in memory.ts; content voice = brand.md)
- AGENTS.md:160: `bot/src/zoe/persona.md` -> the runtime path truth (no committed persona file exists)

Verified: zoe-drift no longer flags persona.md/human.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9