### PR TITLE
feat(bus): bus-cli - client for any tasern-contract bus

### DIFF
--- a/infra/bus/bus-cli.js
+++ b/infra/bus/bus-cli.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * zao-bus-cli - the little client every bus side runs (Jim's spec: "each side
+ * connects with a little cli: check for new messages, send, read, list files,
+ * upload, download").
+ *
+ * Works against ANY bus speaking the tasern wire contract - ours (infra/bus/bus.js)
+ * or Jim's - because the contract is the whole interface. Spec credit: Jim /
+ * Meme for Trees (tasern coordinator).
+ *
+ * Env: BUS_URL (e.g. https://example.com/bus or http://localhost:3099/bus... base
+ *      WITHOUT the trailing verb; /bus is included), BUS_TOKEN (bearer).
+ * Token hygiene: the token lives in env / a chmod-600 file - NEVER in argv (ps
+ * leaks argv), never in a URL.
+ *
+ *   bus-cli health
+ *   bus-cli check                        # unread for me (status=new)
+ *   bus-cli send <to> <body...>          # send a message
+ *   bus-cli read <message-id>            # mark read
+ *   bus-cli list                         # all messages I can see
+ *   bus-cli files                        # list files
+ *   bus-cli upload <path>                # upload a file
+ *   bus-cli download <name> [dest]       # download a file
+ */
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+
+function usage(code) {
+  console.error('usage: bus-cli health|check|send|read|list|files|upload|download (env: BUS_URL, BUS_TOKEN)');
+  process.exit(code);
+}
+
+const BUS_URL = (process.env.BUS_URL || '').replace(/\/$/, '');
+const BUS_TOKEN = process.env.BUS_TOKEN || '';
+
+async function call(method, p, { body, raw, headers = {} } = {}) {
+  const h = { ...headers };
+  if (BUS_TOKEN) h.Authorization = `Bearer ${BUS_TOKEN}`;
+  let payload;
+  if (raw !== undefined) payload = raw;
+  else if (body !== undefined) { h['Content-Type'] = 'application/json'; payload = JSON.stringify(body); }
+  const res = await fetch(`${BUS_URL}${p}`, { method, headers: h, body: payload });
+  return res;
+}
+
+async function main() {
+  const [verb, ...args] = process.argv.slice(2);
+  if (!verb) usage(2);
+  if (verb !== 'health' && (!BUS_URL || !BUS_TOKEN)) {
+    console.error('bus-cli: set BUS_URL and BUS_TOKEN in the environment');
+    process.exit(2);
+  }
+  if (verb === 'health') {
+    if (!BUS_URL) { console.error('bus-cli: set BUS_URL'); process.exit(2); }
+    const r = await call('GET', '/health');
+    console.log(await r.text());
+    process.exit(r.ok ? 0 : 1);
+  }
+  if (verb === 'check' || verb === 'list') {
+    const q = verb === 'check' ? '/messages?status=new' : '/messages';
+    const r = await call('GET', q);
+    if (!r.ok) { console.error(`bus-cli: HTTP ${r.status}`); process.exit(1); }
+    const { messages } = await r.json();
+    if (!messages.length) { console.log('(no messages)'); return; }
+    for (const m of messages) {
+      console.log(`${m.status === 'new' ? '*' : ' '} ${m.id}  ${m.created}  ${m.from}->${m.to}  ${m.subject || '(no subject)'}`);
+      console.log(`    ${String(m.body).slice(0, 200).replace(/\n/g, '\n    ')}`);
+    }
+    return;
+  }
+  if (verb === 'send') {
+    const [to, ...bodyParts] = args;
+    if (!to || bodyParts.length === 0) usage(2);
+    const r = await call('POST', '/send', { body: { to, body: bodyParts.join(' ') } });
+    if (!r.ok) { console.error(`bus-cli: HTTP ${r.status} ${await r.text()}`); process.exit(1); }
+    console.log(JSON.stringify(await r.json()));
+    return;
+  }
+  if (verb === 'read') {
+    const [id] = args;
+    if (!id) usage(2);
+    const r = await call('PATCH', `/messages/${id}`, { body: { status: 'read' } });
+    if (!r.ok) { console.error(`bus-cli: HTTP ${r.status}`); process.exit(1); }
+    console.log('marked read');
+    return;
+  }
+  if (verb === 'files') {
+    const r = await call('GET', '/files');
+    if (!r.ok) { console.error(`bus-cli: HTTP ${r.status}`); process.exit(1); }
+    console.log(JSON.stringify(await r.json(), null, 2));
+    return;
+  }
+  if (verb === 'upload') {
+    const [file] = args;
+    if (!file || !fs.existsSync(file)) usage(2);
+    const r = await call('POST', '/files/upload', {
+      raw: fs.readFileSync(file),
+      headers: { 'X-Filename': path.basename(file) },
+    });
+    if (!r.ok) { console.error(`bus-cli: HTTP ${r.status} ${await r.text()}`); process.exit(1); }
+    console.log(JSON.stringify(await r.json()));
+    return;
+  }
+  if (verb === 'download') {
+    const [name, dest] = args;
+    if (!name) usage(2);
+    const r = await call('GET', `/files/${encodeURIComponent(name)}`);
+    if (!r.ok) { console.error(`bus-cli: HTTP ${r.status}`); process.exit(1); }
+    const out = dest || name;
+    fs.writeFileSync(out, Buffer.from(await r.arrayBuffer()));
+    console.log(`saved ${out}`);
+    return;
+  }
+  usage(2);
+}
+
+main().catch((e) => { console.error(`bus-cli: ${e.message}`); process.exit(1); });

--- a/infra/bus/bus.js
+++ b/infra/bus/bus.js
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+/**
+ * zao-bus - ZAO's agent message bus, built to the tasern wire contract.
+ *
+ * Spec credit: Jim (Meme for Trees) / the tasern coordinator, who shared their
+ * full bus shape on the tasern lane 2026-08-06 ("How we built the bus - full
+ * shape for interop") so ZAO could build sovereign-but-interoperable. Same wire
+ * object, same verbs, same auth model - so a Spore adapter at the DreamNet
+ * Federation Gateway only maps names, never translates shapes.
+ *
+ * Deliberately boring (that's why it stays up): vanilla node:http, NO framework,
+ * flat JSON storage, one process. The bus is transport, not the system of record.
+ *
+ * WIRE CONTRACT (interop - do not change):
+ *   message = { id: uuid, from, to, subject, body, status: "new"|"read", created: ISO8601 }
+ *   POST   /bus/send            {to, body, subject?}          -> {id}
+ *   GET    /bus/messages        ?to=<name>&status=new         -> {messages:[...]}
+ *   PATCH  /bus/messages/:id    {status:"read"}               -> {ok:true}
+ *   POST   /bus/files/upload    raw body + X-Filename header  -> {ok,name}
+ *   GET    /bus/files                                          -> {files, quota}
+ *   GET    /bus/files/:filename                                -> download
+ *   DELETE /bus/files/:filename  (admin or own)                -> {ok}
+ *   GET    /bus/health          (no auth)                      -> {status:"ok"}
+ *
+ * AUTH (bearer -> role, all server-side):
+ *   BUS_ADMIN_TOKEN         -> role admin,   agent "coordinator"
+ *   BUS_GUEST_TOKEN         -> role guest,   agent from BUS_GUEST_AGENT (default "zoe")
+ *   BUS_GUEST_TOKEN_<NAME>  -> role partner, agent lowercase(NAME)  [^BUS_GUEST_TOKEN_([A-Z0-9]+)$ - A-Z0-9 ONLY]
+ * Partner scope is ENFORCED here, never trusted from the client:
+ *   send only to "coordinator"; `from` is forced; read own thread only;
+ *   files: own uploads or "<name>-" prefixed only (uploads auto-prefixed).
+ *
+ * Env: BUS_PORT (default 3099), BUS_DATA_DIR (default ./bus-data).
+ * DEPLOY IS GATED - running this on the VPS behind nginx is Zaal's step.
+ */
+'use strict';
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const MAX_JSON_BYTES = 50 * 1024; // reject early on the stream, never buffer unbounded
+const MAX_FILE_BYTES = 50 * 1024 * 1024;
+const MAX_FILES = 200;
+const MAX_TOTAL_BYTES = 500 * 1024 * 1024;
+const RING_MAX = 200; // keep the last N messages; partners keep their own copy
+
+function dataDir() {
+  return process.env.BUS_DATA_DIR || path.join(process.cwd(), 'bus-data');
+}
+function messagesPath() { return path.join(dataDir(), 'messages.json'); }
+function fileMetaPath() { return path.join(dataDir(), 'file-meta.json'); }
+function filesDir() { return path.join(dataDir(), 'shared-files'); }
+
+function ensureDirs() {
+  fs.mkdirSync(filesDir(), { recursive: true });
+}
+function loadJson(p, fallback) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return fallback; }
+}
+function saveJson(p, val) {
+  fs.writeFileSync(p, JSON.stringify(val, null, 2));
+}
+
+/** token -> {role, agent} - the whole auth model, all server-side. */
+function resolveAuth(header) {
+  if (!header || !header.startsWith('Bearer ')) return null;
+  const token = header.slice(7).trim();
+  if (!token) return null;
+  if (process.env.BUS_ADMIN_TOKEN && token === process.env.BUS_ADMIN_TOKEN) {
+    return { role: 'admin', agent: 'coordinator' };
+  }
+  if (process.env.BUS_GUEST_TOKEN && token === process.env.BUS_GUEST_TOKEN) {
+    return { role: 'guest', agent: (process.env.BUS_GUEST_AGENT || 'zoe').toLowerCase() };
+  }
+  for (const [key, val] of Object.entries(process.env)) {
+    const m = /^BUS_GUEST_TOKEN_([A-Z0-9]+)$/.exec(key); // A-Z0-9 ONLY (tasern gotcha)
+    if (m && val && token === val) return { role: 'partner', agent: m[1].toLowerCase() };
+  }
+  return null;
+}
+
+function sanitizeFilename(name) {
+  return String(name || '').replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 100);
+}
+
+function sendJson(res, code, obj) {
+  res.writeHead(code, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+/** Read a JSON body, rejecting early once it exceeds the cap. */
+function readJsonBody(req, res, cb) {
+  let size = 0;
+  const chunks = [];
+  let rejected = false;
+  req.on('data', (c) => {
+    size += c.length;
+    if (size > MAX_JSON_BYTES && !rejected) {
+      rejected = true;
+      sendJson(res, 413, { error: 'body too large' });
+      req.destroy();
+      return;
+    }
+    chunks.push(c);
+  });
+  req.on('end', () => {
+    if (rejected) return;
+    try { cb(JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')); }
+    catch { sendJson(res, 400, { error: 'invalid json' }); }
+  });
+}
+
+function handler(req, res) {
+  const url = new URL(req.url, 'http://localhost');
+  const p = url.pathname;
+
+  // CORS open + preflight
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, X-Filename');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
+  if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+
+  // health - the one unauthenticated endpoint
+  if (p === '/bus/health' && req.method === 'GET') {
+    sendJson(res, 200, { status: 'ok' });
+    return;
+  }
+
+  const auth = resolveAuth(req.headers.authorization);
+  if (!auth) {
+    // browser guard: a human tapping a link gets a friendly page, not a bare 401
+    if ((req.headers.accept || '').includes('text/html')) {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><body><p>This is an agent API, not a webpage. Nothing to see here.</p></body></html>');
+      return;
+    }
+    sendJson(res, 401, { error: 'unauthorized' });
+    return;
+  }
+
+  ensureDirs();
+
+  // POST /bus/send
+  if (p === '/bus/send' && req.method === 'POST') {
+    readJsonBody(req, res, (body) => {
+      const to = String(body.to || '').toLowerCase();
+      if (!to || typeof body.body !== 'string' || !body.body) {
+        sendJson(res, 400, { error: 'to and body required' });
+        return;
+      }
+      // partner scope: only to coordinator; from is ALWAYS forced server-side
+      if (auth.role === 'partner' && to !== 'coordinator') {
+        sendJson(res, 403, { error: 'partners may only send to coordinator' });
+        return;
+      }
+      const from = auth.role === 'admin' && body.from ? String(body.from).toLowerCase() : auth.agent;
+      const msg = {
+        id: crypto.randomUUID(),
+        from,
+        to,
+        subject: typeof body.subject === 'string' ? body.subject : '',
+        body: body.body,
+        status: 'new',
+        created: new Date().toISOString(),
+      };
+      const messages = loadJson(messagesPath(), []);
+      messages.push(msg);
+      while (messages.length > RING_MAX) messages.shift(); // ring buffer
+      saveJson(messagesPath(), messages);
+      sendJson(res, 200, { id: msg.id });
+    });
+    return;
+  }
+
+  // GET /bus/messages
+  if (p === '/bus/messages' && req.method === 'GET') {
+    let messages = loadJson(messagesPath(), []);
+    if (auth.role === 'partner') {
+      // partners see their own thread ONLY - never internal traffic
+      messages = messages.filter((m) => m.to === auth.agent || m.from === auth.agent);
+    }
+    const qTo = url.searchParams.get('to');
+    const qStatus = url.searchParams.get('status');
+    if (qTo) messages = messages.filter((m) => m.to === qTo.toLowerCase());
+    if (qStatus) messages = messages.filter((m) => m.status === qStatus);
+    sendJson(res, 200, { messages });
+    return;
+  }
+
+  // PATCH /bus/messages/:id
+  const patchMatch = /^\/bus\/messages\/([0-9a-f-]+)$/.exec(p);
+  if (patchMatch && req.method === 'PATCH') {
+    readJsonBody(req, res, (body) => {
+      if (body.status !== 'read') { sendJson(res, 400, { error: 'only status:"read"' }); return; }
+      const messages = loadJson(messagesPath(), []);
+      const msg = messages.find((m) => m.id === patchMatch[1]);
+      if (!msg) { sendJson(res, 404, { error: 'not found' }); return; }
+      if (auth.role === 'partner' && msg.to !== auth.agent && msg.from !== auth.agent) {
+        sendJson(res, 403, { error: 'not your thread' });
+        return;
+      }
+      msg.status = 'read';
+      saveJson(messagesPath(), messages);
+      sendJson(res, 200, { ok: true });
+    });
+    return;
+  }
+
+  // POST /bus/files/upload  (raw body + X-Filename or ?name=)
+  if (p === '/bus/files/upload' && req.method === 'POST') {
+    const meta = loadJson(fileMetaPath(), []);
+    if (meta.length >= MAX_FILES) { sendJson(res, 507, { error: 'file count quota' }); req.destroy(); return; }
+    const used = meta.reduce((s, f) => s + (f.size || 0), 0);
+    let name = sanitizeFilename(req.headers['x-filename'] || url.searchParams.get('name') || 'upload.bin');
+    // quarantine: partner uploads auto-prefixed so they can NEVER overwrite internal files
+    if (auth.role === 'partner' && !name.startsWith(`${auth.agent}-`)) name = `${auth.agent}-${name}`;
+    const dest = path.join(filesDir(), name);
+    let size = 0;
+    let aborted = false;
+    const out = fs.createWriteStream(dest);
+    req.on('data', (c) => {
+      size += c.length;
+      if ((size > MAX_FILE_BYTES || used + size > MAX_TOTAL_BYTES) && !aborted) {
+        aborted = true;
+        out.destroy();
+        fs.rmSync(dest, { force: true }); // single self-created partial file, exact path
+        sendJson(res, 413, { error: 'file quota exceeded' });
+        req.destroy();
+      }
+    });
+    req.pipe(out);
+    out.on('finish', () => {
+      if (aborted) return;
+      const rest = meta.filter((f) => f.name !== name);
+      rest.push({ name, uploadedBy: auth.agent, size, created: new Date().toISOString() });
+      saveJson(fileMetaPath(), rest);
+      sendJson(res, 200, { ok: true, name });
+    });
+    return;
+  }
+
+  // GET /bus/files (list, scoped)
+  if (p === '/bus/files' && req.method === 'GET') {
+    let meta = loadJson(fileMetaPath(), []);
+    if (auth.role === 'partner') {
+      meta = meta.filter((f) => f.uploadedBy === auth.agent || f.name.startsWith(`${auth.agent}-`));
+    }
+    const used = loadJson(fileMetaPath(), []).reduce((s, f) => s + (f.size || 0), 0);
+    sendJson(res, 200, {
+      files: meta,
+      quota: { usedBytes: used, maxBytes: MAX_TOTAL_BYTES, fileCount: loadJson(fileMetaPath(), []).length, maxFiles: MAX_FILES },
+    });
+    return;
+  }
+
+  // GET|DELETE /bus/files/:filename
+  const fileMatch = /^\/bus\/files\/([^/]+)$/.exec(p);
+  if (fileMatch && (req.method === 'GET' || req.method === 'DELETE')) {
+    const name = sanitizeFilename(decodeURIComponent(fileMatch[1]));
+    const meta = loadJson(fileMetaPath(), []);
+    const entry = meta.find((f) => f.name === name);
+    if (!entry) { sendJson(res, 404, { error: 'not found' }); return; }
+    const mine = entry.uploadedBy === auth.agent || name.startsWith(`${auth.agent}-`);
+    if (auth.role === 'partner' && !mine) { sendJson(res, 403, { error: 'not your file' }); return; }
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      fs.createReadStream(path.join(filesDir(), name)).pipe(res);
+      return;
+    }
+    // DELETE: admin or own
+    if (auth.role !== 'admin' && !mine) { sendJson(res, 403, { error: 'admin or owner only' }); return; }
+    fs.rmSync(path.join(filesDir(), name), { force: true }); // single tracked file by exact path
+    saveJson(fileMetaPath(), meta.filter((f) => f.name !== name));
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  sendJson(res, 404, { error: 'no such route' });
+}
+
+function createBus() {
+  return http.createServer(handler);
+}
+
+module.exports = { createBus, resolveAuth, sanitizeFilename, RING_MAX };
+
+if (require.main === module) {
+  const port = Number(process.env.BUS_PORT || 3099);
+  createBus().listen(port, () => {
+    console.log(`[zao-bus] listening on :${port} (data: ${dataDir()})`);
+  });
+}

--- a/infra/bus/bus.test.js
+++ b/infra/bus/bus.test.js
@@ -1,0 +1,155 @@
+/**
+ * zao-bus tests - the tasern wire contract, enforced.
+ * Run: node --test infra/bus/
+ */
+'use strict';
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// hermetic env BEFORE requiring the bus
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'zao-bus-'));
+process.env.BUS_DATA_DIR = TMP;
+process.env.BUS_ADMIN_TOKEN = 'admin-token-test';
+process.env.BUS_GUEST_TOKEN = 'guest-token-test';
+process.env.BUS_GUEST_AGENT = 'zoe';
+process.env.BUS_GUEST_TOKEN_JIM = 'jim-token-test';
+
+const { createBus, resolveAuth, sanitizeFilename } = require('./bus.js');
+
+let server;
+let base;
+
+before(async () => {
+  server = createBus();
+  await new Promise((resolve) => server.listen(0, resolve));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+after(() => server.close());
+
+function req(method, p, { token, body, headers = {}, raw } = {}) {
+  const h = { ...headers };
+  if (token) h.Authorization = `Bearer ${token}`;
+  let payload;
+  if (raw !== undefined) { payload = raw; }
+  else if (body !== undefined) { h['Content-Type'] = 'application/json'; payload = JSON.stringify(body); }
+  return fetch(`${base}${p}`, { method, headers: h, body: payload });
+}
+
+test('health needs no auth', async () => {
+  const r = await fetch(`${base}/bus/health`);
+  assert.strictEqual(r.status, 200);
+  assert.deepStrictEqual(await r.json(), { status: 'ok' });
+});
+
+test('unauthenticated JSON call gets 401; browser gets the friendly page', async () => {
+  const r = await fetch(`${base}/bus/messages`);
+  assert.strictEqual(r.status, 401);
+  const b = await fetch(`${base}/bus/messages`, { headers: { Accept: 'text/html' } });
+  assert.strictEqual(b.status, 200);
+  assert.match(await b.text(), /agent API, not a webpage/);
+});
+
+test('auth mapping: admin=coordinator, guest=zoe, partner=jim; A-Z0-9 regex only', () => {
+  assert.deepStrictEqual(resolveAuth('Bearer admin-token-test'), { role: 'admin', agent: 'coordinator' });
+  assert.deepStrictEqual(resolveAuth('Bearer guest-token-test'), { role: 'guest', agent: 'zoe' });
+  assert.deepStrictEqual(resolveAuth('Bearer jim-token-test'), { role: 'partner', agent: 'jim' });
+  assert.strictEqual(resolveAuth('Bearer nope'), null);
+  assert.strictEqual(resolveAuth(undefined), null);
+});
+
+test('guest sends to coordinator; wire object shape is exact', async () => {
+  const r = await req('POST', '/bus/send', { token: 'guest-token-test', body: { to: 'coordinator', subject: 'hi', body: 'first message' } });
+  assert.strictEqual(r.status, 200);
+  const { id } = await r.json();
+  assert.ok(id);
+  const list = await (await req('GET', '/bus/messages?to=coordinator', { token: 'admin-token-test' })).json();
+  const msg = list.messages.find((m) => m.id === id);
+  assert.ok(msg, 'message present');
+  assert.deepStrictEqual(Object.keys(msg).sort(), ['body', 'created', 'from', 'id', 'status', 'subject', 'to']);
+  assert.strictEqual(msg.from, 'zoe');
+  assert.strictEqual(msg.status, 'new');
+  assert.ok(!Number.isNaN(Date.parse(msg.created)), 'created is ISO8601');
+});
+
+test('partner can only send to coordinator, and from is server-forced (no spoofing)', async () => {
+  const bad = await req('POST', '/bus/send', { token: 'jim-token-test', body: { to: 'zoe', body: 'sneaky' } });
+  assert.strictEqual(bad.status, 403);
+  const ok = await req('POST', '/bus/send', { token: 'jim-token-test', body: { to: 'coordinator', body: 'legit', from: 'coordinator' } });
+  assert.strictEqual(ok.status, 200);
+  const { id } = await ok.json();
+  const list = await (await req('GET', '/bus/messages', { token: 'admin-token-test' })).json();
+  const msg = list.messages.find((m) => m.id === id);
+  assert.strictEqual(msg.from, 'jim', 'from forced to the caller agent, spoof ignored');
+});
+
+test('partner reads own thread only - never internal traffic', async () => {
+  await req('POST', '/bus/send', { token: 'guest-token-test', body: { to: 'coordinator', body: 'internal zoe->coordinator' } });
+  const list = await (await req('GET', '/bus/messages', { token: 'jim-token-test' })).json();
+  assert.ok(list.messages.length > 0, 'jim sees his own');
+  for (const m of list.messages) {
+    assert.ok(m.to === 'jim' || m.from === 'jim', `leaked: ${m.from}->${m.to}`);
+  }
+});
+
+test('PATCH marks read; partner cannot touch another thread', async () => {
+  const send = await req('POST', '/bus/send', { token: 'guest-token-test', body: { to: 'coordinator', body: 'to be read' } });
+  const { id } = await send.json();
+  const deny = await req('PATCH', `/bus/messages/${id}`, { token: 'jim-token-test', body: { status: 'read' } });
+  assert.strictEqual(deny.status, 403);
+  const okr = await req('PATCH', `/bus/messages/${id}`, { token: 'admin-token-test', body: { status: 'read' } });
+  assert.strictEqual(okr.status, 200);
+  const list = await (await req('GET', '/bus/messages?status=read', { token: 'admin-token-test' })).json();
+  assert.ok(list.messages.some((m) => m.id === id));
+});
+
+test('ring buffer keeps only the last 200', async () => {
+  for (let i = 0; i < 205; i++) {
+    // write directly through the API would be slow; use it for the last few, seed the file for bulk
+  }
+  const msgsPath = path.join(TMP, 'messages.json');
+  const seed = Array.from({ length: 200 }, (_, i) => ({
+    id: `seed-${i}`, from: 'zoe', to: 'coordinator', subject: '', body: `m${i}`, status: 'new', created: new Date().toISOString(),
+  }));
+  fs.writeFileSync(msgsPath, JSON.stringify(seed));
+  await req('POST', '/bus/send', { token: 'guest-token-test', body: { to: 'coordinator', body: 'the 201st' } });
+  const all = JSON.parse(fs.readFileSync(msgsPath, 'utf8'));
+  assert.strictEqual(all.length, 200, 'ring capped at 200');
+  assert.strictEqual(all[0].id, 'seed-1', 'oldest shifted out');
+  assert.strictEqual(all[all.length - 1].body, 'the 201st');
+});
+
+test('JSON body over 50KB is rejected early with 413', async () => {
+  const big = 'x'.repeat(51 * 1024);
+  const r = await req('POST', '/bus/send', { token: 'guest-token-test', body: { to: 'coordinator', body: big } });
+  assert.strictEqual(r.status, 413);
+});
+
+test('filename sanitization + partner upload quarantine prefix', async () => {
+  assert.strictEqual(sanitizeFilename('../../etc/passwd'), '.._.._etc_passwd');
+  assert.strictEqual(sanitizeFilename('a'.repeat(200)).length, 100);
+  const up = await req('POST', '/bus/files/upload', {
+    token: 'jim-token-test', raw: 'hello file', headers: { 'X-Filename': 'notes.txt' },
+  });
+  assert.strictEqual(up.status, 200);
+  const { name } = await up.json();
+  assert.strictEqual(name, 'jim-notes.txt', 'partner upload auto-prefixed');
+  // partner sees only own/prefixed files
+  const list = await (await req('GET', '/bus/files', { token: 'jim-token-test' })).json();
+  for (const f of list.files) {
+    assert.ok(f.uploadedBy === 'jim' || f.name.startsWith('jim-'));
+  }
+  // download round-trip
+  const dl = await req('GET', `/bus/files/${name}`, { token: 'jim-token-test' });
+  assert.strictEqual(await dl.text(), 'hello file');
+});
+
+test('admin can delete a file; partner cannot delete others files', async () => {
+  await req('POST', '/bus/files/upload', { token: 'guest-token-test', raw: 'internal', headers: { 'X-Filename': 'internal.md' } });
+  const deny = await req('DELETE', '/bus/files/internal.md', { token: 'jim-token-test' });
+  assert.strictEqual(deny.status, 403);
+  const ok = await req('DELETE', '/bus/files/internal.md', { token: 'admin-token-test' });
+  assert.strictEqual(ok.status, 200);
+});


### PR DESCRIPTION
Stacked on #2940 (merge that first). Completes the bus story: the server shipped in #2940, this is the "little cli" from Jim's spec - and it works against ANY bus speaking the tasern contract (ours or theirs), because the wire contract is the whole interface.

## Verbs
`health | check | send <to> <body> | read <id> | list | files | upload <path> | download <name>`

## Verified end-to-end (live local server)
send as guest -> check as admin shows it -> read flips status -> check empties -> upload/download round trip byte-identical. Token hygiene: env only, never argv/URL.

## How you use it (30 seconds)
```
BUS_URL=http://localhost:3099/bus BUS_TOKEN=<token> node infra/bus/bus-cli.js check
```
Same command later points at Jim's bus with a partner token - that's the interop.

Spec credit: Jim / Meme for Trees (tasern coordinator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9