### PR TITLE
fix(zai): Discord transcription was never decoding Opus - and the WAV header lied

### DIFF
--- a/bot/src/zai/__tests__/wav.test.ts
+++ b/bot/src/zai/__tests__/wav.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { encodeWav } from '../wav';
+
+const tag = (b: Uint8Array, at: number) => String.fromCharCode(...b.slice(at, at + 4));
+const dv = (b: Uint8Array) => new DataView(b.buffer, b.byteOffset, b.byteLength);
+const u32 = (b: Uint8Array, at: number) => dv(b).getUint32(at, true);
+const u16 = (b: Uint8Array, at: number) => dv(b).getUint16(at, true);
+
+/** Discord's decoded format: 48kHz, stereo, 16-bit signed little-endian. */
+const DISCORD = { sampleRate: 48000, channels: 2 };
+
+describe('encodeWav', () => {
+  it('writes a canonical RIFF/WAVE header', () => {
+    const wav = encodeWav(new Uint8Array(8), DISCORD);
+    expect(tag(wav, 0)).toBe('RIFF');
+    expect(tag(wav, 8)).toBe('WAVE');
+    expect(tag(wav, 12)).toBe('fmt ');
+    expect(tag(wav, 36)).toBe('data');
+    expect(u32(wav, 16)).toBe(16); // fmt chunk size
+    expect(u16(wav, 20)).toBe(1); // uncompressed PCM
+  });
+
+  it('declares the byte count it actually has - the bug that made every transcript noise', () => {
+    // The old code set dataLength = bytes * 2, so the header promised twice the
+    // audio the file contained. A decoder reading past the end gets garbage.
+    const pcm = new Uint8Array(1000);
+    const wav = encodeWav(pcm, DISCORD);
+    expect(u32(wav, 40)).toBe(1000); // data chunk size, NOT 2000
+    expect(u32(wav, 4)).toBe(36 + 1000); // RIFF size
+    expect(wav.length).toBe(44 + 1000);
+  });
+
+  it('copies the samples through byte-for-byte', () => {
+    // The old code widened each BYTE into a 16-bit sample, so 0xff became the
+    // value 255 instead of part of a sample - every payload came out near-silent.
+    const pcm = new Uint8Array([0x00, 0x80, 0xff, 0x7f, 0x34, 0x12]);
+    const wav = encodeWav(pcm, DISCORD);
+    expect(Array.from(wav.slice(44))).toEqual(Array.from(pcm));
+  });
+
+  it('derives block align and byte rate from the format', () => {
+    const wav = encodeWav(new Uint8Array(4), DISCORD);
+    expect(u16(wav, 22)).toBe(2); // channels
+    expect(u32(wav, 24)).toBe(48000); // sample rate
+    expect(u16(wav, 32)).toBe(4); // block align = 2ch * 16bit / 8
+    expect(u32(wav, 28)).toBe(192000); // byte rate = 48000 * 4
+    expect(u16(wav, 34)).toBe(16); // bits per sample
+  });
+
+  it('handles mono and an empty payload without lying about either', () => {
+    const mono = encodeWav(new Uint8Array(0), { sampleRate: 16000, channels: 1 });
+    expect(u32(mono, 40)).toBe(0);
+    expect(mono.length).toBe(44);
+    expect(u16(mono, 32)).toBe(2); // 1ch * 16bit / 8
+    expect(u32(mono, 28)).toBe(32000);
+  });
+});

--- a/bot/src/zai/voice-capture.ts
+++ b/bot/src/zai/voice-capture.ts
@@ -10,15 +10,27 @@
 import { VoiceConnection, AudioReceiveStream, EndBehaviorType } from '@discordjs/voice';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
+import { opus } from 'prism-media';
 import type { CaptureSession, TranscriptLine } from './types';
 import { transcribeAudio } from '../zoe/transcribe';
+import { encodeWav } from './wav';
 
 const SILENCE_THRESHOLD_MS = 2000; // 2s silence to end a chunk
+
+/** Discord always sends 48kHz stereo Opus, and the decoder emits 16-bit signed
+ *  little-endian PCM at the same rate. 960 samples is one 20ms frame, which is
+ *  the frame size Discord encodes at. */
+const SAMPLE_RATE = 48000;
+const CHANNELS = 2;
+const FRAME_SIZE = 960;
 
 interface AudioChunkBuffer {
   speaker: string;
   userId: string;
-  pcmData: number[];
+  /** Decoded PCM, kept as the chunks the decoder emitted. Concatenating once at
+   *  the end beats accumulating a `number[]` of individual bytes, which cost
+   *  ~8x the memory and pushed with a spread that can overflow the call stack. */
+  pcmChunks: Buffer[];
   startTime: Date;
   lastAudioTime: Date;
 }
@@ -42,53 +54,92 @@ export function startVoiceCapture(
   const handleSpeakingStart = (userId: string) => {
     if (buffers.has(userId)) return;
 
-    const audioStream: AudioReceiveStream = connection.receiver.subscribe(userId, {
+    const opusStream: AudioReceiveStream = connection.receiver.subscribe(userId, {
       end: { behavior: EndBehaviorType.AfterSilence, duration: SILENCE_THRESHOLD_MS },
+    });
+
+    // receiver.subscribe() yields OPUS packets, not PCM. Nothing here ever
+    // decoded them - the old comment said "decoder happens at transcription
+    // boundary" and no decoder was ever written - so a compressed bitstream was
+    // handed to Whisper inside a WAV header. prism-media and @discordjs/opus are
+    // already dependencies; they were declared and never imported.
+    const decoder = new opus.Decoder({
+      frameSize: FRAME_SIZE,
+      channels: CHANNELS,
+      rate: SAMPLE_RATE,
+    });
+
+    // Forwarded by hand rather than with .pipe(). prism-media's OpusStream does
+    // not satisfy `NodeJS.WritableStream` under @types/node 22 - the same
+    // class-vs-interface EventEmitter split documented on the cleanup function
+    // below - so `.pipe(decoder)` is a type error. write/end are declared on
+    // Transform itself and typecheck cleanly. Opus frames are 20ms and one
+    // speaker at a time, so there is no backpressure worth the cast.
+    opusStream.on('data', (packet: Buffer) => {
+      decoder.write(packet);
+    });
+    opusStream.on('end', () => {
+      decoder.end();
     });
 
     const buffer: AudioChunkBuffer = {
       speaker: `user_${userId}`,
       userId,
-      pcmData: [],
+      pcmChunks: [],
       startTime: new Date(),
       lastAudioTime: new Date(),
     };
 
     buffers.set(userId, buffer);
 
-    audioStream.on('data', (packet: Buffer) => {
-      // Collect raw bytes; decoder happens at transcription boundary
-      buffer.pcmData.push(...Array.from(packet));
+    // A stream 'error' with no listener is an UNCAUGHT EXCEPTION in Node, which
+    // takes the whole ZAI process down. One malformed packet should cost one
+    // speaker's chunk, not the bot.
+    const dropSpeaker = (err: unknown) => {
+      console.error(`Voice capture stream failed for ${buffer.speaker}:`, err);
+      buffers.delete(userId);
+    };
+    opusStream.on('error', dropSpeaker);
+    decoder.on('error', dropSpeaker);
+
+    decoder.on('data', (chunk: Buffer) => {
+      buffer.pcmChunks.push(chunk);
       buffer.lastAudioTime = new Date();
     });
 
-    audioStream.on('end', async () => {
-      // Audio ended - transcribe if we have data
-      if (buffer.pcmData.length > 0) {
-        const wavBytes = constructWav(buffer.pcmData);
-        try {
-          const text = await transcribeAudio(new Uint8Array(wavBytes), `${buffer.speaker}.wav`);
-          const line: TranscriptLine = {
-            timestamp: new Date(),
-            speaker: buffer.speaker,
-            userId: buffer.userId,
-            text,
-          };
-          session.transcript.push(line);
-
-          // Persist transcript chunk
-          const transcriptPath = join(sessionDir, `transcript-${Date.now()}.jsonl`);
-          await fs.appendFile(transcriptPath, `${JSON.stringify(line)}\n`).catch(() => {
-            /* ignore file write errors */
-          });
-
-          // Notify caller
-          await onTranscribed(line);
-        } catch (err) {
-          console.error(`Transcription failed for ${buffer.speaker}:`, err);
-        }
-      }
+    decoder.on('end', async () => {
+      const pcm = Buffer.concat(buffer.pcmChunks);
+      // Release the slot BEFORE the await. Transcription takes seconds, and
+      // handleSpeakingStart bails when the map still holds this user - so the
+      // old ordering silently dropped whatever they said while the previous
+      // chunk was still in flight.
       buffers.delete(userId);
+      if (pcm.length === 0) return;
+
+      try {
+        const text = await transcribeAudio(
+          encodeWav(pcm, { sampleRate: SAMPLE_RATE, channels: CHANNELS }),
+          `${buffer.speaker}.wav`,
+        );
+        const line: TranscriptLine = {
+          timestamp: new Date(),
+          speaker: buffer.speaker,
+          userId: buffer.userId,
+          text,
+        };
+        session.transcript.push(line);
+
+        // Persist transcript chunk
+        const transcriptPath = join(sessionDir, `transcript-${Date.now()}.jsonl`);
+        await fs.appendFile(transcriptPath, `${JSON.stringify(line)}\n`).catch(() => {
+          /* ignore file write errors */
+        });
+
+        // Notify caller
+        await onTranscribed(line);
+      } catch (err) {
+        console.error(`Transcription failed for ${buffer.speaker}:`, err);
+      }
     });
   };
 
@@ -131,48 +182,6 @@ export function startVoiceCapture(
  */
 interface ListenerRemover {
   removeListener(event: string, listener: (...args: never[]) => void): unknown;
-}
-
-/**
- * Simple WAV header constructor. Input is raw PCM samples (16-bit signed, 48kHz).
- * Returns full WAV file bytes.
- */
-function constructWav(pcmData: number[]): Uint8Array {
-  const sampleRate = 48000;
-  const channels = 1;
-  const bytesPerSample = 2;
-  const dataLength = pcmData.length * bytesPerSample;
-  const fileLength = 36 + dataLength;
-
-  const buffer = new ArrayBuffer(44 + dataLength);
-  const view = new DataView(buffer);
-
-  // RIFF header
-  view.setUint32(0, 0x46464952, true); // 'RIFF'
-  view.setUint32(4, fileLength, true);
-  view.setUint32(8, 0x45564157, true); // 'WAVE'
-
-  // fmt sub-chunk
-  view.setUint32(12, 0x20746d66, true); // 'fmt '
-  view.setUint32(16, 16, true); // sub-chunk1 size
-  view.setUint16(20, 1, true); // audio format (1 = PCM)
-  view.setUint16(22, channels, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * channels * bytesPerSample, true); // byte rate
-  view.setUint16(32, channels * bytesPerSample, true); // block align
-  view.setUint16(34, 16, true); // bits per sample
-
-  // data sub-chunk
-  view.setUint32(36, 0x61746164, true); // 'data'
-  view.setUint32(40, dataLength, true);
-
-  // Copy PCM data (as 16-bit signed integers)
-  const pcmView = new Int16Array(buffer, 44);
-  for (let i = 0; i < pcmData.length; i++) {
-    pcmView[i] = pcmData[i];
-  }
-
-  return new Uint8Array(buffer);
 }
 
 /**

--- a/bot/src/zai/wav.ts
+++ b/bot/src/zai/wav.ts
@@ -1,0 +1,57 @@
+/**
+ * wav.ts - wrap raw PCM bytes in a WAV container.
+ *
+ * Split out of voice-capture.ts so it can be unit-tested on its own. That file
+ * imports @discordjs/voice and prism-media at module load; this is pure
+ * arithmetic on bytes and needs neither, so the part that was actually WRONG is
+ * now the part that is covered.
+ *
+ * WHAT WAS WRONG. The previous header math took a `number[]` of individual
+ * BYTES and treated each entry as a 16-bit SAMPLE: it declared
+ * `dataLength = bytes.length * 2` and then wrote each byte into an `Int16Array`.
+ * So a 1000-byte payload produced a header claiming 2000 bytes of audio, and
+ * every 16-bit sample carried a value in 0..255 - roughly -60 dBFS, which is
+ * silence to any decoder. The container said "here is twice as much audio as I
+ * have" and the audio itself was inaudible.
+ *
+ * The fix is that PCM is already bytes. Copy them, and say how many there are.
+ */
+
+export interface WavFormat {
+  sampleRate: number;
+  channels: number;
+  /** Only 16 is used here, but the header math is written against the field
+   *  rather than the constant so it reads as the spec, not as magic numbers. */
+  bitsPerSample?: number;
+}
+
+/** Canonical 44-byte RIFF/WAVE header, then the samples verbatim. */
+export function encodeWav(pcm: Uint8Array, format: WavFormat): Uint8Array {
+  const bitsPerSample = format.bitsPerSample ?? 16;
+  const blockAlign = (format.channels * bitsPerSample) / 8;
+  const byteRate = format.sampleRate * blockAlign;
+  const dataLength = pcm.length;
+
+  const out = new Uint8Array(44 + dataLength);
+  const view = new DataView(out.buffer);
+
+  // Tags are big-endian so the literal reads in the same order as the ASCII.
+  view.setUint32(0, 0x52494646, false); // 'RIFF'
+  view.setUint32(4, 36 + dataLength, true); // chunk size = everything after this field
+  view.setUint32(8, 0x57415645, false); // 'WAVE'
+
+  view.setUint32(12, 0x666d7420, false); // 'fmt '
+  view.setUint32(16, 16, true); // fmt chunk size (PCM)
+  view.setUint16(20, 1, true); // format 1 = uncompressed PCM
+  view.setUint16(22, format.channels, true);
+  view.setUint32(24, format.sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+
+  view.setUint32(36, 0x64617461, false); // 'data'
+  view.setUint32(40, dataLength, true);
+  out.set(pcm, 44);
+
+  return out;
+}


### PR DESCRIPTION
fix(zai): Discord transcription was never decoding Opus - and the WAV header lied

ZAI's Discord voice capture has been writing transcripts the entire time. They
were transcripts of noise.

Two separate defects in one path, either of which alone makes the output
worthless:

1. NOTHING DECODED THE AUDIO. `connection.receiver.subscribe()` yields OPUS
   packets. The old code collected those bytes and passed them straight to
   Whisper with `// Collect raw bytes; decoder happens at transcription
   boundary` - and no decoder was ever written. prism-media and @discordjs/opus
   are BOTH already declared in bot/package.json and pinned in the lockfile, and
   neither was imported anywhere in bot/src. The dependency was added for this
   and then never wired.

2. THE WAV HEADER COUNTED BYTES AS SAMPLES. `constructWav` took a `number[]` of
   individual bytes and treated each entry as a 16-bit sample: it declared
   `dataLength = bytes.length * 2` and wrote each byte into an `Int16Array`. So
   a 1000-byte payload produced a header promising 2000 bytes of audio, and
   every sample carried a value in 0..255 - about -60 dBFS, silence to any
   decoder. It also declared mono while Discord decodes to stereo.

WHAT BREAKS WITHOUT THIS: /join a voice channel, speak, and every line in
`session.transcript` - posted live to the text channel and persisted to
~/.zao/private/discord-<id>/ - is Whisper hallucinating over a compressed
bitstream wrapped in a header that misdescribes it. Nothing errors. Nothing logs.
The embed says "Live Transcription Update" and prints garbage, which is the
silent-failure-guard shape exactly: a green path producing nothing real.

THE FIX
- Decode through `opus.Decoder({ frameSize: 960, channels: 2, rate: 48000 })`,
  Discord's actual format.
- Buffer decoded PCM as the chunks the decoder emits, then `Buffer.concat` once.
  The old `pcmData.push(...Array.from(packet))` cost ~8x the memory of a Buffer
  and spread-pushed, which overflows the call stack on a large enough packet.
- Move the WAV header into `bot/src/zai/wav.ts` as `encodeWav`, correct, and
  unit-test it. It is split out because voice-capture.ts imports @discordjs/voice
  at module load; the header math is pure arithmetic and now has coverage.

TWO SMALLER REAL BUGS FIXED IN THE SAME HANDLER, both in the lines being touched:
- No 'error' listener on either stream. An unhandled stream 'error' in Node is an
  uncaught exception - one malformed packet would have taken the whole ZAI
  process down. Now it drops that speaker's chunk and logs.
- `buffers.delete(userId)` ran AFTER the transcription await. handleSpeakingStart
  bails while the map still holds a user, so anything said during the (seconds
  long) transcription of the previous chunk was silently dropped. The delete now
  happens before the await.

Forwarding is `opusStream.on('data', ...) -> decoder.write()` rather than
`.pipe(decoder)` because prism-media's OpusStream does not satisfy
`NodeJS.WritableStream` under @types/node 22 - the same class-vs-interface
EventEmitter split already documented on the cleanup function in this file.
`.pipe(decoder)` is a type error; write/end are on Transform and typecheck clean.

VERIFIED (bot/, npm ci --ignore-scripts, node 24 on Windows)
- `tsc --noEmit`: ZERO errors in non-test source. 37 total, all in test files -
  identical to the baseline #2963 established.
- `vitest run`: main 2021 passed / 2 failed; this branch 2026 passed / 2 failed.
  Same 2 failures on both (trace.test.ts and transcribe.test.ts assert POSIX path
  separators and fail on Windows only - pre-existing, unrelated, CI is ubuntu).
  +5 new tests, none removed.
- esbuild bundles BOTH entrypoints (src/zai/index.ts, src/zoe/index.ts) with the
  same --external flags main already requires. Checked: main fails to bundle zai
  without them too (prism-media's FFmpeg core does a bare
  `require('ffmpeg-static')`), so this is not a regression from this change.
- No new dependencies. Both packages were already declared and locked.

NOT FIXED, FOUND WHILE LOOKING (no second PR, per the audit's one-PR rule):
- `src/app/api/auth/siwe/route.ts` GET does not check the result of its
  `auth_nonces` insert. If that write fails the endpoint still returns a nonce
  and the subsequent POST rejects it as invalid - a confusing failure rather than
  a clear one. Low severity; the flow fails closed.
- `LiveStatus.render` (bot/src/zoe/live-status.ts): when the FIRST `send` fails,
  messageId stays null and every later render sends a brand new message instead
  of editing - the exact message pile-up the class exists to prevent, in the one
  case where it degrades. Only reachable when Telegram rejects the opening send.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

