### PR TITLE
fix(swarm): the loop lock was check-then-act and could let two ticks run

### DIFF
--- a/bot/src/zoe/__tests__/tick-lock.test.ts
+++ b/bot/src/zoe/__tests__/tick-lock.test.ts
@@ -1,0 +1,158 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  acquireTickLock,
+  DEFAULT_STALE_MS,
+  releaseTickLock,
+  withTickLock,
+} from '../tick-lock';
+
+let dir: string;
+let lock: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(join(tmpdir(), 'ticklock-'));
+  lock = join(dir, 'nested', 'tick.lock');
+});
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('acquireTickLock', () => {
+  it('acquires when free, and creates the directory', async () => {
+    expect((await acquireTickLock(lock)).acquired).toBe(true);
+    await expect(fs.stat(lock)).resolves.toBeTruthy();
+  });
+
+  it('refuses a second acquire while held', async () => {
+    await acquireTickLock(lock);
+    const second = await acquireTickLock(lock);
+    expect(second.acquired).toBe(false);
+    expect(second.reason).toBe('held');
+  });
+
+  // THE BUG THIS MODULE EXISTS FOR. The old stat-then-write let two concurrent
+  // callers both observe a free lock and both proceed. Exactly one may win.
+  it('gives exactly ONE winner when many callers race', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 25 }, () => acquireTickLock(lock)),
+    );
+    expect(results.filter((r) => r.acquired)).toHaveLength(1);
+  });
+
+  it('gives exactly one winner on a repeated race', async () => {
+    for (let round = 0; round < 5; round++) {
+      const results = await Promise.all(
+        Array.from({ length: 10 }, () => acquireTickLock(lock)),
+      );
+      expect(results.filter((r) => r.acquired)).toHaveLength(1);
+      await releaseTickLock(lock);
+    }
+  });
+
+  it('reacquires after release', async () => {
+    await acquireTickLock(lock);
+    await releaseTickLock(lock);
+    expect((await acquireTickLock(lock)).acquired).toBe(true);
+  });
+
+  it('reports how long a blocking lock has been held', async () => {
+    let t = 1_000_000;
+    await acquireTickLock(lock, { now: () => t });
+    t += 5000;
+    const blocked = await acquireTickLock(lock, { now: () => t });
+    expect(blocked.acquired).toBe(false);
+    expect(blocked.heldForMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('breaks a stale lock so a dead process cannot wedge the loop forever', async () => {
+    await acquireTickLock(lock);
+    // Age the lock past the threshold the way a crashed holder would. The module
+    // reads the timestamp it wrote, so age the CONTENT.
+    await fs.writeFile(lock, String(Date.now() - (DEFAULT_STALE_MS + 60_000)));
+    expect((await acquireTickLock(lock)).acquired).toBe(true);
+  });
+
+  it('still yields ONE winner when several callers break a stale lock at once', async () => {
+    await acquireTickLock(lock);
+    await fs.writeFile(lock, String(Date.now() - (DEFAULT_STALE_MS + 60_000)));
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => acquireTickLock(lock)),
+    );
+    expect(results.filter((r) => r.acquired)).toHaveLength(1);
+  });
+
+  it('honours a custom staleness threshold', async () => {
+    await acquireTickLock(lock);
+    await fs.writeFile(lock, String(Date.now() - 5000));
+    expect((await acquireTickLock(lock, { staleMs: 1000 })).acquired).toBe(true);
+  });
+});
+
+describe('withTickLock', () => {
+  it('runs the body and returns its value', async () => {
+    const r = await withTickLock(lock, async () => 42);
+    expect(r).toEqual({ ran: true, value: 42 });
+  });
+
+  it('releases afterwards so the next tick can run', async () => {
+    await withTickLock(lock, async () => 1);
+    expect((await acquireTickLock(lock)).acquired).toBe(true);
+  });
+
+  // A throwing tick that kept the lock would block every future tick until the
+  // staleness timeout - a 30-minute outage caused by one bug.
+  it('releases even when the body throws, and propagates the error', async () => {
+    await expect(
+      withTickLock(lock, async () => {
+        throw new Error('tick blew up');
+      }),
+    ).rejects.toThrow('tick blew up');
+    expect((await acquireTickLock(lock)).acquired).toBe(true);
+  });
+
+  it('reports a skip rather than throwing when the lock is held', async () => {
+    await acquireTickLock(lock);
+    const r = await withTickLock(lock, async () => 'should not run');
+    expect(r.ran).toBe(false);
+    if (!r.ran) expect(r.reason).toContain('held');
+  });
+
+  it('never runs the body twice under concurrency', async () => {
+    let runs = 0;
+    await Promise.all(
+      Array.from({ length: 15 }, () =>
+        withTickLock(lock, async () => {
+          runs++;
+          await new Promise((r) => setTimeout(r, 5));
+        }),
+      ),
+    );
+    expect(runs).toBe(1);
+  });
+});
+
+// Regression: staleness once compared an injected now() against the filesystem
+// mtime, producing ages like -1786146576072ms. Any caller passing a clock got
+// nonsense. Age must come from the timestamp the lock itself carries.
+describe('clock consistency', () => {
+  it('computes age from its own written timestamp, not the filesystem mtime', async () => {
+    let t = 1_000_000;
+    const clock = () => t;
+    await acquireTickLock(lock, { now: clock });
+    t += 5000;
+    const blocked = await acquireTickLock(lock, { now: clock });
+    expect(blocked.acquired).toBe(false);
+    expect(blocked.heldForMs).toBe(5000);
+  });
+
+  it('breaks a stale lock using the injected clock alone', async () => {
+    let t = 1_000_000;
+    const clock = () => t;
+    await acquireTickLock(lock, { now: clock, staleMs: 10_000 });
+    t += 20_000;
+    expect((await acquireTickLock(lock, { now: clock, staleMs: 10_000 })).acquired).toBe(true);
+  });
+});

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -30,6 +30,7 @@
  */
 
 import { promises as fs } from 'node:fs';
+import { acquireTickLock, releaseTickLock } from './tick-lock';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQuestion } from './questions';
@@ -263,19 +264,18 @@ async function bumpToday(date: string): Promise<void> {
 }
 
 async function acquireLock(): Promise<boolean> {
-  const st = await fs.stat(ORCHESTRATOR_LOCK()).catch(() => null);
-  if (st && Date.now() - st.mtimeMs < LOCK_STALE_MS) return false;
-  await fs.mkdir(join(ORCHESTRATOR_LOCK(), '..'), { recursive: true });
-  await fs.writeFile(ORCHESTRATOR_LOCK(), String(Date.now()));
-  return true;
+  // See tick-lock.ts: the stat-then-write version this replaces was check-then-act
+  // and could let two overlapping ticks both acquire.
+  const r = await acquireTickLock(ORCHESTRATOR_LOCK(), { staleMs: LOCK_STALE_MS });
+  if (!r.acquired && r.reason === 'held') {
+    const held = r.heldForMs !== undefined ? ` (held ${Math.round(r.heldForMs / 1000)}s)` : '';
+    console.log(`[zoe/orchestrator] another tick holds the lock${held} - skipping`);
+  }
+  return r.acquired;
 }
 
 async function releaseLock(): Promise<void> {
-  try {
-    await fs.unlink(ORCHESTRATOR_LOCK());
-  } catch {
-    // best-effort
-  }
+  await releaseTickLock(ORCHESTRATOR_LOCK());
 }
 
 /**

--- a/bot/src/zoe/tick-lock.ts
+++ b/bot/src/zoe/tick-lock.ts
@@ -1,0 +1,165 @@
+/**
+ * tick-lock.ts - an ATOMIC single-instance lock for the autonomous loops.
+ *
+ * THE BUG THIS REPLACES. work-loop.ts and orchestrator-tick.ts each carried their
+ * own copy of:
+ *
+ *     const st = await fs.stat(LOCK).catch(() => null);
+ *     if (st && Date.now() - st.mtimeMs < LOCK_STALE_MS) return false;
+ *     await fs.writeFile(LOCK, String(Date.now()));
+ *     return true;
+ *
+ * That is check-then-act. Two ticks that overlap both stat (each sees no lock, or
+ * the same stale one), both fall through, both write, and BOTH RETURN TRUE. The
+ * window is small but it is exactly the window that matters, because ticks are
+ * started by a cron and by a manual kick that can land on top of each other -
+ * which is how ZOE gets two runs doing the same work, spending twice, and
+ * `agent-loops.md` rule 9 (one instance per resource) is violated by the very
+ * code written to enforce it.
+ *
+ * A guard that looks like a guard but is not one is the worst kind: it stops
+ * anyone from looking again.
+ *
+ * THE FIX. `fs.open(path, 'wx')` is atomic - the kernel either creates the file
+ * or fails with EEXIST, with no window between the two. One winner, always.
+ * Staleness is then handled explicitly and separately, which is also the only
+ * safe way to do it.
+ *
+ * WHAT THIS STILL DOES NOT DO. A filesystem lock is per-machine. It cannot stop
+ * the Mac and the VPS from both running a tick, because they do not share a
+ * filesystem - and Zaal runs loops on a Mac, a VPS, a Pi and a Windows desktop.
+ * The durable answer is the lease layer in packages/heart-fleet, which fences on
+ * a shared Supabase row and is already built, tested, and gated OFF behind
+ * ZOE_HEART_FLEET_CANARY. This module makes the single-machine case correct;
+ * the Heart makes the multi-machine case correct. Both are needed, and this one
+ * needs no migration to land.
+ */
+import { promises as fs } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** How long before a held lock is assumed to belong to a dead process. */
+export const DEFAULT_STALE_MS = 30 * 60 * 1000;
+
+export interface TickLockOptions {
+  staleMs?: number;
+  /** Injected for tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+export interface AcquireResult {
+  acquired: boolean;
+  /** Why it was refused, for an honest log line rather than a silent skip. */
+  reason?: 'held' | 'error';
+  /** Age of the existing lock, when one blocked us. */
+  heldForMs?: number;
+}
+
+
+/**
+ * How long the existing lock has been held, or null if it is gone.
+ *
+ * Prefers the timestamp written into the file so the caller's clock is used on
+ * both sides; falls back to the filesystem mtime when the contents cannot be
+ * read or parsed.
+ */
+async function lockAgeMs(path: string, now: () => number): Promise<number | null> {
+  const raw = await fs.readFile(path, 'utf8').catch(() => null);
+  if (raw !== null) {
+    const written = Number(raw.trim());
+    if (Number.isFinite(written) && written > 0) return now() - written;
+  }
+  const st = await fs.stat(path).catch(() => null);
+  if (!st) return null;
+  return now() - st.mtimeMs;
+}
+
+/**
+ * Try to take the lock. Atomic: exactly one caller can win, even if several race.
+ *
+ * A stale lock is broken and retried ONCE. The retry is deliberately not a loop -
+ * if two processes both decide a lock is stale, the atomic create still lets only
+ * one of them win, and the loser should back off rather than spin.
+ */
+export async function acquireTickLock(
+  path: string,
+  opts: TickLockOptions = {},
+): Promise<AcquireResult> {
+  const staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+  const now = opts.now ?? (() => Date.now());
+
+  const attempt = async (): Promise<AcquireResult | null> => {
+    try {
+      await fs.mkdir(dirname(path), { recursive: true });
+      // 'wx' = create exclusively. EEXIST if it is already there. This is the
+      // whole fix: the check and the create are one kernel operation.
+      const fh = await fs.open(path, 'wx');
+      try {
+        await fh.writeFile(String(now()));
+      } finally {
+        await fh.close();
+      }
+      return { acquired: true };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EEXIST') return null; // someone holds it
+      return { acquired: false, reason: 'error' };
+    }
+  };
+
+  const first = await attempt();
+  if (first) return first;
+
+  // Held. Is it stale?
+  //
+  // Age comes from the timestamp written INSIDE the lock, not from the file's
+  // mtime. The two are not interchangeable: mtime is always real wall-clock,
+  // while now() is injectable, so comparing them mixes clocks and yields a
+  // meaningless age - a test caught this by getting -1786146576072ms, and the
+  // same corruption would hit any caller that passed a custom clock. Reading our
+  // own written value keeps one clock on both sides.
+  //
+  // mtime remains the fallback for a lock whose contents are missing or
+  // unparseable, which also covers locks written by the previous implementation
+  // (it wrote String(Date.now()), the same format).
+  const age = await lockAgeMs(path, now);
+  if (age === null) {
+    // Released between our create and our read - race again, once.
+    return (await attempt()) ?? { acquired: false, reason: 'held' };
+  }
+  if (age < staleMs) return { acquired: false, reason: 'held', heldForMs: age };
+
+  // Stale: the holder is presumed dead. Remove and retry exactly once. If another
+  // process breaks it at the same moment, the atomic create still picks one
+  // winner - the loser simply skips this tick, which is the correct outcome.
+  await fs.unlink(path).catch(() => {});
+  return (await attempt()) ?? { acquired: false, reason: 'held', heldForMs: age };
+}
+
+/** Release the lock. Best-effort: a failure here must never break a finished tick. */
+export async function releaseTickLock(path: string): Promise<void> {
+  await fs.unlink(path).catch(() => {});
+}
+
+/**
+ * Run `fn` holding the lock, releasing it even if `fn` throws.
+ *
+ * Returns `{ ran: false }` when the lock was not available - a skipped tick is a
+ * normal, expected outcome, not an error, so it is reported rather than thrown.
+ */
+export async function withTickLock<T>(
+  path: string,
+  fn: () => Promise<T>,
+  opts: TickLockOptions = {},
+): Promise<{ ran: true; value: T } | { ran: false; reason: string }> {
+  const got = await acquireTickLock(path, opts);
+  if (!got.acquired) {
+    const held = got.heldForMs !== undefined ? ` (held ${Math.round(got.heldForMs / 1000)}s)` : '';
+    return { ran: false, reason: `${got.reason ?? 'held'}${held}` };
+  }
+  try {
+    return { ran: true, value: await fn() };
+  } finally {
+    // finally, not after: a throwing tick that keeps the lock would block every
+    // future tick until the staleness timeout - a 30-minute outage from one bug.
+    await releaseTickLock(path);
+  }
+}

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -17,6 +17,7 @@
  *  - the watcher (watcher.ts) independently flags cost/quality anomalies.
  */
 import { promises as fs } from 'node:fs';
+import { acquireTickLock, releaseTickLock } from './tick-lock';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { DecompositionPlan } from './decompose';
@@ -120,20 +121,22 @@ async function bumpToday(date: string): Promise<void> {
   await fs.writeFile(COUNTER(), JSON.stringify({ date, n }));
 }
 
+// Lock acquisition moved to tick-lock.ts. The version that lived here was
+// stat-then-write, which is check-then-act: two overlapping ticks could both see
+// a free lock and both proceed. tick-lock uses an atomic exclusive create, so
+// exactly one caller ever wins - which is what agent-loops rule 9 (one instance
+// per resource) actually requires.
 async function acquireLock(): Promise<boolean> {
-  const st = await fs.stat(LOCK()).catch(() => null);
-  if (st && Date.now() - st.mtimeMs < LOCK_STALE_MS) return false;
-  await fs.mkdir(dir(), { recursive: true });
-  await fs.writeFile(LOCK(), String(Date.now()));
-  return true;
+  const r = await acquireTickLock(LOCK(), { staleMs: LOCK_STALE_MS });
+  if (!r.acquired && r.reason === 'held') {
+    const held = r.heldForMs !== undefined ? ` (held ${Math.round(r.heldForMs / 1000)}s)` : '';
+    console.log(`[zoe/work-loop] another tick holds the lock${held} - skipping`);
+  }
+  return r.acquired;
 }
 
 async function releaseLock(): Promise<void> {
-  try {
-    await fs.unlink(LOCK());
-  } catch {
-    /* best-effort */
-  }
+  await releaseTickLock(LOCK());
 }
 
 /** Run one queued research item through the existing pipeline. Safe to call on a cron. */


### PR DESCRIPTION
Swarm upgrade - and the honest first step was reading what the swarm actually uses to coordinate.

**Both autonomous loops carried their own copy of this:**

```js
const st = await fs.stat(LOCK).catch(() => null);
if (st && Date.now() - st.mtimeMs < LOCK_STALE_MS) return false;
await fs.writeFile(LOCK, String(Date.now()));
return true;
```

**That's check-then-act.** Two overlapping ticks both `stat`, both see a free or stale lock, both fall through, both write, and **both return true.**

The window is small but it's precisely the window that occurs - a tick can be started by cron *and* by a manual kick landing on top of it. That's how ZOE ends up with two runs doing the same work and spending twice.

`agent-loops` rule 9 (*one instance per resource*) was being violated by the code written to enforce it. **A guard that looks like a guard but isn't is the worst kind - it stops anyone from looking again.**

## The fix

`fs.open(path, 'wx')` - the kernel either creates the file or fails `EEXIST`, with **no window between**. One winner, always. Both loops now share `tick-lock.ts` instead of each carrying a subtly-wrong copy.

## A test caught a second bug in my own fix

Staleness first compared the injectable `now()` against the **filesystem mtime** - two different clocks - producing an age of **-1,786,146,576,072ms**. Any caller passing a custom clock got nonsense, and a negative age reads as "not stale" *forever*.

Age now comes from the timestamp the lock itself carries, so one clock is used on both sides. mtime remains the fallback, which also covers locks written by the old code (same format).

`withTickLock` releases in a **`finally`** - a throwing tick that kept the lock would block every later tick until the 30-minute staleness timeout. One bug becoming a half-hour outage.

## What this does NOT fix, stated plainly

**A filesystem lock is per-machine.** It cannot stop the Mac and the VPS from both running a tick - and you run loops on a Mac, a VPS, a Pi and a Windows desktop.

The durable answer is the lease layer in `packages/heart-fleet`, which fences on a shared Supabase row. It's **already built and tested**, gated OFF behind `ZOE_HEART_FLEET_CANARY` with a canary as its only consumer. This PR makes the single-machine case correct today with no migration; the Heart makes the multi-machine case correct when that flag goes on.

## Verified

- **16 new tests** - including a **25-way concurrent race asserting exactly one winner**, a stale-break race asserting the same, and a regression for the mixed-clock bug
- Non-test source at **zero** type errors
- **esbuild bundles the boot graph**
- Bot suite **2,023 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
