### PR TITLE
fix(heart): the lease flags stop the loops instead of fencing them

### DIFF
--- a/bot/src/zoe/__tests__/heart-run.test.ts
+++ b/bot/src/zoe/__tests__/heart-run.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureLeaseRun, resetRunReady, type RunTableClient } from '../heart-run';
+
+/**
+ * A minimal stand-in for the Supabase chains heart-run.ts uses. It records every
+ * call so the tests can assert the SHAPE of the query - which is the whole point
+ * here: the bug was querying the right table by the wrong column.
+ */
+function makeClient(opts: {
+  existingId?: string | null;
+  insertId?: string | null;
+  insertError?: { message: string } | null;
+  racedId?: string | null;
+  throwOn?: 'select' | 'insert' | 'update';
+}) {
+  const calls: { op: string; args: unknown[] }[] = [];
+  let selects = 0;
+  const client = {
+    from(table: string) {
+      calls.push({ op: 'from', args: [table] });
+      return {
+        select() {
+          return {
+            eq(field: string, value: unknown) {
+              calls.push({ op: 'select.eq', args: [field, value] });
+              return {
+                async maybeSingle() {
+                  if (opts.throwOn === 'select') throw new Error('network down');
+                  selects += 1;
+                  // First read is the find; a second read is the raced re-read.
+                  const id = selects === 1 ? (opts.existingId ?? null) : (opts.racedId ?? null);
+                  return { data: id ? { id } : null, error: null };
+                },
+              };
+            },
+          };
+        },
+        insert(values: Record<string, unknown>) {
+          calls.push({ op: 'insert', args: [values] });
+          return {
+            select() {
+              return {
+                async single() {
+                  if (opts.throwOn === 'insert') throw new Error('insert exploded');
+                  return {
+                    data: opts.insertId ? { id: opts.insertId } : null,
+                    error: opts.insertError ?? null,
+                  };
+                },
+              };
+            },
+          };
+        },
+        update(values: Record<string, unknown>) {
+          calls.push({ op: 'update', args: [values] });
+          return {
+            eq(field: string, value: unknown) {
+              calls.push({ op: 'update.eq', args: [field, value] });
+              return {
+                async in(field2: string, values2: readonly string[]) {
+                  if (opts.throwOn === 'update') throw new Error('update exploded');
+                  calls.push({ op: 'update.in', args: [field2, [...values2]] });
+                  return { data: null, error: null };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as RunTableClient;
+  return { client, calls };
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('ensureLeaseRun', () => {
+  it('returns the existing row id when the resource already exists', async () => {
+    const { client, calls } = makeClient({ existingId: 'a1b2c3d4-0000-4000-8000-000000000001' });
+    const id = await ensureLeaseRun(client, 'zoe.work-loop', 'singleton', 'obj');
+    expect(id).toBe('a1b2c3d4-0000-4000-8000-000000000001');
+    // It must look the resource up by idempotency_key, never by id.
+    expect(calls.find((c) => c.op === 'select.eq')?.args[0]).toBe('idempotency_key');
+  });
+
+  // THE BUG THIS MODULE EXISTS FOR. executeWithLease resolves a lease by PRIMARY
+  // KEY, so what comes back here has to be the row's uuid - not the
+  // `heart:resource:<sha>` idempotency key the scheduler used to pass straight
+  // through, which no row can ever match.
+  it('returns a row UUID, never the heart:resource idempotency key', async () => {
+    const { client } = makeClient({ existingId: null, insertId: 'b1b2c3d4-0000-4000-8000-000000000002' });
+    const id = await ensureLeaseRun(client, 'zoe.work-loop', 'singleton', 'obj');
+    expect(id).toBe('b1b2c3d4-0000-4000-8000-000000000002');
+    expect(id).not.toMatch(/^heart:resource:/);
+  });
+
+  it('creates the row with a schema-valid shape when it is missing', async () => {
+    const { client, calls } = makeClient({ existingId: null, insertId: 'c1b2c3d4-0000-4000-8000-000000000003' });
+    await ensureLeaseRun(client, 'zoe.orchestrator-tick', 'singleton', 'the objective');
+    const inserted = calls.find((c) => c.op === 'insert')?.args[0] as Record<string, unknown>;
+    expect(inserted.idempotency_key).toMatch(/^heart:resource:[0-9a-f]{64}$/);
+    expect(String(inserted.id)).toMatch(UUID_RE);
+    // agent_runs.assignment_id is a UUID column with a UNIQUE constraint.
+    expect(String(inserted.assignment_id)).toMatch(UUID_RE);
+    // visibility has a CHECK constraint: private | team | public.
+    expect(['private', 'team', 'public']).toContain(inserted.visibility);
+    expect(inserted.status).toBe('ready');
+    expect(inserted.objective).toBe('the objective');
+  });
+
+  it('gives the same idempotency key for the same (kind, key) and different for different', async () => {
+    const a = makeClient({ existingId: null, insertId: 'd1b2c3d4-0000-4000-8000-000000000004' });
+    await ensureLeaseRun(a.client, 'zoe.work-loop', 'singleton', 'o');
+    const b = makeClient({ existingId: null, insertId: 'd1b2c3d4-0000-4000-8000-000000000004' });
+    await ensureLeaseRun(b.client, 'zoe.work-loop', 'singleton', 'o');
+    const c = makeClient({ existingId: null, insertId: 'd1b2c3d4-0000-4000-8000-000000000004' });
+    await ensureLeaseRun(c.client, 'zoe.orchestrator-tick', 'singleton', 'o');
+
+    const keyOf = (m: ReturnType<typeof makeClient>) =>
+      (m.calls.find((x) => x.op === 'insert')?.args[0] as Record<string, unknown>).idempotency_key;
+    expect(keyOf(a)).toBe(keyOf(b));
+    expect(keyOf(a)).not.toBe(keyOf(c));
+  });
+
+  it('re-reads instead of failing when a sibling host wins the insert race', async () => {
+    const { client } = makeClient({
+      existingId: null,
+      insertId: null,
+      insertError: { message: 'duplicate key value violates unique constraint' },
+      racedId: 'e1b2c3d4-0000-4000-8000-000000000005',
+    });
+    expect(await ensureLeaseRun(client, 'zoe.work-loop', 'singleton', 'o')).toBe(
+      'e1b2c3d4-0000-4000-8000-000000000005',
+    );
+  });
+
+  it('returns null rather than throwing when the row can neither be read nor created', async () => {
+    const { client } = makeClient({ existingId: null, insertId: null, insertError: { message: 'boom' }, racedId: null });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(await ensureLeaseRun(client, 'zoe.work-loop', 'singleton', 'o')).toBeNull();
+    // Never silent: the caller has to be able to see why it fell back.
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('returns null rather than throwing when the client itself throws', async () => {
+    const { client } = makeClient({ throwOn: 'select' });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(await ensureLeaseRun(client, 'zoe.work-loop', 'singleton', 'o')).toBeNull();
+    spy.mockRestore();
+  });
+});
+
+describe('resetRunReady', () => {
+  // THE SECOND WEDGE. executeWithLease releases to a terminal status but
+  // canAcquire only takes 'ready' or an expired lease, so without this the
+  // resource works once and then refuses every later tick forever.
+  it('parks the row back at ready, conditional on it still being terminal', async () => {
+    const { client, calls } = makeClient({});
+    await resetRunReady(client, 'f1b2c3d4-0000-4000-8000-000000000006');
+    const update = calls.find((c) => c.op === 'update')?.args[0] as Record<string, unknown>;
+    expect(update.status).toBe('ready');
+    expect(calls.find((c) => c.op === 'update.eq')?.args).toEqual([
+      'id',
+      'f1b2c3d4-0000-4000-8000-000000000006',
+    ]);
+    // 'failed' too: a tick that throws must not wedge the loop permanently.
+    expect(calls.find((c) => c.op === 'update.in')?.args[1]).toEqual(['completed', 'failed']);
+  });
+
+  it('swallows a failure - the tick it follows has already done its work', async () => {
+    const { client } = makeClient({ throwOn: 'update' });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(resetRunReady(client, 'f1b2c3d4-0000-4000-8000-000000000007')).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/bot/src/zoe/heart-run.ts
+++ b/bot/src/zoe/heart-run.ts
@@ -1,0 +1,155 @@
+/**
+ * heart-run.ts - resolve the agent_runs ROW that a Heart lease fences on.
+ *
+ * THE BUG THIS EXISTS FOR. Both lease wrappers in scheduler.ts passed
+ * `deterministicResourceId(...)` straight into `executeWithLease` as its runId:
+ *
+ *     const resourceId = deterministicResourceId('zoe.work-loop', 'singleton');
+ *     await executeWithLease(heart(), { runId: resourceId, ... }, run);
+ *
+ * That value is an IDEMPOTENCY KEY (`heart:resource:<sha256>`), which is what its
+ * own docstring says it is - "used as agent_runs idempotency_key". But the store
+ * resolves a lease by PRIMARY KEY: `SupabaseLeaseStore.getRun` does
+ * `.eq('id', runId)`, and `agent_runs.id` is a UUID (scripts/1410). So the lookup
+ * can never match - on a uuid column it does not even miss, it errors - `acquire`
+ * returns "Run not found", and `executeWithLease` returns `{ ran: false }`.
+ *
+ * The effect is the exact inversion of what the flags advertise. Turning on
+ * ZOE_LOOP_LEASES does not make the work-loop and orchestrator tick safe across
+ * machines; it stops them running at all. Turning on ZOE_REPO_IMPROVER_LEASES
+ * does the same to the repo-improver scout - and flipping that flag is written
+ * up as the single highest-leverage next milestone (doc 2175).
+ *
+ * Nothing created a row for those resources either. The only code that ever did
+ * find-or-create was the canary's private `ensureCanaryRun`, and it passed the
+ * created row's real UUID. This module is that step, generalised, so a lease
+ * wrapper cannot forget it again.
+ *
+ * AND THE SECOND WEDGE. `executeWithLease` releases to status 'completed' (or
+ * 'failed' when the work throws), while `canAcquire` accepts only 'ready' or an
+ * EXPIRED 'leased'/'running'. So even with the right id, a resource row would
+ * work exactly once and then refuse every later tick forever. The canary resets
+ * itself to 'ready' after each beat; the scheduler wrappers had no such step.
+ * `resetRunReady` is it, and it clears 'failed' too - a tick that throws must not
+ * wedge the loop permanently, the same lesson `withTickLock`'s `finally` encodes.
+ */
+import { randomUUID } from 'node:crypto';
+import { deterministicResourceId } from '../../../packages/heart-fleet/src/index';
+
+/** One row shape this module reads back - only the primary key is needed. */
+interface RunIdRow {
+  id: string;
+}
+interface QueryResult<T> {
+  data: T | null;
+  error?: { message: string } | null;
+}
+
+/**
+ * Structural type for the injected Supabase client - kept local, and narrowed to
+ * exactly the three chains used below, so this module is testable without a
+ * database and without importing the bot's client.
+ */
+export interface RunTableClient {
+  from(table: string): {
+    select(columns: string): {
+      eq(field: string, value: unknown): { maybeSingle(): Promise<QueryResult<RunIdRow>> };
+    };
+    insert(values: Record<string, unknown>): {
+      select(columns: string): { single(): Promise<QueryResult<RunIdRow>> };
+    };
+    update(values: Record<string, unknown>): {
+      eq(field: string, value: unknown): {
+        in(field: string, values: readonly string[]): Promise<QueryResult<unknown>>;
+      };
+    };
+  };
+}
+
+/** Statuses a resource row may be parked in between ticks. */
+const TERMINAL_STATUSES = ['completed', 'failed'] as const;
+
+/**
+ * Find-or-create the singleton agent_runs row for a lease resource, and return
+ * its PRIMARY KEY - the value `executeWithLease` actually needs.
+ *
+ * Returns null when the row can neither be read nor created; the caller decides
+ * what that means. It must never throw: a lease bookkeeping problem must not be
+ * the thing that takes down a scheduler tick.
+ */
+export async function ensureLeaseRun(
+  client: RunTableClient,
+  kind: string,
+  key: string,
+  objective: string,
+): Promise<string | null> {
+  const idempotencyKey = deterministicResourceId(kind, key);
+  try {
+    const { data: existing } = await client
+      .from('agent_runs')
+      .select('id')
+      .eq('idempotency_key', idempotencyKey)
+      .maybeSingle();
+    if (existing?.id) return existing.id as string;
+
+    const { data: created, error } = await client
+      .from('agent_runs')
+      .insert({
+        id: randomUUID(),
+        // assignment_id is a UUID column with a UNIQUE constraint (scripts/1410).
+        // These resource rows have no external assignment, so mint one.
+        assignment_id: randomUUID(),
+        objective,
+        required_capabilities: [],
+        status: 'ready',
+        retries: 0,
+        approval_state: 'auto',
+        visibility: 'team',
+        idempotency_key: idempotencyKey,
+        created_by: `zoe:${kind}`,
+      })
+      .select('id')
+      .single();
+    if (!error && created?.id) return created.id as string;
+
+    // A unique violation on idempotency_key means a sibling host created the row
+    // between our read and our insert - re-read rather than fail.
+    const { data: raced } = await client
+      .from('agent_runs')
+      .select('id')
+      .eq('idempotency_key', idempotencyKey)
+      .maybeSingle();
+    if (raced?.id) return raced.id as string;
+
+    console.error(
+      `[zoe/heart-run] could not ensure lease run for ${kind}:${key}: ${error?.message ?? 'unknown error'}`,
+    );
+    return null;
+  } catch (err) {
+    console.error(
+      `[zoe/heart-run] could not ensure lease run for ${kind}:${key}: ${(err as Error)?.message ?? String(err)}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Park a resource row back at 'ready' so the NEXT tick can acquire it.
+ *
+ * Conditional on the row still being terminal, so this can never stomp a lease a
+ * different host has already taken. Best-effort: a failure here is logged, not
+ * thrown, because the tick it follows has already done its work.
+ */
+export async function resetRunReady(client: RunTableClient, runId: string): Promise<void> {
+  try {
+    await client
+      .from('agent_runs')
+      .update({ status: 'ready', updated_at: new Date().toISOString() })
+      .eq('id', runId)
+      .in('status', TERMINAL_STATUSES);
+  } catch (err) {
+    console.error(
+      `[zoe/heart-run] could not reset run ${runId} to ready: ${(err as Error)?.message ?? String(err)}`,
+    );
+  }
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -42,10 +42,10 @@ import {
   HeartFleet,
   SupabaseLeaseStore,
   executeWithLease,
-  deterministicResourceId,
   type ExecuteOutcome,
   type SupabaseLikeClient,
 } from '../../../packages/heart-fleet/src/index';
+import { ensureLeaseRun, resetRunReady, type RunTableClient } from './heart-run';
 import { db } from '../supabase';
 import { runPreflight } from './preflight';
 import { shouldFireAlert, shouldPauseAutonomousWork, formatSpendStatus } from './cost-governance';
@@ -133,41 +133,75 @@ function loopLeasesEnabled(): boolean {
 }
 
 /**
- * Run a named loop tick under a Heart lease when ZOE_LOOP_LEASES is on.
+ * Run a named tick under a Heart lease when its flag is on. The ONE wrapper all
+ * three leased loops go through - work-loop, orchestrator-tick and the
+ * repo-improver scout - because two hand-written copies of the lease dance is how
+ * the same resource-id bug got into both of them.
  *
- * Deliberately the same shape as runRepoImproverScout above - that wrapper has
- * been in the tree and working, so this generalises a proven pattern rather than
- * inventing a second one (code-restraint rung 2: reuse beats rewrite). Flag OFF
- * means the tick runs exactly as it does today, byte for byte.
+ * `enabled` off means the tick runs exactly as it does today, byte for byte.
  */
-async function runLoopTickLeased(
+async function runTickLeased(
   name: string,
+  enabled: boolean,
+  ttlSeconds: number,
   run: () => Promise<void>,
 ): Promise<ExecuteOutcome<void>> {
-  if (!loopLeasesEnabled()) {
+  if (!enabled) {
+    await run();
+    console.log(`[zoe/scheduler] ${name} ran (lease disabled)`);
+    return { ran: true, result: undefined };
+  }
+
+  // The lease fences on an agent_runs ROW, so the row has to exist and we have
+  // to pass its primary key. deterministicResourceId is the idempotency_key, not
+  // the id - passing it straight through meant acquire never found a row and the
+  // tick never ran. See heart-run.ts.
+  const runId = await ensureLeaseRun(
+    db() as unknown as RunTableClient,
+    `zoe.${name}`,
+    'singleton',
+    `ZOE ${name}: cross-machine single-instance lease for the scheduler's ${name} tick`,
+  );
+  if (!runId) {
+    // Fail OPEN, loudly. Running unleased is exactly what the flag-off path does
+    // today, so this is no worse than the current production behaviour and the
+    // per-machine tick-lock still holds; skipping instead would mean a Supabase
+    // blip silently stops ZOE's autonomous loops, which is the failure mode we
+    // are here to remove.
+    console.error(
+      `[zoe/scheduler] ${name} could not establish a lease row - running UNLEASED (per-machine tick-lock still applies)`,
+    );
     await run();
     return { ran: true, result: undefined };
   }
 
-  const resourceId = deterministicResourceId(`zoe.${name}`, 'singleton');
   const owner = `zoe:scheduler:${process.env.HOSTNAME ?? 'host'}:${process.pid}`;
   const outcome = await executeWithLease(
     heart(),
-    { runId: resourceId, owner, ttlSeconds: 600 },
+    { runId, owner, ttlSeconds },
     async () => {
       await run();
       return undefined;
     },
   );
 
+  // executeWithLease releases to a terminal status, but canAcquire only takes
+  // 'ready' or an expired lease - so without this the resource works once and
+  // then refuses every later tick forever.
+  await resetRunReady(db() as unknown as RunTableClient, runId);
+
   // Log BOTH outcomes. A skip is the feature working - another host already has
   // it - and a silent skip is indistinguishable from a loop that stopped running,
-  // which is exactly how a broken loop hides (silent-failure-guard).
-  console.log(
-    outcome.ran
-      ? `[zoe/scheduler] ${name} ran (lease acquired)`
-      : `[zoe/scheduler] ${name} skipped (lease held elsewhere - ${outcome.reason})`,
-  );
+  // which is exactly how a broken loop hides (silent-failure-guard). 'lease-held'
+  // and 'lease-error' are reported apart: only the first one means the feature
+  // worked, and calling an error "held elsewhere" is the lie that hid this bug.
+  if (outcome.ran) {
+    console.log(`[zoe/scheduler] ${name} ran (lease acquired)`);
+  } else if (outcome.reason === 'lease-held') {
+    console.log(`[zoe/scheduler] ${name} skipped (lease held elsewhere)`);
+  } else {
+    console.error(`[zoe/scheduler] ${name} DID NOT RUN - lease error (${outcome.reason})`);
+  }
   return outcome;
 }
 
@@ -187,31 +221,15 @@ function heart(): HeartFleet {
 /**
  * Wraps runRepoImproverTick through the Heart lease layer when the flag is on.
  * When the flag is off, runs the scout exactly as today (zero behavior change).
- * Deterministic resource id prevents duplicate scouts running concurrently.
+ *
+ * This now goes through the SAME wrapper as the other loops rather than carrying
+ * its own copy of the lease dance. Two hand-written copies is how the resource-id
+ * bug reached both of them (code-restraint rung 2: reuse beats rewrite).
  */
 async function runRepoImproverScout(log: (m: string) => Promise<void>): Promise<ExecuteOutcome<void>> {
-  if (!repoImproverLeaseEnabled()) {
-    // Flag OFF: run scout directly, no lease (zero behavior change from baseline).
-    await runRepoImproverTick(log);
-    console.log('[zoe/scheduler] repo-improver scout ran (lease disabled)');
-    return { ran: true, result: undefined };
-  }
-
-  // Flag ON: run scout inside a lease to prevent double-runs.
-  const resourceId = deterministicResourceId('zoe.repo-improver-scout', 'singleton');
-  const owner = `zoe:scheduler:${process.env.HOSTNAME ?? 'host'}:${process.pid}`;
-  const outcome = await executeWithLease(heart(), { runId: resourceId, owner, ttlSeconds: 120 }, async () => {
-    await runRepoImproverTick(log);
-    return undefined;
-  });
-
-  if (outcome.ran) {
-    console.log('[zoe/scheduler] repo-improver scout ran (lease acquired)');
-  } else {
-    console.log(`[zoe/scheduler] repo-improver scout skipped (lease held - reason: ${outcome.reason})`);
-  }
-
-  return outcome;
+  return runTickLeased('repo-improver-scout', repoImproverLeaseEnabled(), 120, () =>
+    runRepoImproverTick(log),
+  );
 }
 
 export interface SchedulerOptions {
@@ -892,7 +910,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           }
           const rGid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
           const rThread = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
-          await runLoopTickLeased('work-loop', () => runWorkTick({
+          await runTickLeased('work-loop', loopLeasesEnabled(), 600, () => runWorkTick({
             sendToZaal: (t: string) => {
               // Work-loop messages are status messages
               if (opts.routingDeps) {
@@ -1084,7 +1102,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
             console.log('[zoe/scheduler] orchestrator tick skipped (cost hard-stop at 95%+)');
             return;
           }
-          await runLoopTickLeased('orchestrator-tick', () => runOrchestratorTick({
+          await runTickLeased('orchestrator-tick', loopLeasesEnabled(), 600, () => runOrchestratorTick({
             bot: opts.bot,
             groupId: gid,
             zaalTgId: opts.zaalTgId,


### PR DESCRIPTION
## Executive summary

The two Heart lease flags do the opposite of what they say. `ZOE_LOOP_LEASES=true` does not make the work-loop and orchestrator tick safe across machines - it stops them running at all. `ZOE_REPO_IMPROVER_LEASES=true` does the same to the repo-improver scout. And the log line prints the dead loop as `skipped (lease held elsewhere)`, so it reads as the feature working.

Flipping `ZOE_REPO_IMPROVER_LEASES=true` is written up in doc 2175 as the single highest-leverage next milestone. Today that flip silently switches the scout off.

## What breaks without this fix, concretely

Both wrappers in `bot/src/zoe/scheduler.ts` passed `deterministicResourceId(...)` straight into `executeWithLease` as its `runId`:

```ts
const resourceId = deterministicResourceId('zoe.work-loop', 'singleton');
await executeWithLease(heart(), { runId: resourceId, ... }, run);
```

That value is an **idempotency key**. Its own docstring says so - `packages/heart-fleet/src/canonical.ts:41-47`, "Used as agent_runs idempotency_key" - and its shape is `heart:resource:<sha256>`.

But a lease is resolved by **primary key**:

- `packages/heart-fleet/src/supabase-store.ts:44` - `getRun` does `.select('*').eq('id', runId).single()`
- `scripts/1410-agent-control-plane.sql:40` - `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`

`heart:resource:<sha>` can never match a uuid column. So:

1. `getRun` returns null -> `acquire` returns `{ acquired: false, run: null, reason: 'Run not found' }` (`lease.ts:96`)
2. `executeWithLease` maps `run === null` to `{ ran: false, reason: 'lease-error' }` (`execute.ts:92`)
3. the tick never runs

No row existed for those resources either. The only find-or-create in the tree is the canary's private `ensureCanaryRun` (`heart-canary.ts`), which passes the created row's **real UUID** - exactly the step both scheduler wrappers were missing.

### The log is why nobody saw it

```ts
outcome.ran ? `... ran (lease acquired)` : `... skipped (lease held elsewhere - ${outcome.reason})`
```

`lease-error` printed as "held elsewhere". A completely dead loop that reads as the feature working, on a repo that shipped `noisy-signal-guard.md` and the `zoe-liveness` wrong-value fix the same night. Held and error are now reported apart, and the error path goes to `console.error`.

### Second wedge, fixed in the same change

`executeWithLease` releases to a terminal status (`'completed'`, or `'failed'` when the work throws - `execute.ts:114`), while `canAcquire` accepts only `'ready'` or an **expired** `'leased'`/`'running'` (`lease.ts:80-84`). So even with the right id, a resource row would work exactly **once** and then refuse every later tick forever. The canary resets itself to `'ready'` after each beat; the scheduler wrappers had no such step.

`resetRunReady` is that step, and it clears `'failed'` as well as `'completed'` - a tick that throws must not wedge the loop permanently, the same lesson `withTickLock`'s `finally` encodes.

## The change

- **New** `bot/src/zoe/heart-run.ts` - `ensureLeaseRun()` (find-or-create by `idempotency_key`, returns the row's **UUID**, race-safe re-read on unique violation) and `resetRunReady()`. Client injected, so it is testable with no database.
- `runLoopTickLeased` -> `runTickLeased`, now the **one** wrapper all three leased ticks go through. Two hand-written copies of the lease dance is how the identical bug reached both of them (`code-restraint.md` rung 2).
- Insert shape follows the committed DDL: `assignment_id` a real UUID (it is `UUID NOT NULL UNIQUE`), `visibility: 'team'` (the CHECK allows private/team/public), `status: 'ready'`.
- 9 tests, including one asserting the returned id is a row UUID and never a `heart:resource:` key.

### Fail-open, deliberately

If the row can neither be read nor created, the tick runs **unleased** with a `console.error`, rather than skipping. That is byte-for-byte the flag-off path running in production today, and the per-machine `tick-lock` still holds. Skipping instead would mean a Supabase blip silently stops ZOE's autonomous loops - the exact failure mode this PR exists to remove. Say the word if you want it fail-closed instead; it is a one-line flip.

### Minor behaviour change worth knowing

The flag-off path now logs `<name> ran (lease disabled)` for all three ticks. Previously only the scout did. One extra log line per tick.

## Evidence

**Proven**
- 9 new tests pass (`vitest run src/zoe/__tests__/heart-run.test.ts`)
- Full bot suite: **2030 passing / 2 failed (162 files)** on this branch vs **2021 passing / 2 failed (161 files)** on `origin/main` in the same checkout. Identical two failures - `trace.test.ts` and `transcribe.test.ts`, both pre-existing `/tmp` path-separator failures on Windows. No new failures, +9 tests.
- `tsc --noEmit`: **zero** errors in non-test source (the 37 remaining are all in test files, same as main)
- `esbuild --bundle src/zoe/index.ts` succeeds - the boot graph still bundles

**Not run**
- `biome check` - root `node_modules` is not installed on this box and installing the full Next.js monorepo for a lint pass was disproportionate. CI runs it. Flagging rather than claiming clean.

**Unverified - needs a look at the live table**
- The canary's own `ensureCanaryRun` inserts `assignment_id: 'heart-canary:singleton'` (not a UUID) and `visibility: 'internal'` (not in the CHECK list) - both would be rejected by the committed DDL in `scripts/1410`. Either the live table has drifted from the migration, or the canary's insert has been failing too. I had no DB access to check, so I left `heart-canary.ts` alone rather than guess. **Worth checking before flipping any of these flags.**

## Also seen, not fixed (one PR only)

- `executeWithLease`'s heartbeat keeps renewing with a **stale fence** after a renew returns null - it retries the same rejected token every interval instead of surfacing the loss. Irreversible effects are still safe (`guardIrreversible` re-verifies), but the work keeps running with no live lease. `packages/heart-fleet/src/execute.ts:97-104`.
- `tick-lock` breaks a lock older than 30 minutes. A tick that legitimately runs longer than that can have its lock stolen mid-run. Documented behaviour, but the work-loop's lease TTL is 600s, so the two layers disagree about how long a tick may take.
- `heart-canary.ts` still carries its own copy of find-or-create and its own reset-to-`ready` (which handles `'completed'` but not `'failed'`). It could now delegate to `heart-run.ts`. Left alone deliberately - it sits behind a live flag and I did not want to touch a working path in a bug-fix PR.

## Founder test

Two flags exist so ZOE's autonomous loops cannot run twice across the Mac, the VPS, the Pi and the Windows desktop. Turning either one on today switches those loops **off** and prints a message saying everything is fine. This makes them do what they say, tells the truth in the log when they cannot, and puts the one piece of bookkeeping they were missing somewhere a future wrapper cannot forget it.

Found by the hourly repo auditor. PR-only - not merged, not deployed.
