### PR TITLE
docs: ICM currency audit - 23 boxes, 15 snapshots captured (doc 2241)

### DIFF
--- a/research/identity/2241-icm-currency-audit/README.md
+++ b/research/identity/2241-icm-currency-audit/README.md
@@ -1,0 +1,84 @@
+---
+topic: identity
+type: audit
+status: research-complete
+last-validated: 2026-08-07
+related-docs: 2218, 1016, 1021
+original-query: "ICM currency audit (task #70): every live box vs repo truth - which are stale/drifted, staged update commands, no publishing"
+tier: STANDARD
+---
+
+# 2241 - ICM currency audit: 23 live boxes vs repo truth
+
+> **Goal:** The ICM boxes are the AI-readable source of truth for every ZAO brand
+> (icm-grounding.md: the box wins; downstream is generated FROM it). This audits every
+> LIVE box against the repo copies - who drifted, who has no backup, what to publish.
+
+## Method (real fetches, 2026-08-07)
+
+Registry via `python3 ~/bin/zao-icm.py list` (23 live boxes; note: run from `$HOME` -
+a worktree cwd breaks it). Each live box fetched from
+`useicm.com/api/objects/<id>/llm.txt` (public read). Diffed byte-exact against repo
+truth (`research/identity/icm-boxes/` + `drafts/` + `generated/` on main). All 23
+fetches FULL, 0 failed.
+
+## The verdict table
+
+| Verdict | Count | Boxes |
+|---------|-------|-------|
+| IN-SYNC | 1 | zao-assistant |
+| DRIFTED, repo richer (updates written, never published) | 7 | thezao, wavewarz, fractal, poidh, sparkz, coc-concertz, zaostock |
+| DRIFTED, live richer (live edited, repo stale) | 1 | zabalgamez (live 2139c vs repo 973c) |
+| LIVE-ONLY (no repo backup existed) | 14 | bettercallzaal, channelz, farcaster, gmfarcaster, loop-engineering, magnetiq, milk-road, zao-festivals, zao-newsletter, zao-video-editor, zaolingo, zaoscout, zlank, zuke |
+| REPO-ONLY (drafted, not yet published) | 4 | zaal, zoe, zai, zol |
+
+Drift detail (repo-richer sizes, live vs repo chars): fractal 1247/3771, poidh
+1185/3431, sparkz 2491/5058, zaostock 854/2443, coc-concertz 904/2188, thezao
+2039/2218, wavewarz 2106/2142.
+
+## Fixed in this PR (autonomous-safe)
+
+**All 14 LIVE-ONLY boxes + the live-richer zabalgamez are now captured byte-pure into
+`research/identity/icm-boxes/live-snapshots/`** (15 snapshots, 0 failed) - so every
+live box finally has a repo copy and future audits diff against ground truth. Reading
+public boxes into the repo publishes nothing.
+
+## Needs Zaal (publishing is gated - staged, print-only)
+
+1. **Publish the 7 repo-richer updates** (the repo copy is the newer truth per
+   icm-grounding.md). Per box: `python3 ~/bin/zao-icm.py update-cmd <slug>` prints the
+   gated PUT (owner key from ~/.zao/private/icm-keys.json). Slugs: thezao, wavewarz,
+   fractal, poidh, sparkz, coc-concertz, zaostock.
+2. **Publish the 4 REPO-ONLY drafts**: zaal + the agent trio (zoe/zol/zai - the
+   morning batch already staged on your clipboard page).
+3. **Decide zabalgamez direction**: live is richer - either bless the live version
+   (replace the repo file with the snapshot: one `cp` from live-snapshots/) or merge.
+4. **Retire the magnetiq box**: Magnetiq is retired per the glossary ("do not
+   reference") yet its box is LIVE (817c). Recommend delete/archive - your call +
+   your key.
+
+## How you use this (30 seconds)
+
+- See any live box: `icm <slug>` in a terminal.
+- Compare live vs repo: `diff research/identity/icm-boxes/live-snapshots/<slug>.llm.txt research/identity/icm-boxes/<slug>.llm.txt`
+- Re-run this whole audit: the method above; next run diffs against these snapshots.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Run the 7 update-cmds + 4 create-cmds (publishing, gated) | @Zaal | Gated publish | 2026-08-10 |
+| Decide zabalgamez (bless live snapshot or merge) | @Zaal | Decision | 2026-08-10 |
+| Retire/delete the live magnetiq box | @Zaal | Gated | 2026-08-10 |
+| Re-audit after publishing (same method) | @Zaal (Claude) | Audit | 2026-08-17 |
+
+## Sources
+
+- Registry: `~/bin/zao-icm.py list` (23 live). [FULL]
+- 23 live boxes fetched from useicm.com/api (all FULL, 0 failed) + byte-diff vs
+  `research/identity/icm-boxes/` on main. [FULL]
+- 15 live snapshots captured in this PR (`live-snapshots/`). [FULL]
+
+## Also See
+
+- [Doc 2218](2218-icm-coverage-currency-audit/) - the overnight coverage map this completes (task #70).

--- a/research/identity/README.md
+++ b/research/identity/README.md
@@ -145,3 +145,4 @@
 | 2196 | [Agent-native docs, adoption reality: llms.txt is hygiene, MCP is the lever](./2196-agent-native-docs-llmstxt-mcp-reality/) | STANDALONE | Doc 2194 recommended adopting basehub.org's agent-native pattern (llms.txt + .md + MCP) for ZAO. This checks what the developer community ACTUALLY found works - and it materially refines that recommendation. |
 | 2218 | [ICM Coverage + Currency Audit (overnight loop tracking doc)](./2218-icm-coverage-currency-audit/) | STANDALONE | One map of every real ZAO project/product/idea, whether it has an ICM |
 | 2224 | [Farcaster High-Signal Discovery (batch 1, grounded via the graph)](./2224-farcaster-high-signal-discovery-batch1/) | STANDALONE | Accounts @zaal (FID 19640) does NOT follow that many of his follows DO |
+| 2241 | [ICM currency audit: 23 live boxes vs repo truth](./2241-icm-currency-audit/) | STANDALONE | The ICM boxes are the AI-readable source of truth for every ZAO brand |

--- a/research/identity/icm-boxes/live-snapshots/bettercallzaal.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/bettercallzaal.llm.txt
@@ -1,0 +1,17 @@
+# BetterCallZaal
+
+BetterCallZaal is the personal brand and operator layer of Zaal Panthaki, founder of The ZAO. It is one word, camelCase, and it is where his build-in-public practice, consulting, and web3-music work live under a single name. The legal entity behind it is BCZ Strategies LLC.
+
+## What it is
+
+Zaal builds at the intersection of music, culture, and emerging technology, using blockchain and AI as means rather than headlines. BetterCallZaal is the layer that ships that work. Through it he founded and runs The ZAO, a decentralized impact network that returns profit margin, data, and IP rights to artists, with music as its first artist domain. The same operator layer runs WaveWarZ, ZABAL Games, and the ZAOstock festival.
+
+BetterCallZaal is also an agency. It advises and builds for other founders and communities moving into web3 and AI, with a strong bias toward open source and shipping in public rather than pitching decks. The working style is direct, builder-first, and allergic to hype.
+
+## How to reach it
+
+Farcaster @zaal, X and YouTube @bettercallzaal, and the site bettercallzaal.com. Zaal wakes early and builds in focused blocks, documenting the process as he goes.
+
+## Related
+
+The ZAO, WaveWarZ, ZABAL Games, ZAOstock, Fractal.

--- a/research/identity/icm-boxes/live-snapshots/channelz.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/channelz.llm.txt
@@ -1,0 +1,11 @@
+# channelz
+
+channelz is a lightweight Farcaster client from the ZAO ecosystem, built for people who want their channels their way.
+
+## What it is
+
+Where most Farcaster clients push one algorithmic feed, channelz puts channel control back in the user's hands: it sorts and filters your channels by favorites, chronological order, and custom filters, stripping the experience down to something clean and fast. It is a focused, single-purpose tool rather than a full social platform, and it reflects the ZAO preference for lightweight open builds over heavy all-in-one apps. Live at channelz-lilac.vercel.app.
+
+## Related
+
+The ZAO, Farcaster, BetterCallZaal.

--- a/research/identity/icm-boxes/live-snapshots/farcaster.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/farcaster.llm.txt
@@ -1,0 +1,34 @@
+# ICM: Farcaster (knowledge)
+
+General knowledge about Farcaster - the open social protocol - that any assistant can use, plus how The ZAO builds on it. Style note: always say "Farcaster," never "Warpcast."
+
+## What it is
+- A public, open, "sufficiently onchain" social protocol. Accounts are FIDs; posts are casts; there are channels and follows; identity is portable across apps, not owned by any single client.
+- Onchain identity on Optimism/Base; social data lives off-chain on Snapchain (the hub/data layer).
+- The official app was called Warpcast; it is now just "the Farcaster app."
+
+## Who runs it (2026)
+- Neynar acquired Farcaster from Merkle (founders Dan Romero + Varun Srinivasan) on Jan 21 2026 - the protocol contracts, code repos, official app, and Clanker moved to Neynar. Neynar already powered ~90% of Farcaster infrastructure through its API. Leadership: Rish Mukherji + Manan Patel (Coinbase alums).
+- Merkle returned ~$180M to investors (Paradigm, a16z, USV) - roughly an 82% markdown from the 2024 $1B valuation, acknowledging the social-first strategy stalled. No shutdown: the protocol stays public, free, and open, and product stability was maintained under Neynar.
+
+## The primitives
+- Casts, channels, follows, and SIWF (Sign In With Farcaster) auth.
+- Mini Apps (formerly Frames) - interactive apps that render inside a cast. Snaps - the newer primitive, the biggest feature launch since Frames.
+- Snapchain - the data/hub layer. XMTP - encrypted direct messaging.
+- Neynar API - powers most apps (reads, writes, feeds, webhooks, notifications). Reputation/discovery signals: Neynar score, OpenRank, ERC-8004.
+- Clanker - the AI token launchpad on Farcaster/Base (now under Neynar); fees flow to creators.
+
+## State of the network (2026)
+- Post-hype, utility phase. Daily actives came off the 2024 peak; the audience skews web3-insider (a churn risk for mainstream users). Neynar's stewardship is builder-focused and stable. FarCon is the annual gathering (Rome, May 2026).
+
+## The ZAO on Farcaster
+- Channels: /zao, /zabal, /wavewarz, /cocconcertz. Zaal is @zaal on Farcaster (@bettercallzaal on X).
+- ZOL (@zolbot) is The ZAO's Farcaster agent - a music scout and the ZAO's build-in-public voice on Farcaster (X is handled separately by the Paragraph agent).
+- The ZAO ships Snaps and mini apps and runs mini-app discovery inside ZAO OS.
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (bettercallzaal)
+- ZABAL Games (zabalgamez)
+- WaveWarZ (wavewarz)
+- ZAO Assistant (zao-assistant)

--- a/research/identity/icm-boxes/live-snapshots/gmfarcaster.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/gmfarcaster.llm.txt
@@ -1,0 +1,17 @@
+# GM Farcaster
+
+GM Farcaster is Farcaster's number one news show, a daily rundown billed as "29 minutes of Farcaster news." It is hosted by nounishprof and Adrienne (co-founder, FID 5818), and it covers the whole Farcaster ecosystem: protocol announcements, developer updates, app launches, events, and memes.
+
+## What it is
+
+GM Farcaster runs on Farcaster in the /gmfarcaster channel, with a site at gmfarcaster.com, a mini app at miniapp.gmfarcaster.com, and episodes on YouTube, Spotify, and Apple Podcasts. It has become the default news surface for the network.
+
+For builders it is more than a show. It exposes an agent-callable API: your agent can call it to get your project mentioned on an upcoming episode ("ask your agent to call our api and get your project mentioned on our show tomorrow"). There is also an x402 pay-per-call API that returns citation-backed answers from the GM Farcaster podcast library, plus the gmfc101 bot (trained on GM Farcaster content, tag it with a Farcaster question) and the Warpee AI assistant.
+
+## Why it matters to The ZAO
+
+GM Farcaster is a distribution channel for ZAO projects. ZOL, ZAO's Farcaster agent, can call the shoutout API to get ZABAL Games, WaveWarZ, ZAOstock, or any ZAO project featured on the number one Farcaster show, and can pull citation-backed Farcaster news via the x402 API. Payment is x402 micropayments; posting and spend stay human-gated.
+
+## Related
+
+Farcaster, WaveWarZ, ZABAL Games, The ZAO.

--- a/research/identity/icm-boxes/live-snapshots/loop-engineering.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/loop-engineering.llm.txt
@@ -1,0 +1,43 @@
+# ICM: Loop Engineering (knowledge)
+
+Reference knowledge on "loop engineering" - the mid-2026 way of building autonomous AI agents - and how The ZAO applies it. Full analysis: ZAOOS research doc 994. Core idea: you don't prompt agents, you design the loops that run them.
+
+## The 5 loops (name which one you mean before arguing about autonomy)
+- Execution loop - one task: call tool, read result, decide, repeat; ends on env feedback (tests, API).
+- Task loop (the "Ralph loop", Geoffrey Huntley) - restart a fresh-context agent on the SAME spec over and over; re-feeding the spec each time prevents context rot. Ends on spec + tests.
+- Product loop (the "software factory": Factory, Warp Oz, Anthropic internal) - iterates a whole codebase + backlog: triage, spec, implement, review, verify, ship, monitor. Signals come from outside (issues, logs, feedback).
+- System loop (autoresearch: Karpathy, Meta) - the outer loop improves the system itself: prompts, harnesses, model, and the evals. "The loop is the product."
+- Oversight loop - set goals, allocate budget, cull work. Exit condition = a human. "Inner loop is capability; outer loop is agency."
+
+## Core principles
+- Autonomy is a separate dial on EVERY loop, not on/off. The real question is "what signal sets this dial," not "auto or not."
+- A loop without a wired-in stop signal does not converge - it runs until money, rate limit, or a human stops it. Every loop needs a nameable exit + a hard cap.
+- Fan-out (dispatch -> gather -> validate) is a PIPELINE, not a loop - no feedback = "just a for statement."
+- The bottleneck is human REVIEW, not agent capability (even Anthropic is review-bound).
+
+## The Karpathy method
+- A loop = a goal the AI works toward until met: discover, plan, do, check, feed back, repeat. Three parts: clear goal, a feedback signal, a hard stop (goal met OR after N tries). Origin: Karpathy's AutoResearch (Mar 2026).
+- When a loop is a mistake: it earns its cost only when the task is real, repeatable, checkable, and worth the tokens. On limited-token plans a heavy loop hits the wallet before the payoff.
+
+## How The ZAO maps
+- Claude Code session = execution loop. ZOE fix-PR pipeline = task/Ralph loop. ZOE orchestrator = product loop. /loop = system loop. Zaal on the board = oversight loop.
+
+## Related boxes
+- ZAO Assistant (zao-assistant)
+- The ZAO (thezao)
+
+## Deeper (primary sources, DEEP pass)
+- Karpathy AutoResearch ("the Karpathy Loop"): propose -> execute -> evaluate -> commit/rollback; the model cannot override the stop; git is ground truth.
+- Ralph loop (Huntley): fresh agent per iteration vs long sessions - higher token cost, lower error accumulation.
+- Inner vs outer (Osmani): inner = capability, outer = agency; most teams only invest in the inner.
+- LangChain four-loop: agent work -> verification -> event/analysis -> improvement; value compounds in the outer two.
+- Software factories (Warp Oz, Factory): ratchet auto-merge as trust grows (e.g. 20% -> 60%).
+- Critique camp: understanding is the real bottleneck (Litt); "there is no auto" - agents do 80% grunt, humans the 20% (Bakaus); step DOWN an abstraction, prefer deterministic control loops (Horthy).
+- Failure mode to avoid: "loopmaxxing" - adding loops to vague goals with no eval/stop.
+
+## Loop checklist (build a good loop)
+- Pre: clear goal, a rubric/eval for done, context strategy (fresh vs compacted), a token/cost budget.
+- During: an exit signal the model cannot fake (tests/eval/git), an iteration cap, a cost ceiling, no-progress detection.
+- Post: a human checkpoint sized to risk, an audit of changes, and a review-throughput plan (review is the real bottleneck).
+
+Full analysis: ZAOOS research doc 994 (DEEP).

--- a/research/identity/icm-boxes/live-snapshots/magnetiq.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/magnetiq.llm.txt
@@ -1,0 +1,13 @@
+# Magnetiq
+
+Magnetiq is an all-in-one event and launch platform at magnetiq.io, founded by Tyler Stambaugh. It brings event hosting, launches, and community programming into one surface.
+
+## What it is
+
+For the ZAO ecosystem, Magnetiq is where the ZABAL Games workshop library and builder portal run. Workshops, slots, and the program's builder-facing materials live on Magnetiq, with streaming handled through Restream and slot booking through Cal.com. It is the operational home for running the ZABAL Games build-a-thon month to month.
+
+Magnetiq matters to The ZAO because it lets a small team run real programming, workshops, launches, and events, without stitching together a dozen separate tools. Tyler Stambaugh is the founder and the primary point of contact.
+
+## Related
+
+ZABAL Games, The ZAO, BetterCallZaal.

--- a/research/identity/icm-boxes/live-snapshots/milk-road.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/milk-road.llm.txt
@@ -1,0 +1,26 @@
+# ICM: Milk Road (reference)
+
+Milk Road is a crypto media/newsletter company. This box is reference knowledge (used to study the newsletter/media playbook for The ZAO). Full analysis: ZAOOS research doc 993.
+
+## What it is
+- Founded Jan 2022 by Shaan Puri and Ben Levy. "The smart friend explaining crypto in plain English." Mascot: the Milk Man.
+- Acquired by Bitfo in Dec 2022, ~10 months after launch - an 8-figure deal paid in shares (exact price undisclosed).
+- 2026: three newsletters (Milk Road Crypto, Macro, AI), each with a PRO tier.
+
+## How it grew (0 to ~250k subs in 10 months)
+- 85%+ paid acquisition (Facebook/TikTok at ~$1-1.30/subscriber, meme + social-proof creative), run like a startup.
+- A dead-simple ONE-referral loop unlocking a high-value free report (roughly doubled the viral coefficient).
+- The $1M public wallet stunt: readers watched + voted on real trades; transparency was the moat (signups kept climbing even down 70%).
+- ~$1M ARR by month 6; 45% open rate at scale.
+
+## Business model
+- Native in-voice sponsorships ($10-25k/send at peak) + affiliate + a PRO premium tier. Free daily feeds the funnel; PRO monetizes the core.
+
+## The ZAO takeaways
+- COPY: smart-friend anti-jargon voice; multi-format (a weekly recap pod); authenticity as moat; a one-referral loop rewarded in ZOLs.
+- AVOID: 85% paid acquisition (wrong market for a niche music/builder audience); sponsorship-heavy revenue; growth-at-all-costs / built-to-exit.
+
+## Related boxes
+- The ZAO (thezao)
+- The ZAO Newsletter (zao-newsletter)
+- Zaal (bettercallzaal)

--- a/research/identity/icm-boxes/live-snapshots/zabalgamez.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zabalgamez.llm.txt
@@ -1,0 +1,31 @@
+# ICM: ZABAL Games (ZABAL Gamez)
+
+ZABAL Games is The ZAO's 3-month build-a-thon. Free to join, anyone welcome. It is a Farcaster-native onboarding event: ship something real in public, with a ZAO mentor in your corner, and earn Respect plus an on-chain credential. Build for a real 100+ member community, not a weekend you forget.
+
+## Three tracks
+- Artist - musical / visual builds
+- Builder - developer / aspiring-coder builds
+- Creator - media / distribution / content builds
+
+## The arc (2026)
+- June: recorded workshops (ZAO teachers + ecosystem partners on governance, Respect, tools like Claude Code, Empire Builder, POIDH, Juke, SongJam). Watchable live or async at zabalgamez.com/recordings.
+- July: open build month. Goal set by Zaal (2026-07-04): 200 distinct builders, multiple submissions each. Ship a live URL + open-source repo + short demo + a cast to /zabal. Every build that clears the bar earns Respect. Partial and WIP drafts count.
+- August: Finals. Mentor-and-builder pairs lock; a 24h build + promote + Respect-weighted vote + live reveal stream. Finalists paid in USDC (tiered).
+
+## How it works
+- Entry: register on the site (/enter) with a wallet + GitHub repo; signups + collectibles run through Magnetiq (app.magnetiq.xyz).
+- Mentors: open roster (not a fixed panel) - each mentor defines the builder archetype they want and pairs with an open-submission builder; they get a Hats Protocol "ZAO Mentor" role.
+- Submissions: a public GitHub-backed board; Bonfire (knowledge graph) is the system of record.
+- Empire Builder + Clanker are optional tools (leaderboards, token launch), not requirements.
+- What you walk away with: a live artifact + open repo; Respect for July finishers; a Hats Protocol collectible NFT on Base as a universal "I shipped at ZABAL Games" credential.
+
+## Find it
+- Site: zabalgamez.com (with a Z; old zabalgames.com redirects here)
+- Signup + collectibles: app.magnetiq.xyz (ZABAL brand)
+- Farcaster: the /zabal channel; tag posts "zabal gamez"
+- Stream overlay for workshops/finals: zaoos.com/overlay/zabal-games
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- WaveWarZ (wavewarz)

--- a/research/identity/icm-boxes/live-snapshots/zao-festivals.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zao-festivals.llm.txt
@@ -1,0 +1,21 @@
+# ICM: ZAO Festivals
+
+The ZAO Festivals are the IRL / live-culture arm of The ZAO - real events where the community and artists show up in person. Part of The ZAO ecosystem (see thezao).
+
+## The festivals
+- ZAOstock - the flagship. 2026 edition: Oct 3 2026, Ellsworth, Maine. Community-run music + culture festival; budget in the low five figures ($5-25k range). Ties to the Art of Ellsworth / Maine Craft Weekend calendar.
+- ZAOville - a ZAO festival/gathering (mid-2026 prep, ~Jul 25).
+- ZAO-PALOOZA and ZAO-CHELLA - earlier/recurring ZAO festival brands under the umbrella.
+
+## Why it matters
+- Festivals are how The ZAO returns value to artists in the physical world, not just on-chain. They are a production lane alongside WaveWarZ and ZABAL Games.
+- ZAOstock is spinning toward its own repo/ops as it graduates.
+
+## Find it
+- thezao.xyz (events), the ZAO calendar
+- Farcaster: /zao
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (bettercallzaal)
+- COC Concertz (coc-concertz)

--- a/research/identity/icm-boxes/live-snapshots/zao-newsletter.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zao-newsletter.llm.txt
@@ -1,0 +1,25 @@
+# ICM: The ZAO Newsletter
+
+The ZAO Newsletter is the daily build log of The ZAO - published on Paragraph (paragraph.com/@thezao). Written as BetterCallZaal (Zaal) on behalf of the ZABAL Team.
+
+## What it is
+- A daily "Year of the ZABAL - Day N" build-in-public log: what shipped, what is coming, the quiet work compounding.
+- Audience: builders, artists, and web3/Farcaster people who care about artists owning their work.
+
+## The voice (strict)
+- All prose lowercase. Zero commas in the body. Open with "zm". No emojis, no em dashes, no bullet lists, no exclamation.
+- Short punchy fragments, line by line. Links render as rich cards, never bare urls.
+- One canonical signature only: "- BetterCallZaal on behalf of the ZABAL Team".
+- Catchphrases used naturally: play a game take a board; it reads the record not your word; builders building for builders; the quiet work compounds; small moves out loud every day.
+
+## How it runs
+- Drafted with Paragraph's AI agent; the repo (ZAODEVZ/zaoonparagraph) is the durable ledger / source of truth for voice + facts (Paragraph's own memory is unreliable).
+- X distribution via the Paragraph agent (@bettercallzaal); Farcaster build-in-public via ZOL. Posting is human-gated: approve -> lock -> post.
+
+## Find it
+- paragraph.com/@thezao
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (bettercallzaal)
+- Farcaster (farcaster)

--- a/research/identity/icm-boxes/live-snapshots/zao-video-editor.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zao-video-editor.llm.txt
@@ -1,0 +1,11 @@
+# ZAO Video Editor
+
+ZAO Video Editor is a browser-based video editing tool in the ZAO ecosystem, built for fast turnaround on clips and content. Live at zao-video-editor.vercel.app.
+
+## What it is
+
+It focuses on quick editing with fast automatic transcription, using Groq for speed, so creators can cut, caption, and repurpose video without heavy desktop software. It fits the ZAO pattern of lightweight, single-purpose web tools that help members ship content faster.
+
+## Related
+
+The ZAO, BetterCallZaal.

--- a/research/identity/icm-boxes/live-snapshots/zaolingo.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zaolingo.llm.txt
@@ -1,0 +1,13 @@
+# ZAOlingo
+
+ZAOlingo is a Duolingo-style, gamified web app that teaches people to build with Claude Code the ZAO way. It is phone-first, bite-sized, and built so anyone can go from zero to shipping.
+
+## What it is
+
+The north star is concrete: get a learner confident enough to submit a project to the ZABAL Games build-a-thon, where a submission can be partial and built on top of later. The first track is Claude Code Mechanics, a path of short lessons and small real tasks covering what Claude Code is, starting work with worksession and branches, skills and slash commands, subagents and orchestration, and a capstone that has you open your first pull request.
+
+Learners earn XP, keep a daily streak, and collect ZOLs, the ZAO contribution credit, as they progress. Lessons are community-contributed over time, and the app is open for the ZAO community to extend. It is the on-ramp that turns curious members into builders.
+
+## Related
+
+ZABAL Games, The ZAO, BetterCallZaal, zao-assistant.

--- a/research/identity/icm-boxes/live-snapshots/zaoscout.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zaoscout.llm.txt
@@ -1,0 +1,11 @@
+# ZAOscout
+
+ZAOscout is a toolkit of no-login scrapers extracted from ZAO OS. It pulls public data without requiring accounts or API keys.
+
+## What it is
+
+ZAOscout fetches X tweets and Articles, X timelines, Farcaster history, WaveWarZ stats and battles, and bettercallzaal.com content, all without logging in. It was pulled out of the main ZAO OS monorepo as a standalone data-gathering layer, the kind of reusable building block the ZAO reuses across its agents and research. It embodies the ZAO pattern of open, composable, no-friction tooling.
+
+## Related
+
+The ZAO, WaveWarZ, Farcaster, BetterCallZaal.

--- a/research/identity/icm-boxes/live-snapshots/zlank.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zlank.llm.txt
@@ -1,0 +1,11 @@
+# zlank
+
+zlank is a no-code Farcaster Snap builder. You stack blocks, hit Deploy, and share the result straight to your feed.
+
+## What it is
+
+Built on the @farcaster/snap SDK and Next.js 16, zlank lets anyone assemble a Farcaster mini-app, a Snap, by composing blocks with no coding required, then deploy and share it in a single flow. It collapses the distance from idea to shipped mini-app, which fits the ZAO mission of turning community members into builders. Live at zlank.vercel.app.
+
+## Related
+
+The ZAO, Farcaster, ZABAL Games, BetterCallZaal.

--- a/research/identity/icm-boxes/live-snapshots/zuke.llm.txt
+++ b/research/identity/icm-boxes/live-snapshots/zuke.llm.txt
@@ -1,0 +1,20 @@
+# ICM: Zuke (ZAO Spaces)
+
+Zuke is The ZAO's audio-spaces app - live audio rooms for the community, integrated with Juke. Runs at zuke.thezao.com.
+
+## What it is
+- A Next.js app (repo: ZAODEVZ/Zuke) that hosts and records ZAO audio spaces, built on Juke.
+- Juke = nickysap's Farcaster-native live audio app (juke.audio, LiveKit transport, SIWF auth). Zaal hosts ZAO spaces on Juke; Zuke wraps + records them.
+- Has a recordings pipeline: import X Space recordings, generate recaps and snippets, create/end Juke spaces.
+- Multi-provider path in progress (moving off 100ms toward a clean seam/HMS setup).
+
+## How it connects
+- Zuke recordings are the source that the ZAO video pipeline (ZAOVideoEditor) turns into YouTube-ready videos, and that the clip pipeline (research doc 992) turns into POIDH clip bounties.
+
+## Find it
+- zuke.thezao.com
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (bettercallzaal)
+- Farcaster (farcaster)


### PR DESCRIPTION
Task #70 done. Every live ICM box audited vs repo truth (23/23 fetches FULL, byte-diff).

## Verdicts
- **1 in-sync** (zao-assistant)
- **7 drifted, repo richer** - updates written but never published: thezao, wavewarz, fractal, poidh, sparkz, coc-concertz, zaostock
- **1 drifted, live richer** - zabalgamez (live 2139c vs repo 973c)
- **14 live-only** - no repo backup existed
- **4 repo-only** - the unpublished drafts (zaal, zoe, zol, zai)

## Fixed in this PR
All 14 live-only + zabalgamez **captured byte-pure into `icm-boxes/live-snapshots/`** (15 snapshots, 0 failed) - every live box now has a repo copy.

## Yours (gated, staged in the doc)
- Publish the 7 repo-richer updates (`zao-icm.py update-cmd <slug>` per box)
- Publish the 4 drafts (the clipboard batch)
- Decide zabalgamez (bless live or merge)
- **Retire the live magnetiq box** (Magnetiq is retired per glossary but its box is still up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9