### PR TITLE
fix(zoe): the DM build was unreachable through its own syntax - THE 1/10

### DIFF
--- a/bot/src/zoe/__tests__/dm-build-unreachable.test.ts
+++ b/bot/src/zoe/__tests__/dm-build-unreachable.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { isCommandPrefixed, parseBatchAnswer } from '../tg-interactions';
+import { detectBuildIntent } from '../build-intent';
+
+/**
+ * THE 1/10 BUG, 2026-08-08.
+ *
+ * Zaal sent "build: add a comment at the top of README.md saying hello from
+ * the phone" to the ZOE DM. Twice. Both times ZOE replied "Logged 1 answer
+ * from batch." and nothing built.
+ *
+ * The batch-answer guard accepted any lowercase-word-plus-colon as a question
+ * key, and it sits ~1000 lines above detectBuildIntent and RETURNS. So every
+ * verb in the build vocabulary was swallowed before the classifier ran - the
+ * feature was unreachable through its own documented syntax.
+ *
+ * Confirmed by the journal: zero [zoe/ran] lines for build-intent, meaning it
+ * never executed rather than executing and declining.
+ */
+describe('a build request must never be parsed as a batch answer', () => {
+  const THE_MESSAGE = 'build: add a comment at the top of README.md saying hello from the phone';
+
+  it('the exact message that failed now reaches the build classifier', () => {
+    expect(parseBatchAnswer(THE_MESSAGE)).toEqual([]);
+    expect(detectBuildIntent(THE_MESSAGE).build).toBe(true);
+  });
+
+  // Every verb in EXPLICIT_PREFIX is lowercase letters plus a colon, so every
+  // one of them was swallowed. Not just "build".
+  it.each(['build', 'code', 'fix', 'ship', 'implement'])(
+    '"%s:" is a command, not a batch answer',
+    (verb) => {
+      const msg = `${verb}: add a health endpoint to the api router`;
+      expect(isCommandPrefixed(msg)).toBe(true);
+      expect(parseBatchAnswer(msg)).toEqual([]);
+    },
+  );
+
+  it.each(['note', 'todo', 'research', 'capture'])(
+    'the other capture prefixes are protected too: "%s:"',
+    (verb) => {
+      expect(parseBatchAnswer(`${verb}: something worth keeping`)).toEqual([]);
+    },
+  );
+
+  it('is case-insensitive - Build: is still a command', () => {
+    expect(isCommandPrefixed('Build: add a thing to the codebase')).toBe(true);
+  });
+
+  it('tolerates a space before the colon', () => {
+    expect(isCommandPrefixed('build : add a thing')).toBe(true);
+  });
+});
+
+describe('real batch answers still parse - the fix must not break the feature', () => {
+  it('numeric keys work', () => {
+    const a = parseBatchAnswer('1:A\n2:best\n3:skip');
+    expect(a).toHaveLength(3);
+    expect(a[0].choice).toBe(1);
+    expect(a[1].value).toBe('best');
+  });
+
+  it('a non-command alphabetic key still works', () => {
+    const a = parseBatchAnswer('a:yes');
+    expect(a).toHaveLength(1);
+    expect(a[0].choice).toBe('a');
+  });
+
+  it('a single numeric answer works', () => {
+    expect(parseBatchAnswer('2:option b')).toHaveLength(1);
+  });
+
+  it('ordinary prose is not a batch answer', () => {
+    expect(parseBatchAnswer('hey what is on the board today')).toEqual([]);
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -127,8 +127,7 @@ import {
   formatPulse,
   formatAgenda,
   parseBatchAnswer,
-  classifyIntent,
-} from './tg-interactions';
+  classifyIntent, isCommandPrefixed } from './tg-interactions';
 import { recordMessageContext, getMessageContext, clearMessageContext } from './message-context';
 import { takePendingAnswer } from './pending-answers';
 import { tryInstantRelayReply } from './relay-bridge';
@@ -1397,7 +1396,17 @@ bot.on('message:text', async (ctx) => {
 
   // FEATURE 6: BATCH-ANSWER parsing
   // Parse "1:A 2:best 3:skip" format for multi-question answers
-  if (chatType === 'private' && isFromZaal(ctx) && text.includes(':') && /^\d+:|^[a-z]+:/i.test(text.trim())) {
+  // isCommandPrefixed keeps `build:`/`fix:`/`ship:` out of the batch parser.
+  // Guarding here as well as inside parseBatchAnswer is deliberate: this branch
+  // RETURNS, so if it matches, nothing downstream ever runs. Defence at the
+  // gate as well as in the room.
+  if (
+    chatType === 'private' &&
+    isFromZaal(ctx) &&
+    text.includes(':') &&
+    !isCommandPrefixed(text) &&
+    /^\d+:|^[a-z]+:/i.test(text.trim())
+  ) {
     const answers = parseBatchAnswer(text);
     if (answers.length > 0) {
       // Log each batch answer

--- a/bot/src/zoe/tg-interactions.ts
+++ b/bot/src/zoe/tg-interactions.ts
@@ -422,7 +422,40 @@ export interface BatchAnswer {
   value: string;
 }
 
+/**
+ * Words that are COMMANDS, not batch-answer keys.
+ *
+ * The batch-answer format is "1:A 2:best 3:skip" - a question id, a colon, a
+ * choice. The id was allowed to be alphabetic ("a:yes") as well as numeric,
+ * which quietly made every lowercase-word-plus-colon look like a batch answer.
+ *
+ * That included `build:`. On 2026-08-08 Zaal sent
+ * "build: add a comment at the top of README.md" to the ZOE DM twice and got
+ * "Logged 1 answer from batch." both times. The batch handler runs about a
+ * thousand lines before detectBuildIntent, so the build classifier never ran -
+ * confirmed by zero [zoe/ran] lines in the journal.
+ *
+ * Every verb in build-intent's EXPLICIT_PREFIX (build|code|fix|ship|implement)
+ * is lowercase letters followed by a colon, so ALL of them were swallowed. The
+ * DM build feature was unreachable through its own documented syntax, which is
+ * the mechanical cause of the 1/10 Zaal graded it.
+ */
+export const COMMAND_PREFIXES = new Set([
+  'build', 'code', 'fix', 'ship', 'implement',
+  'note', 'todo', 'research', 'capture', 'remember', 'ask', 'brief',
+]);
+
+/** Does this text open with a command prefix rather than a batch-answer key? */
+export function isCommandPrefixed(text: string): boolean {
+  const m = /^\s*([a-z]+)\s*:/i.exec(text);
+  return m ? COMMAND_PREFIXES.has(m[1].toLowerCase()) : false;
+}
+
 export function parseBatchAnswer(text: string): BatchAnswer[] {
+  // A command is not an answer. Bail before parsing so a build request can
+  // reach the classifier that is supposed to handle it.
+  if (isCommandPrefixed(text)) return [];
+
   const answers: BatchAnswer[] = [];
   const lines = text.split('\n').filter((l) => l.trim());
 


### PR DESCRIPTION
## What happened

Zaal ran the phone test. He sent the ZOE DM exactly what the instructions said to send:

```
build: add a comment at the top of README.md saying hello from the phone
```

Twice. Both times ZOE replied **"Logged 1 answer from batch."** Nothing built.

## Root cause

`index.ts:1398` treated any lowercase word followed by a colon as a batch-answer key:

```js
text.includes(':') && /^\d+:|^[a-z]+:/i.test(text.trim())
```

`build:` matches `^[a-z]+:`. That branch sits ~1000 lines above `detectBuildIntent` and **returns**, so the classifier never ran.

It was never only "build". Every verb in `EXPLICIT_PREFIX` - `build|code|fix|ship|implement` - is lowercase letters plus a colon. **The entire documented build vocabulary was swallowed.** The feature graded 1/10 was not broken. It was unreachable through the exact syntax we told him to use.

## How it was localised

By the `feature-ran` instrument shipped hours earlier today. **Zero `[zoe/ran]` lines** for `build-intent` proved the classifier had never executed - separating "ran and declined" from "never reached".

Without it, this debugging session starts inside the classifier, where nothing is wrong.

## The fix

`parseBatchAnswer` returns `[]` for command-prefixed text, and the call site guards with the same predicate. Both layers deliberately: the call site returns, so a miss there means nothing downstream runs at all.

`COMMAND_PREFIXES` also covers the capture verbs (`note`, `todo`, `research`, `capture`, `remember`, `ask`, `brief`) which carried the same latent collision.

## Evidence

| Check | Result |
|---|---|
| Regression test | The verbatim failing message now reaches the classifier |
| All 5 build verbs | Covered - it was never only "build" |
| Batch answers still work | `1:A` / `2:best` / `a:yes` all still parse |
| Full bot suite | 167 files / 2098 tests pass |
| Typecheck | 0 non-test errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
