### PR TITLE
feat(publish): compose route + /publish dashboard - make POST actually post

### DIFF
--- a/src/app/api/publish/compose/__tests__/route.test.ts
+++ b/src/app/api/publish/compose/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * compose route - the missing "post once, everywhere" orchestrator.
+ * Publishing is irreversible, so the tests that matter most are: dry run publishes
+ * NOTHING, auth is enforced, and over-limit text is caught before any send.
+ */
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getSessionData: vi.fn(),
+  autoCastToZao: vi.fn(),
+  publishToX: vi.fn(),
+  publishToBluesky: vi.fn(),
+  broadcastToChannels: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({ getSessionData: mocks.getSessionData }));
+vi.mock('@/lib/publish/auto-cast', () => ({ autoCastToZao: mocks.autoCastToZao }));
+vi.mock('@/lib/publish/x', () => ({ publishToX: mocks.publishToX }));
+vi.mock('@/lib/publish/bluesky', () => ({ publishToBluesky: mocks.publishToBluesky }));
+vi.mock('@/lib/publish/broadcast', () => ({ broadcastToChannels: mocks.broadcastToChannels }));
+vi.mock('@/lib/publish/normalize', () => ({
+  normalizeForX: (i: { text: string; castHash: string }) => ({ ...i, images: [], embeds: [], attribution: '', castUrl: '' }),
+  normalizeForBluesky: (i: { text: string; castHash: string }) => ({ ...i, images: [], embeds: [], attribution: '', castUrl: '' }),
+}));
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn(), info: vi.fn() } }));
+
+import { POST } from '../route';
+
+function req(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/publish/compose', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/publish/compose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSessionData.mockResolvedValue({ isAdmin: true, fid: 19640 });
+    mocks.autoCastToZao.mockResolvedValue('0xcast');
+    mocks.publishToX.mockResolvedValue({ tweetId: '1', tweetUrl: 'https://x.com/p/1' });
+    mocks.publishToBluesky.mockResolvedValue({ uri: 'at://1', cid: 'c', postUrl: 'https://bsky/p/1' });
+    mocks.broadcastToChannels.mockResolvedValue({
+      telegram: { success: true },
+      discord: { success: true },
+    });
+  });
+
+  it('401s with no session', async () => {
+    mocks.getSessionData.mockResolvedValue(null);
+    const res = await POST(req({ text: 'hi', platforms: ['farcaster'] }));
+    expect(res.status).toBe(401);
+    expect(mocks.autoCastToZao).not.toHaveBeenCalled();
+  });
+
+  it('403s for a non-admin', async () => {
+    mocks.getSessionData.mockResolvedValue({ isAdmin: false, fid: 1 });
+    const res = await POST(req({ text: 'hi', platforms: ['farcaster'] }));
+    expect(res.status).toBe(403);
+    expect(mocks.autoCastToZao).not.toHaveBeenCalled();
+  });
+
+  it('DRY RUN (the default) publishes NOTHING', async () => {
+    const res = await POST(
+      req({ text: 'test post', platforms: ['farcaster', 'x', 'bluesky', 'telegram', 'discord'] }),
+    );
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.data.dryRun).toBe(true);
+    expect(json.data.results).toHaveLength(5);
+    expect(json.data.results.every((r: { simulated: boolean }) => r.simulated)).toBe(true);
+    // the load-bearing assertion: no publisher was called
+    expect(mocks.autoCastToZao).not.toHaveBeenCalled();
+    expect(mocks.publishToX).not.toHaveBeenCalled();
+    expect(mocks.publishToBluesky).not.toHaveBeenCalled();
+    expect(mocks.broadcastToChannels).not.toHaveBeenCalled();
+  });
+
+  it('omitting dryRun defaults to a dry run (never accidental publishing)', async () => {
+    const res = await POST(req({ text: 'no flag given', platforms: ['x'] }));
+    expect((await res.json()).data.dryRun).toBe(true);
+    expect(mocks.publishToX).not.toHaveBeenCalled();
+  });
+
+  it('live run casts to Farcaster FIRST and mirrors with that hash', async () => {
+    const res = await POST(
+      req({ text: 'real post', platforms: ['farcaster', 'x', 'bluesky'], dryRun: false }),
+    );
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.castHash).toBe('0xcast');
+    expect(mocks.autoCastToZao).toHaveBeenCalledWith('real post', undefined);
+    expect(mocks.publishToX).toHaveBeenCalledWith(
+      expect.objectContaining({ castHash: '0xcast', text: 'real post' }),
+    );
+    expect(mocks.publishToBluesky).toHaveBeenCalledWith(
+      expect.objectContaining({ castHash: '0xcast' }),
+    );
+  });
+
+  it('rejects text over a selected platform limit BEFORE sending anything', async () => {
+    const res = await POST(
+      req({ text: 'x'.repeat(400), platforms: ['farcaster', 'telegram'], dryRun: false }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.details.join(' ')).toContain('farcaster: 400/320');
+    expect(mocks.autoCastToZao).not.toHaveBeenCalled();
+  });
+
+  it('reports a partial failure honestly instead of claiming success', async () => {
+    mocks.publishToX.mockRejectedValue(new Error('rate limited'));
+    const res = await POST(req({ text: 'post', platforms: ['farcaster', 'x'], dryRun: false }));
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    const x = json.data.results.find((r: { platform: string }) => r.platform === 'x');
+    expect(x.ok).toBe(false);
+    expect(x.detail).toBe('rate limited');
+  });
+
+  it('reports a failed cast rather than silently continuing', async () => {
+    mocks.autoCastToZao.mockResolvedValue(null);
+    const res = await POST(req({ text: 'post', platforms: ['farcaster'], dryRun: false }));
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.data.results[0].detail).toContain('failed');
+  });
+
+  it('400s on an empty platform list or empty text', async () => {
+    expect((await POST(req({ text: 'hi', platforms: [] }))).status).toBe(400);
+    expect((await POST(req({ text: '', platforms: ['x'] }))).status).toBe(400);
+  });
+});

--- a/src/app/api/publish/compose/route.ts
+++ b/src/app/api/publish/compose/route.ts
@@ -1,0 +1,225 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { logger } from '@/lib/logger';
+import { autoCastToZao } from '@/lib/publish/auto-cast';
+import { publishToBluesky } from '@/lib/publish/bluesky';
+import { broadcastToChannels } from '@/lib/publish/broadcast';
+import { normalizeForBluesky, normalizeForX } from '@/lib/publish/normalize';
+import { publishToX } from '@/lib/publish/x';
+
+/**
+ * POST /api/publish/compose - compose once, publish to several platforms.
+ *
+ * The missing orchestrator. ZAO already had every publisher (auto-cast, x,
+ * bluesky, broadcast) but nothing that took ONE piece of text and fanned it out:
+ * the existing routes mirror an EXISTING Farcaster cast (they require a castHash),
+ * and /api/publish/farcaster only publishes governance proposals. So ZOE's POST
+ * button had nothing to call and fell back to "approved - paste it".
+ *
+ * The chain this runs:
+ *   1. Farcaster FIRST (autoCastToZao) - it produces the castHash the mirrors need
+ *   2. X + Bluesky mirror that cast (they take {castHash, text})
+ *   3. Telegram + Discord via broadcastToChannels
+ *
+ * dryRun (DEFAULT TRUE) validates + reports what WOULD happen and publishes
+ * nothing - so the dashboard can be tested safely before anything goes public.
+ * Publishing is irreversible, so the safe mode is the default and the caller must
+ * explicitly opt out.
+ */
+const PLATFORMS = ['farcaster', 'x', 'bluesky', 'telegram', 'discord'] as const;
+type Platform = (typeof PLATFORMS)[number];
+
+const composeSchema = z.object({
+  text: z.string().min(1).max(4096),
+  platforms: z.array(z.enum(PLATFORMS)).min(1),
+  /** Publish for real. Omitted/false = dry run (nothing leaves the building). */
+  dryRun: z.boolean().default(true),
+  embedUrl: z.string().url().optional(),
+  imageUrl: z.string().url().optional(),
+});
+
+/** Per-platform hard limits, checked before anything is sent. */
+const LIMITS: Record<Platform, number> = {
+  farcaster: 320,
+  x: 280,
+  bluesky: 300,
+  telegram: 4096,
+  discord: 2000,
+};
+
+export interface PlatformOutcome {
+  platform: Platform;
+  ok: boolean;
+  detail: string;
+  /** true when this was a dry run (nothing published). */
+  simulated: boolean;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    // Admin only - this publishes to ZAO's official accounts.
+    const session = await getSessionData();
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (!session.isAdmin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const parsed = composeSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request', details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const { text, platforms, dryRun, embedUrl, imageUrl } = parsed.data;
+
+    // Length check FIRST - report every over-limit platform at once rather than
+    // failing halfway through a fan-out.
+    const tooLong = platforms.filter((p) => text.length > LIMITS[p]);
+    if (tooLong.length > 0) {
+      return NextResponse.json(
+        {
+          error: 'Text too long for selected platforms',
+          details: tooLong.map((p) => `${p}: ${text.length}/${LIMITS[p]}`),
+        },
+        { status: 400 },
+      );
+    }
+
+    const results: PlatformOutcome[] = [];
+    let castHash: string | null = null;
+
+    // 1. Farcaster first - the mirrors need its hash.
+    if (platforms.includes('farcaster')) {
+      if (dryRun) {
+        results.push({
+          platform: 'farcaster',
+          ok: true,
+          detail: 'would cast to /zao',
+          simulated: true,
+        });
+      } else {
+        castHash = await autoCastToZao(text, embedUrl);
+        results.push({
+          platform: 'farcaster',
+          ok: Boolean(castHash),
+          detail: castHash ? `cast ${castHash}` : 'failed (signer/API key missing or Neynar error)',
+          simulated: false,
+        });
+      }
+    }
+
+    // 2. Mirrors - X and Bluesky take the cast hash. Without a real cast (dry run,
+    // or Farcaster not selected/failed) we use a placeholder marker so the mirror
+    // still validates but never claims a link it does not have.
+    const mirrorHash = castHash ?? 'compose-no-cast';
+
+    if (platforms.includes('x')) {
+      if (dryRun) {
+        results.push({ platform: 'x', ok: true, detail: 'would post to X', simulated: true });
+      } else {
+        // publishToX takes NormalizedContent and THROWS on failure - catch so one
+        // platform's outage never aborts the rest of the fan-out.
+        try {
+          const r = await publishToX(
+            normalizeForX({
+              text,
+              castHash: mirrorHash,
+              embedUrls: embedUrl ? [embedUrl] : undefined,
+              imageUrls: imageUrl ? [imageUrl] : undefined,
+            }),
+          );
+          results.push({ platform: 'x', ok: true, detail: r.tweetUrl, simulated: false });
+        } catch (e: unknown) {
+          results.push({
+            platform: 'x',
+            ok: false,
+            detail: e instanceof Error ? e.message : 'failed',
+            simulated: false,
+          });
+        }
+      }
+    }
+
+    if (platforms.includes('bluesky')) {
+      if (dryRun) {
+        results.push({
+          platform: 'bluesky',
+          ok: true,
+          detail: 'would post to Bluesky',
+          simulated: true,
+        });
+      } else {
+        try {
+          const r = await publishToBluesky(
+            normalizeForBluesky({
+              text,
+              castHash: mirrorHash,
+              embedUrls: embedUrl ? [embedUrl] : undefined,
+              imageUrls: imageUrl ? [imageUrl] : undefined,
+            }),
+          );
+          results.push({ platform: 'bluesky', ok: true, detail: r.postUrl, simulated: false });
+        } catch (e: unknown) {
+          results.push({
+            platform: 'bluesky',
+            ok: false,
+            detail: e instanceof Error ? e.message : 'failed',
+            simulated: false,
+          });
+        }
+      }
+    }
+
+    // 3. Telegram + Discord in one call.
+    const wantsBroadcast = platforms.includes('telegram') || platforms.includes('discord');
+    if (wantsBroadcast) {
+      if (dryRun) {
+        for (const p of ['telegram', 'discord'] as const) {
+          if (platforms.includes(p)) {
+            results.push({
+              platform: p,
+              ok: true,
+              detail: `would broadcast to ${p}`,
+              simulated: true,
+            });
+          }
+        }
+      } else {
+        const b = await broadcastToChannels({ text, imageUrl, castHash: castHash ?? undefined });
+        if (platforms.includes('telegram')) {
+          results.push({
+            platform: 'telegram',
+            ok: b.telegram.success,
+            detail: b.telegram.error ?? 'sent',
+            simulated: false,
+          });
+        }
+        if (platforms.includes('discord')) {
+          results.push({
+            platform: 'discord',
+            ok: b.discord.success,
+            detail: b.discord.error ?? 'sent',
+            simulated: false,
+          });
+        }
+      }
+    }
+
+    const failed = results.filter((r) => !r.ok);
+    if (failed.length > 0 && !dryRun) {
+      logger.error('[publish/compose] some platforms failed', { failed });
+    }
+
+    return NextResponse.json({
+      success: failed.length === 0,
+      data: { dryRun, castHash, results, chars: text.length },
+    });
+  } catch (error: unknown) {
+    logger.error('[publish/compose] unhandled error', error);
+    return NextResponse.json({ error: 'Publish failed' }, { status: 500 });
+  }
+}

--- a/src/app/publish/page.tsx
+++ b/src/app/publish/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+/**
+ * /publish - the compose + test dashboard.
+ *
+ * Zaal tapped POST on a ZOE draft and it just echoed the text back (posts/buttons.ts
+ * only marks a draft approved and resends it as a copy-target). ZAO had every
+ * publisher already but nothing that fanned ONE piece of text out. This is the
+ * surface to test that path by hand before wiring it to ZOE's button.
+ *
+ * DRY RUN IS ON BY DEFAULT - publishing is irreversible, so going live is an
+ * explicit, deliberate toggle every single time.
+ */
+
+const PLATFORMS = [
+  {
+    id: 'farcaster',
+    name: 'Farcaster',
+    limit: 320,
+    color: '#8A63D2',
+    note: 'posts first - the others mirror it',
+  },
+  { id: 'x', name: 'X', limit: 280, color: '#e0ddaa', note: 'mirrors the cast' },
+  { id: 'bluesky', name: 'Bluesky', limit: 300, color: '#0085FF', note: 'mirrors the cast' },
+  { id: 'telegram', name: 'Telegram', limit: 4096, color: '#2AABEE', note: 'ZAO channel' },
+  { id: 'discord', name: 'Discord', limit: 2000, color: '#5865F2', note: 'webhook' },
+] as const;
+
+type PlatformId = (typeof PLATFORMS)[number]['id'];
+
+interface Outcome {
+  platform: string;
+  ok: boolean;
+  detail: string;
+  simulated: boolean;
+}
+
+export default function PublishDashboard() {
+  const [text, setText] = useState('');
+  const [selected, setSelected] = useState<PlatformId[]>(['farcaster']);
+  const [dryRun, setDryRun] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [results, setResults] = useState<Outcome[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const chars = text.length;
+  const overLimit = useMemo(
+    () => PLATFORMS.filter((p) => selected.includes(p.id) && chars > p.limit),
+    [selected, chars],
+  );
+  const canSend = chars > 0 && selected.length > 0 && overLimit.length === 0 && !busy;
+
+  function toggle(id: PlatformId) {
+    setSelected((cur) => (cur.includes(id) ? cur.filter((p) => p !== id) : [...cur, id]));
+  }
+
+  async function send() {
+    setBusy(true);
+    setError(null);
+    setResults(null);
+    try {
+      const res = await fetch('/api/publish/compose', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, platforms: selected, dryRun }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(
+          json.details
+            ? `${json.error}: ${JSON.stringify(json.details)}`
+            : (json.error ?? 'failed'),
+        );
+        return;
+      }
+      setResults(json.data.results as Outcome[]);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'request failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] px-4 py-8 text-white sm:px-8">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="text-2xl font-semibold text-[#f5a623]">Publish</h1>
+        <p className="mt-1 text-sm text-white/60">
+          Compose once, send to several places. Dry run is on by default - nothing leaves the
+          building until you turn it off.
+        </p>
+
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={6}
+          placeholder="What are you posting?"
+          className="mt-6 w-full rounded-lg border border-white/15 bg-white/5 p-3 text-base outline-none focus:border-[#f5a623]"
+        />
+
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-white/50">
+          <span>{chars} chars</span>
+          {PLATFORMS.filter((p) => selected.includes(p.id)).map((p) => (
+            <span key={p.id} className={chars > p.limit ? 'text-red-400' : ''}>
+              {p.name} {chars}/{p.limit}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-5 flex flex-wrap gap-2">
+          {PLATFORMS.map((p) => {
+            const on = selected.includes(p.id);
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => toggle(p.id)}
+                title={p.note}
+                className={`rounded-full border px-3 py-1.5 text-sm transition ${
+                  on ? 'border-transparent text-[#0a1628]' : 'border-white/20 text-white/70'
+                }`}
+                style={on ? { backgroundColor: p.color } : undefined}
+              >
+                {p.name}
+              </button>
+            );
+          })}
+        </div>
+
+        <label className="mt-5 flex items-center gap-3 text-sm">
+          <input
+            type="checkbox"
+            checked={dryRun}
+            onChange={(e) => setDryRun(e.target.checked)}
+            className="h-4 w-4 accent-[#f5a623]"
+          />
+          <span>
+            Dry run{' '}
+            <span className="text-white/50">
+              {dryRun ? '- validates only, publishes nothing' : '- LIVE, this really posts'}
+            </span>
+          </span>
+        </label>
+
+        <button
+          type="button"
+          onClick={send}
+          disabled={!canSend}
+          className={`mt-4 w-full rounded-lg px-4 py-3 font-medium transition disabled:opacity-40 ${
+            dryRun ? 'bg-white/15 text-white' : 'bg-[#f5a623] text-[#0a1628]'
+          }`}
+        >
+          {busy
+            ? 'Sending...'
+            : dryRun
+              ? `Test (${selected.length})`
+              : `Publish for real (${selected.length})`}
+        </button>
+
+        {overLimit.length > 0 && (
+          <p className="mt-3 text-sm text-red-400">
+            Too long for {overLimit.map((p) => p.name).join(', ')} - trim or deselect.
+          </p>
+        )}
+        {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
+
+        {results && (
+          <div className="mt-6 rounded-lg border border-white/15 bg-white/5 p-4">
+            <h2 className="text-sm font-medium text-white/80">
+              {results.every((r) => r.simulated) ? 'Dry run results' : 'Published'}
+            </h2>
+            <ul className="mt-2 space-y-1 text-sm">
+              {results.map((r) => (
+                <li key={r.platform} className={r.ok ? 'text-green-400' : 'text-red-400'}>
+                  {r.ok ? 'OK' : 'FAIL'} {r.platform} - {r.detail}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
You tapped POST and got the same text back. Here is why, and the dashboard to test the real thing.

## Root cause
`posts/buttons.ts:135` - POST was **never a publish button**. It marks the draft approved and resends the text as a copy-target (`answerCallbackQuery('approved - paste it')`). Working as written.

## The bigger finding
**ZAO already had every publisher** - auto-cast (Farcaster), x, bluesky, broadcast (TG+Discord), threads, lens, hive, and 9 admin-gated `/api/publish/*` routes. But **nothing fanned one piece of text out**: the existing routes MIRROR an existing cast (they need a `castHash`), and `/api/publish/farcaster` only publishes governance proposals. The button had nothing to call.

## What this adds
**`POST /api/publish/compose`** - the missing orchestrator:
1. Farcaster first (`autoCastToZao` produces the castHash the mirrors need)
2. X + Bluesky mirror that cast
3. Telegram + Discord via `broadcastToChannels`

Admin-gated, Zod-validated, **per-platform length checks before any send**, each publisher wrapped so one outage never aborts the rest, and honest per-platform results (partial failure = `success:false`).

**`dryRun` defaults to TRUE** - publishing is irreversible, so going live is an explicit opt-out every time.

**`/publish` dashboard** - compose box, platform toggles with live char counts, dry-run toggle (on by default), per-platform results. ZAO palette, mobile-first.

## Evidence
9/9 route tests - including the load-bearing **"dry run calls NO publisher"** and **"omitting the flag stays a dry run"**; tsc **0 errors**; biome clean.

## How you test it
Open `/publish`, type something, leave Dry run ON, tap Test - you see exactly what would go where. Then untick Dry run when you trust it.

Wiring ZOE's POST button to this route is the next step - by hand first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9