### PR TITLE
fix(scripts): gen-surface-map wrote Windows paths into a URL map, then crashed

### DIFF
--- a/scripts/agents/gen-surface-map.py
+++ b/scripts/agents/gen-surface-map.py
@@ -26,6 +26,17 @@ That combination is what `review` flags.
 
 `auth` remains INFERRED FROM SOURCE TEXT. It is a strong hint and an audit
 starting point, never a proof. Read the handler before you trust the label.
+
+ROUTE PATHS ARE ALWAYS POSIX, ON EVERY OS (the 2026-08-07 Windows fix)
+----------------------------------------------------------------------
+A URL path is not a filesystem path. Building one out of os.sep meant that
+running this script on Windows - now one of the always-on machines - wrote all
+324 routes as `\\api\\...`, which is not a URL and breaks every link in
+/surface. The `/cron/` fallback in auth_of() also cannot match a backslash path;
+today that changes no label (all 14 cron routes are caught earlier by their
+CRON_SECRET marker), but a cron route without that marker would silently be
+labelled `public`. The separator is normalised once, where the relative path is
+built, and everything downstream consumes that one posix string.
 """
 import json
 import os
@@ -34,7 +45,8 @@ import subprocess
 import sys
 
 ROOT = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], text=True).strip()
-API = os.path.join(ROOT, 'src', 'app', 'api')
+APP = os.path.join(ROOT, 'src', 'app')
+API = os.path.join(APP, 'api')
 OUT = os.path.join(ROOT, 'src', 'lib', 'surface-map.ts')
 SUFFIX_LEN = len('/route.ts')  # 9. Getting this wrong silently truncates every path.
 
@@ -112,10 +124,14 @@ def main():
             src = open(p, encoding='utf-8', errors='ignore').read()
         except OSError:
             continue
-        rel = p.replace(os.path.join(ROOT, 'src', 'app'), '')[:-SUFFIX_LEN]
+        # A URL path, not a filesystem path: posix separators on every OS.
+        rel = '/' + os.path.relpath(p, APP).replace(os.sep, '/')
+        rel = rel[:-SUFFIX_LEN]
         methods = [m for m in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')
                    if re.search(rf'export async function {m}\b', src)]
-        auth = auth_of(src, p)
+        # The route path, never the filesystem path - auth_of()'s `/cron/` test
+        # only matches a posix URL path.
+        auth = auth_of(src, rel)
         service_role = any(m in src for m in SERVICE_ROLE_MARKERS)
         rate_limited = any(m in src for m in RATELIMIT_MARKERS)
         # The one combination worth a human's eyes: no gate at all, yet holding a
@@ -164,11 +180,34 @@ export interface RouteEntry {{
 export const GENERATED_AT = '{stamp}';
 export const ROUTES: RouteEntry[] = {json.dumps(routes, indent=2)};
 """
-    open(OUT, 'w').write(body)
+    # LF and utf-8 explicitly: text mode on Windows would write CRLF and make
+    # every line of a 300-route file show up as changed.
+    with open(OUT, 'w', encoding='utf-8', newline='\n') as fh:
+        fh.write(body)
     # Format with the repo's own formatter so a regeneration never shows up as a
     # lint failure - the generator has to agree with biome, not fight it.
-    subprocess.run(['npx', 'biome', 'format', '--write', OUT],
-                   cwd=ROOT, capture_output=True)
+    #
+    # Two things went wrong with the old `npx biome ...` call:
+    #
+    #  1. npx is a .cmd on Windows, which CreateProcess will not run without a
+    #     shell, so it raised FileNotFoundError AFTER the file was written - a
+    #     traceback on top of a half-done job.
+    #  2. With node_modules absent, `npx biome` does not fail. It fetches the
+    #     unrelated public package named `biome` (0.3.3, not @biomejs/biome) and
+    #     runs THAT - exit 0, no formatting, and a stranger's code executed.
+    #
+    # So: run the repo's own installed binary by path, and if it is not there,
+    # say so instead of reaching for whatever the registry hands back.
+    bin_dir = os.path.join(ROOT, 'node_modules', '.bin')
+    biome = os.path.join(bin_dir, 'biome.cmd' if sys.platform == 'win32' else 'biome')
+    if os.path.exists(biome):
+        fmt = subprocess.run([biome, 'format', '--write', OUT], cwd=ROOT, capture_output=True)
+        if fmt.returncode != 0:
+            print(f'  WARNING: biome format exited {fmt.returncode} - '
+                  'the file is written but unformatted')
+    else:
+        print('  WARNING: @biomejs/biome is not installed (run `npm install`); '
+              'the file is written but UNFORMATTED - format it before committing')
 
     by_auth = {}
     for r in routes:


### PR DESCRIPTION
## Executive Summary

`scripts/agents/gen-surface-map.py` regenerates `src/lib/surface-map.ts`, the
route map behind `/surface` and doc 2245. Repo convention says to run it in the
same PR as any route change. On Windows - now one of the always-on machines -
that command corrupts the file it maintains and then exits 1 with a traceback.

This is a three-line-of-cause fix in that one script. Nothing else changes.

## What breaks without the fix (measured on this Windows box)

Run `python scripts/agents/gen-surface-map.py` on Windows today:

- **All 324 route paths come out as `\api\100ms\rooms`, not `/api/100ms/rooms`.**
  The URL path was built from a filesystem path, so `os.sep` came along.
  `/surface` renders those as links; a backslash path is not a URL.
- **The script exits 1 with a `FileNotFoundError` traceback** - `npx` is a `.cmd`
  on Windows and `CreateProcess` will not run it without a shell. The traceback
  lands *after* the file is written, so you get a crash on top of a corrupt file.
- Anyone who does not notice and commits it ships a broken route explorer.

Two more defects found while fixing it:

- **`auth_of()`'s `/cron/` fallback cannot match a backslash path.** Today no
  label actually moves - all 14 cron routes are caught earlier by their
  `CRON_SECRET` marker - so this is latent, not live. But a cron route that
  lacked that marker would be labelled `public` on Windows and `cron` on Linux:
  the same input producing two different security labels. Graded low because it
  changes nothing today; fixed because a guard fallback that silently does not
  run is exactly the shape of `silent-failure-guard.md`.
- **`npx biome` with no `node_modules` runs a stranger's package.** It does not
  fail - it fetches the unrelated public npm package named `biome` (0.3.3; the
  repo's formatter is `@biomejs/biome` 2.4.12), executes it, formats nothing, and
  exits 0. Verified here: `npx biome --version` prints `0.3.3`.

## The fix

- Normalise the separator once, where the relative path is built
  (`os.path.relpath(...).replace(os.sep, '/')`), and feed that one posix string
  to everything downstream, including `auth_of`.
- Write with explicit `encoding='utf-8', newline='\n'` so Windows text mode does
  not turn a regeneration into a whole-file CRLF diff.
- Run the repo's own `node_modules/.bin/biome` by path. If it is missing, print a
  loud warning and leave the file unformatted - never reach for whatever the
  registry hands back under that name.

## Evidence

**Proven.** On this Windows machine, the fixed generator followed by
`biome format` reproduces the committed, Linux-generated `src/lib/surface-map.ts`
**byte-for-byte** - `git diff` on that file is empty. Same counts as committed:
324 routes; `admin=68 cron=14 public=28 session=202 signed=10 token=2`; 0 needing
review; 3 reviewed-and-intentional. Exit 0, no traceback.

`src/lib/surface-map.ts` is deliberately **not** in this diff - the fixed script
reproduces it exactly, which is the proof.

Also run this audit pass:
- `bot` suite: 2021 passing, 161 files. The 2 failures are the known Windows
  path-separator assertions in `trace.test.ts` and `transcribe.test.ts` -
  untouched by this PR (see below).
- `bot` typecheck: **zero** errors in non-test source. All 40 remaining errors are
  in `__tests__` files.

**Not tested:** the Linux path. The change is separator-normalisation, which is a
no-op where `os.sep == '/'`, and CI regenerates on Linux.

## Other things this hour's audit found and did NOT fix (one PR, per the rules)

1. **2 permanently failing tests on Windows.** `src/zoe/__tests__/trace.test.ts:60`
   and `src/zoe/__tests__/transcribe.test.ts:187` assert `toContain('/traces/...')`
   and `toContain('/tmp/zoe-files')` against `path.join` output. Green on Linux,
   red forever on the desktop. Two permanently-red tests are exactly the
   `noisy-signal-guard.md` failure: nobody reads a suite that is never green.
   Fix is `toContain(path.join(...))` in both.
2. **`npx biome` is the documented convention repo-wide** (`CLAUDE.md`,
   `AGENTS.md`, `CONTRIBUTING.md`, `packages/*/CLAUDE.md`). Every one of those has
   the same registry-substitution hazard when `node_modules` is absent. Worth a
   sweep to `npx @biomejs/biome` or `npm run lint:biome`.

Neither is in this diff.

## Scope

One file, 45 insertions, 6 deletions. No route, no handler, no dependency, no
config touched. Safe to read in five minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
