### PR TITLE
feat(zoe): bus-bridge - full partner message + phone-native grounded reply

### DIFF
--- a/bot/src/zoe/__tests__/bus-bridge.test.ts
+++ b/bot/src/zoe/__tests__/bus-bridge.test.ts
@@ -1,0 +1,120 @@
+/**
+ * bus-bridge.test.ts - see the full partner message, reply from the phone with grounded info.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildReplyContext,
+  extractAsks,
+  parseBusReply,
+  renderBusMessage,
+  renderReplyPreview,
+  resolveByShortId,
+  shortId,
+  type BusMessage,
+} from '../bus-bridge';
+
+const msg: BusMessage = {
+  id: 'eb823873-f02a-4898-b8c1-f99614c83c3c',
+  from: 'coordinator',
+  to: 'zao',
+  subject: 'How we built the bus - full shape for interop',
+  body: [
+    'Happy to help - sovereign-but-interoperable is the right call.',
+    'The wire contract is {id,from,to,subject,body,status,created}.',
+    'Think your stack could plug into this?',
+    'Yell if you want the actual vps-bus.js as a reference file dropped on your lane - happy to.',
+  ].join('\n'),
+  status: 'new',
+  created: '2026-08-06T20:24:03.564Z',
+};
+
+describe('renderBusMessage (fix 1: never truncate)', () => {
+  it('includes the FULL body, not a 120-char preview', () => {
+    const out = renderBusMessage(msg).join('\n');
+    expect(out).toContain('Yell if you want the actual vps-bus.js');
+    expect(out).toContain(msg.body.slice(0, 120));
+    expect(out).toContain('coordinator -> zao');
+    expect(out).toContain('How we built the bus');
+  });
+
+  it('chunks a very long body under the Telegram limit instead of cutting it', () => {
+    const long: BusMessage = { ...msg, body: 'x'.repeat(9000) };
+    const chunks = renderBusMessage(long);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(4096);
+    expect(chunks.join('').length).toBeGreaterThan(9000 - 50); // nothing dropped
+  });
+});
+
+describe('extractAsks (what a reply must answer)', () => {
+  it('pulls questions and offer idioms', () => {
+    const asks = extractAsks(msg.body);
+    expect(asks.some((a) => a.includes('Think your stack could plug into this?'))).toBe(true);
+    expect(asks.some((a) => a.startsWith('Yell if you want'))).toBe(true);
+  });
+
+  it('returns nothing for a body with no asks', () => {
+    expect(extractAsks('Just a status update. All green.')).toEqual([]);
+  });
+});
+
+describe('buildReplyContext (fix 3: grounded, never invented)', () => {
+  it('pairs their asks with OUR verified state', () => {
+    const ctx = buildReplyContext(msg, {
+      shipped: ['#2940 zao-bus server to your wire contract (11/11 tests)', '#2943 bus-cli'],
+      pending: ['VPS deploy + tokens (Zaal-gated)'],
+      openQuestions: ['Drop vps-bus.js on our lane?'],
+    });
+    expect(ctx).toContain('They asked:');
+    expect(ctx).toContain('Think your stack could plug into this?');
+    expect(ctx).toContain('Our state (verified, cite these):');
+    expect(ctx).toContain('#2940 zao-bus server');
+    expect(ctx).toContain('Still pending on our side:');
+    expect(ctx).toContain('Ask them:');
+  });
+
+  it('omits sections with no facts - never fabricates state', () => {
+    const ctx = buildReplyContext(msg);
+    expect(ctx).not.toContain('Our state');
+    expect(ctx).not.toContain('Still pending');
+  });
+});
+
+describe('parseBusReply + resolveByShortId (fix 2: phone-typed reply, no ssh)', () => {
+  it('parses "reply <shortid> <text>"', () => {
+    const p = parseBusReply('reply eb8238 yes please, drop the file');
+    expect(p).toEqual({ shortId: 'eb8238', text: 'yes please, drop the file' });
+  });
+
+  it('is case-insensitive and keeps multi-line text', () => {
+    const p = parseBusReply('REPLY EB8238 line one\nline two');
+    expect(p?.shortId).toBe('eb8238');
+    expect(p?.text).toBe('line one\nline two');
+  });
+
+  it('rejects non-replies and empty bodies', () => {
+    expect(parseBusReply('hello there')).toBeNull();
+    expect(parseBusReply('reply eb8238   ')).toBeNull();
+  });
+
+  it('resolves a short id back to the exact message', () => {
+    expect(shortId(msg.id)).toBe('eb8238');
+    expect(resolveByShortId([msg], 'eb8238')?.id).toBe(msg.id);
+    expect(resolveByShortId([msg], 'zzzzzz')).toBeNull();
+  });
+
+  it('returns null when a short id is ambiguous - never guesses', () => {
+    const twin: BusMessage = { ...msg, id: 'eb823873-0000-0000-0000-000000000000' };
+    expect(resolveByShortId([msg, twin], 'eb8238')).toBeNull();
+  });
+});
+
+describe('renderReplyPreview', () => {
+  it('shows the draft plus both reply paths', () => {
+    const out = renderReplyPreview(msg, 'Building to your contract now - yes, drop vps-bus.js.');
+    expect(out).toContain('Draft reply to coordinator');
+    expect(out).toContain('Building to your contract now');
+    expect(out).toContain('Tap Post to send');
+    expect(out).toContain('reply eb8238');
+  });
+});

--- a/bot/src/zoe/bus-bridge.ts
+++ b/bot/src/zoe/bus-bridge.ts
@@ -1,0 +1,139 @@
+/**
+ * bus-bridge.ts - see a partner-bus message and reply WELL, from the phone.
+ *
+ * Zaal, looking at the tasern-bus ping on his phone (2026-08-07): "How can we
+ * improve me seeing this to me replying with the best info?" Three concrete
+ * failures in the current `tasern-bus-poll.sh`:
+ *   1. the body is TRUNCATED at 120 chars - he cannot read what was actually said
+ *   2. the only reply path is `ssh vps tasern-bus send "subj" "body"` - unusable
+ *      from a phone
+ *   3. no grounding - even if he could reply, the facts (what ZAO shipped, what
+ *      the partner asked for) live in the repo, not in his head at 9am
+ *
+ * This module fixes all three as PURE functions (no Telegram/network calls - the
+ * live wiring is a small reviewed step, same discipline as mission-control):
+ *   renderBusMessage()  - the FULL body, phone-readable, chunked, never truncated
+ *   buildReplyContext() - the grounding a drafted reply must cite (asks + our state)
+ *   renderReplyPreview()- what Zaal taps Approve on
+ *   parseBusReply()     - "reply <id> <text>" typed in TG -> a bus send
+ * Reuses ZOE's existing draft-approval pattern (drafts.ts Post/Skip/Edit keyboard)
+ * and tg-chunk for the 4096 limit.
+ */
+import { chunkForTelegram } from './tg-chunk';
+
+/** The tasern wire contract (identical to infra/bus/bus.js - one shape, both ends). */
+export interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  status: 'new' | 'read';
+  created: string;
+}
+
+/** A short id Zaal can type on a phone instead of a uuid. */
+export function shortId(id: string): string {
+  return id.replace(/-/g, '').slice(0, 6);
+}
+
+/**
+ * FIX 1 - the full message, phone-readable, never truncated. Returns chunks so a
+ * long partner message survives Telegram's 4096 limit instead of being cut to 120.
+ */
+export function renderBusMessage(msg: BusMessage): string[] {
+  const header = [
+    `BUS ${msg.from} -> ${msg.to}`,
+    msg.subject ? `Subject: ${msg.subject}` : '',
+    `${msg.created.slice(0, 16).replace('T', ' ')}  id ${shortId(msg.id)}`,
+    '',
+  ].filter(Boolean).join('\n');
+  return chunkForTelegram(`${header}\n${msg.body}`);
+}
+
+/** What the partner actually asked for - the lines a reply must answer. */
+export function extractAsks(body: string): string[] {
+  const asks: string[] = [];
+  for (const raw of body.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    // a question, or an explicit offer/request idiom
+    if (line.endsWith('?') || /\b(yell if|let me know|want (me|us) to|happy to|if you want|shall we|do you want)\b/i.test(line)) {
+      asks.push(line.length > 200 ? `${line.slice(0, 197)}...` : line);
+    }
+  }
+  return asks.slice(0, 5);
+}
+
+/** Repo-side facts a drafted reply is allowed to cite (caller supplies, never invented). */
+export interface ReplyGrounding {
+  /** e.g. "#2940 zao-bus server (11/11 tests)" - things we actually shipped. */
+  shipped?: string[];
+  /** e.g. "VPS deploy + tokens" - what is still gated/pending on our side. */
+  pending?: string[];
+  /** Anything we want to ask them back. */
+  openQuestions?: string[];
+}
+
+/**
+ * FIX 3 - the grounding block for a drafted reply. This is what makes the reply
+ * carry "the best info": their asks paired with OUR verified state, so the draft
+ * cites shipped PRs instead of vibes. Nothing here is generated - the caller
+ * passes facts read from the repo (anti-fabrication: no invented status).
+ */
+export function buildReplyContext(msg: BusMessage, grounding: ReplyGrounding = {}): string {
+  const asks = extractAsks(msg.body);
+  const lines = [`Replying to ${msg.from}${msg.subject ? ` re: ${msg.subject}` : ''}.`];
+  if (asks.length) {
+    lines.push('', 'They asked:', ...asks.map((a) => `- ${a}`));
+  }
+  if (grounding.shipped?.length) {
+    lines.push('', 'Our state (verified, cite these):', ...grounding.shipped.map((s) => `- ${s}`));
+  }
+  if (grounding.pending?.length) {
+    lines.push('', 'Still pending on our side:', ...grounding.pending.map((s) => `- ${s}`));
+  }
+  if (grounding.openQuestions?.length) {
+    lines.push('', 'Ask them:', ...grounding.openQuestions.map((s) => `- ${s}`));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * FIX 2 - the approve-from-the-phone preview. Pairs with drafts.ts's existing
+ * Post/Skip/Edit keyboard (putDraft + draftKeyboard) - no new UI concept.
+ */
+export function renderReplyPreview(msg: BusMessage, draftText: string): string {
+  return [
+    `Draft reply to ${msg.from} (id ${shortId(msg.id)}):`,
+    '',
+    draftText,
+    '',
+    'Tap Post to send on the bus, Edit to change, Skip to hold.',
+    `Or type: reply ${shortId(msg.id)} <your own words>`,
+  ].join('\n');
+}
+
+export interface ParsedBusReply {
+  shortId: string;
+  text: string;
+}
+
+/**
+ * FIX 2 (typed path) - "reply ab12cd thanks, shipping today" typed in Telegram
+ * becomes a bus send. No ssh, no uuid, no quoting rules.
+ */
+export function parseBusReply(input: string): ParsedBusReply | null {
+  const m = /^\s*reply\s+([a-z0-9]{4,12})\s+([\s\S]+)$/i.exec(input);
+  if (!m) return null;
+  const text = m[2].trim();
+  if (!text) return null;
+  return { shortId: m[1].toLowerCase(), text };
+}
+
+/** Resolve a phone-typed short id back to the real message (exact, unambiguous). */
+export function resolveByShortId(messages: BusMessage[], sid: string): BusMessage | null {
+  const target = sid.toLowerCase();
+  const hits = messages.filter((m) => shortId(m.id) === target);
+  return hits.length === 1 ? hits[0] : null; // ambiguous = null, never guess
+}


### PR DESCRIPTION
Answers Zaal's question from the phone screenshot: *"How can we improve me seeing this to me replying with the best info?"*

## The three failures in today's ping
Looking at `~/bin/tasern-bus-poll.sh` on the VPS:
1. `(m.get("body") or "")[:120]` - **the message is truncated at 120 chars**
2. `reply: ssh vps tasern-bus send "subj" "body"` - **unusable from a phone**
3. No grounding - a reply would be composed from memory, not from what we actually shipped

## The fix (pure functions, PR-only)
`bot/src/zoe/bus-bridge.ts`:
- **`renderBusMessage`** - the FULL body, chunked via tg-chunk. Nothing cut.
- **`extractAsks` + `buildReplyContext`** - their questions paired with OUR verified state ("#2940 zao-bus built to your contract, 11/11 tests"). Caller supplies repo facts; the module invents nothing.
- **`renderReplyPreview`** - reuses drafts.ts's existing Post/Skip/Edit keyboard (no new UI concept).
- **`parseBusReply` + `resolveByShortId`** - **"reply eb8238 yes, drop the file"** typed in Telegram becomes a bus send. No ssh, no uuid. An ambiguous short id returns null - never a guess.

## Evidence
12/12 new tests; **FULL suite 153 files / 1899 green**; tsc 40 = baseline, 0 in touched files; esbuild ZOE entry EXIT 0; boot-import renders the full body.

## What you'd see after wiring (a small reviewed step + a poller swap on the VPS - gated)
> BUS coordinator -> zao | Subject: How we built the bus... (full text, chunked)
> **Draft reply:** "Built to your contract - #2940 server + #2943 CLI, 11/11 tests. Yes, drop vps-bus.js."
> [Post] [Edit] [Skip]  or type: `reply eb8238 <your words>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9