### PR TITLE
fix(hermes): a cancel must not still open a PR

### DIFF
--- a/bot/src/hermes/__tests__/runner-cancel.test.ts
+++ b/bot/src/hermes/__tests__/runner-cancel.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+//
+// The cancel contract of dispatchHermesRun.
+//
+// ZOE's DM stop reply promises "No PR will open". The runner polled
+// shouldCancel() only at the TOP of the attempt loop, so a stop that arrived
+// while the winning attempt was running was read too late: the attempt finished,
+// the critic passed, and the run pushed a branch and opened a PR anyway - then
+// narrated "Built it: PR #N" one message after telling the user it was stopping.
+//
+// These tests pin both directions: a cancel must not produce a PR, and no cancel
+// must still produce one.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateRun = vi.hoisted(() => vi.fn());
+const mockUpdateRun = vi.hoisted(() => vi.fn());
+const mockGetRun = vi.hoisted(() => vi.fn());
+const mockRunFixer = vi.hoisted(() => vi.fn());
+const mockRunCritic = vi.hoisted(() => vi.fn());
+const mockPreFlight = vi.hoisted(() => vi.fn());
+const mockCommitAndPush = vi.hoisted(() => vi.fn());
+const mockOpenPullRequest = vi.hoisted(() => vi.fn());
+const mockRunCmd = vi.hoisted(() => vi.fn());
+
+vi.mock('../db', () => ({
+  createRun: mockCreateRun,
+  updateRun: mockUpdateRun,
+  getRun: mockGetRun,
+}));
+vi.mock('../coder', () => ({ runFixer: mockRunFixer }));
+vi.mock('../critic', () => ({ runCritic: mockRunCritic }));
+vi.mock('../preflight', () => ({ runPreFlightGate: mockPreFlight }));
+vi.mock('../pr', () => ({ openPullRequest: mockOpenPullRequest }));
+vi.mock('../pr-watcher', () => ({ watchPullRequest: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../zoe/receipts', () => ({ emitReceipt: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../git', () => ({
+  makeWorkdir: vi.fn().mockResolvedValue('/tmp/hermes-test'),
+  cleanupWorkdir: vi.fn().mockResolvedValue(undefined),
+  cloneAndBranch: vi.fn().mockResolvedValue(undefined),
+  commitAndPush: mockCommitAndPush,
+  runCmd: mockRunCmd,
+}));
+
+import { dispatchHermesRun } from '../runner';
+
+const RUN = { id: 'run-0001', status: 'pending' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateRun.mockResolvedValue(RUN);
+  mockUpdateRun.mockResolvedValue(undefined);
+  mockGetRun.mockResolvedValue(RUN);
+  mockRunFixer.mockResolvedValue({
+    filesChanged: ['src/foo.ts'],
+    commitMessage: 'fix: foo',
+    prTitle: 'fix: foo',
+    prBody: 'body',
+    inputTokens: 10,
+    outputTokens: 20,
+  });
+  mockPreFlight.mockResolvedValue({ ok: true });
+  // 85 clears HERMES_PASS_THRESHOLD (70), so without a cancel this run opens a PR.
+  mockRunCritic.mockResolvedValue({ score: 85, feedback: 'good', inputTokens: 5, outputTokens: 5 });
+  mockCommitAndPush.mockResolvedValue(undefined);
+  mockOpenPullRequest.mockResolvedValue({ number: 42, url: 'https://github.com/x/y/pull/42' });
+  mockRunCmd.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+});
+
+const INPUT = { triggered_by_telegram_id: 1, triggered_in_chat_id: 2, issue_text: 'add a /health route' };
+
+describe('dispatchHermesRun cancellation', () => {
+  it('opens the PR when nothing asked it to stop', async () => {
+    const res = await dispatchHermesRun(INPUT);
+    expect(res.kind).toBe('ready');
+    expect(mockOpenPullRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not spend an attempt when the cancel is already set', async () => {
+    const res = await dispatchHermesRun({ ...INPUT, shouldCancel: () => true });
+    expect(res.kind).toBe('failed');
+    expect(mockRunFixer).not.toHaveBeenCalled();
+    expect(mockOpenPullRequest).not.toHaveBeenCalled();
+  });
+
+  // The regression this file exists for: the stop lands mid-attempt, the attempt
+  // still passes the critic, and the run must NOT push or open a PR.
+  it('does not open a PR when the cancel arrives while the passing attempt runs', async () => {
+    let cancelled = false;
+    mockRunCritic.mockImplementation(async () => {
+      cancelled = true; // "stop" arrives after the coder, before the PR
+      return { score: 85, feedback: 'good', inputTokens: 5, outputTokens: 5 };
+    });
+    const onFailed = vi.fn().mockResolvedValue(undefined);
+    const onPrOpened = vi.fn().mockResolvedValue(undefined);
+
+    const res = await dispatchHermesRun({ ...INPUT, shouldCancel: () => cancelled }, { onFailed, onPrOpened });
+
+    expect(mockCommitAndPush).not.toHaveBeenCalled();
+    expect(mockOpenPullRequest).not.toHaveBeenCalled();
+    expect(onPrOpened).not.toHaveBeenCalled();
+    expect(res.kind).toBe('failed');
+    expect((res as { reason: string }).reason).toBe('cancelled by request');
+    expect(onFailed).toHaveBeenCalledWith('run-0001', 'cancelled by request');
+  });
+
+  // The tokens were already spent on the attempt that got cancelled - the run
+  // row has to say so, or the spend disappears from the ledger.
+  it('records the tokens spent by the cancelled attempt', async () => {
+    let cancelled = false;
+    mockRunCritic.mockImplementation(async () => {
+      cancelled = true;
+      return { score: 85, feedback: 'good', inputTokens: 5, outputTokens: 5 };
+    });
+
+    await dispatchHermesRun({ ...INPUT, shouldCancel: () => cancelled });
+
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      'run-0001',
+      expect.objectContaining({
+        status: 'failed',
+        error_message: 'cancelled by request',
+        total_input_tokens: 15,
+        total_output_tokens: 25,
+      }),
+    );
+  });
+});

--- a/bot/src/hermes/runner.ts
+++ b/bot/src/hermes/runner.ts
@@ -125,6 +125,29 @@ export async function dispatchHermesRun(
 
   const targetRepo: HermesRepoTarget = input.target_repo ?? 'zaoos';
 
+  /**
+   * Finish the run as cancelled, or return null if no cancel was asked for.
+   *
+   * Checked at TWO points: before an attempt starts (nothing spent yet), and
+   * after the critic passes but BEFORE anything is pushed. The second check is
+   * the one that keeps the promise the caller makes to the user - ZOE's stop
+   * reply says "No PR will open", and without it a cancel that arrives while the
+   * winning attempt is running still opens a PR and pings back "Built it".
+   */
+  const finishIfCancelled = async (): Promise<DispatchResult | null> => {
+    if (!input.shouldCancel?.()) return null;
+    await updateRun(created.id, {
+      status: 'failed',
+      error_message: 'cancelled by request',
+      total_input_tokens: totalIn,
+      total_output_tokens: totalOut,
+      completed_at: new Date().toISOString(),
+    });
+    const stopped = (await reloadRun(created.id)) ?? created;
+    await narrator?.onFailed?.(created.id, 'cancelled by request');
+    return { kind: 'failed', run: stopped, reason: 'cancelled by request' };
+  };
+
   try {
     await cloneAndBranch(workdir, branchName, targetRepo);
 
@@ -135,16 +158,8 @@ export async function dispatchHermesRun(
       // Cooperative cancel, checked BEFORE this attempt spends anything. A run
       // stopped here has done no work on the current attempt, so there is
       // nothing half-finished to reconcile.
-      if (input.shouldCancel?.()) {
-        await updateRun(created.id, {
-          status: 'failed',
-          error_message: 'cancelled by request',
-          completed_at: new Date().toISOString(),
-        });
-        const stopped = (await reloadRun(created.id)) ?? created;
-        await narrator?.onFailed?.(created.id, 'cancelled by request');
-        return { kind: 'failed', run: stopped, reason: 'cancelled by request' };
-      }
+      const cancelledBeforeAttempt = await finishIfCancelled();
+      if (cancelledBeforeAttempt) return cancelledBeforeAttempt;
 
       await updateRun(created.id, { fixer_attempts: attempt, status: 'fixing' });
       await narrator?.onCoderStart?.(created.id, attempt, HERMES_DEFAULT_MAX_ATTEMPTS, input.issue_text);
@@ -218,6 +233,14 @@ export async function dispatchHermesRun(
       }
 
       if (critique.score >= HERMES_PASS_THRESHOLD) {
+        // Last exit before anything leaves this machine. The attempt is over, so
+        // nothing is half-written - but a cancel that arrived while it ran must
+        // not still produce a PR. Pushing here would put an unwanted branch and
+        // PR on the repo after the user explicitly said stop, and the run would
+        // report "Built it: PR #N" one message after "No PR will open".
+        const cancelledBeforePr = await finishIfCancelled();
+        if (cancelledBeforePr) return cancelledBeforePr;
+
         await commitAndPush(workdir, branchName, fixerOut.commitMessage);
         const pr = await openPullRequest({
           workdir,


### PR DESCRIPTION
## What breaks without this

ZOE's DM build surface (`ZOE_DM_BUILD=1`, landed an hour ago in #2957) replies to
"stop" with:

> Stopping after the current attempt - killing it mid-attempt would leave a
> half-written worktree and nothing to show for the tokens. **No PR will open.**

That last sentence was not true. `dispatchHermesRun` polled `shouldCancel()` only
at the **top of the attempt loop** (`bot/src/hermes/runner.ts:138`). Concretely:

1. Zaal sends `build: <thing>`; attempt 1 starts.
2. Zaal sends `stop` 40s later. `requestCancel()` sets the flag. He is told no PR
   will open.
3. Attempt 1 finishes and the critic scores >= 70 - the common case, since most
   runs pass on the first attempt.
4. The loop never returns to the top, so the flag is never read. The run does
   `commitAndPush` + `openPullRequest`, and the chat receives
   "Built it: PR #N" one message after "No PR will open".

So a stop only worked if the run happened to need a second attempt. The cost is
an unwanted branch and PR on the repo after an explicit stop, plus a surface that
visibly contradicts itself - the exact way trust in a build surface dies.

## The fix

One more poll of the same flag, at the last point before anything leaves the
machine (after the critic passes, before `commitAndPush`). Both call sites share
a small `finishIfCancelled()` helper so the failure row and the `onFailed`
narration stay identical.

The "never kill mid-attempt" design is unchanged: the attempt still runs to
completion, so there is no half-written worktree. What changes is that the
finished work is discarded rather than published - which is what "stop" meant.

The cancelled run now also writes `total_input_tokens` / `total_output_tokens`,
because a cancel can now land after real tokens were spent; previously that spend
vanished from the run row.

Every other caller of `dispatchHermesRun` omits `shouldCancel`, so their behavior
is byte-identical.

## Evidence

- 4 new tests, `bot/src/hermes/__tests__/runner-cancel.test.ts` - the first
  runner-level tests for `dispatchHermesRun`. **2 of them fail on main** (verified
  by stashing the fix and re-running: `2 failed | 2 passed`) and all 4 pass here.
- Bot suite: **1979 passing** (from 1975), same **2 pre-existing failures**
  (`transcribe.test.ts`, `git.test.ts` - Windows `\` vs `/` path assertions),
  untouched by this change.
- Bot typecheck: **40 errors before, 40 after** - zero new, none in the touched
  files.
- Not verified here: `esbuild` boot-bundle (rule 30). esbuild is not in `bot`'s
  dependency set in this checkout, and this change adds no imports and no
  top-level code, so the boot graph is unchanged.

## Also found, deliberately not fixed here (one PR per audit run)

`bot/src/zoe/index.ts` reports the critic score as `/10` in two places
(`onCriticDone` phase string and the `onPrOpened` message), but
`HERMES_PASS_THRESHOLD` is **70** and the PR body writes `/100`. A passing run
tells Zaal "critic 85/10". Cosmetic, one-line, left for a separate change.
