### PR TITLE
feat(zoe): one live message per build, not six - from the TG API changelog gap analysis

### DIFF
--- a/bot/src/zoe/__tests__/live-status.test.ts
+++ b/bot/src/zoe/__tests__/live-status.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LiveStatus, MIN_EDIT_INTERVAL_MS, renderBuildStatus } from '../live-status';
+
+/** A fake Telegram with a controllable clock, so nothing sleeps. */
+function harness(opts: { failEdits?: boolean } = {}) {
+  const sends: string[] = [];
+  const edits: Array<{ id: number; text: string }> = [];
+  let clock = 1_000_000;
+  let nextId = 100;
+  const live = new LiveStatus({
+    send: async (text) => {
+      sends.push(text);
+      return nextId++;
+    },
+    edit: async (id, text) => {
+      if (opts.failEdits) throw new Error('message to edit not found');
+      edits.push({ id, text });
+    },
+    now: () => clock,
+  });
+  return { live, sends, edits, tick: (ms: number) => { clock += ms; } };
+}
+
+describe('LiveStatus', () => {
+  it('sends once, then edits - one message, not six', async () => {
+    const h = harness();
+    await h.live.render('coding');
+    h.tick(MIN_EDIT_INTERVAL_MS);
+    await h.live.render('critic reviewing');
+    h.tick(MIN_EDIT_INTERVAL_MS);
+    await h.live.render('opened PR');
+
+    expect(h.sends).toEqual(['coding']);          // exactly one message created
+    expect(h.edits.map((e) => e.text)).toEqual(['critic reviewing', 'opened PR']);
+    expect(new Set(h.edits.map((e) => e.id)).size).toBe(1); // all edits hit the same message
+  });
+
+  // Telegram returns an ERROR for an identical edit, not a no-op.
+  it('never re-sends identical text', async () => {
+    const h = harness();
+    await h.live.render('coding');
+    h.tick(MIN_EDIT_INTERVAL_MS);
+    await h.live.render('coding');
+    await h.live.render('coding');
+    expect(h.edits).toHaveLength(0);
+  });
+
+  it('throttles rapid updates', async () => {
+    const h = harness();
+    await h.live.render('a');
+    await h.live.render('b'); // immediately after - throttled
+    await h.live.render('c');
+    expect(h.edits).toHaveLength(0);
+  });
+
+  // A dropped intermediate frame is invisible; a dropped FINAL frame is a lie.
+  it('flush() lands the last throttled state', async () => {
+    const h = harness();
+    await h.live.render('a');
+    await h.live.render('b');
+    await h.live.render('c'); // c replaces b as the pending state
+    await h.live.flush();
+    expect(h.edits.map((e) => e.text)).toEqual(['c']);
+  });
+
+  it('flush() is a no-op when nothing is pending', async () => {
+    const h = harness();
+    await h.live.render('a');
+    await h.live.flush();
+    await h.live.flush();
+    expect(h.edits).toHaveLength(0);
+  });
+
+  it('force bypasses the throttle, for terminal states', async () => {
+    const h = harness();
+    await h.live.render('coding');
+    await h.live.render('Built it: PR #1', undefined, true); // no clock advance
+    expect(h.edits.map((e) => e.text)).toEqual(['Built it: PR #1']);
+  });
+
+  it('falls back to a new message when the original is gone', async () => {
+    const h = harness({ failEdits: true });
+    await h.live.render('coding');
+    h.tick(MIN_EDIT_INTERVAL_MS);
+    await h.live.render('critic reviewing');
+    // Losing the thread mid-build is worse than an extra message.
+    expect(h.sends).toEqual(['coding', 'critic reviewing']);
+  });
+
+  it('keeps working after a failed edit', async () => {
+    const h = harness({ failEdits: true });
+    await h.live.render('one');
+    h.tick(MIN_EDIT_INTERVAL_MS);
+    await h.live.render('two');
+    h.tick(MIN_EDIT_INTERVAL_MS);
+    await h.live.render('three');
+    expect(h.sends).toEqual(['one', 'two', 'three']);
+  });
+
+  it('exposes the live message id', async () => {
+    const h = harness();
+    expect(h.live.id).toBeNull();
+    await h.live.render('x');
+    expect(typeof h.live.id).toBe('number');
+  });
+});
+
+describe('renderBuildStatus', () => {
+  const base = { task: 'add a /health route', phase: 'coding', history: [], elapsedSec: 12 };
+
+  it('leads with the phase - often the only line a notification shows', () => {
+    expect(renderBuildStatus(base).split('\n')[0]).toBe('coding - 12s');
+  });
+
+  it('switches seconds to minutes as a run gets long', () => {
+    expect(renderBuildStatus({ ...base, elapsedSec: 300 })).toContain('5m');
+  });
+
+  it('drops the timer once done - a finished build has no clock', () => {
+    const out = renderBuildStatus({ ...base, phase: 'Built it: PR #12', done: true });
+    expect(out.split('\n')[0]).toBe('Built it: PR #12');
+    expect(out).not.toContain('12s');
+  });
+
+  it('shows history oldest-first so it reads as a growing log', () => {
+    const out = renderBuildStatus({ ...base, history: ['wrote 3 files', 'critic 6/10'] });
+    expect(out.indexOf('wrote 3 files')).toBeLessThan(out.indexOf('critic 6/10'));
+  });
+
+  // An unbounded log would eventually blow Telegram's 4096-char cap.
+  it('keeps only the recent tail of a long history', () => {
+    const history = Array.from({ length: 20 }, (_, i) => `step ${i}`);
+    const out = renderBuildStatus({ ...base, history });
+    expect(out).toContain('step 19');
+    expect(out).not.toContain('step 0');
+    expect(out.length).toBeLessThan(4096);
+  });
+
+  it('truncates a very long task rather than blowing the message', () => {
+    const out = renderBuildStatus({ ...base, task: 'x'.repeat(500) });
+    expect(out.length).toBeLessThan(400);
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -39,6 +39,7 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { detectBuildIntent } from './build-intent';
 import { doneKeyboard, maybeKeyboard, runningKeyboard } from './dm-build-buttons';
+import { LiveStatus, renderBuildStatus } from './live-status';
 import { stashPending, takePending, worthOffering } from './dm-build-pending';
 import {
   beginBuild,
@@ -1071,7 +1072,7 @@ bot.callbackQuery(/^dmb:yes:(.+)$/, async (ctx) => {
     return;
   }
   await ctx.answerCallbackQuery('Building').catch(() => {});
-  await startDmBuild(ctx, chatId, task, 'you tapped Build it');
+  await startDmBuild(chatId, task, 'you tapped Build it');
 });
 
 bot.callbackQuery(/^dmb:no:(.+)$/, async (ctx) => {
@@ -2329,23 +2330,44 @@ function startProgressNarration(
  * reassuring thing to see - it means the critic caught something and the loop is
  * working, not that it is stuck.
  */
-async function startDmBuild(
-  ctx: Context,
-  chatId: number,
-  task: string,
-  reason: string,
-): Promise<void> {
+async function startDmBuild(chatId: number, task: string, reason: string): Promise<void> {
   beginBuild(chatId, task);
-  const say = (t: string) => bot.api.sendMessage(chatId, t).catch(() => {});
 
-  await ctx
-    .reply(
-      `Building this (${reason}).\n\n` +
-        'Phases report here. Tap Stop any time, or send a correction and I will ' +
-        'run that next.',
-      { reply_markup: runningKeyboard() },
-    )
-    .catch(() => {});
+  // ONE message that updates, not six that pile up. Found by reading the
+  // Telegram Bot API changelog: ZOE only ever edited messages inside button
+  // callbacks and had never held a message id across a long operation, so a
+  // single build emitted start / coded / critic / retry / PR as separate blocks -
+  // a screenful on a phone to find the one line that matters.
+  const live = new LiveStatus({
+    send: async (text, markup) => {
+      const m = await bot.api
+        .sendMessage(chatId, text, markup ? { reply_markup: markup as never } : {})
+        .catch(() => null);
+      return m?.message_id ?? null;
+    },
+    edit: async (messageId, text, markup) => {
+      await bot.api.editMessageText(chatId, messageId, text, {
+        ...(markup ? { reply_markup: markup as never } : {}),
+      });
+    },
+  });
+
+  const startedAt = Date.now();
+  const history: string[] = [];
+  const show = (phase: string, opts: { done?: boolean; force?: boolean } = {}) =>
+    live.render(
+      renderBuildStatus({
+        task,
+        phase,
+        history,
+        elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+        done: opts.done,
+      }),
+      opts.done ? undefined : runningKeyboard(),
+      opts.force ?? opts.done,
+    );
+
+  await show(`Building (${reason})`);
 
   void dispatchHermesRun(
     {
@@ -2358,56 +2380,70 @@ async function startDmBuild(
       onCoderStart: async (runId, attempt, max) => {
         setRunId(chatId, runId);
         setPhase(chatId, `coding (attempt ${attempt}/${max})`);
-        if (attempt > 1) await say(`Attempt ${attempt}/${max} - coding.`);
+        await show(`Coding - attempt ${attempt}/${max}`);
       },
       onCoderDone: async (_id, _attempt, filesChanged) => {
         setPhase(chatId, 'coded, awaiting critic');
         const n = filesChanged.length;
-        const list = filesChanged.slice(0, 4).join(', ');
-        await say(
-          `Wrote ${n} file${n === 1 ? '' : 's'}${list ? `: ${list}` : ''}${n > 4 ? ' ...' : ''}\nCritic reviewing.`,
-        );
+        history.push(`wrote ${n} file${n === 1 ? '' : 's'}: ${filesChanged.slice(0, 3).join(', ')}`);
+        await show('Critic reviewing');
       },
-      onCriticStart: async () => setPhase(chatId, 'critic reviewing'),
+      onCriticStart: async () => {
+        setPhase(chatId, 'critic reviewing');
+        await show('Critic reviewing');
+      },
       onCriticDone: async (_id, score) => {
         setPhase(chatId, `critic scored ${score}/10`);
+        history.push(`critic scored ${score}/10`);
+        await show(`Critic scored ${score}/10`);
       },
-      // A retry is good news - the loop caught something. Say so, or it reads
-      // like failure.
+      // A retry is GOOD news - the critic caught something and the loop works.
+      // Said plainly, or it reads as failure.
       onRetry: async (_id, nextAttempt, feedback) => {
         setPhase(chatId, `retrying (attempt ${nextAttempt})`);
-        await say(`Critic pushed back - going again (attempt ${nextAttempt}).\n${feedback.slice(0, 220)}`);
+        history.push(`retry ${nextAttempt}: ${feedback.slice(0, 90)}`);
+        await show(`Critic pushed back - going again (attempt ${nextAttempt})`);
       },
       onPrOpened: async (_id, prNumber, prUrl, score) => {
         const followUp = takeFollowUp(chatId);
         endBuild(chatId);
-        await bot.api
-          .sendMessage(chatId, `Built it: PR #${prNumber} (critic ${score}/10)\n\nYours to merge.`, {
-            reply_markup: doneKeyboard(prUrl),
-          })
-          .catch(() => {});
+        await live.flush();
+        history.push(`PR #${prNumber} opened`);
+        await live.render(
+          renderBuildStatus({
+            task,
+            phase: `Built it: PR #${prNumber} (critic ${score}/10) - yours to merge`,
+            history,
+            elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+            done: true,
+          }),
+          doneKeyboard(prUrl),
+          true,
+        );
         if (followUp) await runQueuedFollowUp(chatId, followUp);
       },
       onEscalated: async (_id, escalateReason) => {
         const followUp = takeFollowUp(chatId);
         endBuild(chatId);
-        await say(`Stopped - needs your eyes: ${escalateReason.slice(0, 220)}`);
+        await live.flush();
+        await show(`Stopped - needs your eyes: ${escalateReason.slice(0, 180)}`, { done: true });
         if (followUp) await runQueuedFollowUp(chatId, followUp);
       },
       onFailed: async (_id, failReason) => {
         const cancelled = failReason.includes('cancelled');
         const followUp = takeFollowUp(chatId);
         endBuild(chatId);
-        await say(
-          cancelled
-            ? 'Stopped. Nothing was merged and no PR opened.'
-            : `Could not build it: ${failReason.slice(0, 220)}`,
+        await live.flush();
+        await show(
+          cancelled ? 'Stopped. No PR opened, nothing merged.' : `Could not build it: ${failReason.slice(0, 180)}`,
+          { done: true },
         );
-        // A cancel means he changed his mind about the whole thing, so a queued
-        // correction is almost certainly stale. Surface it, do not run it.
+        // A cancel makes a queued correction stale - surface it, do not run it.
         if (followUp) {
           if (cancelled) {
-            await say(`You had queued: "${followUp.slice(0, 140)}"\nSend it again if you still want it.`);
+            await bot.api
+              .sendMessage(chatId, `You had queued: "${followUp.slice(0, 140)}"\nSend it again if you still want it.`)
+              .catch(() => {});
           } else {
             await runQueuedFollowUp(chatId, followUp);
           }
@@ -2416,7 +2452,7 @@ async function startDmBuild(
     },
   ).catch(async (e) => {
     endBuild(chatId);
-    await say(`Build pipeline error: ${(e as Error).message.slice(0, 160)}`);
+    await show(`Build pipeline error: ${(e as Error).message.slice(0, 160)}`, { done: true });
   });
 }
 
@@ -2431,15 +2467,7 @@ async function runQueuedFollowUp(chatId: number, text: string): Promise<void> {
     return;
   }
   await say(`Now the follow-up: "${intent.task.slice(0, 140)}"`);
-  await startDmBuildFromQueue(chatId, intent.task, intent.reason);
-}
-
-/** Same as startDmBuild but without a ctx to reply to (the queued path). */
-async function startDmBuildFromQueue(chatId: number, task: string, reason: string): Promise<void> {
-  const fakeCtx = {
-    reply: (t: string) => bot.api.sendMessage(chatId, t),
-  } as unknown as Context;
-  await startDmBuild(fakeCtx, chatId, task, reason);
+  await startDmBuild(chatId, intent.task, intent.reason);
 }
 
 async function dispatchConcierge(
@@ -2493,7 +2521,7 @@ async function dispatchConcierge(
 
     const intent = detectBuildIntent(text);
     if (intent.build && intent.task) {
-      await startDmBuild(ctx, chatId, intent.task, intent.reason);
+      await startDmBuild(chatId, intent.task, intent.reason);
       return;
     }
     // Declined, but borderline: offer the tap instead of making him retype the

--- a/bot/src/zoe/live-status.ts
+++ b/bot/src/zoe/live-status.ts
@@ -1,0 +1,149 @@
+/**
+ * live-status.ts - one message that updates in place, instead of six new ones.
+ *
+ * FOUND BY READING THE TELEGRAM BOT API CHANGELOG (2026-08-07), which is the
+ * cheapest way to answer "what are we missing" - it is the authoritative list of
+ * what the platform can do, and the gap is whatever we never adopted.
+ *
+ * The gap it exposed was not a new API. ZOE only ever calls editMessageText from
+ * inside a button callback (editing the message the tap came from); it has never
+ * held a message id and updated it over time. So a single DM build emitted up to
+ * six separate messages - start, coder done, critic pushback, retry, PR - which
+ * on a phone is a screenful of near-identical blocks you have to scroll past to
+ * find the one line that matters. Telegram has supported editing since forever;
+ * we were just not using it.
+ *
+ * A build is ONE event. It should be ONE message that changes.
+ *
+ * ALSO NOTED, NOT YET BUILDABLE: Bot API 10.1 (2026-06-11) added Rich Messages
+ * explicitly "allowing bots to ... stream AI-generated replies with seamless rich
+ * formatting", including an InputRichBlockThinking block, and 10.2 (2026-07-14)
+ * added Ephemeral Messages (group messages visible to one user). Those are the
+ * real end state for an agent surface. This repo is on grammy ^1.29.0, which
+ * predates both, so they are a deliberate follow-up rather than something to
+ * hand-roll against raw HTTP today.
+ *
+ * DESIGN NOTES THAT MATTER IN PRACTICE
+ *
+ * - Telegram rejects an edit whose text is byte-identical ("message is not
+ *   modified"). That is an error response, not a no-op, so identical renders are
+ *   skipped before the call rather than after.
+ * - Edits are rate-limited per chat. Updates are throttled, and the LAST state
+ *   always lands - a dropped intermediate frame is invisible, a dropped final
+ *   frame is a lie.
+ * - If the message is gone (deleted, too old), fall back to sending a new one.
+ *   Losing the thread of a running build is worse than an extra message.
+ */
+
+export interface LiveStatusDeps {
+  send: (text: string, replyMarkup?: unknown) => Promise<number | null>;
+  edit: (messageId: number, text: string, replyMarkup?: unknown) => Promise<void>;
+  /** Injected so tests are deterministic and do not sleep. */
+  now?: () => number;
+}
+
+/** Minimum gap between edits. Telegram tolerates roughly one edit per second per
+ *  chat; 1200ms leaves headroom without feeling laggy. */
+export const MIN_EDIT_INTERVAL_MS = 1200;
+
+export class LiveStatus {
+  private messageId: number | null = null;
+  private lastText = '';
+  private lastEditAt = 0;
+  /** Set when a render was throttled, so flush() knows it owes an update. */
+  private pending: { text: string; markup?: unknown } | null = null;
+  private readonly now: () => number;
+
+  constructor(private deps: LiveStatusDeps) {
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /**
+   * Show `text`. Sends on the first call, edits after that.
+   *
+   * `force` bypasses the throttle - used for terminal states (the PR link, a
+   * failure), because those must never be the frame that got dropped.
+   */
+  async render(text: string, markup?: unknown, force = false): Promise<void> {
+    if (this.messageId === null) {
+      const id = await this.deps.send(text, markup).catch(() => null);
+      this.messageId = id;
+      this.lastText = text;
+      this.lastEditAt = this.now();
+      return;
+    }
+
+    // Telegram treats an identical edit as an error, not a no-op.
+    if (text === this.lastText) return;
+
+    const since = this.now() - this.lastEditAt;
+    if (!force && since < MIN_EDIT_INTERVAL_MS) {
+      this.pending = { text, markup };
+      return;
+    }
+
+    await this.write(text, markup);
+  }
+
+  /** Push any throttled update through. Call before finishing so the last
+   *  intermediate state is not silently lost. */
+  async flush(): Promise<void> {
+    if (!this.pending) return;
+    const { text, markup } = this.pending;
+    this.pending = null;
+    if (text === this.lastText) return;
+    await this.write(text, markup);
+  }
+
+  private async write(text: string, markup?: unknown): Promise<void> {
+    if (this.messageId === null) return;
+    try {
+      await this.deps.edit(this.messageId, text, markup);
+      this.lastText = text;
+      this.lastEditAt = this.now();
+      this.pending = null;
+    } catch {
+      // The message is probably gone - deleted, or older than Telegram's edit
+      // window. Losing the thread of a running build is worse than an extra
+      // message, so start a new one and keep going.
+      const id = await this.deps.send(text, markup).catch(() => null);
+      this.messageId = id;
+      this.lastText = text;
+      this.lastEditAt = this.now();
+      this.pending = null;
+    }
+  }
+
+  /** The live message's id, once it exists. */
+  get id(): number | null {
+    return this.messageId;
+  }
+}
+
+/**
+ * Render a build's state as one block.
+ *
+ * The shape is deliberate: the CURRENT phase is the first line, because on a
+ * phone that is often the only line visible in a notification. History goes
+ * underneath, oldest first, so the message reads as a growing log rather than
+ * something that reshuffles under you.
+ */
+export function renderBuildStatus(opts: {
+  task: string;
+  phase: string;
+  history: string[];
+  elapsedSec: number;
+  done?: boolean;
+}): string {
+  const { task, phase, history, elapsedSec, done } = opts;
+  const elapsed = elapsedSec < 90 ? `${elapsedSec}s` : `${Math.round(elapsedSec / 60)}m`;
+  const head = done ? phase : `${phase} - ${elapsed}`;
+  const lines = [head, '', `"${task.slice(0, 140)}"`];
+  if (history.length > 0) {
+    lines.push('');
+    // Keep the tail: on a long run the recent steps are what you want, and an
+    // unbounded log would eventually blow Telegram's 4096-char message cap.
+    lines.push(...history.slice(-6).map((h) => `- ${h}`));
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
You said: keep learning agentic coding + Telegram bots/UI, find what we're missing, build it.

**The cheapest way to answer "what are we missing" turned out to be the Telegram Bot API changelog** - it's the authoritative list of what the platform can do, so the gap is whatever we never adopted.

## The gap needed no new API at all

ZOE calls `editMessageText` in **14 places - every one inside a button callback**, editing the message the tap came from. It has never held a message id and updated it over time.

So a single DM build emitted **up to six separate messages** - start, coded, critic, retry, PR. On a phone that's a screenful of near-identical blocks you scroll past to find the one line that matters.

**A build is one event. It's now one message that changes.**

## What the changelog also says - recorded for later

**Bot API 10.1 (2026-06-11) added Rich Messages**, explicitly *"allowing bots to ... stream AI-generated replies with seamless rich formatting"* - including an `InputRichBlockThinking` block. **Telegram shipped a native primitive for exactly the surface we're building.**

**10.2 (2026-07-14) added Ephemeral Messages** - group messages visible only to one user and the bot. That's the right shape for ZAAL BOTZ.

Neither is buildable yet: we're on **grammy ^1.29.0**, which predates both. Documented as the follow-up rather than hand-rolled against raw HTTP today.

## Three things that make in-place editing actually work

- Telegram returns an **error** for a byte-identical edit, not a no-op - so identical renders are skipped *before* the call
- Edits are rate-limited, so updates throttle at 1200ms - **but terminal states force through.** A dropped intermediate frame is invisible; a dropped **final** frame is a lie. `flush()` exists so the last throttled state still lands.
- If the message is gone (deleted, too old), **fall back to sending a new one** - losing the thread of a running build is worse than an extra message

Layout is deliberate: **current phase on line one**, because on a phone that's often the only line a notification shows. History underneath, oldest-first so it reads as a growing log, capped at the recent tail so a long run can't blow the 4096-char limit.

Also deleted a fake-`ctx` wrapper that existed only to satisfy a parameter this change made unused.

## Verified

- **15 new tests** - throttle, identical-skip, flush, edit-failure fallback, render shape
- Bot suite **1,993 passing**, same 3 pre-existing failures
- **esbuild bundles the boot graph**
- **Zero new typecheck errors** measured against *current* main. My first comparison used a stale baseline and showed six - those were already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
