### PR TITLE
fix(ci): nothing ever typechecked the bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,16 @@ jobs:
       - run: npm ci
         working-directory: bot
 
+      # Typecheck the bot's runtime source. Nothing did this before: the root
+      # tsconfig excludes "bot", and this job ran only vitest - so the ~50 bot
+      # modules that no test imports were never type-checked by anything, and
+      # since the bot runs under tsx (which strips types without checking them),
+      # the first thing to notice a bad type was the live bot at runtime.
+      # Scoped to non-test sources via tsconfig.ci.json - see the comment there.
+      - name: Typecheck (bot runtime source)
+        run: npx tsc --noEmit -p tsconfig.ci.json
+        working-directory: bot
+
       - run: npm test
         working-directory: bot
 

--- a/bot/tsconfig.ci.json
+++ b/bot/tsconfig.ci.json
@@ -1,0 +1,23 @@
+{
+  // Typecheck config for CI: the bot's RUNTIME source only.
+  //
+  // WHY THIS EXISTS. `bot/` runs under tsx, which strips types without checking
+  // them, and nothing in CI ever ran `tsc` over it: the root tsconfig excludes
+  // "bot", and the bot-test job runs only `vitest run`. So a type error in the
+  // 199 bot source modules reached main whenever no test happened to import the
+  // broken module - and the first thing that noticed was the live bot at
+  // runtime. `npm run typecheck` existed in bot/package.json the whole time; it
+  // simply had no caller.
+  //
+  // WHY IT EXCLUDES TESTS RATHER THAN USING tsconfig.json DIRECTLY. The plain
+  // `tsc --noEmit` currently reports 37 errors, all of them in `__tests__` and
+  // all of them stale vitest generics (`Mock<[number, number]>` is the vitest-2
+  // form; vitest 3 parameterises Mock by the function type). Zero are in runtime
+  // source. Gating on the full config would mean a check that is red on arrival,
+  // which is a check nobody reads (noisy-signal-guard). This one is green today,
+  // so the only thing that can turn it red is a real regression in code that
+  // actually ships. Fixing the test generics is worth doing separately; it does
+  // not need to block the gate that protects production code.
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## What breaks without this

`bot/` is ZOE's runtime - the autonomous loops that spend money, close board
tasks, and open PRs. **No gate anywhere typechecks it.**

- `tsconfig.json` (root) ends its `exclude` list with `"bot"`, so
  `npm run typecheck` never reads a line of bot source.
- The `bot-test` CI job runs `npm ci` then `npm test` (vitest) - and nothing else.
- `.husky/pre-commit` runs a doc-collision check, a secret scan, and a research
  index check. No typecheck.
- `bot/package.json` has had `"typecheck": "tsc --noEmit"` the entire time. It
  had no caller.

The bot runs under `tsx`, which strips types without checking them. So the only
thing standing between a bad type in bot source and production was whether some
test happened to import that module. A name-based scan finds **~50 of the 199
bot source modules that no test file imports**, including `src/zoe/approvals.ts`,
`src/zoe/agents/newsletter.ts`, `src/zai/llm-handler.ts` and `src/schedule.ts`.
For those, a rename of an export, a changed signature, or a wrong argument type
merges green and is first noticed by the live bot crashing at runtime, unattended.

This is `silent-failure-guard.md` incident 3 in a new place - a job named "Bot
Tests" that reports success while never running the check it appears to cover -
and it is the gate `agent-loops.md` rule 1 and `loop-evals.md` gate A both assume
is already running.

## The fix

Two files, 33 added lines, no source changes:

- `bot/tsconfig.ci.json` - extends the bot tsconfig, excludes `__tests__` and
  `*.test.ts`.
- one step in the `bot-test` job: `npx tsc --noEmit -p tsconfig.ci.json`.

## Why it excludes tests

Plain `tsc --noEmit` in `bot/` reports **37 errors, all 37 in test files, zero in
runtime source**. They are stale vitest generics - `Mock<[number, number]>` is
the vitest-2 form, and vitest 3 parameterises `Mock` by the function type
(`src/zoe/__tests__/tg-interactions.test.ts`, `transcribe.test.ts`,
`safety/__tests__/klearu.test.ts`). Gating on the full config would ship a check
that is red on arrival, which is a check nobody reads
(`noisy-signal-guard.md`). Scoped this way the check is green today, so the only
thing that can turn it red is a real regression in code that actually ships.

## Evidence

```
$ cd bot && npx tsc --noEmit -p tsconfig.ci.json
EXIT=0                       # green on this commit

$ npx tsc --noEmit           # unscoped, for contrast
37 errors, all in src/**/__tests__/ and *.test.ts, 0 in runtime source
```

Proof the gate catches what the suite misses - one deliberate type error added
to `src/zoe/approvals.ts` (a module no test imports):

```
$ npx tsc --noEmit -p tsconfig.ci.json
src/zoe/approvals.ts(338,7): error TS2322: Type 'string' is not assignable to type 'number'.
TSC_EXIT=2

$ npx vitest run
Tests  2 failed | 2080 passed (2082)     # same 2 as before the error - suite is blind to it
```

The 2 failing tests are pre-existing and **Windows-only** - `trace.test.ts` and
`transcribe.test.ts` assert forward-slash paths against `path.join` output
(`expected 'C:\Users\...\traces\...' to contain '/traces/2026-08-05.jsonl'`).
CI on ubuntu is green on `main`, so these are an artifact of the audit machine,
not a repo bug. Not touched here.

## Also seen this pass, deliberately not fixed here (one PR per run)

- `src/app/api/crm/capture/route.ts:197-202` builds an unused Supabase query
  (`upsertQuery`) and an unused `conflictTarget` const - dead code, harmless.
- Same file, `checkCors` - the `origin.endsWith('.thezao.com')` clause inside
  `.some()` does not use the loop variable, so the allowlist array is doing less
  than it looks like it is doing. Same effective result, misleading shape.
- `bot/src/zoe/build-intent.ts:107` calls `featureRan('build-intent')` before the
  empty-message guard, so it announces on a message it then rejects. Cosmetic
  against that module's own "call it on the success path" rule.
- `recordCall()` (the spend ledger behind the 95% hard-stop) is wired into
  concierge, workers, reflect and critic, but not into most other
  `callClaudeCli` sites - so the daily budget under-counts. Worth its own look;
  it is a design decision, not a one-line fix.

Not merged, not pushed to main. Zaal merges.

Generated with [Claude Code](https://claude.com/claude-code)
