### PR TITLE
fix(bot): three real type errors that 143 phantom ones were hiding

### DIFF
--- a/bot/src/zai/voice-capture.ts
+++ b/bot/src/zai/voice-capture.ts
@@ -7,7 +7,7 @@
  * per session and periodically flushes to ~/.zao/private/.
  */
 
-import { VoiceConnection, VoiceReceiveStream, EndBehaviorType } from '@discordjs/voice';
+import { VoiceConnection, AudioReceiveStream, EndBehaviorType } from '@discordjs/voice';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import type { CaptureSession, TranscriptLine } from './types';
@@ -42,7 +42,7 @@ export function startVoiceCapture(
   const handleSpeakingStart = (userId: string) => {
     if (buffers.has(userId)) return;
 
-    const audioStream: VoiceReceiveStream = connection.receiver.subscribe(userId, {
+    const audioStream: AudioReceiveStream = connection.receiver.subscribe(userId, {
       end: { behavior: EndBehaviorType.AfterSilence, duration: SILENCE_THRESHOLD_MS },
     });
 
@@ -94,10 +94,43 @@ export function startVoiceCapture(
 
   connection.receiver.speaking.on('start', handleSpeakingStart);
 
-  // Return cleanup function
+  // Return cleanup function.
+  //
+  // The cast is deliberate and narrow. @discordjs/voice declares
+  // `interface SpeakingMap extends EventEmitter` carrying ONLY `on` overloads,
+  // which leaves the inherited removal methods off the visible type - so neither
+  // `removeListener` nor `off` typechecks, even though SpeakingMap really does
+  // extend EventEmitter and both exist at runtime. That is a gap in the library's
+  // typings, not in this code, so the honest fix is to say so at the call site
+  // rather than change behaviour or silence the file.
+  //
+  // Without this, the listener is never detached and every capture session leaks
+  // one. It went unnoticed because the bot's dependencies were not installed
+  // locally, so tsc reported 183 phantom errors and buried the three real ones.
   return () => {
-    connection.receiver.speaking.removeListener('start', handleSpeakingStart);
+    (connection.receiver.speaking as unknown as ListenerRemover).removeListener(
+      'start',
+      handleSpeakingStart,
+    );
   };
+}
+
+/**
+ * The single EventEmitter method this module needs from SpeakingMap.
+ *
+ * Declared here rather than imported because neither route typechecks:
+ * @discordjs/voice declares `interface SpeakingMap extends EventEmitter` carrying
+ * ONLY `on` overloads, which hides the inherited removal methods, and node's own
+ * `EventEmitter` type splits its class and interface in @types/node 22 such that
+ * `off` is not on the imported interface either.
+ *
+ * SpeakingMap genuinely extends EventEmitter, so removeListener exists at
+ * runtime. Naming the exact method we rely on is narrower and more honest than
+ * casting to `any` - if this assumption ever stops holding, the failure is a
+ * visible one line, not a silent no-op.
+ */
+interface ListenerRemover {
+  removeListener(event: string, listener: (...args: never[]) => void): unknown;
 }
 
 /**

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -502,9 +502,19 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           }
 
           const result = await runCuratorTick(
-            (chatId, text, sendOpts) => sendOpts?.message_thread_id
-              ? opts.bot.api.sendMessage(chatId, text, { message_thread_id: sendOpts.message_thread_id })
-              : opts.bot.api.sendMessage(chatId, text),
+            // Braces, not a bare expression: the callback is typed Promise<void>
+            // and sendMessage resolves to a TextMessage. Returning it happened to
+            // work but did not typecheck, and the returned message was discarded
+            // anyway - so discard it explicitly.
+            async (chatId, text, sendOpts) => {
+              if (sendOpts?.message_thread_id) {
+                await opts.bot.api.sendMessage(chatId, text, {
+                  message_thread_id: sendOpts.message_thread_id,
+                });
+                return;
+              }
+              await opts.bot.api.sendMessage(chatId, text);
+            },
             zaoGroupId,
           );
 


### PR DESCRIPTION
I've been reporting "**21 files carry `TS2307: Cannot find module 'grammy'`**" and "**93 `ctx` parameters are implicitly `any`**" all session, and calling that the blocker for upgrading grammy.

**It was not a repo defect.** `bot/node_modules` on my Mac was an **empty directory** - the bot's dependencies were never installed locally. CI runs `npm ci` in `bot/` and its Bot Tests job is green on main.

One `npm install`: **183 errors → 40.** Every grammy `TS2307` gone. Every implicit-any `ctx` gone.

## Which is the point

Buried under 143 phantom errors were **three real ones in live source**, and the noise is exactly why nobody saw them.

**1. A non-existent import.** `voice-capture.ts` imported `VoiceReceiveStream` from `@discordjs/voice`. No such export - `receiver.subscribe()` returns `AudioReceiveStream`. Type-only usage, so it was erased at compile time and never crashed, but the annotation was meaningless.

**2. The one with teeth.** The cleanup function calls `speaking.removeListener(...)` - and it's the **only** thing that detaches the speaking listener. If it were wrong at runtime, every capture session would leak one.

It isn't wrong at runtime - `SpeakingMap` really does extend `EventEmitter`. But the library hides it: `interface SpeakingMap extends EventEmitter` declares **only `on` overloads**, and node's own `EventEmitter` splits class from interface in `@types/node` 22, so neither `off` nor an `EventEmitter` cast typechecks either.

I declared the single method we depend on. Narrower and more honest than `any`: if the assumption breaks, it breaks in **one visible line**.

**3.** `scheduler.ts` passed a callback returning `Promise<TextMessage>` where `Promise<void>` was expected. The value was discarded anyway; now explicitly.

## Result

**Non-test source is at zero type errors.** The 37 remaining are all in test files (mostly `TS2345` on mock shapes) - real, worth fixing, out of scope here.

## The lesson, for the third time today

A signal that fires constantly gets ignored, and something real hides inside it. A route detector cried wolf 35 times. A review flag could never reach zero. And **a typecheck reporting 183 errors on a healthy repo trained me to read "no NEW errors" instead of "no errors."**

## Verified

- `tsc` non-test source **clean**
- **esbuild bundles both entrypoints** - zoe and zai. `voice-capture` is reachable from `zai/index.ts`, so it's live code, not dead
- Bot suite **2,007 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
