### PR TITLE
fix(zoe): the voice glossary path escapes the repo, so it never loaded

### DIFF
--- a/bot/src/zoe/__tests__/transcribe-glossary-path.test.ts
+++ b/bot/src/zoe/__tests__/transcribe-glossary-path.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+//
+// The one thing transcribe.test.ts structurally cannot check.
+//
+// That suite mocks `node:fs` in its entirety, so its glossary cases prove the
+// JSON is parsed and the corrections applied - they say nothing about WHERE the
+// file is read from. The path was `../../../../research/...` from `bot/src/zoe`,
+// which resolves above the repository root, so the real glossary was never
+// found on any machine and the whole suite stayed green anyway.
+//
+// This file deliberately does NOT mock fs: it asserts the exported path points
+// at a file that actually exists, which is the only assertion that would have
+// failed. Keep it in its own file - adding it to the mocked suite would make it
+// pass against the mock again.
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { GLOSSARY_PATH } from '../transcribe';
+
+describe('GLOSSARY_PATH', () => {
+  it('resolves to a file that exists on disk', () => {
+    expect(existsSync(GLOSSARY_PATH)).toBe(true);
+  });
+
+  it('stays inside the repository (a path that escapes it can never resolve)', () => {
+    expect(GLOSSARY_PATH.replace(/\\/g, '/')).toContain('/research/reference/');
+  });
+
+  it('parses and carries the fields transcribeAudio reads', () => {
+    const glossary = JSON.parse(readFileSync(GLOSSARY_PATH, 'utf8')) as {
+      whisperPrompt?: string;
+      corrections?: Record<string, string>;
+    };
+    expect(typeof glossary.whisperPrompt).toBe('string');
+    expect(glossary.whisperPrompt?.length).toBeGreaterThan(0);
+    expect(glossary.corrections && typeof glossary.corrections).toBe('object');
+  });
+});

--- a/bot/src/zoe/transcribe.ts
+++ b/bot/src/zoe/transcribe.ts
@@ -8,7 +8,8 @@
 // Optional GROQ_WHISPER_MODEL (default whisper-large-v3-turbo).
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const GROQ_URL = 'https://api.groq.com/openai/v1/audio/transcriptions';
 
@@ -17,11 +18,51 @@ interface VoiceGlossary {
   corrections: Record<string, string>;
 }
 
+/**
+ * Absolute path to the ZAO proper-noun glossary.
+ *
+ * TWO THINGS WERE WRONG HERE, and both were invisible because the only reader
+ * swallowed every error and returned null.
+ *
+ * 1. THE DEPTH. This file lives at `bot/src/zoe/`, so `../../../../` from here
+ *    resolves ABOVE the repository root - the glossary was never at the path
+ *    being read, on any machine. Three levels reach the repo root; four leave it.
+ *
+ * 2. `__dirname`. `bot/package.json` is `"type": "module"` and this file is an
+ *    ES module, where `__dirname` is not a module-scope binding - referencing it
+ *    is a ReferenceError under plain node, and whether a loader shims it is a
+ *    property of the loader, not of the code. Every other file in `bot/src` that
+ *    needs its own directory already uses `fileURLToPath(import.meta.url)`
+ *    (mcp/farcaster-client.ts, the heart-fleet and spore tests); this one was
+ *    the outlier.
+ *
+ * Exported so a test can assert the path RESOLVES against the real filesystem.
+ * The existing suite mocks `node:fs` wholesale, so it exercised the parsing and
+ * never the location - which is exactly how a path that escapes the repo stayed
+ * green through CI.
+ */
+export const GLOSSARY_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../research/reference/zao-voice-glossary.json',
+);
+
+/** Log the glossary miss once per process, not once per voice note. */
+let warnedAboutGlossary = false;
+
 function loadGlossary(): VoiceGlossary | null {
   try {
-    const p = join(__dirname, '../../../../research/reference/zao-voice-glossary.json');
-    return JSON.parse(readFileSync(p, 'utf8')) as VoiceGlossary;
-  } catch {
+    return JSON.parse(readFileSync(GLOSSARY_PATH, 'utf8')) as VoiceGlossary;
+  } catch (err) {
+    // Optional input, so this stays non-fatal - but it is logged, once, because
+    // silence is what let a broken path survive. A soft-fail nobody can see is
+    // indistinguishable from a feature that works (`silent-failure-guard.md`).
+    if (!warnedAboutGlossary) {
+      warnedAboutGlossary = true;
+      console.warn(
+        `[zoe/transcribe] voice glossary unavailable at ${GLOSSARY_PATH} - ` +
+          `transcribing without ZAO proper-noun bias: ${(err as Error)?.message ?? String(err)}`,
+      );
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Executive Summary

ZOE's voice transcription has a ZAO proper-noun glossary - the list that keeps Whisper from turning "WaveWarZ" into "wave wars" and "ZABAL" into "z a b a l". It has never once loaded.

The path it reads from climbs four directory levels out of `bot/src/zoe/`, which lands one level ABOVE the repository root. The file is not there and never was. The only reader wraps the whole thing in `catch { return null }`, so there is no error, no log line, and no symptom other than transcripts that quietly get the brand names wrong.

This fixes the path, switches to the ESM-correct way of finding it (which the rest of `bot/src` already uses), makes the failure log itself once instead of vanishing, and adds the one test that would have caught it.

## What breaks without this fix, concretely

Every Telegram voice note to ZOE and every Discord voice capture in ZAI goes through `transcribeAudio`, which calls `loadGlossary()`. Today that returns `null` on every call, so:

- **`whisperPrompt` is never sent to Groq.** The prompt biases Whisper toward ZAO vocabulary at the source: `ZAO, ZABAL, WaveWarZ, COC Concertz, Zaalcaster, ZAOstock, Sparkz, POIDH, Bonfire, Neynar, Clanker, Base, 0xSplits...`. Without it, Whisper falls back to whatever ordinary English it thinks it heard.
- **The `corrections` map is never applied.** The post-pass that rewrites `wave wars` to `WaveWarZ` and `z a b a l` to `ZABAL` is skipped entirely.

Net effect: every transcript that feeds a meeting recap, a capture note, or a Bonfire episode carries mis-spelled ZAO brand names - the exact spellings CLAUDE.md's brand glossary calls non-negotiable - and nothing anywhere reports a problem.

## Root cause: two defects, one silence

**1. The path escapes the repository.** `transcribe.ts` lives at `bot/src/zoe/`, so `../../../../` resolves above the repo root. Three levels reach the root; four leave it.

Measured from that exact directory:

```
OLD  ../../../../  ->  <tmp>/research/reference/zao-voice-glossary.json    exists: false
NEW  ../../../     ->  <repo>/research/reference/zao-voice-glossary.json   exists: true
```

**2. `__dirname` in an ES module.** `bot/package.json` is `"type": "module"`, so `__dirname` is not a module-scope binding - it is a `ReferenceError` under plain node, and whether a given loader shims it is a property of the loader, not of the code. Every other file in `bot/src` that needs its own directory already uses `fileURLToPath(import.meta.url)` (`mcp/farcaster-client.ts`, the heart-fleet and spore tests). This one was the outlier.

**3. The silence that hid both.** `catch { return null }` treated "the file does not exist" and "the path is nonsense" identically to "no glossary configured". Per `.claude/rules/silent-failure-guard.md` rule 6, a soft-fail has to be loud or it is indistinguishable from working.

## Why CI stayed green

`src/zoe/__tests__/transcribe.test.ts` mocks `node:fs` in its entirety:

```ts
vi.mock('node:fs', () => ({ promises: {...}, readFileSync: mockReadFileSync }));
```

Its glossary cases (`sends whisperPrompt as prompt field`, `applies corrections map`) feed JSON straight through the mock. They prove the parsing and the corrections work. They cannot observe **where** the file is read from, so a path that escapes the repo passed every one of them.

The new test is in its own file precisely so it does not inherit that mock. Adding it to the existing suite would have made it pass against the mock again.

## Evidence

**Proven:**
- Old path `exists: false`, new path `exists: true`, executed from the real `bot/src/zoe/` with `import.meta.url` (output above).
- `__dirname` in an ESM module under node: `ReferenceError: __dirname is not defined`.
- New test red-then-green: pointed at the old 4-level path it fails `expected false to be true`; with the fix all 3 pass.
- `bot` vitest, before -> after: **16 passed / 1 failed -> 19 passed / 1 failed**. Test count up 3, no regression.
- The 1 failure is pre-existing on `origin/main` and Windows-only - `downloadTelegramFile` asserts `toContain('/tmp/zoe-files')` against a backslash path. Identical failure with my change stashed. Untouched here; it passes on CI's Linux runner.
- `bot` typecheck: **37 errors on my branch, 37 on `origin/main`** - byte-identical baseline, all in `__tests__` files, **zero in `src`**.

**Not verified:** the Next.js app suite and typecheck were not run - this change touches only `bot/`.

## Also found, not fixed here (one PR per the audit's rules)

- **`bot` typecheck is not gated by CI.** `.github/workflows/ci.yml` `bot-test` runs `npm ci` then `npm test` - no `tsc --noEmit`. That is why 37 type errors sit on main unnoticed. They are all vitest `Mock<...>` generic mismatches in test files, so they are cheap to fix, but the missing gate is the actual finding.
- **`voice-capture.ts` leaks per-speaker streams on the error path.** `dropSpeaker` removes the speaker from `buffers` but never destroys the `opusStream` or ends the `decoder`, so a malformed packet leaves both alive and lets a duplicate subscription open for that user. Small, and strictly less costly than the above.

## Anti-bloat pass

- **Reused, not rewritten:** `fileURLToPath(import.meta.url)` is the pattern already used in 4 other `bot/src` files. No new dependency, no new helper.
- **Diff size:** 2 files. One import line, one exported const, one `if` for the once-only warn, plus a 35-line test. Proportionate.
- **Dead code:** none left; the old `join(__dirname, ...)` expression is gone, not commented out.
- **Scope:** only the glossary path. The pre-existing Windows test failure, the 37 type errors, and the voice-capture leak are all named above and all left alone.
- **Safety:** unchanged. No auth, no route, no Zod schema, no secret touched. The glossary stays optional - a missing file still degrades to plain transcription, it just says so now.

## Files

- `bot/src/zoe/transcribe.ts` - correct depth, `import.meta.url`, exported `GLOSSARY_PATH`, warn-once on miss.
- `bot/src/zoe/__tests__/transcribe-glossary-path.test.ts` - new, unmocked, asserts the path resolves on disk.
