### PR TITLE
feat(zoe): wire live step emission into ZOE loops (mission-control data)

### DIFF
--- a/bot/src/zoe/__tests__/mission-control.test.ts
+++ b/bot/src/zoe/__tests__/mission-control.test.ts
@@ -1,0 +1,121 @@
+/**
+ * mission-control.test.ts - the pinned mission-control render + emit layer (doc 2226).
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  emitStep,
+  readStepJournal,
+  renderPinnedText,
+  type JournalStep,
+} from '../mission-control';
+
+function step(partial: Partial<JournalStep> & Pick<JournalStep, 'id' | 'topic' | 'text'>): JournalStep {
+  return {
+    ts: '2026-08-07T05:00:00.000Z',
+    actor: 'zoe',
+    severity: 3,
+    parent: null,
+    kind: 'step',
+    ...partial,
+  };
+}
+
+describe('readStepJournal + emitStep', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'mc-'));
+  const path = join(dir, 'journal.jsonl');
+
+  it('missing journal = empty feed, not an error', async () => {
+    await expect(readStepJournal(join(dir, 'nope.jsonl'))).resolves.toEqual([]);
+  });
+
+  it('emitStep appends python-compatible rows with sequential ids', async () => {
+    const a = await emitStep('panel', 'builder', 5, 'started the run', { path });
+    const b = await emitStep('panel', 'critic', 8, 'found a disagreement', { path, parent: a.id, kind: 'correction' });
+    expect(a.id).toBe('s1');
+    expect(b.id).toBe('s2');
+    expect(b.parent).toBe('s1');
+    const rows = await readStepJournal(path);
+    expect(rows).toHaveLength(2);
+    expect(rows[1].kind).toBe('correction');
+  });
+
+  it('severity is clamped to 0-10', async () => {
+    const s = await emitStep('panel', 'zoe', 99, 'clamped', { path });
+    expect(s.severity).toBe(10);
+  });
+
+  it('corrupt lines are skipped, never a crash', async () => {
+    const { promises: fs } = await import('node:fs');
+    await fs.appendFile(path, 'not json\n', 'utf8');
+    const rows = await readStepJournal(path);
+    expect(rows.length).toBeGreaterThanOrEqual(3); // the valid rows survive
+  });
+});
+
+describe('renderPinnedText', () => {
+  it('empty journal renders the quiet state', () => {
+    expect(renderPinnedText([])).toContain('quiet');
+  });
+
+  it('priority steps (>=7) render in NEEDS YOU on top', () => {
+    const out = renderPinnedText([
+      step({ id: 's1', topic: 'relay', text: 'routine ping', severity: 2 }),
+      step({ id: 's2', topic: 'deploy', text: 'boot FAILED on vps', severity: 9, ts: '2026-08-07T06:00:00.000Z' }),
+    ]);
+    const needsYou = out.indexOf('NEEDS YOU');
+    expect(needsYou).toBeGreaterThan(-1);
+    expect(out.indexOf('boot FAILED')).toBeGreaterThan(needsYou);
+    expect(out.indexOf('boot FAILED')).toBeLessThan(out.indexOf('# deploy'));
+  });
+
+  it('threads are topic-grouped with counts; corrections marked FIX', () => {
+    const out = renderPinnedText([
+      step({ id: 's1', topic: 'panel', text: 'run started' }),
+      step({ id: 's2', topic: 'panel', text: 'redo step 2', kind: 'correction', parent: 's1', severity: 6 }),
+    ]);
+    expect(out).toContain('# panel (2)');
+    expect(out).toContain('FIX redo step 2');
+  });
+
+  it('muted topics are hidden (mutable channels)', () => {
+    const out = renderPinnedText(
+      [
+        step({ id: 's1', topic: 'noise', text: 'chatter' }),
+        step({ id: 's2', topic: 'signal', text: 'real work' }),
+      ],
+      { mutedTopics: ['noise'] },
+    );
+    expect(out).not.toContain('chatter');
+    expect(out).toContain('real work');
+  });
+
+  it('stays within the Telegram limit and notes dropped topics', () => {
+    const steps: JournalStep[] = [];
+    for (let t = 0; t < 40; t++) {
+      for (let i = 0; i < 5; i++) {
+        steps.push(
+          step({
+            id: `s${t * 5 + i}`,
+            topic: `topic-${t}`,
+            text: `a fairly long step description line number ${i} with details `.repeat(3),
+            ts: `2026-08-07T05:${String(t).padStart(2, '0')}:00.000Z`,
+          }),
+        );
+      }
+    }
+    const out = renderPinnedText(steps);
+    expect(out.length).toBeLessThanOrEqual(4096);
+    expect(out).toContain('older topics');
+  });
+
+  it('most-recent-activity topic renders first', () => {
+    const out = renderPinnedText([
+      step({ id: 's1', topic: 'old', text: 'stale', ts: '2026-08-07T01:00:00.000Z' }),
+      step({ id: 's2', topic: 'fresh', text: 'active', ts: '2026-08-07T06:00:00.000Z' }),
+    ]);
+    expect(out.indexOf('# fresh')).toBeLessThan(out.indexOf('# old'));
+  });
+});

--- a/bot/src/zoe/error-remediation.ts
+++ b/bot/src/zoe/error-remediation.ts
@@ -19,6 +19,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { mcEmit } from './mission-control';
 import type { HermesRepoTarget } from '../hermes/types';
 import { db } from '../supabase';
 import { dispatchHermesRun } from '../hermes/runner';
@@ -121,6 +122,7 @@ export async function runErrorRemediationTick(deps: RemediationDeps): Promise<st
 
   const claimed = await deps.claimError(next.id);
   if (!claimed) return `lost claim race on ${next.id}`;
+  mcEmit('error-remediation', 'zoe', 3, `claimed error ${next.ref_code ?? next.id.slice(0, 8)} in ${next.repo}`);
 
   const target = repoToTarget(next.repo);
   if (!target) {
@@ -150,6 +152,7 @@ export async function runErrorRemediationTick(deps: RemediationDeps): Promise<st
     await deps.report(
       `Error ${tag} (${target}${next.brand ? `, brand ${next.brand}` : ''}): diagnosed -> fixed -> ${prLabel} open${result.prUrl ? ` ${result.prUrl}` : ''}. Ready for your merge.`,
     );
+    mcEmit('error-remediation', 'zoe', 5, `error ${tag} fixed -> ${result.prUrl ?? 'PR open'}`);
     return `fixed -> ${result.prUrl ?? 'pr'}`;
   }
 
@@ -157,6 +160,7 @@ export async function runErrorRemediationTick(deps: RemediationDeps): Promise<st
   await deps.report(
     `Error ${tag} (${target}) - pipeline could not auto-fix (${result.kind}): ${result.reason}. Needs you.`,
   );
+  mcEmit('error-remediation', 'zoe', 8, `error ${tag} NEEDS ZAAL (${result.kind}): ${result.reason}`);
   return `escalated (${result.kind})`;
 }
 

--- a/bot/src/zoe/mission-control.ts
+++ b/bot/src/zoe/mission-control.ts
@@ -1,0 +1,171 @@
+/**
+ * mission-control.ts - render + emit layer for the TG pinned mission-control.
+ *
+ * Doc 2226 (task #73): a live pinned Telegram message where Zaal READS everything
+ * the swarm is doing and steers it. This module is the PURE layer: parse the
+ * step-journal, render the pinned text, and let bot loops emit steps. It makes NO
+ * Telegram calls - the actual pin/edit call site is a later, reviewed insertion
+ * (same pattern as the guardrail 1-liner in #2932).
+ *
+ * The substrate is the step-journal (scripts/agents/step-journal.py, #2911):
+ * JSONL of {id, ts, topic, actor, severity 0-10, text, parent, kind}. The spec's
+ * four features map directly: topic-threaded (group by topic), priority (>=7 on
+ * top), mutable channels (mute topics at render), reply-to-step (kind=correction
+ * rows linked by parent - rendered inline under their target).
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** One step-journal row (mirrors step-journal.py's append() shape exactly). */
+export interface JournalStep {
+  id: string;
+  ts: string;
+  topic: string;
+  actor: string;
+  severity: number;
+  text: string;
+  parent: string | null;
+  kind: string; // 'step' | 'correction'
+}
+
+export const DEFAULT_JOURNAL_PATH = join(homedir(), '.zao', 'step-journal', 'journal.jsonl');
+
+/** Telegram hard limit is 4096; leave headroom so the header/footer never overflow. */
+const RENDER_BUDGET = 3900;
+
+/** Parse the step-journal JSONL. Corrupt lines are skipped, never a crash. */
+export async function readStepJournal(path: string = DEFAULT_JOURNAL_PATH): Promise<JournalStep[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(path, 'utf8');
+  } catch {
+    return []; // no journal yet = empty feed, not an error
+  }
+  const steps: JournalStep[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line) as Partial<JournalStep>;
+      if (typeof row.id === 'string' && typeof row.topic === 'string' && typeof row.text === 'string') {
+        steps.push({
+          id: row.id,
+          ts: typeof row.ts === 'string' ? row.ts : '',
+          topic: row.topic,
+          actor: typeof row.actor === 'string' ? row.actor : 'unknown',
+          severity: typeof row.severity === 'number' ? row.severity : 0,
+          text: row.text,
+          parent: typeof row.parent === 'string' ? row.parent : null,
+          kind: typeof row.kind === 'string' ? row.kind : 'step',
+        });
+      }
+    } catch {
+      // corrupt line - skip (mirrors step-journal.py's tolerant reader)
+    }
+  }
+  return steps;
+}
+
+/**
+ * Append a step from bot code so ZOE's loops write the same journal the python
+ * primitive reads. Same id scheme (s1, s2...) and shape as step-journal.py.
+ */
+export async function emitStep(
+  topic: string,
+  actor: string,
+  severity: number,
+  text: string,
+  opts: { parent?: string | null; kind?: string; path?: string } = {},
+): Promise<JournalStep> {
+  const path = opts.path ?? DEFAULT_JOURNAL_PATH;
+  const existing = await readStepJournal(path);
+  const step: JournalStep = {
+    id: `s${existing.length + 1}`,
+    ts: new Date().toISOString(),
+    topic,
+    actor,
+    severity: Math.max(0, Math.min(10, Math.round(severity))),
+    text,
+    parent: opts.parent ?? null,
+    kind: opts.kind ?? 'step',
+  };
+  await fs.mkdir(join(path, '..'), { recursive: true });
+  await fs.appendFile(path, `${JSON.stringify(step)}\n`, 'utf8');
+  return step;
+}
+
+export interface RenderOptions {
+  /** Topics muted at render time (the spec's mutable channels). */
+  mutedTopics?: string[];
+  /** Steps with severity >= this render in the NEEDS-YOU block (spec: 7). */
+  priorityThreshold?: number;
+  /** Most recent N steps per topic thread (keep the pin phone-readable). */
+  perTopic?: number;
+}
+
+function shortTime(ts: string): string {
+  // "2026-08-07T05:31:00.000Z" -> "05:31"
+  const m = ts.match(/T(\d{2}:\d{2})/);
+  return m ? m[1] : '';
+}
+
+function stepLine(s: JournalStep): string {
+  const mark = s.kind === 'correction' ? 'FIX ' : '';
+  return `- [${s.severity}] ${shortTime(s.ts)} ${s.actor}: ${mark}${s.text}`;
+}
+
+/**
+ * Render the pinned mission-control text (doc 2226): NEEDS-YOU (severity >=
+ * threshold) on top, then topic threads newest-activity-first, corrections inline
+ * under their thread. Phone-readable (brand.md: short lines, blank line between
+ * blocks), and always within the Telegram budget - oldest threads drop first.
+ */
+export function renderPinnedText(steps: JournalStep[], opts: RenderOptions = {}): string {
+  const muted = new Set(opts.mutedTopics ?? []);
+  const threshold = opts.priorityThreshold ?? 7;
+  const perTopic = opts.perTopic ?? 3;
+
+  const visible = steps.filter((s) => !muted.has(s.topic));
+  if (visible.length === 0) return 'MISSION CONTROL\n\nquiet - no steps yet';
+
+  const lines: string[] = ['MISSION CONTROL'];
+
+  // NEEDS-YOU: priority steps, newest first (the notify->=7 rule)
+  const hot = visible.filter((s) => s.severity >= threshold).slice(-5).reverse();
+  if (hot.length > 0) {
+    lines.push('', `NEEDS YOU (sev >= ${threshold})`);
+    for (const s of hot) lines.push(`${stepLine(s)} [${s.topic}]`);
+  }
+
+  // topic threads, most-recent-activity first
+  const byTopic = new Map<string, JournalStep[]>();
+  for (const s of visible) {
+    const arr = byTopic.get(s.topic) ?? [];
+    arr.push(s);
+    byTopic.set(s.topic, arr);
+  }
+  const topics = [...byTopic.entries()].sort(
+    (a, b) => (b[1][b[1].length - 1]?.ts ?? '').localeCompare(a[1][a[1].length - 1]?.ts ?? ''),
+  );
+
+  const threadBlocks: string[] = [];
+  for (const [topic, arr] of topics) {
+    const recent = arr.slice(-perTopic);
+    const block = [`# ${topic} (${arr.length})`, ...recent.map(stepLine)].join('\n');
+    threadBlocks.push(block);
+  }
+
+  // fit within budget - drop the OLDEST-activity threads first, note the omission
+  let body = lines.join('\n');
+  const kept: string[] = [];
+  for (const block of threadBlocks) {
+    const candidate = `${body}\n\n${[...kept, block].join('\n\n')}`;
+    if (candidate.length > RENDER_BUDGET) {
+      kept.push(`(+${threadBlocks.length - kept.length} older topics - reply /mc all)`);
+      break;
+    }
+    kept.push(block);
+  }
+  body = `${body}\n\n${kept.join('\n\n')}`;
+  return body.length <= 4096 ? body : `${body.slice(0, 4090)}\n...`;
+}

--- a/bot/src/zoe/mission-control.ts
+++ b/bot/src/zoe/mission-control.ts
@@ -94,6 +94,20 @@ export async function emitStep(
   return step;
 }
 
+/**
+ * Fire-and-forget step emission for ZOE's loops, gated on ZOE_MISSION_CONTROL=1
+ * (default OFF = zero I/O, keeps unit tests hermetic). A journal failure never
+ * breaks the loop - but it logs LOUDLY (silent-failure-guard rule 6: a silent
+ * audit-trail outage is silent data loss).
+ */
+export function mcEmit(topic: string, actor: string, severity: number, text: string): void {
+  if (process.env.ZOE_MISSION_CONTROL !== '1') return;
+  emitStep(topic, actor, severity, text).catch((error: unknown) => {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[mission-control] emit failed (${topic}/${actor}): ${msg}`);
+  });
+}
+
 export interface RenderOptions {
   /** Topics muted at render time (the spec's mutable channels). */
   mutedTopics?: string[];

--- a/bot/src/zoe/repo-improver.ts
+++ b/bot/src/zoe/repo-improver.ts
@@ -22,6 +22,7 @@
  */
 
 import { z } from 'zod';
+import { mcEmit } from './mission-control';
 import type { HermesRepoTarget } from '../hermes/types';
 
 /** The repos the scout rotates through. hermesTarget=null => surface-only (no auto-fix target yet). */
@@ -193,6 +194,7 @@ export async function runRepoImproverScout(deps: ScoutDeps): Promise<string> {
     pr_url: null,
     run_id: null,
   });
+  mcEmit('repo-improver', 'scout', 4, `proposed improvement: ${target.repo} - ${finding.area}`);
   return `proposed: ${target.repo} - ${finding.area}`;
 }
 

--- a/bot/src/zoe/watcher.ts
+++ b/bot/src/zoe/watcher.ts
@@ -7,6 +7,7 @@
  * the scheduler decides whether to ping. No autonomous actions of its own.
  */
 import { readRuns, type RunRecord } from './runs';
+import { mcEmit } from './mission-control';
 
 export interface WatcherAlert {
   level: 'info' | 'warn';
@@ -77,7 +78,9 @@ export async function runWatcherTick(
   cfg: WatcherConfig = DEFAULT_WATCHER,
 ): Promise<WatcherAlert[]> {
   const runs = await readRuns(1);
-  return analyzeRuns(runs, cfg);
+  const alerts = analyzeRuns(runs, cfg);
+  for (const a of alerts) mcEmit('watcher', 'watcher', 8, a.message);
+  return alerts;
 }
 
 /** One-line render for a Telegram ping to Zaal. */


### PR DESCRIPTION
Stacked on #2936 (merge that first). Makes the pinned mission-control REAL - ZOE's loops now write the journal the pinned surface renders.

## What (24-line diff)
- `mcEmit()` in mission-control.ts: fire-and-forget emission, gated on **`ZOE_MISSION_CONTROL=1` (default OFF = zero I/O)**; journal failure never breaks a loop but logs LOUDLY (no silent `.catch(() => {})`)
- **error-remediation**: claimed (sev 3) -> fixed+PR (sev 5) -> **NEEDS ZAAL (sev 8)**
- **repo-improver scout**: proposed improvement (sev 4)
- **watcher**: every anomaly (sev 8)

Severity mapping = doc 2226's notify->=7 NEEDS-YOU rule.

## Evidence
tsc 40 = baseline / 0 in touched files; vitest FULL suite **1897 green**; esbuild both entries EXIT 0; flag-off boot-import clean.

## Rollout (yours)
Merge #2936 -> this -> deploy -> flip ZOE_MISSION_CONTROL=1. Then the remaining piece is the pin/edit call site (a reviewed insertion once you pick the group to pin in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9