### PR TITLE
fix(docs): correct a wrong grammy version I shipped in #2961

### DIFF
--- a/bot/src/zoe/live-status.ts
+++ b/bot/src/zoe/live-status.ts
@@ -19,9 +19,27 @@
  * explicitly "allowing bots to ... stream AI-generated replies with seamless rich
  * formatting", including an InputRichBlockThinking block, and 10.2 (2026-07-14)
  * added Ephemeral Messages (group messages visible to one user). Those are the
- * real end state for an agent surface. This repo is on grammy ^1.29.0, which
- * predates both, so they are a deliberate follow-up rather than something to
- * hand-roll against raw HTTP today.
+ * real end state for an agent surface.
+ *
+ * CORRECTION (2026-08-07): an earlier version of this comment said the repo runs
+ * grammy ^1.29.0. That is the RANGE in package.json, not what is installed - the
+ * lockfile pins 1.42.0 and the live bot confirms 1.42.0. Read the lockfile, not
+ * the range; a caret range tells you the floor, never the version.
+ *
+ * The conclusion survives the correction, for a different reason. grammy 1.42.0
+ * ships @grammyjs/types 3.26.0 (2026-04-03), which predates both API releases -
+ * verified by grepping the installed package for InputRichMessage, RichTextBold,
+ * ephemeral_message_id, receiver_user_id and Community: zero occurrences of any
+ * of them. So the types genuinely are absent; the version number was just wrong.
+ *
+ * THE REAL BLOCKER IS NOT THE VERSION. grammy 1.42.0 -> 1.45.1 is a minor bump
+ * (same major, semver-safe at runtime), and 1.45.1 pulls @grammyjs/types 4.0.0,
+ * released 2026-07-15 - one day after Bot API 10.2 - so it almost certainly
+ * carries these types. But grammy's types DO NOT RESOLVE in this repo's tsconfig
+ * at all: 21 files carry `TS2307: Cannot find module 'grammy'`, which is why
+ * every ctx parameter is implicitly `any`. Upgrading into that would mean writing
+ * Rich Message calls with no type checking whatsoever. Fix the type resolution
+ * first, then upgrade, then build on it - in that order.
  *
  * DESIGN NOTES THAT MATTER IN PRACTICE
  *


### PR DESCRIPTION
`live-status.ts` (merged in #2961) claimed the repo runs **grammy ^1.29.0**. That's the *range* in package.json, not what's installed. **The lockfile pins 1.42.0** and the live bot confirms 1.42.0. I read the range and reported it as the version.

## The conclusion survives, for a different reason

grammy 1.42.0 ships **@grammyjs/types 3.26.0** (2026-04-03), which predates Bot API 10.1 and 10.2. Verified properly this time - grepped the installed package for `InputRichMessage`, `RichTextBold`, `ephemeral_message_id`, `receiver_user_id`, `Community`: **zero occurrences of any of them.**

The types really are absent. The version number was just wrong.

## But the upgrade story that error implied is wrong

| | Claimed | Actual |
|---|---|---|
| Installed | 1.29.0 (Aug 2024) | **1.42.0** (Apr 2026) |
| Gap to latest | ~2 years, 35 releases | **3 minor versions** |
| Risk | sounds like a rewrite | **semver-safe minor bump** |

grammy 1.45.1 pulls **@grammyjs/types 4.0.0**, released **2026-07-15 - one day after Bot API 10.2** - so it almost certainly carries these types.

## The real blocker isn't the version

**grammy's types don't resolve in this repo's tsconfig at all.** 21 files carry `TS2307: Cannot find module 'grammy'`, which is why every `ctx` parameter is implicitly `any`.

Upgrading into that means writing Rich Message calls with **zero type checking** - on an API we've never used, whose whole value is a complex nested block structure. That's the wrong order.

**Fix the type resolution first, then upgrade, then build on it.**

## Lesson

A caret range tells you the floor, never the version. **Read the lockfile.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
