### PR TITLE
fix(bus): make the reply instruction in every bus message actually work

### DIFF
--- a/bot/src/zoe/__tests__/bus-send.test.ts
+++ b/bot/src/zoe/__tests__/bus-send.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { parseBusReply } from '../bus-bridge';
+import { busConfigured, replySubject, sendBusReply } from '../bus-send';
+
+const CFG = { url: 'https://bus.example/bus', token: 't0k' };
+const ok = (json: unknown = { id: 'abcdef123456' }) =>
+  vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => json }) as unknown as typeof fetch;
+
+describe('busConfigured', () => {
+  it('needs BOTH url and token', () => {
+    expect(busConfigured({ url: 'x', token: 'y' })).toBe(true);
+    expect(busConfigured({ url: 'x' })).toBe(false);
+    expect(busConfigured({ token: 'y' })).toBe(false);
+    expect(busConfigured({})).toBe(false);
+  });
+});
+
+describe('sendBusReply - unconfigured', () => {
+  // The live host has no BUS_URL/BUS_TOKEN today, so this is the path that
+  // actually runs. It must never claim success and never swallow the text.
+  it('does not pretend it sent', async () => {
+    const r = await sendBusReply({ to: 'coordinator', subject: 'Re: x', body: 'shipping today' }, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('unconfigured');
+    expect(r.reply).toContain('did not send');
+  });
+
+  it('shows what it WOULD have sent, so the thinking is not wasted', async () => {
+    const r = await sendBusReply({ to: 'coordinator', subject: 'Re: x', body: 'the full reply text' }, {});
+    expect(r.reply).toContain('the full reply text');
+    expect(r.reply).toContain('coordinator');
+  });
+
+  it('names the exact missing thing', async () => {
+    const r = await sendBusReply({ to: 'c', subject: 's', body: 'b' }, {});
+    expect(r.reply).toContain('BUS_URL');
+    expect(r.reply).toContain('BUS_TOKEN');
+  });
+
+  it('never calls fetch when unconfigured', async () => {
+    const f = ok();
+    await sendBusReply({ to: 'c', subject: 's', body: 'b' }, {}, f);
+    expect(f).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendBusReply - configured', () => {
+  it('posts to /send with a bearer token', async () => {
+    const f = ok();
+    const r = await sendBusReply({ to: 'coordinator', subject: 'Re: bus', body: 'yes please' }, CFG, f);
+    expect(r.ok).toBe(true);
+    const [url, init] = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://bus.example/bus/send');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer t0k');
+    expect(JSON.parse(init.body as string)).toMatchObject({ to: 'coordinator', body: 'yes please' });
+  });
+
+  it('tolerates a trailing slash on the url', async () => {
+    const f = ok();
+    await sendBusReply({ to: 'c', subject: 's', body: 'b' }, { ...CFG, url: 'https://bus.example/bus/' }, f);
+    expect((f as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('https://bus.example/bus/send');
+  });
+
+  it('confirms with the id so the send is checkable', async () => {
+    const r = await sendBusReply({ to: 'coordinator', subject: 's', body: 'b' }, CFG, ok());
+    expect(r.reply).toContain('Sent to coordinator');
+    expect(r.reply).toContain('abcdef12');
+  });
+
+  // A failure must keep his words. Losing a typed reply is the one unforgivable
+  // outcome - he wrote it on a phone.
+  it('reports an HTTP failure and reassures the text is safe', async () => {
+    const f = vi.fn().mockResolvedValue({ ok: false, status: 503 }) as unknown as typeof fetch;
+    const r = await sendBusReply({ to: 'c', subject: 's', body: 'b' }, CFG, f);
+    expect(r.ok).toBe(false);
+    expect(r.reply).toContain('503');
+    expect(r.reply).toContain('safe');
+  });
+
+  it('reports a network failure without throwing', async () => {
+    const f = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    const r = await sendBusReply({ to: 'c', subject: 's', body: 'b' }, CFG, f);
+    expect(r.ok).toBe(false);
+    expect(r.reply).toContain('ECONNREFUSED');
+    expect(r.reply).toContain('safe');
+  });
+
+  it('refuses an empty body', async () => {
+    const f = ok();
+    const r = await sendBusReply({ to: 'c', subject: 's', body: '   ' }, CFG, f);
+    expect(r.ok).toBe(false);
+    expect(f).not.toHaveBeenCalled();
+  });
+});
+
+describe('replySubject', () => {
+  it('prefixes Re: once and only once', () => {
+    expect(replySubject('How we built the bus')).toBe('Re: How we built the bus');
+    expect(replySubject('Re: How we built the bus')).toBe('Re: How we built the bus');
+    expect(replySubject('RE: shouting')).toBe('RE: shouting');
+  });
+
+  it('handles a missing subject honestly', () => {
+    expect(replySubject()).toBe('Re: (no subject)');
+    expect(replySubject('   ')).toBe('Re: (no subject)');
+  });
+});
+
+// The end-to-end shape: what the poller TELLS him to type must parse, and what
+// parses must be sendable. These two modules were written weeks apart and never
+// checked against each other.
+describe('the instruction in every bus message actually works', () => {
+  it('parses the exact syntax bus-poll prints', () => {
+    const parsed = parseBusReply('reply eb8238 yes please, drop vps-bus.js on our lane');
+    expect(parsed).not.toBeNull();
+    expect(parsed?.shortId).toBe('eb8238');
+    expect(parsed?.text).toBe('yes please, drop vps-bus.js on our lane');
+  });
+
+  it('feeds straight into a send', async () => {
+    const parsed = parseBusReply('reply eb8238 shipping tonight');
+    const f = ok();
+    const r = await sendBusReply(
+      { to: 'coordinator', subject: replySubject('How we built the bus'), body: parsed!.text },
+      CFG,
+      f,
+    );
+    expect(r.ok).toBe(true);
+    expect(JSON.parse((f as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].body).body)
+      .toBe('shipping tonight');
+  });
+
+  it('ignores ordinary chat that merely starts with the word reply', () => {
+    expect(parseBusReply('reply to jim when you get a sec')).toBeNull();
+    expect(parseBusReply('replying now')).toBeNull();
+  });
+});

--- a/bot/src/zoe/bus-send.ts
+++ b/bot/src/zoe/bus-send.ts
@@ -1,0 +1,111 @@
+/**
+ * bus-send.ts - make the reply instruction in every bus message actually work.
+ *
+ * THE BUG. Every message `bus-poll.py` pushes to Telegram ends with:
+ *
+ *     TO REPLY: type   reply eb8238 <your words>
+ *
+ * Typing that does nothing. Nothing in ZOE parses it, so it falls through to the
+ * concierge and is answered as ordinary chat. The instruction has been a lie for
+ * as long as the poller has been running.
+ *
+ * bus-bridge.ts already had `parseBusReply()` for exactly this and was left
+ * deliberately unwired - its header says "the live wiring is a small reviewed
+ * step". This is that step. The parsing was never the missing part; the send was.
+ *
+ * This is the same failure as the POST button that re-sent the draft instead of
+ * publishing: a surface that TELLS you to do something and then ignores you is
+ * worse than one that offers nothing, because you blame yourself first.
+ *
+ * HONEST WHEN UNCONFIGURED. BUS_URL / BUS_TOKEN are not set on the live host
+ * today, so this cannot actually deliver yet. It says so, in one line, and shows
+ * what it would have sent - rather than silently swallowing the reply or claiming
+ * a success that did not happen (silent-failure-guard).
+ */
+
+export interface BusSendResult {
+  ok: boolean;
+  /** What to say back in Telegram. Always present - never a silent outcome. */
+  reply: string;
+  /** Set when the send failed or was impossible, for logs. */
+  reason?: string;
+}
+
+export interface BusConfig {
+  url?: string;
+  token?: string;
+}
+
+export function busConfig(): BusConfig {
+  return { url: process.env.BUS_URL || '', token: process.env.BUS_TOKEN || '' };
+}
+
+export function busConfigured(cfg: BusConfig = busConfig()): boolean {
+  return Boolean(cfg.url && cfg.token);
+}
+
+/**
+ * Deliver a reply to the partner bus.
+ *
+ * `to` defaults to the coordinator because that is who the poller surfaces; a
+ * caller that knows better should pass it explicitly rather than let this guess.
+ */
+export async function sendBusReply(
+  input: { to: string; subject: string; body: string },
+  cfg: BusConfig = busConfig(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<BusSendResult> {
+  const body = (input.body || '').trim();
+  if (!body) {
+    return { ok: false, reply: 'Nothing to send - the reply was empty.', reason: 'empty' };
+  }
+
+  if (!busConfigured(cfg)) {
+    // Do NOT pretend. Show him exactly what would have gone out so the thinking
+    // is not wasted, and name the one thing that is missing.
+    return {
+      ok: false,
+      reason: 'unconfigured',
+      reply:
+        'Bus not connected - BUS_URL and BUS_TOKEN are not set, so this did not send.\n\n' +
+        `Would have sent to ${input.to}:\n"${body.slice(0, 500)}"\n\n` +
+        'Set both on the VPS and send it again.',
+    };
+  }
+
+  try {
+    const res = await fetchImpl(`${cfg.url!.replace(/\/$/, '')}/send`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cfg.token}`,
+      },
+      body: JSON.stringify({ to: input.to, subject: input.subject, body }),
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        reason: `http ${res.status}`,
+        reply: `Bus rejected it (${res.status}). Your text is safe - try again or check the bus.`,
+      };
+    }
+    const data = (await res.json().catch(() => ({}))) as { id?: string };
+    const id = data.id ? ` (id ${String(data.id).slice(0, 8)})` : '';
+    return { ok: true, reply: `Sent to ${input.to}${id}.` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'request failed';
+    return {
+      ok: false,
+      reason: msg,
+      reply: `Could not reach the bus: ${msg.slice(0, 120)}\n\nYour text is safe - try again.`,
+    };
+  }
+}
+
+/** Subject line for a reply, derived from what we are replying to. */
+export function replySubject(originalSubject?: string): string {
+  const s = (originalSubject || '').trim();
+  if (!s) return 'Re: (no subject)';
+  return s.toLowerCase().startsWith('re:') ? s : `Re: ${s}`;
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -38,6 +38,8 @@ import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { detectBuildIntent } from './build-intent';
+import { parseBusReply } from './bus-bridge';
+import { replySubject, sendBusReply } from './bus-send';
 import { doneKeyboard, maybeKeyboard, runningKeyboard } from './dm-build-buttons';
 import { LiveStatus, renderBuildStatus } from './live-status';
 import { stashPending, takePending, worthOffering } from './dm-build-pending';
@@ -2489,6 +2491,30 @@ async function dispatchConcierge(
   //
   // Flag-gated (ZOE_DM_BUILD=1, default OFF). PR-only is what makes auto-
   // dispatch safe: the pipeline opens a PR, a human merges (agent-loops rule 8).
+  // "reply <id> <your words>" - the syntax every bus message tells him to type.
+  //
+  // Until now nothing parsed it, so typing it fell through to the concierge and
+  // was answered as ordinary chat. bus-bridge.ts has had parseBusReply() for
+  // exactly this and was left deliberately unwired; this is that wiring step.
+  //
+  // Checked BEFORE the build classifier, because "reply ab12cd fix the api" must
+  // be a bus reply, not a build request - the prefix is explicit and wins.
+  if (scope === 'private') {
+    const busReply = parseBusReply(text);
+    if (busReply) {
+      const res = await sendBusReply({
+        to: process.env.BUS_PARTNER ?? 'coordinator',
+        subject: replySubject(),
+        body: busReply.text,
+      });
+      await ctx.reply(res.reply).catch(() => {});
+      if (!res.ok) {
+        console.warn(`[zoe/index] bus reply not sent (${res.reason}) - text preserved in the chat`);
+      }
+      return;
+    }
+  }
+
   if (scope === 'private' && process.env.ZOE_DM_BUILD === '1') {
     const running = getActiveBuild(chatId);
 


### PR DESCRIPTION
Every message `bus-poll.py` pushes to Telegram ends with:

```
TO REPLY: type   reply eb8238 <your words>
```

**Typing that did nothing.** Nothing in ZOE parsed it, so it fell through to the concierge and came back as ordinary chat.

The instruction has been a lie for as long as the poller has been running - and it's the same failure as the POST button that re-sent your draft instead of publishing. **A surface that tells you to do something and then ignores you is worse than one that offers nothing, because you blame yourself first.**

`bus-bridge.ts` has had `parseBusReply()` for exactly this, left deliberately unwired ("the live wiring is a small reviewed step"). This is that step. **The parsing was never missing - the send was.**

Checked *before* the build classifier, so `reply ab12cd fix the api` is a bus reply, not a build request. An explicit prefix wins.

## Honest when unconfigured - which is today

`BUS_URL` and `BUS_TOKEN` aren't set on the live host, so this can't deliver yet. It says so in one line, **names the two missing variables**, and **prints back what it would have sent** - rather than swallowing a reply typed on a phone or claiming a success that didn't happen.

Losing your words is the one unforgivable outcome here. There's a test for each failure path asserting the text survives.

## A gap between two modules written weeks apart

They'd never been checked against each other. A test now asserts the exact syntax `bus-poll` **prints** is the syntax `parseBusReply` **accepts**, and that what parses feeds straight into a send.

## Verified

- **16 new tests**
- Non-test source **zero** type errors
- **esbuild bundles the boot graph**
- Full bot suite: **2,039 passing, 162 files, zero failures**

Worth noting: the 3 long-standing bot-test failures are also gone. They were the same missing-dependency problem, not real breakage.

## PR-only

**Not merged, not deployed.** You're asleep; overnight work is reviewable artifacts, never a live change (`agent-loops` rule 35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
