### PR TITLE
fix(zoe): the stale break let two ticks hold the same lock

### DIFF
--- a/bot/src/zoe/__tests__/tick-lock.test.ts
+++ b/bot/src/zoe/__tests__/tick-lock.test.ts
@@ -84,6 +84,31 @@ describe('acquireTickLock', () => {
     expect(results.filter((r) => r.acquired)).toHaveLength(1);
   });
 
+  // The break is guarded by `<lock>.break` so only one contender at a time may
+  // decide a lock is dead. While another contender holds that, the correct answer
+  // is to skip this tick - not to break a lock somebody else may be about to win.
+  it('does not break a stale lock while another contender is mid-break', async () => {
+    await acquireTickLock(lock);
+    await fs.writeFile(lock, String(Date.now() - (DEFAULT_STALE_MS + 60_000)));
+    await fs.writeFile(`${lock}.break`, String(Date.now()));
+
+    const blocked = await acquireTickLock(lock);
+    expect(blocked.acquired).toBe(false);
+    // The stale lock is still there: nobody deleted it behind the break lock.
+    await expect(fs.stat(lock)).resolves.toBeTruthy();
+  });
+
+  // ...but a process killed mid-break must not wedge every future break forever.
+  it('clears an abandoned break lock so a crash cannot wedge the break', async () => {
+    await acquireTickLock(lock);
+    await fs.writeFile(lock, String(Date.now() - (DEFAULT_STALE_MS + 60_000)));
+    await fs.writeFile(`${lock}.break`, String(Date.now() - 10 * 60_000));
+
+    expect((await acquireTickLock(lock)).acquired).toBe(true);
+    // The break lock is released again, not left behind for the next tick.
+    await expect(fs.stat(`${lock}.break`)).rejects.toThrow();
+  });
+
   it('honours a custom staleness threshold', async () => {
     await acquireTickLock(lock);
     await fs.writeFile(lock, String(Date.now() - 5000));

--- a/bot/src/zoe/tick-lock.ts
+++ b/bot/src/zoe/tick-lock.ts
@@ -25,6 +25,15 @@
  * Staleness is then handled explicitly and separately, which is also the only
  * safe way to do it.
  *
+ * AND THE PLACE THAT WAS NOT ENOUGH. Making the create atomic is necessary, not
+ * sufficient. The STALE BREAK was left as a bare `fs.unlink` followed by that
+ * atomic create - and while each call is atomic, the pair is not, so the break
+ * reintroduced check-then-act one line further down and two contenders could
+ * again both come away holding the lock. `breakStaleLock` below closes it. The
+ * lesson this header already states turned out to apply to its own fix: a guard
+ * that looks like a guard is the worst kind, because it stops anyone looking
+ * again - including at the guard.
+ *
  * WHAT THIS STILL DOES NOT DO. A filesystem lock is per-machine. It cannot stop
  * the Mac and the VPS from both running a tick, because they do not share a
  * filesystem - and Zaal runs loops on a Mac, a VPS, a Pi and a Windows desktop.
@@ -39,6 +48,14 @@ import { dirname } from 'node:path';
 
 /** How long before a held lock is assumed to belong to a dead process. */
 export const DEFAULT_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * How long the break lock (below) may be held before it is itself assumed
+ * abandoned. The critical section it guards is two filesystem calls, so a minute
+ * is already several orders of magnitude of headroom - it exists only so a
+ * process killed mid-break cannot wedge every future stale break forever.
+ */
+const BREAK_STALE_MS = 60 * 1000;
 
 export interface TickLockOptions {
   staleMs?: number;
@@ -71,6 +88,69 @@ async function lockAgeMs(path: string, now: () => number): Promise<number | null
   const st = await fs.stat(path).catch(() => null);
   if (!st) return null;
   return now() - st.mtimeMs;
+}
+
+/**
+ * Remove a stale lock, but only ever the stale one - under a second lock so that
+ * exactly one contender is deciding at a time.
+ *
+ * WHY THIS IS NOT JUST `unlink`. The break used to be an unconditional
+ * `fs.unlink(path)` followed by an atomic create. The create is atomic; the
+ * *pair* is not. Two contenders that both read the same stale age interleave as:
+ *
+ *     A unlink -> A create (WINS) -> B unlink (deletes A's FRESH lock) -> B create (WINS)
+ *
+ * and both return `acquired: true`. That is the identical check-then-act shape
+ * this module was written to delete, just moved one call further down, and it is
+ * strictly worse than the bug it replaced because the loser also destroys the
+ * winner's lock on its way through.
+ *
+ * THE FIX HAS TWO HALVES, and it needs both:
+ *  1. Re-read the age and unlink ONLY while it is still stale, so a lock a winner
+ *     has already refreshed is never deleted.
+ *  2. Do that re-read and unlink inside `path.break`, itself taken with the same
+ *     atomic 'wx' create, so step 1 cannot be raced by a second contender.
+ *
+ * The final create deliberately stays OUTSIDE this section: it is already atomic,
+ * so whichever contenders reach it, exactly one wins. All this has to guarantee
+ * is that nobody deletes a lock somebody else is holding.
+ */
+async function breakStaleLock(path: string, staleMs: number, now: () => number): Promise<void> {
+  const breakPath = `${path}.break`;
+
+  type BreakHandle = { writeFile(data: string): Promise<void>; close(): Promise<void> };
+  const openBreak = async (): Promise<BreakHandle | null> => {
+    try {
+      return await fs.open(breakPath, 'wx');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return null;
+      // Either another contender is mid-break - in which case backing off is the
+      // correct outcome, it will have broken the lock by the next tick - or a
+      // process died holding it. Only the second case may be cleared.
+      const breakAge = await lockAgeMs(breakPath, now);
+      if (breakAge === null || breakAge < BREAK_STALE_MS) return null;
+      await fs.unlink(breakPath).catch(() => {});
+      return await fs.open(breakPath, 'wx').catch(() => null);
+    }
+  };
+
+  const fh = await openBreak();
+  if (!fh) return;
+  try {
+    // Stamp it with OUR clock, for the same reason the main lock carries one:
+    // reading age from the filesystem mtime instead would compare an injectable
+    // now() against real wall-clock and yield a meaningless number.
+    await fh.writeFile(String(now()));
+
+    // Re-read UNDER the break lock. `null` means someone already broke it and has
+    // not created theirs yet; anything fresher than staleMs means someone broke it
+    // and won. Neither is ours to delete.
+    const age = await lockAgeMs(path, now);
+    if (age !== null && age >= staleMs) await fs.unlink(path).catch(() => {});
+  } finally {
+    await fh.close().catch(() => {});
+    await fs.unlink(breakPath).catch(() => {});
+  }
 }
 
 /**
@@ -127,10 +207,11 @@ export async function acquireTickLock(
   }
   if (age < staleMs) return { acquired: false, reason: 'held', heldForMs: age };
 
-  // Stale: the holder is presumed dead. Remove and retry exactly once. If another
-  // process breaks it at the same moment, the atomic create still picks one
-  // winner - the loser simply skips this tick, which is the correct outcome.
-  await fs.unlink(path).catch(() => {});
+  // Stale: the holder is presumed dead. Break it - guarded, so a lock somebody
+  // else has already taken is never deleted - then retry exactly once. If several
+  // processes break at the same moment, the atomic create still picks one winner;
+  // the losers simply skip this tick, which is the correct outcome.
+  await breakStaleLock(path, staleMs, now);
   return (await attempt()) ?? { acquired: false, reason: 'held', heldForMs: age };
 }
 


### PR DESCRIPTION
## Executive Summary

`acquireTickLock` is the guard that stops two ZOE ticks running at once. It can currently let two of them run at once. The atomic create it was written around is fine; the **stale-break path around it is not**, and that path reintroduces exactly the check-then-act race the module was created to delete.

The repo's own test for this (`still yields ONE winner when several callers break a stale lock at once`) **fails on main**. It fails intermittently, so CI has been passing on luck rather than on correctness.

Measured on main, under filesystem load, interleaved against the fixed version so both saw identical conditions:

```
OLD (main): != 1 winner in 12/250 rounds   (worst round: 3 simultaneous winners)
NEW (this): != 1 winner in  0/250 rounds   (worst round: 1)
```

## What breaks without this fix

`acquireTickLock` returns `{ acquired: true }` to **two or three callers at the same time** whenever a stale lock is broken concurrently.

Concretely, the interleaving is:

```
A unlink -> A create (WINS) -> B unlink (deletes A's FRESH lock) -> B create (WINS)
```

The final create is atomic, so only one caller can win it. But the `unlink` before it is unconditional, so a slower contender deletes the lock a faster one has *already won* and then creates its own. Both come away holding the lock, and the loser has destroyed the winner's lock on the way through.

The callers are the two autonomous loops that spend money and open PRs:

- `bot/src/zoe/work-loop.ts:130` - pulls a queued research item, runs the full decompose/dispatch/commit pipeline, opens a doc PR
- `bot/src/zoe/orchestrator-tick.ts:269` - the orchestrator tick

So the real-world failure is: a ZOE host restarts or crashes and leaves a stale lock; the next cron tick and a manual kick land together; both break the stale lock, both acquire, both run the same work item. Duplicate research, duplicate spend, duplicate PRs. That is `.claude/rules/agent-loops.md` rule 9 (one instance per resource) being violated by the code written to enforce it, which is the failure mode the module's own header calls "the worst kind" because it stops anyone looking again.

## The fix

`breakStaleLock()`, a new function in the same file. Two halves, both needed:

1. Re-read the age and unlink **only while it is still stale**, so a lock a winner has already refreshed is never deleted.
2. Do that re-read and unlink inside `<lock>.break`, taken with the same atomic `'wx'` create, so step 1 cannot itself be raced.

The final create deliberately stays outside the critical section. It is already atomic, so whichever contenders reach it, exactly one wins. All the section has to guarantee is that nobody deletes a lock somebody else is holding.

An abandoned `.break` file (a process killed mid-break) is cleared after 60s, so a crash cannot wedge every future stale break. The break file carries its own timestamp so its age is read from the caller's clock rather than the filesystem mtime, which is the mixed-clock trap this module already documents in `lockAgeMs`.

## Evidence

**Proven:**

- `bot/src/zoe/__tests__/tick-lock.test.ts` goes from failing to passing. That test file: 16 tests -> 18 tests, 18/18 passing across 3 consecutive runs.
- Bot suite test files: 161 passed / 3 failed on main -> 162 passed / 2 failed here. No test removed, coverage up by 2.
- `tsc --noEmit` reports zero errors for `tick-lock.ts`.
- The interleaved old-vs-new measurement above (250 rounds each, same load window, 12 concurrent contenders per round breaking one stale lock).

**Not fixed here, and why:**

- The 2 remaining bot-suite failures (`trace.test.ts`, `transcribe.test.ts`) are **pre-existing on main and unrelated**. Both are Windows-only test assertions: the tests assert a literal forward-slash path (`/traces/`, `/tmp/zoe-files`) against a value built with `path.join`, which yields backslashes on Windows. CI runs ubuntu, so these are green there. Test-portability, not product bugs. Left alone to keep this diff to one thing.
- `bot/` `tsc --noEmit` also reports 37 errors, all in `__tests__` files and all `vitest` `Mock<...>` generic-arity mismatches from a fresh install picking a newer vitest. Environment noise, not repo state. CI does not run bot typecheck (`.github/workflows/ci.yml` runs `npm test` in `bot/` only).
- `acquireTickLock` has a second path where a loser re-races (`age === null` -> `attempt()` again). I changed it, could **not** demonstrate it causes a duplicate run in practice, and reverted the change rather than ship an unproven behaviour change. Noting it here as an observation, not a finding.
- The `never runs the body twice under concurrency` test also fails intermittently on Windows. I measured this one: every double-run had a **positive** gap between the first body ending and the second starting (1.0ms to 12.1ms), meaning the late contender arrived after the winner had legitimately released. Present at the same rate on main and on this branch. That is the test's 5ms hold being too short on a loaded Windows filesystem, not a lock defect.

**Not verified:** biome was not run - the repo root `node_modules` is not installed in this checkout and `bot/` has no biome. The diff adds no new imports and no formatting changes.

## Scope

Two files, both `bot/src/zoe/`. One function added, one call site changed, two tests added. No behaviour change on any path except the stale break. Nothing outbound, nothing merged, nothing deployed.
