### PR TITLE
fix(pwa): the service worker may never register - the load listener races hydration

### DIFF
--- a/src/components/pwa/ServiceWorkerRegistration.tsx
+++ b/src/components/pwa/ServiceWorkerRegistration.tsx
@@ -5,20 +5,37 @@ import { useEffect } from 'react';
 /**
  * Registers the service worker on mount.
  * Place this component in the root layout.
+ *
+ * WHY THE readyState CHECK. This used to register only from inside
+ * `window.addEventListener('load', ...)`. A React effect runs after hydration,
+ * and hydration is not ordered against `load` - `load` waits on subresources,
+ * not on React's scheduler. On a cached, image-light page (or any page where
+ * the main thread is busy enough that the passive-effect flush slips a task)
+ * `load` has ALREADY fired by the time this effect runs, the listener is
+ * attached to an event that will never fire again, and the service worker is
+ * silently never registered: no offline page, no precache, no periodic update
+ * check, and no error anywhere to say so.
+ *
+ * So: if the document has already finished loading, register now; otherwise
+ * wait for `load` as before (still the right thing - registration should not
+ * compete with the initial render for bandwidth).
  */
 export function ServiceWorkerRegistration() {
   useEffect(() => {
     if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
 
-    // Register after page load to avoid blocking initial render
-    window.addEventListener('load', () => {
+    let updateInterval: ReturnType<typeof setInterval> | undefined;
+    let cancelled = false;
+
+    const register = () => {
       navigator.serviceWorker
         .register('/sw.js')
         .then((registration) => {
+          if (cancelled) return;
           console.log('[SW] Registered, scope:', registration.scope);
 
           // Check for updates periodically (every 60 min)
-          setInterval(
+          updateInterval = setInterval(
             () => {
               registration.update();
             },
@@ -28,7 +45,21 @@ export function ServiceWorkerRegistration() {
         .catch((error) => {
           console.error('[SW] Registration failed:', error);
         });
-    });
+    };
+
+    // Register after page load to avoid blocking initial render - unless load
+    // has already happened, in which case the listener would never fire.
+    if (document.readyState === 'complete') {
+      register();
+    } else {
+      window.addEventListener('load', register);
+    }
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('load', register);
+      if (updateInterval) clearInterval(updateInterval);
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
## Executive summary

The PWA service worker can silently never register. `ServiceWorkerRegistration`
registered `/sw.js` only from inside a `window.addEventListener('load', ...)`
callback attached in a `useEffect`. A React effect runs after hydration, and
hydration is not ordered against the `load` event - `load` waits on
subresources, not on React's scheduler. When `load` has already fired by the
time the effect runs, the listener is attached to an event that will never fire
again, and nothing registers the worker.

One-line fix: if `document.readyState === 'complete'`, register now; otherwise
wait for `load` as before. Plus cleanup of the listener and the update interval.

## What breaks without the fix, concretely

`src/components/pwa/ServiceWorkerRegistration.tsx` is the ONLY place in the repo
that calls `navigator.serviceWorker.register` (grep of `src/**` for
`serviceWorker.register` returns exactly one hit, line 16 pre-fix), and it is
mounted once in the root layout (`src/app/layout.tsx:105`). So when that
callback does not fire, for that visit:

- `public/sw.js` never installs, so `PRECACHE_ASSETS` (`/`, `/offline`,
  `/manifest.json`, icons) is never cached.
- The offline fallback in the SW's navigate handler (`public/sw.js:113-138`)
  never exists - an offline user gets the browser's error page, not `/offline`.
- The 60-minute `registration.update()` poll never starts, so a user who DID
  register on an earlier visit keeps a stale worker longer.
- There is no error and no log. The failure is indistinguishable from success
  from inside the app (`silent-failure-guard.md` rule 6).

This is a race, not a guaranteed failure - it depends on whether the passive
effect flush lands before or after `load` on a given page load. A warm cache and
few subresources make `load` early; a busy main thread makes hydration late.
Both are ordinary. The `readyState` check makes the outcome deterministic either
way, which is the point.

Secondary, in the same effect: the `load` listener and the `setInterval` were
never cleaned up. Under StrictMode's dev double-invoke that leaves two update
intervals running for the life of the document.

## Verification - honest

- The audit checkout has an EMPTY `node_modules` (0 entries, root and `bot/`),
  so I could NOT run `npm run typecheck`, `vitest`, or the build here. Per
  `noisy-signal-guard.md`, I did not report anything measured by a toolchain
  that cannot run. CI on this PR is the verification.
- Main's CI is green as of `f74c56d` (run 31257577690, success), so this PR's
  run is a clean signal rather than a delta against a broken baseline.
- No test added: I cannot execute vitest in this checkout, and shipping a test
  I have not run risks a red PR for no gain. Worth adding a jsdom test that
  asserts registration happens when `readyState === 'complete'` - flagged, not
  done.

## Also seen this pass, deliberately NOT changed (one-PR rule)

- `public/sw.js:71-90` caches responses from `/api/members`, `/api/directory`,
  `/api/library`, `/api/music` into Cache Storage. Those are session-gated
  endpoints; the cached copies survive logout and are served on network
  failure. Same-device only, so not a cross-user leak - but worth a decision
  on whether authenticated API responses should be cached at all.
- `public/sw.js:186-195` `notificationclick` calls `client.navigate(url)` with
  `url` taken from the push payload, with no same-origin check. The payload
  comes from our own VAPID-authenticated push sender, so this is defense in
  depth, not a live hole.
- `bot/src/zoe/index.ts:1025-1085` - the `dmb:*` build callbacks carry no
  `isFromZaal` gate, unlike the `post-*` handler at line 1088 which does. Not
  exploitable today because those keyboards are only ever sent into Zaal's DM
  (`dispatchConcierge` gates on `scope === 'private'`, and the private path
  returns for non-Zaal at line 1538) - but the gate is implicit, and an
  implicit gate is one refactor away from being no gate.

## Scope

One file, 35 insertions / 4 deletions. No behavior change other than "register
in the case where it previously did not" plus unmount cleanup. No dependency,
config, schema, or env change.
