### PR TITLE
feat(zoe): wire memory-git versioning + guardrail pipeline (task #76, greenlit)

### DIFF
--- a/bot/src/zoe/__tests__/guardrails.test.ts
+++ b/bot/src/zoe/__tests__/guardrails.test.ts
@@ -1,0 +1,69 @@
+/**
+ * guardrails.test.ts - the composable guardrail abstraction (doc 2235 #2 adopt).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  runGuardrails,
+  runGuardrailsAsync,
+  costGuard,
+  piiGuard,
+  preflightGuard,
+  type Guardrail,
+  type AsyncGuardrail,
+} from '../guardrails';
+
+describe('runGuardrails', () => {
+  it('trips a preflight critical failure on the input stage', () => {
+    const guards = [costGuard(() => false), preflightGuard(() => true)];
+    const res = runGuardrails(guards, { input: 'go' }, 'input');
+    expect(res.passed).toBe(false);
+    expect(res.trips.map((t) => t.name)).toEqual(['preflight']);
+  });
+
+  it('passes when all input guards are clear', () => {
+    const guards = [costGuard(() => false), preflightGuard(() => false)];
+    expect(runGuardrails(guards, { input: 'go' }, 'input').passed).toBe(true);
+  });
+
+  it('only runs guards that apply to the stage (pii is output-only)', () => {
+    const guards = [piiGuard((t) => t.includes('555-12'))];
+    // input stage: pii guard does not apply, so it passes
+    expect(runGuardrails(guards, { input: 'call 555-1234' }, 'input').passed).toBe(true);
+    // output stage: it applies and trips
+    const out = runGuardrails(guards, { output: 'call 555-1234' }, 'output');
+    expect(out.passed).toBe(false);
+    expect(out.trips[0].name).toBe('pii');
+  });
+
+  it('collects ALL trips (does not short-circuit)', () => {
+    const res = runGuardrails(
+      [costGuard(() => true), preflightGuard(() => true)],
+      { input: 'x' },
+      'input',
+    );
+    expect(res.trips.length).toBe(2);
+  });
+
+  it('respects the both stage', () => {
+    const both: Guardrail = {
+      name: 'always',
+      stage: 'both',
+      check: () => ({ tripwire: true, reason: 'nope' }),
+    };
+    expect(runGuardrails([both], {}, 'input').passed).toBe(false);
+    expect(runGuardrails([both], {}, 'output').passed).toBe(false);
+  });
+});
+
+describe('runGuardrailsAsync', () => {
+  it('awaits async guards and collects trips', async () => {
+    const g: AsyncGuardrail = {
+      name: 'remote',
+      stage: 'input',
+      check: async () => ({ tripwire: true, reason: 'remote check failed' }),
+    };
+    const res = await runGuardrailsAsync([g], { input: 'x' }, 'input');
+    expect(res.passed).toBe(false);
+    expect(res.trips[0].reason).toContain('remote');
+  });
+});

--- a/bot/src/zoe/guardrail-adapters.ts
+++ b/bot/src/zoe/guardrail-adapters.ts
@@ -1,0 +1,65 @@
+/**
+ * guardrail-adapters.ts - ZOE's real guards bound to the Guardrail interface.
+ *
+ * The #2 adopt from the ZOE-vs-toolkits audit (doc 2235), wired: cost-governance,
+ * pii, and preflight each implement the composable Guardrail interface from
+ * guardrails.ts (#2926), so the concierge/worker path can run ONE uniform
+ * pre/post pipeline instead of three ad-hoc call sites.
+ *
+ * This module only BINDS existing guards - zero behavior change to the guards
+ * themselves. Call-path wiring: `runConciergeGuardrails(ctx, stage)` is the single
+ * entry; inserting it into concierge.ts is a 1-line change left for the wiring PR
+ * review (live call-path edits get human eyes per the workflow contract).
+ *
+ * Pattern credit: openai/openai-agents-python guardrail.py (Apache-2.0).
+ */
+import { runGuardrails, type Guardrail, type GuardrailContext, type GuardrailRunResult } from './guardrails';
+import { shouldPauseAutonomousWork } from './cost-governance';
+import { containsPii } from './pii';
+import { checkCapabilities, hasCriticalFailure } from './preflight';
+
+/** cost-governance.ts -> input guard: spend at hard-stop pauses autonomous work. */
+export const zoeCostGuard: Guardrail = {
+  name: 'cost-governance',
+  stage: 'input',
+  check: () =>
+    shouldPauseAutonomousWork()
+      ? { tripwire: true, reason: 'spend at hard-stop threshold - autonomous work paused (cost-governance)' }
+      : { tripwire: false, reason: '' },
+};
+
+/** pii.ts -> output guard: never emit non-allowlisted PII in a response. */
+export const zoePiiGuard: Guardrail = {
+  name: 'pii',
+  stage: 'output',
+  check: (ctx) =>
+    ctx.output && containsPii(ctx.output)
+      ? { tripwire: true, reason: 'output contains PII outside the allowlist - redact before sending (pii-hygiene)' }
+      : { tripwire: false, reason: '' },
+};
+
+/** preflight.ts -> input guard: a critical capability (env/key) missing = fail loud. */
+export const zoePreflightGuard: Guardrail = {
+  name: 'preflight',
+  stage: 'input',
+  check: () =>
+    hasCriticalFailure(checkCapabilities(process.env))
+      ? { tripwire: true, reason: 'a critical capability (env/key) is missing - fail loud, do not proceed (preflight)' }
+      : { tripwire: false, reason: '' },
+};
+
+/** The default ZOE pipeline, in check order. */
+export const ZOE_GUARDRAILS: Guardrail[] = [zoePreflightGuard, zoeCostGuard, zoePiiGuard];
+
+/**
+ * The single uniform entry the concierge/worker path calls:
+ *   pre:  runConciergeGuardrails({ input }, 'input')  -> block the turn if !passed
+ *   post: runConciergeGuardrails({ output }, 'output') -> redact/hold if !passed
+ * Collects ALL trips (no short-circuit) so every reason surfaces at once.
+ */
+export function runConciergeGuardrails(
+  ctx: GuardrailContext,
+  stage: 'input' | 'output',
+): GuardrailRunResult {
+  return runGuardrails(ZOE_GUARDRAILS, ctx, stage);
+}

--- a/bot/src/zoe/guardrails.ts
+++ b/bot/src/zoe/guardrails.ts
@@ -1,0 +1,169 @@
+/**
+ * guardrails.ts - a composable guardrail abstraction for ZOE.
+ *
+ * The #2 adopt from the ZOE-vs-toolkits audit (doc 2235): ZOE's safety checks
+ * (cost-governance, pii, preflight) each have their own shape and are called ad hoc.
+ * OpenAI's Agents SDK (openai/openai-agents-python, Apache-2.0) models guardrails as a
+ * first-class, composable interface with a "tripwire" result. This brings the same
+ * pattern to ZOE: one `Guardrail` interface + a `runGuardrails` pipeline, so every
+ * pre/post check is uniform, ordered, and testable.
+ *
+ * This FORMALIZES the existing guards, it does not replace them. Adoption = have
+ * cost-governance.ts / pii.ts / preflight.ts each expose a `Guardrail` (adapters at the
+ * bottom show exactly how). Wiring the live concierge/worker path to call
+ * `runGuardrails` is a separate, gated step - this module is additive and imported by
+ * nothing yet.
+ *
+ * Pattern credit: openai/openai-agents-python guardrail.py (Apache-2.0).
+ */
+
+/** When a guardrail runs relative to the model call. */
+export type GuardrailStage = 'input' | 'output' | 'both';
+
+/** What a guardrail sees. `input` = the prompt/request; `output` = the model result. */
+export interface GuardrailContext {
+  input?: string;
+  output?: string;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * A guardrail's verdict. `tripwire: true` means BLOCK (the check failed / a limit was
+ * hit); `reason` explains why, for logging + the user-facing surface.
+ */
+export interface GuardrailResult {
+  tripwire: boolean;
+  reason: string;
+}
+
+/** One composable safety check. Pure + synchronous by default; see AsyncGuardrail for I/O. */
+export interface Guardrail {
+  name: string;
+  stage: GuardrailStage;
+  check(ctx: GuardrailContext): GuardrailResult;
+}
+
+/** A guardrail that needs I/O (a network/db check) returns a promise. */
+export interface AsyncGuardrail {
+  name: string;
+  stage: GuardrailStage;
+  check(ctx: GuardrailContext): Promise<GuardrailResult>;
+}
+
+/** The outcome of running a pipeline: passed only if NO guardrail tripped. */
+export interface GuardrailRunResult {
+  passed: boolean;
+  trips: Array<{ name: string; reason: string }>;
+}
+
+function appliesTo(g: { stage: GuardrailStage }, stage: 'input' | 'output'): boolean {
+  return g.stage === stage || g.stage === 'both';
+}
+
+/**
+ * Run the guardrails that apply to `stage`, in order. Collects EVERY trip (does not
+ * short-circuit) so a caller sees all reasons at once. `passed` is true iff zero trips.
+ */
+export function runGuardrails(
+  guards: Guardrail[],
+  ctx: GuardrailContext,
+  stage: 'input' | 'output',
+): GuardrailRunResult {
+  const trips: Array<{ name: string; reason: string }> = [];
+  for (const g of guards) {
+    if (!appliesTo(g, stage)) continue;
+    const r = g.check(ctx);
+    if (r.tripwire) trips.push({ name: g.name, reason: r.reason });
+  }
+  return { passed: trips.length === 0, trips };
+}
+
+/** Async variant for guardrails that do I/O. Same collect-all semantics. */
+export async function runGuardrailsAsync(
+  guards: AsyncGuardrail[],
+  ctx: GuardrailContext,
+  stage: 'input' | 'output',
+): Promise<GuardrailRunResult> {
+  const trips: Array<{ name: string; reason: string }> = [];
+  for (const g of guards) {
+    if (!appliesTo(g, stage)) continue;
+    const r = await g.check(ctx);
+    if (r.tripwire) trips.push({ name: g.name, reason: r.reason });
+  }
+  return { passed: trips.length === 0, trips };
+}
+
+// ── Adapter examples: how ZOE's REAL guards map onto this interface ──────────────
+// These are self-contained reference adapters (no imports, so this module stays
+// additive + testable in isolation). Adoption = replace each stub body with a call to
+// the real function named in the comment.
+
+/** Maps `cost-governance.ts shouldPauseAutonomousWork()` -> an input guardrail. */
+export function costGuard(shouldPause: () => boolean): Guardrail {
+  return {
+    name: 'cost-governance',
+    stage: 'input',
+    check: () => shouldPause()
+      ? { tripwire: true, reason: 'spend at hard-stop threshold (>=95%) - autonomous work paused' }
+      : { tripwire: false, reason: '' },
+  };
+}
+
+/** Maps `pii.ts` scan -> an output guardrail (never emit PII in a response). */
+export function piiGuard(scan: (text: string) => boolean): Guardrail {
+  return {
+    name: 'pii',
+    stage: 'output',
+    check: (ctx) => ctx.output && scan(ctx.output)
+      ? { tripwire: true, reason: 'output contains PII - redact before sending' }
+      : { tripwire: false, reason: '' },
+  };
+}
+
+/** Maps `preflight.ts hasCriticalFailure()` -> an input guardrail (don't run if broken). */
+export function preflightGuard(hasCriticalFailure: () => boolean): Guardrail {
+  return {
+    name: 'preflight',
+    stage: 'input',
+    check: () => hasCriticalFailure()
+      ? { tripwire: true, reason: 'a critical capability (env/key) is missing - fail loud, do not proceed' }
+      : { tripwire: false, reason: '' },
+  };
+}
+
+/** Self-test - exported so a runner (or vitest) can call it; returns 0 on success. */
+export function _selftest(): number {
+  const guards = [
+    costGuard(() => false),
+    preflightGuard(() => true), // critical failure -> should trip on input
+    piiGuard((t) => t.includes('555-12')), // trips on a fake phone in output
+  ];
+  // input stage: costGuard passes, preflightGuard trips; piiGuard is output-only, skipped
+  const inRes = runGuardrails(guards, { input: 'do the thing' }, 'input');
+  if (inRes.passed) throw new Error('preflight critical failure must trip on input');
+  if (inRes.trips.length !== 1 || inRes.trips[0].name !== 'preflight') {
+    throw new Error('exactly the preflight guard should trip on input: ' + JSON.stringify(inRes.trips));
+  }
+  // output stage: only piiGuard applies; trips on the PII
+  const outTrip = runGuardrails(guards, { output: 'call 555-1234' }, 'output');
+  if (outTrip.passed || outTrip.trips[0].name !== 'pii') {
+    throw new Error('pii guard should trip on output with a phone number');
+  }
+  // clean output passes
+  const outClean = runGuardrails(guards, { output: 'all good' }, 'output');
+  if (!outClean.passed) throw new Error('clean output must pass');
+  // all-clear input (no critical failure) passes
+  const okGuards = [costGuard(() => false), preflightGuard(() => false)];
+  if (!runGuardrails(okGuards, { input: 'go' }, 'input').passed) {
+    throw new Error('all-clear input must pass');
+  }
+  // collect-all: two input trips both reported, not short-circuited
+  const twoTrip = runGuardrails(
+    [costGuard(() => true), preflightGuard(() => true)],
+    { input: 'x' }, 'input',
+  );
+  if (twoTrip.trips.length !== 2) throw new Error('runGuardrails must collect ALL trips, got ' + twoTrip.trips.length);
+  // eslint-disable-next-line no-console
+  console.log('selftest OK');
+  return 0;
+}

--- a/bot/src/zoe/memory-git.ts
+++ b/bot/src/zoe/memory-git.ts
@@ -1,0 +1,142 @@
+/**
+ * memory-git.ts - commit-per-edit versioning for ZOE's memory files.
+ *
+ * TS port of scripts/agents/zoe-memory-git.py (#2925), the #1 adopt from the
+ * ZOE-vs-toolkits audit (doc 2235): memory at ~/.zao/zoe/*.md had no version
+ * history - no what-changed/when/why, no rollback. This wraps memory writes in git
+ * commits (git IS the backend - native platform feature, no new dependency).
+ *
+ * FLAG-GATED + best-effort: only active when ZOE_MEMORY_GIT=1 (default OFF = exact
+ * current behavior). A git failure NEVER breaks the memory write - the write already
+ * happened; versioning is an audit layer. Failures log loudly (silent-failure-guard
+ * rule 6: soft-fail must be loud, never silent).
+ *
+ * Pattern credit: letta-ai/letta (Apache-2.0) - versioned memory blocks.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const execFileAsync = promisify(execFile);
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+
+/** Versioning is opt-in: absent/other values = current behavior, zero git calls. */
+export function memoryGitEnabled(): boolean {
+  return process.env.ZOE_MEMORY_GIT === '1';
+}
+
+async function git(args: string[], dir: string = ZOE_HOME): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['-C', dir, ...args]);
+  return stdout.trim();
+}
+
+/** git init the memory dir on first use (idempotent). Never touches file contents. */
+export async function ensureMemoryRepo(dir: string = ZOE_HOME): Promise<void> {
+  if (!existsSync(join(dir, '.git'))) {
+    await git(['init', '-q'], dir);
+    // local identity so commits work even with no global git config on the box
+    await git(['config', 'user.email', 'zoe@thezao.com'], dir).catch(() => undefined);
+    await git(['config', 'user.name', 'ZOE memory'], dir).catch(() => undefined);
+  }
+}
+
+/**
+ * Commit an already-written memory file with (reason, author). Returns the short sha,
+ * '' when nothing changed (idempotent no-op writes create no empty commit), or null
+ * when versioning is disabled or git failed (the write itself is unaffected).
+ */
+export async function commitMemoryWrite(
+  file: string,
+  reason: string,
+  author = 'zoe',
+): Promise<string | null> {
+  if (!memoryGitEnabled()) return null;
+  try {
+    await ensureMemoryRepo();
+    await git(['add', file]);
+    // nothing staged (identical content) -> honest no-op
+    try {
+      await git(['diff', '--cached', '--quiet', '--', file]);
+      return ''; // exit 0 = no staged change
+    } catch {
+      // non-zero exit = there IS a staged change; commit it
+    }
+    await git([
+      'commit', '-q',
+      '-m', `memory: ${file} - ${reason}\n\nAuthor: ${author}`,
+      '--author', `${author} <${author}@thezao.com>`,
+    ]);
+    return await git(['rev-parse', '--short', 'HEAD']);
+  } catch (error: unknown) {
+    // LOUD soft-fail: versioning must never break a memory write, but a silent
+    // versioning outage is silent data loss of the audit trail.
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[memory-git] commit failed for ${file} (write itself is fine): ${msg}`);
+    return null;
+  }
+}
+
+export interface MemoryCommit {
+  sha: string;
+  date: string;
+  reason: string;
+}
+
+/** What changed, when, why - newest first. Empty when unversioned/disabled. */
+export async function memoryHistory(file: string): Promise<MemoryCommit[]> {
+  if (!existsSync(join(ZOE_HOME, '.git'))) return [];
+  try {
+    const out = await git(['log', '--format=%h\x1f%ad\x1f%s', '--date=short', '--', file]);
+    return out
+      .split('\n')
+      .filter((l) => l.includes('\x1f'))
+      .map((l) => {
+        const [sha, date, subject] = l.split('\x1f');
+        const reason = subject.includes(' - ') ? subject.split(' - ').slice(1).join(' - ') : subject;
+        return { sha, date, reason };
+      });
+  } catch {
+    return [];
+  }
+}
+
+/** The why-changed traversal: just the reasons, newest first. */
+export async function memoryWhy(file: string): Promise<string[]> {
+  return (await memoryHistory(file)).map((c) => c.reason);
+}
+
+/**
+ * Restore a memory file to a prior commit's version, recorded as a NEW commit -
+ * never rewrites history (no-rm-rf-adjacent principle: history is append-only).
+ */
+export async function rollbackMemory(
+  file: string,
+  ref: string,
+  author = 'zoe',
+): Promise<string | null> {
+  if (!memoryGitEnabled()) return null;
+  try {
+    await ensureMemoryRepo();
+    await git(['checkout', ref, '--', file]);
+    await git(['add', file]);
+    try {
+      await git(['diff', '--cached', '--quiet', '--', file]);
+      return ''; // already at that version
+    } catch {
+      // staged change exists - commit the rollback
+    }
+    await git([
+      'commit', '-q',
+      '-m', `memory: ${file} - rollback to ${ref}\n\nAuthor: ${author}`,
+      '--author', `${author} <${author}@thezao.com>`,
+    ]);
+    return await git(['rev-parse', '--short', 'HEAD']);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[memory-git] rollback failed for ${file}: ${msg}`);
+    return null;
+  }
+}

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -22,6 +22,7 @@ import { dirname, join } from 'node:path';
 import type { ZoeTask, DecisionRecord, BuildStateRecord, InboxContextRecord } from './types';
 import { buildQuestsBlock } from './sidequests';
 import { getTeamContextBlock } from './team-tracker';
+import { commitMemoryWrite } from './memory-git';
 
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
 const PERSONA_PATH = join(ZOE_HOME, 'persona.md');
@@ -468,14 +469,18 @@ export async function readHuman(): Promise<string> {
  * to persist a Zaal-approved memory patch. Only ever called after explicit
  * y/n approval — never autonomously.
  */
-export async function writeHuman(contents: string): Promise<void> {
+export async function writeHuman(contents: string, reason = 'human.md update'): Promise<void> {
   await ensureZoeHome();
   await fs.writeFile(HUMAN_PATH, contents, 'utf8');
+  // Flag-gated audit trail (ZOE_MEMORY_GIT=1): commit-per-edit versioning, doc 2235
+  // #1 adopt. Best-effort - a git failure never breaks the write (loud log inside).
+  await commitMemoryWrite('human.md', reason);
 }
 
-export async function writePersona(contents: string): Promise<void> {
+export async function writePersona(contents: string, reason = 'persona.md update'): Promise<void> {
   await ensureZoeHome();
   await fs.writeFile(PERSONA_PATH, contents, 'utf8');
+  await commitMemoryWrite('persona.md', reason);
 }
 
 function recentPathFor(scope: ChatScope): string {


### PR DESCRIPTION
Zaal-greenlit wiring of both audit adopts (doc 2235) into live ZOE code. Flag-gated, additive, fully verified. Supersedes #2926 (its commit is cherry-picked here).

## What
1. **`memory-git.ts`** - TS port of #2925: commit-per-edit versioning of `~/.zao/zoe` memory. `writeHuman`/`writePersona` call `commitMemoryWrite` after the fs write, **behind `ZOE_MEMORY_GIT=1` (default OFF = exact current behavior)**. Git failure never breaks the write (loud log, silent-failure-guard rule 6). Rollback = a NEW commit, history never rewritten.
2. **`guardrail-adapters.ts`** - the real guards implement the #2926 Guardrail interface: `zoeCostGuard` (shouldPauseAutonomousWork), `zoePiiGuard` (containsPii on output), `zoePreflightGuard` (hasCriticalFailure) + `runConciergeGuardrails()` single entry. Zero behavior change to the guards. Concierge call-path insertion deliberately left as a reviewed 1-liner.

## Evidence (loop-evals A-F)
- **tsc --noEmit:** 40 errors = the known pre-existing baseline (tg-interactions/critic/commands tests), **0 in touched files, 0 new**
- **vitest FULL suite:** **153 files, 1893 tests, ALL PASS** (count up - guardrails tests added)
- **esbuild:** `src/index.ts` AND ZOE's real entry `src/zoe/index.ts` (744KB) both bundle EXIT 0; `commitMemoryWrite` present in the ZOE graph (3 refs) - not a vacuous pass (first attempt WAS vacuous via a zsh glob; caught + redone)
- **boot-verify (rule 21):** non-entrypoint imports clean via tsx; guardrail pipeline executes (preflight trips correctly in a keyless env)
- **secret scan:** standalone step, 0 matches (first run failed CLOSED on a ugrep regex error - fixed, rerun clean)

## Gated / not done
Bot restart + deploy (yours). Concierge call-path 1-liner (wants your eyes on the exact insertion point).

## Credit
letta-ai/letta (Apache-2.0); openai/openai-agents-python (Apache-2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9