### PR TITLE
feat(zoe): let a feature say once that it actually ran

### DIFF
--- a/bot/src/zoe/__tests__/feature-ran.test.ts
+++ b/bot/src/zoe/__tests__/feature-ran.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { announcedFeatures, featureRan, resetAnnouncedForTest } from '../feature-ran';
+
+afterEach(() => {
+  resetAnnouncedForTest();
+  vi.restoreAllMocks();
+});
+
+describe('featureRan', () => {
+  it('prints the first time a feature runs', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    featureRan('dm-build');
+    expect(spy).toHaveBeenCalledWith('[zoe/ran] dm-build');
+  });
+
+  it('includes the detail when given', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    featureRan('dm-build', 'chat 123');
+    expect(spy).toHaveBeenCalledWith('[zoe/ran] dm-build - chat 123');
+  });
+
+  // The whole point of once-per-process. tick-lock runs every tick; a line per
+  // call would be thousands a day and become the noise nobody greps.
+  it('stays silent on every later call, however many', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    for (let i = 0; i < 500; i += 1) featureRan('tick-lock', `call ${i}`);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks each feature separately', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    featureRan('a');
+    featureRan('b');
+    featureRan('a');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(announcedFeatures()).toEqual(['a', 'b']);
+  });
+
+  it('uses a greppable prefix - one grep answers what is alive', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    featureRan('guardrails');
+    expect((spy.mock.calls[0][0] as string).startsWith('[zoe/ran] ')).toBe(true);
+  });
+
+  // A closed pipe or a detached service must cost a log line, not the work.
+  it('never throws when stdout is gone', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {
+      throw new Error('stdout gone');
+    });
+    expect(() => featureRan('x')).not.toThrow();
+  });
+});

--- a/bot/src/zoe/build-intent.ts
+++ b/bot/src/zoe/build-intent.ts
@@ -29,6 +29,8 @@
  * everything ambiguous stays conversation.
  */
 
+import { featureRan } from './feature-ran';
+
 export type BuildConfidence = 'explicit' | 'likely';
 
 export interface BuildIntent {
@@ -102,6 +104,7 @@ const has = (haystack: string, needles: string[]): boolean =>
  */
 export function detectBuildIntent(message: string): BuildIntent {
   const text = (message || '').trim();
+  featureRan('build-intent');
   if (!text) return { build: false, reason: 'empty message' };
 
   // 1. The explicit prefix. Zaal typed it on purpose; do not second-guess it.

--- a/bot/src/zoe/bus-bridge.ts
+++ b/bot/src/zoe/bus-bridge.ts
@@ -20,6 +20,7 @@
  * and tg-chunk for the 4096 limit.
  */
 import { chunkForTelegram } from './tg-chunk';
+import { featureRan } from './feature-ran';
 
 /** The tasern wire contract (identical to infra/bus/bus.js - one shape, both ends). */
 export interface BusMessage {
@@ -42,6 +43,7 @@ export function shortId(id: string): string {
  * long partner message survives Telegram's 4096 limit instead of being cut to 120.
  */
 export function renderBusMessage(msg: BusMessage): string[] {
+  featureRan('bus-bridge');
   const header = [
     `BUS ${msg.from} -> ${msg.to}`,
     msg.subject ? `Subject: ${msg.subject}` : '',

--- a/bot/src/zoe/dm-build-session.ts
+++ b/bot/src/zoe/dm-build-session.ts
@@ -25,6 +25,8 @@
  * reply says so.
  */
 
+import { featureRan } from './feature-ran';
+
 export interface ActiveBuild {
   /** Hermes run id, once the runner has created it. */
   runId?: string;
@@ -51,6 +53,7 @@ export function isStopRequest(message: string): boolean {
 }
 
 export function beginBuild(chatId: number, task: string): ActiveBuild {
+  featureRan('dm-build', `chat ${chatId}`);
   const b: ActiveBuild = {
     task,
     startedAt: Date.now(),

--- a/bot/src/zoe/feature-ran.ts
+++ b/bot/src/zoe/feature-ran.ts
@@ -1,0 +1,61 @@
+/**
+ * feature-ran.ts - let a feature say, once, that it actually executed.
+ *
+ * THE PROBLEM (measured 2026-08-08)
+ * --------------------------------
+ * Eight features shipped this week. Asked "which of them have run in
+ * production?", seven days of journald could not answer, because five of the
+ * eight (dm-build-session, build-intent, live-status, tick-lock, bus-bridge)
+ * contain no logging statement at all, and the other three
+ * (guardrails, memory-git, mission-control) speak only from inside a catch.
+ *
+ * So silence meant "no errors", never "it ran" - and a flag reading ON in
+ * zoe-liveness told us the code was REACHABLE, not that it had been reached.
+ * That gap is the whole of "merged is not running", and it is why a week of
+ * work could not be tested.
+ *
+ * WHY ONCE PER PROCESS, AND NOT PER CALL
+ * -------------------------------------
+ * tick-lock runs every tick; a line per call would produce thousands a day and
+ * become the noise nobody greps (noisy-signal-guard: a check that always fires
+ * is a check nobody reads). One line the FIRST time a feature executes after a
+ * boot answers the only question actually being asked - "is this thing alive?" -
+ * and leaves the log quiet enough to read.
+ *
+ * The result is a single decisive grep:
+ *   journalctl --user -u zoe-bot.service | grep '\[zoe/ran\]'
+ * which lists exactly which features have executed since the bot started.
+ */
+
+/** Features that have already announced themselves this process. */
+const announced = new Set<string>();
+
+/**
+ * Record that `feature` executed. Only the first call per process prints.
+ *
+ * Call this on the SUCCESS path, at the point where the feature has actually
+ * done its work - not at import time, which would only prove the module was
+ * loaded (the same mistake as a flag that proves reachability).
+ */
+export function featureRan(feature: string, detail?: string): void {
+  if (announced.has(feature)) return;
+  announced.add(feature);
+  try {
+    console.log(`[zoe/ran] ${feature}${detail ? ` - ${detail}` : ''}`);
+  } catch {
+    // Observability must never break the feature it observes. If stdout is
+    // gone (a closed pipe, a detached service), the feature carries on - we
+    // lose a log line, not the work. The flag is already set, so a broken
+    // stdout costs one announcement, not a retry storm.
+  }
+}
+
+/** Which features have announced themselves. For tests and selftests. */
+export function announcedFeatures(): string[] {
+  return [...announced].sort();
+}
+
+/** Test-only: forget what has been announced. */
+export function resetAnnouncedForTest(): void {
+  announced.clear();
+}

--- a/bot/src/zoe/guardrails.ts
+++ b/bot/src/zoe/guardrails.ts
@@ -17,6 +17,8 @@
  * Pattern credit: openai/openai-agents-python guardrail.py (Apache-2.0).
  */
 
+import { featureRan } from './feature-ran';
+
 /** When a guardrail runs relative to the model call. */
 export type GuardrailStage = 'input' | 'output' | 'both';
 
@@ -70,6 +72,7 @@ export function runGuardrails(
   stage: 'input' | 'output',
 ): GuardrailRunResult {
   const trips: Array<{ name: string; reason: string }> = [];
+  featureRan('guardrails', `${guards.length} guards, ${stage}`);
   for (const g of guards) {
     if (!appliesTo(g, stage)) continue;
     const r = g.check(ctx);

--- a/bot/src/zoe/live-status.ts
+++ b/bot/src/zoe/live-status.ts
@@ -53,6 +53,8 @@
  *   Losing the thread of a running build is worse than an extra message.
  */
 
+import { featureRan } from './feature-ran';
+
 export interface LiveStatusDeps {
   send: (text: string, replyMarkup?: unknown) => Promise<number | null>;
   edit: (messageId: number, text: string, replyMarkup?: unknown) => Promise<void>;
@@ -153,6 +155,7 @@ export function renderBuildStatus(opts: {
   elapsedSec: number;
   done?: boolean;
 }): string {
+  featureRan('live-status');
   const { task, phase, history, elapsedSec, done } = opts;
   const elapsed = elapsedSec < 90 ? `${elapsedSec}s` : `${Math.round(elapsedSec / 60)}m`;
   const head = done ? phase : `${phase} - ${elapsed}`;

--- a/bot/src/zoe/memory-git.ts
+++ b/bot/src/zoe/memory-git.ts
@@ -18,6 +18,7 @@ import { promisify } from 'node:util';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { featureRan } from './feature-ran';
 
 const execFileAsync = promisify(execFile);
 
@@ -69,6 +70,7 @@ export async function commitMemoryWrite(
       '-m', `memory: ${file} - ${reason}\n\nAuthor: ${author}`,
       '--author', `${author} <${author}@thezao.com>`,
     ]);
+    featureRan('memory-git', file);
     return await git(['rev-parse', '--short', 'HEAD']);
   } catch (error: unknown) {
     // LOUD soft-fail: versioning must never break a memory write, but a silent

--- a/bot/src/zoe/mission-control.ts
+++ b/bot/src/zoe/mission-control.ts
@@ -16,6 +16,7 @@
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { featureRan } from './feature-ran';
 
 /** One step-journal row (mirrors step-journal.py's append() shape exactly). */
 export interface JournalStep {
@@ -102,6 +103,7 @@ export async function emitStep(
  */
 export function mcEmit(topic: string, actor: string, severity: number, text: string): void {
   if (process.env.ZOE_MISSION_CONTROL !== '1') return;
+  featureRan('mission-control');
   emitStep(topic, actor, severity, text).catch((error: unknown) => {
     const msg = error instanceof Error ? error.message : String(error);
     console.error(`[mission-control] emit failed (${topic}/${actor}): ${msg}`);

--- a/bot/src/zoe/tick-lock.ts
+++ b/bot/src/zoe/tick-lock.ts
@@ -36,6 +36,7 @@
  */
 import { promises as fs } from 'node:fs';
 import { dirname } from 'node:path';
+import { featureRan } from './feature-ran';
 
 /** How long before a held lock is assumed to belong to a dead process. */
 export const DEFAULT_STALE_MS = 30 * 60 * 1000;
@@ -98,6 +99,7 @@ export async function acquireTickLock(
       } finally {
         await fh.close();
       }
+      featureRan('tick-lock');
       return { acquired: true };
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'EEXIST') return null; // someone holds it


### PR DESCRIPTION
## Executive summary

Today's job was testing what we built this week. That started by asking which of the eight features shipped since Aug 1 have actually executed in production - and seven days of production logs could not answer it.

Not because they failed. Because they say nothing.

## Why this matters

| Module | Can it log at all? |
|---|---|
| dm-build-session, build-intent, live-status, tick-lock, bus-bridge | **No logging statement of any kind** |
| memory-git, mission-control | Only inside `catch` |
| guardrails | One line, inside a selftest |

So silence meant "no errors", never "it ran". And `zoe-liveness` reporting a flag ON proved the code was **reachable**, not that it had been **reached**. That is the whole distance between merged and running, and it is exactly why a week of work was untestable.

## Before vs after

**BEFORE:** "Is the DM build working?" -> grep the journal -> 0 results -> unknown, because 0 results is also what a perfectly healthy silent module produces.

**AFTER:** one grep, one decisive answer:

```
journalctl --user -u zoe-bot.service | grep '\[zoe/ran\]'
[zoe/ran] build-intent
[zoe/ran] dm-build - chat 12345
[zoe/ran] guardrails - 3 guards, input
[zoe/ran] tick-lock
```

## The design decision worth reading

**Once per process, not per call.** `tick-lock` runs every tick - a line per call would be thousands a day and become the noise nobody greps (`noisy-signal-guard.md`: a check that always fires is a check nobody reads). One line per boot answers the only question being asked - *is this alive* - and keeps the log readable.

**On the success path, at the point of effect.** Never at import time, which would only prove the module loaded - the same empty proof a flag already gives. So `tick-lock` announces on a genuine acquisition rather than a contended tick, `memory-git` on a real commit rather than the rollback path, `mission-control` after its flag gate, and `build-intent` once at entry rather than at each of three positive returns, so a fourth return added later cannot silently drift out of sync.

**Wrapped in try/catch.** Observability must never break the feature it observes. A closed pipe costs a log line, not the work.

## Evidence

| Check | Result |
|---|---|
| Unit tests | 6 pass, incl. 500 calls producing exactly 1 line |
| Runtime proof | Called the real success paths: exactly 4 lines, correct detail, repeats silent |
| Full bot suite | 165 files / 2059 tests pass |
| Typecheck | 0 non-test errors |

## What this does NOT claim

It does not prove any of the eight features work. It makes it *possible to find out* - after this deploys, the same grep gives a real answer instead of an ambiguous zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
