### PR TITLE
feat(zoe): auto-close board tasks whose tracked PR has concluded

### DIFF
--- a/bot/src/zoe/__tests__/done-work-detector.test.ts
+++ b/bot/src/zoe/__tests__/done-work-detector.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+  capCloses,
+  findVacuousReviewReminders,
+  MAX_CLOSES_PER_RUN,
+  planAutoCloses,
+  trackedDocNum,
+  trackedPrNum,
+  type OpenTask,
+  type RepoFacts,
+} from '../done-work-detector';
+
+const facts = (over: Partial<RepoFacts> = {}): RepoFacts => ({
+  mergedPrNums: new Set<string>(),
+  closedUnmergedPrNums: new Set<string>(),
+  mergedDocNums: new Set<string>(),
+  ...over,
+});
+
+const task = (title: string, legacySource?: string, id = 't1'): OpenTask => ({ id, title, legacySource });
+
+describe('trackedPrNum / trackedDocNum - legacy_source only', () => {
+  it('reads the PR from legacy_source', () => {
+    expect(trackedPrNum(task('anything at all', 'pr-auto:2867'))).toBe('2867');
+  });
+
+  it('reads the doc from legacy_source', () => {
+    expect(trackedDocNum(task('anything at all', 'research-doc:2207'))).toBe('2207');
+  });
+
+  // The defect that nearly shipped. A number in a title is a CITATION - the doc
+  // is where the ask is written down, not the ask itself.
+  it.each([
+    'Build zao-claude-kit open-source repo via opensource-pipeline (doc 946)',
+    'Name Site Lead + First Aid Lead for ZAOstock Oct 3 (doc 1032)',
+    'Decide: publish doc 1168 to zao-papers',
+    'Test plan: PR #2867 - doc 2207: media-to-drive archive',
+  ])('never reads a number out of the title: %s', (t) => {
+    expect(trackedDocNum(task(t))).toBeNull();
+    expect(trackedPrNum(task(t))).toBeNull();
+  });
+
+  it('rejects a legacy_source that merely contains the pattern', () => {
+    expect(trackedPrNum(task('x', 'meeting:pr-auto:2867'))).toBeNull();
+    expect(trackedDocNum(task('x', 'research-doc:2207-extra'))).toBeNull();
+  });
+});
+
+describe('planAutoCloses - closes only on a state change AFTER the task was born', () => {
+  it('closes a PR task when the PR merged', () => {
+    const v = planAutoCloses([task('Test plan: PR #2867', 'pr-auto:2867')], facts({ mergedPrNums: new Set(['2867']) }));
+    expect(v).toHaveLength(1);
+    expect(v[0].reason).toContain('#2867 is merged');
+  });
+
+  it('closes a PR task when the PR was closed WITHOUT merging, and says which', () => {
+    const v = planAutoCloses([task('Test plan: PR #2870', 'pr-auto:2870')], facts({ closedUnmergedPrNums: new Set(['2870']) }));
+    expect(v[0].reason).toContain('closed without merging');
+    expect(v[0].reason).toContain('abandoned');
+    expect(v[0].reason).not.toContain('is merged into main');
+  });
+
+  it('leaves an OPEN PR alone', () => {
+    expect(planAutoCloses([task('Test plan: PR #2952', 'pr-auto:2952')], facts({ mergedPrNums: new Set(['2867']) }))).toEqual([]);
+  });
+
+  // THE CORE SAFETY PROPERTY. A stale repo or an unreachable API yields empty
+  // facts, and empty facts must close nothing.
+  it('closes NOTHING on empty facts', () => {
+    const tasks = [
+      task('Test plan: PR #2867', 'pr-auto:2867', 'a'),
+      task('Review research doc 2207', 'research-doc:2207', 'b'),
+      task('Decide agent-token economics', undefined, 'c'),
+    ];
+    expect(planAutoCloses(tasks, facts())).toEqual([]);
+  });
+
+  // THE VACUOUS-RULE REGRESSION. Measured 2026-08-08: 25 of 25 open doc-review
+  // tasks pointed at an already-merged doc, because the writer creates the task
+  // when the doc ships. A condition true at birth is not evidence.
+  it('NEVER closes a doc-review task, even when the doc is merged', () => {
+    const v = planAutoCloses(
+      [task('Review research doc 2207 - Media to drive', 'research-doc:2207')],
+      facts({ mergedDocNums: new Set(['2207']) }),
+    );
+    expect(v).toEqual([]);
+  });
+
+  // The four titles that would have been wrongly closed by the title regex.
+  it('NEVER closes live work that merely cites a doc', () => {
+    const cited = [
+      task('Build zao-claude-kit open-source repo via opensource-pipeline (doc 946)', 'inbox', 'a'),
+      task('Name Site Lead + First Aid Lead for ZAOstock Oct 3 (doc 1032)', 'inbox', 'b'),
+      task('zaalcaster: one-pager + landing (from doc 988)', 'zaal-master', 'c'),
+      task('ZOE TG upgrade phase 1b: REACTIONS API approvals (doc 1134)', 'escalated', 'd'),
+    ];
+    const all = facts({ mergedDocNums: new Set(['946', '1032', '988', '1134']), mergedPrNums: new Set(['946']) });
+    expect(planAutoCloses(cited, all)).toEqual([]);
+  });
+
+  it('never closes a task that names no artefact - most of the board', () => {
+    const v = planAutoCloses([task('Post to ZAO Festivals LinkedIn', 'inbox')], facts({ mergedPrNums: new Set(['244']) }));
+    expect(v).toEqual([]);
+  });
+
+  it('handles a batch, closing only the concluded PRs', () => {
+    const v = planAutoCloses(
+      [
+        task('Test plan: PR #2867', 'pr-auto:2867', 'a'),
+        task('Test plan: PR #2952', 'pr-auto:2952', 'b'),
+        task('Review research doc 2207', 'research-doc:2207', 'c'),
+        task('Decide something human', 'inbox', 'd'),
+      ],
+      facts({ mergedPrNums: new Set(['2867']), mergedDocNums: new Set(['2207']) }),
+    );
+    expect(v.map((x) => x.id)).toEqual(['a']);
+  });
+
+  it('every verdict carries a reason - a close nobody can explain is untrustworthy', () => {
+    const v = planAutoCloses([task('Test plan: PR #2867', 'pr-auto:2867')], facts({ mergedPrNums: new Set(['2867']) }));
+    expect(v[0].reason.length).toBeGreaterThan(20);
+  });
+});
+
+describe('findVacuousReviewReminders - reports, never closes', () => {
+  it('finds doc-review reminders whose doc was already merged at birth', () => {
+    const found = findVacuousReviewReminders(
+      [
+        task('Review research doc 2207', 'research-doc:2207', 'a'),
+        task('Review research doc 9999', 'research-doc:9999', 'b'),
+        task('Build a thing (doc 946)', 'inbox', 'c'),
+      ],
+      facts({ mergedDocNums: new Set(['2207', '946']) }),
+    );
+    expect(found.map((t) => t.id)).toEqual(['a']);
+  });
+
+  it('is a separate function from the close path, so a report can never close', () => {
+    const tasks = [task('Review research doc 2207', 'research-doc:2207')];
+    const f = facts({ mergedDocNums: new Set(['2207']) });
+    expect(findVacuousReviewReminders(tasks, f)).toHaveLength(1);
+    expect(planAutoCloses(tasks, f)).toHaveLength(0);
+  });
+});
+
+describe('capCloses - blast radius, not performance', () => {
+  const many = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `t${i}`, title: `t${i}`, reason: 'merged' }));
+
+  it('passes a small batch through untouched', () => {
+    const { toClose, deferred } = capCloses(many(5));
+    expect(toClose).toHaveLength(5);
+    expect(deferred).toBe(0);
+  });
+
+  it('caps a large batch and reports what it deferred', () => {
+    const { toClose, deferred } = capCloses(many(100));
+    expect(toClose).toHaveLength(MAX_CLOSES_PER_RUN);
+    expect(deferred).toBe(100 - MAX_CLOSES_PER_RUN);
+  });
+
+  it('never silently drops the overflow', () => {
+    const { toClose, deferred } = capCloses(many(30));
+    expect(toClose.length + deferred).toBe(30);
+  });
+});

--- a/bot/src/zoe/done-work-detector.ts
+++ b/bot/src/zoe/done-work-detector.ts
@@ -1,0 +1,169 @@
+/**
+ * done-work-detector.ts - decide which open board tasks describe work that has
+ * VERIFIABLY concluded, so ZOE's hourly pass can close them.
+ *
+ * THE PROBLEM (measured 2026-08-08)
+ * --------------------------------
+ * The cowork board had 474 open / 122 overdue. The cause is structural: EIGHT
+ * writers can create a task (inbox 112, escalated 93, meeting 56, handoff 28,
+ * research-doc 25, cowork-actions 17, zaal-master 13) and NOTHING can close one.
+ * Closing meant opening a browser and clicking, so closing cost more than
+ * ignoring, and ignoring won.
+ *
+ * THE MISTAKE THIS MODULE ALREADY MADE, KEPT HERE SO IT IS NOT REMADE
+ * ------------------------------------------------------------------
+ * The first version closed a task when the research doc it named was merged into
+ * research/ on main. A dry run against the live board proposed closing 40 tasks -
+ * and the proposal was wrong.
+ *
+ * Two separate defects, both worth naming:
+ *
+ * 1. THE DOC RULE WAS VACUOUS. The research-doc writer creates "Review research
+ *    doc NNNN" the moment the doc ships, so the doc is ALREADY merged when the
+ *    task is born. Measured: 25 of 25 open doc-review tasks pointed at a merged
+ *    doc. A condition true for 100% of the set discriminates nothing - it is not
+ *    evidence of completion, it is a restatement of the task's own existence.
+ *    Closing on it is not detection, it is deleting the queue while producing a
+ *    sentence that sounds like proof.
+ *
+ * 2. A NUMBER IN THE TITLE IS NOT THE TASK\'S SUBJECT. "Build zao-claude-kit via
+ *    opensource-pipeline (doc 946)" and "Name Site Lead for ZAOstock (doc 1032)"
+ *    merely CITE a doc. The doc is where the ask is written down; the ask is
+ *    building a repo and naming a person. Closing those because the doc exists
+ *    would have destroyed live work and reported it as an accomplishment.
+ *
+ * The corrected rule follows from both: a task may be closed only when its
+ * legacy_source proves the task exists SOLELY to track one artefact, AND that
+ * artefact has reached a state that makes the task moot. Title text never
+ * qualifies, and "the artefact exists" never qualifies.
+ *
+ * WHAT SURVIVES
+ * -------------
+ * pr-auto:NNNN - created by the PR-test-plan writer for exactly one PR. When
+ * that PR is merged or closed-without-merge, it has reached a terminal state and
+ * the reminder is moot. That is a genuine state CHANGE after the task was born,
+ * which is what evidence has to be.
+ *
+ * Doc-review tasks are deliberately NOT closed here. They are surfaced by
+ * `findVacuousReviewReminders` so a human can make one bulk decision about a
+ * queue that was never actionable, rather than have a machine quietly delete it.
+ *
+ * This module is PURE - facts in, verdicts out - so the rules are unit-testable
+ * without a board, a repo, or a network (the convention task-classifier.ts and
+ * topic-router.ts already follow).
+ */
+
+export interface OpenTask {
+  id: string;
+  title: string;
+  /** legacy_source, e.g. "research-doc:2207" or "pr-auto:2867". */
+  legacySource?: string | null;
+}
+
+/** What the caller must look up for us, gathered once for the whole batch. */
+export interface RepoFacts {
+  /** PR numbers whose squash commit is on main, i.e. "(#NNNN)" in the log. */
+  mergedPrNums: Set<string>;
+  /** PR numbers CLOSED WITHOUT merge - abandoned, so the task is equally dead.
+   *  Kept separate so the reason we write is honest about which happened. */
+  closedUnmergedPrNums: Set<string>;
+  /** Doc numbers merged on main. Used ONLY for reporting vacuous reminders -
+   *  never as a close condition, for the reason documented above. */
+  mergedDocNums: Set<string>;
+}
+
+export interface CloseVerdict {
+  id: string;
+  title: string;
+  /** Human-readable justification, written into the task\'s notes. Never a bare
+   *  "auto-closed" - a close nobody can explain is one nobody can trust. */
+  reason: string;
+}
+
+/**
+ * The PR number this task exists to track, or null.
+ *
+ * legacy_source ONLY. A "#2867" in a title can be a citation, a cross-reference,
+ * or a mention in passing; legacy_source is the writer\'s own record that this
+ * task was created FOR that PR and tracks nothing else.
+ */
+export function trackedPrNum(task: OpenTask): string | null {
+  const m = /^pr-auto:(\d{1,6})$/.exec(task.legacySource || '');
+  return m ? m[1] : null;
+}
+
+/** The doc number this task exists to track, or null. Same legacy_source-only rule. */
+export function trackedDocNum(task: OpenTask): string | null {
+  const m = /^research-doc:(\d{3,4})$/.exec(task.legacySource || '');
+  return m ? m[1] : null;
+}
+
+/**
+ * Which of these tasks can be closed, and why.
+ *
+ * Closes ONLY on a state change that happened AFTER the task was created. A
+ * condition that was already true at birth (see the doc-rule postmortem above)
+ * is not evidence. Absence of evidence closes nothing - every branch defaults to
+ * leaving the task open, so a stale repo or an unreachable API costs us a missed
+ * close, never a wrong one.
+ */
+export function planAutoCloses(tasks: OpenTask[], facts: RepoFacts): CloseVerdict[] {
+  const out: CloseVerdict[] = [];
+  for (const t of tasks) {
+    const pr = trackedPrNum(t);
+    if (!pr) continue;
+
+    if (facts.mergedPrNums.has(pr)) {
+      out.push({
+        id: t.id,
+        title: t.title,
+        reason: `PR #${pr} is merged into main - this task tracked only that PR, which has concluded`,
+      });
+      continue;
+    }
+    if (facts.closedUnmergedPrNums.has(pr)) {
+      out.push({
+        id: t.id,
+        title: t.title,
+        reason: `PR #${pr} was closed without merging - this task tracked only that PR, which was abandoned`,
+      });
+    }
+    // PR still open, or its state is unknown. Leave the task alone.
+  }
+  return out;
+}
+
+/**
+ * Doc-review reminders whose doc was already merged when the reminder was born.
+ *
+ * NOT a close list. These are reported so Zaal can make ONE decision about a
+ * queue that was never actionable ("close all 25" / "keep, I do read these"),
+ * instead of a machine deleting them under a proof that does not hold.
+ */
+export function findVacuousReviewReminders(tasks: OpenTask[], facts: RepoFacts): OpenTask[] {
+  return tasks.filter((t) => {
+    const doc = trackedDocNum(t);
+    return doc !== null && facts.mergedDocNums.has(doc);
+  });
+}
+
+/**
+ * Cap how many get closed per run.
+ *
+ * Not a performance limit - a blast-radius one. If a bug ever makes this
+ * over-match (it already did once), a bad run costs a reviewable handful rather
+ * than the whole board, and the cap gives a human a chance to see it in the log
+ * before the rest follow.
+ */
+export const MAX_CLOSES_PER_RUN = 25;
+
+export function capCloses(verdicts: CloseVerdict[]): {
+  toClose: CloseVerdict[];
+  deferred: number;
+} {
+  if (verdicts.length <= MAX_CLOSES_PER_RUN) return { toClose: verdicts, deferred: 0 };
+  return {
+    toClose: verdicts.slice(0, MAX_CLOSES_PER_RUN),
+    deferred: verdicts.length - MAX_CLOSES_PER_RUN,
+  };
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -59,7 +59,7 @@ import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidate
 import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
 import { checkAndResend, readLastUserReplyAt } from './escalation';
-import { reconcileUntaggedTasks, getTaskStatusByIds } from './team-tracker';
+import { reconcileUntaggedTasks, getTaskStatusByIds, autoCloseFinishedTasks } from './team-tracker';
 import { ingestAllIdentities } from './fleet';
 import { runTaskCommentReplies } from './task-comment-replies';
 import { runMentionNotify } from './task-mention-notify';
@@ -713,6 +713,40 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           }
         } catch (err) {
           console.warn('[zoe/scheduler] auto-tag reconcile failed (nbd):', (err as Error).message);
+        }
+
+        // Auto-CLOSE the finished ones. The tagger above and this closer are the
+        // two halves of the same hourly pass: eight writers could open a task and
+        // nothing could finish one, so the board reached 474 open / 122 overdue
+        // with every sampled doc-review pointing at an already-merged doc.
+        //
+        // Closes only on POSITIVE evidence (the doc is on main, the PR's merge
+        // commit is on main) and caps the blast radius per run, so the worst a
+        // bug can do is a reviewable handful rather than the whole board.
+        try {
+          const c = await autoCloseFinishedTasks(process.env.ZOE_REPO_DIR ?? '/home/zaal/zao-os');
+          if (c.ok && c.closed > 0) {
+            console.log(
+              `[zoe/scheduler] auto-close: closed ${c.closed}/${c.scanned}` +
+                (c.deferred > 0 ? ` (${c.deferred} deferred to next run)` : ''),
+            );
+            // Log each one. A close nobody can see is a close nobody can undo.
+            for (const r of c.reasons) console.log(`[zoe/scheduler] auto-close: ${r}`);
+          } else if (!c.ok && c.error) {
+            console.warn(`[zoe/scheduler] auto-close skipped: ${c.error}`);
+          }
+          // Surfaced, never closed. These doc-review reminders were created when
+          // their doc shipped, so "the doc is merged" was true from birth and
+          // proves nothing - the queue needs one human decision, not a machine
+          // deleting it under a proof that does not hold.
+          if (c.ok && c.vacuousReminders > 0) {
+            console.log(
+              `[zoe/scheduler] auto-close: ${c.vacuousReminders} doc-review reminders left open ` +
+                '(never actionable - needs one bulk decision from Zaal, not an auto-close)',
+            );
+          }
+        } catch (err) {
+          console.warn('[zoe/scheduler] auto-close failed (nbd):', (err as Error).message);
         }
 
         // Task #930: ping-lifecycle resolution. Hourly check for any teammate-ack

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -16,6 +16,13 @@
  */
 
 import { classifyTask, applyClassification, planReconciliation, type TrackerRow } from './task-classifier';
+import {
+  capCloses,
+  findVacuousReviewReminders,
+  planAutoCloses,
+  trackedPrNum,
+  type RepoFacts,
+} from './done-work-detector';
 import { remember } from './recall';
 
 export interface TeamTask {
@@ -568,4 +575,161 @@ export async function runTeamDigest(opts?: { mirrorToBonfire?: boolean }): Promi
     }
   }
   return { digest, taskCount: tasks.length, mirrored };
+}
+
+
+/**
+ * AUTO-CLOSE: the missing half of the loop (2026-08-08).
+ *
+ * reconcileUntaggedTasks above TAGS. Nothing CLOSED - eight writers could create
+ * a task and none could finish one, so the board reached 474 open / 122 overdue.
+ *
+ * See done-work-detector.ts for WHY this closes so little: the obvious rule
+ * ("the doc it names is merged") turned out to be true for 25 of 25 doc-review
+ * tasks at birth, so it proved nothing. What survives is PR tasks whose PR
+ * reached a terminal state - a real change after the task was created.
+ */
+export interface AutoCloseResult {
+  ok: boolean;
+  scanned: number;
+  closed: number;
+  deferred: number;
+  reasons: string[];
+  /** Doc-review reminders that were never actionable. REPORTED, never closed -
+   *  a bulk decision that belongs to a human. */
+  vacuousReminders: number;
+  error?: string;
+}
+
+/**
+ * Gather PR + doc state.
+ *
+ * Merges come from the LOCAL CLONE (a squash merge writes "(#NNNN)" into the
+ * subject on main) - no token, no rate limit. A CLOSED-WITHOUT-MERGE PR leaves
+ * no trace in the log at all, so that one case needs the API - but only for the
+ * handful of PR numbers actually on the board, never a blanket listing.
+ */
+async function gatherRepoFacts(repoDir: string, prNums: string[]): Promise<RepoFacts> {
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const run = promisify(execFile);
+  const facts: RepoFacts = {
+    mergedPrNums: new Set(),
+    closedUnmergedPrNums: new Set(),
+    mergedDocNums: new Set(),
+  };
+
+  try {
+    // Fetch first - a stale clone under-reports concluded work. That is safe
+    // (it closes nothing) but useless.
+    await run('git', ['-C', repoDir, 'fetch', 'origin', 'main', '--quiet'], { timeout: 60_000 });
+
+    const { stdout: log } = await run(
+      'git', ['-C', repoDir, 'log', 'origin/main', '--format=%s', '-n', '4000'],
+      { timeout: 60_000, maxBuffer: 16 * 1024 * 1024 },
+    );
+    for (const line of log.split('\n')) {
+      const m = /\(#(\d{1,6})\)\s*$/.exec(line.trim());
+      if (m) facts.mergedPrNums.add(m[1]);
+    }
+
+    // ls-tree, not the working tree, so a dirty checkout cannot invent or hide a
+    // doc. Used only to report vacuous reminders - never to close.
+    const { stdout: tree } = await run(
+      'git', ['-C', repoDir, 'ls-tree', '-d', '-r', '--name-only', 'origin/main', 'research/'],
+      { timeout: 60_000, maxBuffer: 32 * 1024 * 1024 },
+    );
+    for (const line of tree.split('\n')) {
+      const m = /research\/[^/]+\/(\d{3,4})-/.exec(line);
+      if (m) facts.mergedDocNums.add(m[1]);
+    }
+  } catch {
+    // Leave the sets empty. Empty facts close NOTHING - the safe failure.
+  }
+
+  // Only the PRs the board actually names, and only those the log did not
+  // already prove merged. Usually two or three calls; often zero.
+  for (const pr of prNums) {
+    if (facts.mergedPrNums.has(pr)) continue;
+    try {
+      const { stdout } = await run(
+        'gh', ['api', `repos/bettercallzaal/ZAOOS/pulls/${pr}`, '--jq', '{state:.state,merged:.merged}'],
+        { timeout: 20_000 },
+      );
+      const info = JSON.parse(stdout) as { state?: string; merged?: boolean };
+      if (info.state === 'closed' && info.merged === true) facts.mergedPrNums.add(pr);
+      else if (info.state === 'closed') facts.closedUnmergedPrNums.add(pr);
+      // open -> record nothing, so the task stays open.
+    } catch {
+      // gh missing, unauthenticated, or the PR is from another repo. Unknown
+      // state means we leave the task alone.
+    }
+  }
+  return facts;
+}
+
+/**
+ * Close open board tasks whose tracked PR has concluded.
+ *
+ * Best-effort, never throws. Appends the reason to the task\'s notes so every
+ * close is auditable and reversible - status only, never a delete.
+ */
+export async function autoCloseFinishedTasks(
+  repoDir: string,
+  limit = 500,
+): Promise<AutoCloseResult> {
+  const empty = { scanned: 0, closed: 0, deferred: 0, reasons: [] as string[], vacuousReminders: 0 };
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return { ok: false, ...empty, error: 'team tracker not configured' };
+  if (!repoDir) return { ok: false, ...empty, error: 'no repoDir' };
+
+  const root = base.replace(/\/$/, '');
+  const headers = { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' };
+
+  try {
+    const res = await fetch(
+      `${root}/rest/v1/tasks?status=eq.todo&archived_at=is.null&select=id,title,notes,legacy_source&limit=${limit}`,
+      { headers, cache: 'no-store' },
+    );
+    if (!res.ok) return { ok: false, ...empty, error: `read ${res.status}` };
+    const rows = (await res.json()) as Array<{
+      id: string;
+      title: string;
+      notes?: string;
+      legacy_source?: string;
+    }>;
+    const tasks = rows.map((r) => ({ id: r.id, title: r.title, legacySource: r.legacy_source }));
+
+    const prNums = [...new Set(tasks.map(trackedPrNum).filter((x): x is string => x !== null))];
+    const facts = await gatherRepoFacts(repoDir, prNums);
+    if (facts.mergedPrNums.size === 0 && facts.closedUnmergedPrNums.size === 0) {
+      // Could not read the repo at all. Closing now would be closing on absence
+      // of evidence, which this must never do.
+      return { ok: false, ...empty, scanned: rows.length, error: 'no repo facts - closed nothing' };
+    }
+
+    const vacuousReminders = findVacuousReviewReminders(tasks, facts).length;
+    const { toClose, deferred } = capCloses(planAutoCloses(tasks, facts));
+
+    let closed = 0;
+    const reasons: string[] = [];
+    for (const v of toClose) {
+      const row = rows.find((r) => r.id === v.id);
+      const stamp = new Date().toISOString().slice(0, 10);
+      const notes = `${(row?.notes || '').trim()}\n\nAUTO-CLOSED ${stamp}: ${v.reason}`.trim();
+      const patch = await fetch(`${root}/rest/v1/tasks?id=eq.${v.id}`, {
+        method: 'PATCH',
+        headers: { ...headers, Prefer: 'return=minimal' },
+        body: JSON.stringify({ status: 'completed', notes }),
+      });
+      if (patch.ok) {
+        closed += 1;
+        reasons.push(`${v.title.slice(0, 60)} - ${v.reason}`);
+      }
+    }
+    return { ok: true, scanned: rows.length, closed, deferred, reasons, vacuousReminders };
+  } catch (e) {
+    return { ok: false, ...empty, error: e instanceof Error ? e.message : 'auto-close failed' };
+  }
 }

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -714,6 +714,7 @@ export async function autoCloseFinishedTasks(
 
     let closed = 0;
     const reasons: string[] = [];
+    const refused: string[] = [];
     for (const v of toClose) {
       const row = rows.find((r) => r.id === v.id);
       const stamp = new Date().toISOString().slice(0, 10);
@@ -721,14 +722,32 @@ export async function autoCloseFinishedTasks(
       const patch = await fetch(`${root}/rest/v1/tasks?id=eq.${v.id}`, {
         method: 'PATCH',
         headers: { ...headers, Prefer: 'return=minimal' },
-        body: JSON.stringify({ status: 'completed', notes }),
+        // 'done', NOT 'completed'. A CHECK constraint on tasks.status rejects
+        // anything else with a 400 (Postgres 23514), and the failure is silent
+        // at this level - patch.ok goes false, the count stays 0, and the pass
+        // looks like "nothing to close" rather than "every close was refused".
+        // The live values are: todo (286), done (710), blocked (2), in_progress
+        // (2). This exact mistake already cost four failed attempts at a
+        // `zao-tracker done` subcommand before the 400 body was ever read.
+        body: JSON.stringify({ status: 'done', notes }),
       });
       if (patch.ok) {
         closed += 1;
         reasons.push(`${v.title.slice(0, 60)} - ${v.reason}`);
+      } else {
+        // Never let a rejected write read as "nothing needed closing".
+        refused.push(`${patch.status} on ${v.title.slice(0, 50)}`);
       }
     }
-    return { ok: true, scanned: rows.length, closed, deferred, reasons, vacuousReminders };
+    return {
+      ok: refused.length === 0,
+      scanned: rows.length,
+      closed,
+      deferred,
+      reasons,
+      vacuousReminders,
+      error: refused.length ? `${refused.length} close(s) REFUSED: ${refused.join('; ')}` : undefined,
+    };
   } catch (e) {
     return { ok: false, ...empty, error: e instanceof Error ? e.message : 'auto-close failed' };
   }


### PR DESCRIPTION
## What changed

ZOE's hourly board pass could TAG untagged tasks but could never CLOSE one. This adds the closing half.

## Why it matters

The board is at 474 open / 122 overdue. That is structural, not a discipline failure: eight writers can create a task (inbox 112, escalated 93, meeting 56, handoff 28, research-doc 25, cowork-actions 17, zaal-master 13) and nothing can finish one. Closing meant opening a browser and clicking, so closing cost more than ignoring.

## Before vs after

BEFORE: a task whose PR was abandoned three weeks ago sits open forever, indistinguishable from live work.

AFTER: the hourly pass closes it and writes why into the notes. Two such tasks exist right now.

## The part worth reading

The first version of this closed a task when the research doc it named was merged. A dry run against the live board proposed **40 closes**. Both of its rules were wrong:

1. **The doc rule was vacuous.** The research-doc writer creates "Review research doc NNNN" *when the doc ships*, so the doc is already merged at the task's birth. Measured: **25 of 25** open doc-review tasks pointed at a merged doc. A condition true for the whole set proves nothing - closing on it is deleting the queue while emitting a sentence that sounds like proof.
2. **A number in a title is a citation, not a subject.** `Build zao-claude-kit (doc 946)`, `Name Site Lead for ZAOstock Oct 3 (doc 1032)`, `zaalcaster: one-pager (from doc 988)` - the doc is where the ask is written down. Closing those destroys live work.

Corrected rule: close only when `legacy_source` proves the task tracks exactly one artefact **and** that artefact changed state *after* the task was created. Doc-review reminders are reported, never closed - that queue needs one bulk decision from a human.

## Evidence

| Check | Result |
|---|---|
| Unit tests | 21 pass, incl. a regression per defect above |
| Full bot suite | 165 files / 2074 tests pass |
| Typecheck | 0 errors in touched files (37 pre-existing, unrelated test files) |
| Dry run vs LIVE board | 2 closes proposed; both confirmed `state=closed merged=false` via the GitHub API |
| Reported not closed | 25 doc-review reminders |

## Safety

- Empty facts close nothing. A stale clone or an unreachable API costs a missed close, never a wrong one.
- 25-close cap per run bounds the blast radius, and the deferred count is logged rather than silently truncated.
- Writes are status + an appended reason. Never a delete, always reversible, always explicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
