### PR TITLE
feat(zoe): teammate heartbeat - schedule in THEIR timezone

### DIFF
--- a/bot/src/zoe/__tests__/teammate-heartbeat.test.ts
+++ b/bot/src/zoe/__tests__/teammate-heartbeat.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  askButtons,
+  IMAN_DEFAULT,
+  isAskDue,
+  isSilenceAlertDue,
+  localHour,
+  renderAsk,
+  renderSilenceAlert,
+  slotHours,
+  type HeartbeatConfig,
+} from '../teammate-heartbeat';
+
+/** A UTC instant at a given hour, so tests read as times not epochs. */
+const utcAt = (hour: number, day = 1): number => Date.UTC(2026, 7, day, hour, 0, 0);
+const H = 3600_000;
+
+describe('localHour - schedule in THEIR time, never the asker\'s', () => {
+  it('applies a positive offset', () => {
+    expect(localHour(utcAt(8), 2)).toBe(10);
+  });
+
+  it('applies a negative offset', () => {
+    expect(localHour(utcAt(8), -4)).toBe(4);
+  });
+
+  it('wraps past midnight', () => {
+    expect(localHour(utcAt(23), 2)).toBe(1);
+  });
+
+  it('wraps backwards past midnight', () => {
+    expect(localHour(utcAt(1), -4)).toBe(21);
+  });
+
+  // The finding that motivated the whole module: Zaal's build window is Iman's
+  // night, so a ping scheduled in Zaal's hours lands while Iman is asleep.
+  it('confirms Zaal 18:00 ET is Iman midnight', () => {
+    const utc = utcAt(22); // 18:00 ET
+    expect(localHour(utc, -4)).toBe(18);
+    expect(localHour(utc, 2)).toBe(0);
+  });
+});
+
+describe('slotHours', () => {
+  it('gives Iman three asks a day, none at night', () => {
+    expect(slotHours(IMAN_DEFAULT)).toEqual([10, 14, 18]);
+  });
+
+  it('never schedules past the end of the working window', () => {
+    const cfg: HeartbeatConfig = { ...IMAN_DEFAULT, workStartHour: 9, workEndHour: 17, everyHours: 4 };
+    expect(slotHours(cfg).every((h) => h <= 17)).toBe(true);
+  });
+});
+
+describe('isAskDue', () => {
+  const base = { cfg: IMAN_DEFAULT, lastAskedUtcMs: null, lastActivityUtcMs: null };
+
+  it('asks at a slot hour inside working hours', () => {
+    // 08:00 UTC = 10:00 for Iman - his first slot.
+    expect(isAskDue({ ...base, nowUtcMs: utcAt(8) }).due).toBe(true);
+  });
+
+  // The single rule that keeps this from becoming the thing he mutes.
+  it.each([
+    ['his midnight', 22],
+    ['his 03:00', 1],
+    ['his 08:00, before work', 6],
+    ['his 21:00, after work', 19],
+  ])('never asks at %s', (_label, utcHour) => {
+    const r = isAskDue({ ...base, nowUtcMs: utcAt(utcHour) });
+    expect(r.due).toBe(false);
+    expect(r.reason).toContain('outside working hours');
+  });
+
+  it('does not ask on a non-slot hour', () => {
+    // 09:00 UTC = 11:00 his time - inside work, not a slot.
+    const r = isAskDue({ ...base, nowUtcMs: utcAt(9) });
+    expect(r.due).toBe(false);
+    expect(r.reason).toContain('not a slot');
+  });
+
+  it('does not ask twice in the same slot', () => {
+    const now = utcAt(8);
+    const r = isAskDue({ ...base, nowUtcMs: now, lastAskedUtcMs: now - 30 * 60_000 });
+    expect(r.due).toBe(false);
+    expect(r.reason).toContain('already asked');
+  });
+
+  it('tolerates a late cron tick rather than double-asking', () => {
+    const now = utcAt(8);
+    expect(isAskDue({ ...base, nowUtcMs: now, lastAskedUtcMs: now - 1.9 * H }).due).toBe(false);
+  });
+
+  it('asks again at the next slot', () => {
+    // Asked at his 10:00, now his 14:00.
+    expect(isAskDue({ ...base, nowUtcMs: utcAt(12), lastAskedUtcMs: utcAt(8) }).due).toBe(true);
+  });
+
+  // Someone visibly working must never be interrupted to confirm it.
+  it('stays quiet when they have been active recently', () => {
+    const now = utcAt(12);
+    const r = isAskDue({ ...base, nowUtcMs: now, lastActivityUtcMs: now - 1 * H });
+    expect(r.due).toBe(false);
+    expect(r.reason).toContain('active recently');
+  });
+
+  it('asks when activity has gone stale', () => {
+    const now = utcAt(12);
+    expect(isAskDue({ ...base, nowUtcMs: now, lastActivityUtcMs: now - 6 * H }).due).toBe(true);
+  });
+});
+
+describe('isSilenceAlertDue - the asker learns in 8h, not 24', () => {
+  const base = { cfg: IMAN_DEFAULT, lastAlertUtcMs: null };
+
+  it('reports silence after two slots during their working day', () => {
+    const now = utcAt(12); // his 14:00
+    const r = isSilenceAlertDue({ ...base, nowUtcMs: now, lastActivityUtcMs: now - 9 * H });
+    expect(r.due).toBe(true);
+    expect(r.reason).toContain('9h');
+  });
+
+  // A normal night must never look like a problem. This is the rule that keeps
+  // the alert meaningful.
+  it('never fires during their night, however long the quiet', () => {
+    const now = utcAt(23); // his 01:00
+    const r = isSilenceAlertDue({ ...base, nowUtcMs: now, lastActivityUtcMs: now - 20 * H });
+    expect(r.due).toBe(false);
+    expect(r.reason).toContain('night');
+  });
+
+  it('does not fire on a short quiet spell', () => {
+    const now = utcAt(12);
+    expect(isSilenceAlertDue({ ...base, nowUtcMs: now, lastActivityUtcMs: now - 3 * H }).due).toBe(false);
+  });
+
+  it('reports once, not repeatedly - a repeating alarm gets muted', () => {
+    const now = utcAt(12);
+    const r = isSilenceAlertDue({
+      ...base,
+      nowUtcMs: now,
+      lastActivityUtcMs: now - 12 * H,
+      lastAlertUtcMs: now - 2 * H,
+    });
+    expect(r.due).toBe(false);
+    expect(r.reason).toContain('already reported');
+  });
+
+  it('does not fire without an activity baseline', () => {
+    expect(isSilenceAlertDue({ ...base, nowUtcMs: utcAt(12), lastActivityUtcMs: null }).due).toBe(false);
+  });
+});
+
+describe('the messages', () => {
+  it('names the open work so a reply can be a tap', () => {
+    const out = renderAsk(['Upload COC Concertz 5 and 6', 'Review ZAO whitepapers']);
+    expect(out).toContain('What are you on');
+    expect(out).toContain('Upload COC Concertz');
+  });
+
+  it('works with nothing open', () => {
+    expect(renderAsk([])).toContain('What are you on');
+  });
+
+  it('always offers buttons, including a way to say blocked', () => {
+    const b = askButtons(['Upload COC Concertz 5 and 6']);
+    expect(b.length).toBeGreaterThanOrEqual(2);
+    expect(b.some((x) => /blocked/i.test(x))).toBe(true);
+  });
+
+  // Stating their local time is what stops the asker reading sleep as slacking.
+  it('the alert states their local time', () => {
+    const out = renderSilenceAlert(IMAN_DEFAULT, 9, utcAt(12));
+    expect(out).toContain('iman');
+    expect(out).toContain('9h');
+    expect(out).toContain('14:00');
+  });
+});

--- a/bot/src/zoe/__tests__/teammate-heartbeat.test.ts
+++ b/bot/src/zoe/__tests__/teammate-heartbeat.test.ts
@@ -152,14 +152,20 @@ describe('isSilenceAlertDue - the asker learns in 8h, not 24', () => {
 });
 
 describe('the messages', () => {
+  // Posted in ZAO Devz, addressed to them - not a DM.
+  it('addresses them by handle so it reads as a group message', () => {
+    const out = renderAsk(['Upload COC Concertz 5 and 6'], IMAN_DEFAULT);
+    expect(out.startsWith('@iman')).toBe(true);
+  });
+
   it('names the open work so a reply can be a tap', () => {
     const out = renderAsk(['Upload COC Concertz 5 and 6', 'Review ZAO whitepapers']);
-    expect(out).toContain('What are you on');
+    expect(out).toContain('what are you on');
     expect(out).toContain('Upload COC Concertz');
   });
 
   it('works with nothing open', () => {
-    expect(renderAsk([])).toContain('What are you on');
+    expect(renderAsk([])).toContain('what are you on');
   });
 
   it('always offers buttons, including a way to say blocked', () => {

--- a/bot/src/zoe/teammate-heartbeat.ts
+++ b/bot/src/zoe/teammate-heartbeat.ts
@@ -1,0 +1,205 @@
+/**
+ * teammate-heartbeat.ts - ask a teammate what they are on, so nobody has to police it.
+ *
+ * WHY (measured from a month of the Zaal/Iman thread, 2026-08-08)
+ * -------------------------------------------------------------
+ * Zaal, in Telegram: "Why didn't I get anything update wise past 24 hours. I
+ * asked every 4 hours when we doing work."
+ *
+ * That expectation lived in his head and nowhere else. Nothing reminded Iman,
+ * and nothing showed Zaal a heartbeat, so the gap was invisible until it was
+ * 24 hours wide - at which point it surfaced as a confrontation rather than a
+ * notification. Both people then spent an afternoon on it.
+ *
+ * THE TIMEZONE IS THE REAL MECHANISM
+ * ---------------------------------
+ * Iman wrote "it's Midnight here" at 6:06 PM Zaal's time, which puts him about
+ * six hours ahead. So:
+ *
+ *   Zaal 09:00 -> Iman 15:00     the standing sync. Good.
+ *   Zaal 14:00 -> Iman 20:00     end of real overlap
+ *   Zaal 16:00 -> Iman 22:00     Zaal's stated build window starts
+ *   Zaal 18:00 -> Iman 00:00     Iman's midnight
+ *
+ * Zaal's most productive hours are precisely when Iman is offline. The 2:54 PM
+ * "why no update" landed at 8:54 PM Iman's time. Reading that silence as
+ * unresponsiveness is a timezone artifact, not a work-ethic one - so this module
+ * schedules in the TEAMMATE's local hours, never the asker's.
+ *
+ * WHAT IT DOES NOT DO
+ * ------------------
+ * It does not chase, escalate on a ladder, or nag. One question per slot, three
+ * slots a day, inside working hours. If someone does not answer, that silence is
+ * reported ONCE to the person who needs to know - and a check that fires
+ * constantly is a check nobody reads (noisy-signal-guard).
+ *
+ * Pure by construction: every decision is a function of (now, config, last
+ * activity), so the whole schedule is unit-testable without a clock, a network,
+ * or a bot.
+ */
+
+/** Minutes past midnight, in the teammate's own local time. */
+const HOUR = 60;
+
+export interface HeartbeatConfig {
+  /** team_members.legacy_owner, e.g. "iman". */
+  slug: string;
+  /** Hours ahead of UTC. Iman is +2; Zaal is -4 in EDT. */
+  utcOffsetHours: number;
+  /** First local hour it is acceptable to ask. */
+  workStartHour: number;
+  /** Last local hour it is acceptable to ask - no pings after this. */
+  workEndHour: number;
+  /** Hours between asks. */
+  everyHours: number;
+}
+
+/**
+ * Iman's window, from the thread itself rather than a guess: he was active at
+ * 09:01 Zaal-time (15:01 his) and signed off at "Midnight here".
+ */
+export const IMAN_DEFAULT: HeartbeatConfig = {
+  slug: 'iman',
+  utcOffsetHours: 2,
+  workStartHour: 10,
+  workEndHour: 20,
+  everyHours: 4,
+};
+
+/** The teammate's local hour for a given UTC instant. */
+export function localHour(nowUtcMs: number, utcOffsetHours: number): number {
+  const utcMinutes = Math.floor(nowUtcMs / 60000) % (24 * HOUR);
+  const local = (utcMinutes + utcOffsetHours * HOUR) % (24 * HOUR);
+  return Math.floor(((local % (24 * HOUR)) + 24 * HOUR) % (24 * HOUR) / HOUR);
+}
+
+/**
+ * The local hours at which this teammate gets asked.
+ *
+ * From workStart, stepping by everyHours, while still inside the window. For
+ * Iman that is 10:00, 14:00, 18:00 - three a day, none at night.
+ */
+export function slotHours(cfg: HeartbeatConfig): number[] {
+  const out: number[] = [];
+  for (let h = cfg.workStartHour; h <= cfg.workEndHour; h += cfg.everyHours) out.push(h);
+  return out;
+}
+
+export interface DueInput {
+  nowUtcMs: number;
+  cfg: HeartbeatConfig;
+  /** When we last ASKED. Null if never. */
+  lastAskedUtcMs: number | null;
+  /** When the teammate last said or did anything. Null if never. */
+  lastActivityUtcMs: number | null;
+}
+
+export interface DueResult {
+  due: boolean;
+  reason: string;
+}
+
+/**
+ * Should we ask right now?
+ *
+ * Order matters and is cheapest-first. The activity check comes before the slot
+ * check on purpose: someone who is visibly working should never be interrupted
+ * to confirm that they are working. The ping exists to make SILENCE visible, not
+ * to collect a status report from someone already talking.
+ */
+export function isAskDue(input: DueInput): DueResult {
+  const { nowUtcMs, cfg, lastAskedUtcMs, lastActivityUtcMs } = input;
+  const hour = localHour(nowUtcMs, cfg.utcOffsetHours);
+
+  if (hour < cfg.workStartHour || hour > cfg.workEndHour) {
+    return { due: false, reason: `outside working hours (their local ${hour}:00)` };
+  }
+  if (!slotHours(cfg).includes(hour)) {
+    return { due: false, reason: `not a slot hour (their local ${hour}:00)` };
+  }
+
+  const sinceAsk = lastAskedUtcMs === null ? Infinity : nowUtcMs - lastAskedUtcMs;
+  // Half a slot of slack absorbs a late cron tick without double-asking.
+  if (sinceAsk < cfg.everyHours * 3600_000 * 0.5) {
+    return { due: false, reason: 'already asked this slot' };
+  }
+
+  const sinceActivity = lastActivityUtcMs === null ? Infinity : nowUtcMs - lastActivityUtcMs;
+  if (sinceActivity < cfg.everyHours * 3600_000) {
+    return { due: false, reason: 'they have been active recently - no need to interrupt' };
+  }
+
+  return { due: true, reason: 'due' };
+}
+
+export interface SilenceInput {
+  nowUtcMs: number;
+  cfg: HeartbeatConfig;
+  lastActivityUtcMs: number | null;
+  /** When we last told the asker about silence. Prevents a repeating alarm. */
+  lastAlertUtcMs: number | null;
+}
+
+/**
+ * Has this gone quiet long enough that the asker should be told?
+ *
+ * Two slots without a word, during working hours. Reported at most once per
+ * working day - the point is that Zaal learns in eight hours instead of
+ * twenty-four, not that he gets a recurring alarm he starts ignoring.
+ *
+ * Never fires outside working hours, so a normal night is never an alert. That
+ * single rule is what stops this becoming the check nobody reads.
+ */
+export function isSilenceAlertDue(input: SilenceInput): DueResult {
+  const { nowUtcMs, cfg, lastActivityUtcMs, lastAlertUtcMs } = input;
+  const hour = localHour(nowUtcMs, cfg.utcOffsetHours);
+  if (hour < cfg.workStartHour || hour > cfg.workEndHour) {
+    return { due: false, reason: 'their night - silence is expected' };
+  }
+  if (lastActivityUtcMs === null) {
+    return { due: false, reason: 'no activity baseline yet' };
+  }
+  const quietMs = nowUtcMs - lastActivityUtcMs;
+  if (quietMs < cfg.everyHours * 2 * 3600_000) {
+    return { due: false, reason: 'not quiet long enough' };
+  }
+  const sinceAlert = lastAlertUtcMs === null ? Infinity : nowUtcMs - lastAlertUtcMs;
+  if (sinceAlert < 12 * 3600_000) {
+    return { due: false, reason: 'already reported today' };
+  }
+  return { due: true, reason: `quiet ${Math.floor(quietMs / 3600_000)}h during their working day` };
+}
+
+/**
+ * The message.
+ *
+ * Short, because it is answered on a phone mid-task. Names the open work so the
+ * reply can be a tap rather than a recall exercise, and never opens with a
+ * reprimand - it is a check-in, not an audit.
+ */
+export function renderAsk(openTitles: string[]): string {
+  const lines = ['What are you on right now?'];
+  if (openTitles.length > 0) {
+    lines.push('');
+    lines.push('Your open ones:');
+    for (const t of openTitles.slice(0, 3)) lines.push(`- ${t.slice(0, 70)}`);
+  }
+  return lines.join('\n');
+}
+
+/** Buttons, always - tapping beats typing when you are mid-task on a phone. */
+export function askButtons(openTitles: string[]): string[] {
+  const b = openTitles.slice(0, 3).map((t) => `On: ${t.slice(0, 24)}`);
+  b.push('Blocked - need Zaal');
+  b.push('Something else');
+  return b;
+}
+
+/** What the asker sees. States the local time so silence reads correctly. */
+export function renderSilenceAlert(cfg: HeartbeatConfig, quietHours: number, nowUtcMs: number): string {
+  const theirHour = localHour(nowUtcMs, cfg.utcOffsetHours);
+  return (
+    `No word from ${cfg.slug} in ${quietHours}h. It is ${String(theirHour).padStart(2, '0')}:00 ` +
+    `their time, so they should be working. Nudged them; telling you now rather than at the end of the day.`
+  );
+}

--- a/bot/src/zoe/teammate-heartbeat.ts
+++ b/bot/src/zoe/teammate-heartbeat.ts
@@ -26,6 +26,22 @@
  * unresponsiveness is a timezone artifact, not a work-ethic one - so this module
  * schedules in the TEAMMATE's local hours, never the asker's.
  *
+ * WHERE IT POSTS: THE GROUP, NOT A DM
+ * ----------------------------------
+ * Zaal, 2026-08-08: "I don't want Zoe to directly dm him I want it to be in the
+ * zao devz group."
+ *
+ * That is the better shape for three reasons. The check-in becomes a normal
+ * team ritual rather than a manager tapping one person on the shoulder, which
+ * is a very different thing to receive three times a day. Zaal sees the answer
+ * where it is posted instead of needing it relayed to him. And the rest of the
+ * team gets ambient awareness of what is moving, which a DM would keep private
+ * to two people.
+ *
+ * The SILENCE alert is the exception and goes to Zaal privately. "No word from
+ * X in 9h" is information a lead needs; announcing it to the group is a public
+ * reprimand, and this module is not built to do that to anyone.
+ *
  * WHAT IT DOES NOT DO
  * ------------------
  * It does not chase, escalate on a ladder, or nag. One question per slot, three
@@ -52,6 +68,11 @@ export interface HeartbeatConfig {
   workEndHour: number;
   /** Hours between asks. */
   everyHours: number;
+  /**
+   * Telegram handle used to address them in the group. The ask is a group
+   * message that mentions them, never a direct message.
+   */
+  mentionHandle: string;
 }
 
 /**
@@ -64,6 +85,7 @@ export const IMAN_DEFAULT: HeartbeatConfig = {
   workStartHour: 10,
   workEndHour: 20,
   everyHours: 4,
+  mentionHandle: '@iman',
 };
 
 /** The teammate's local hour for a given UTC instant. */
@@ -171,14 +193,15 @@ export function isSilenceAlertDue(input: SilenceInput): DueResult {
 }
 
 /**
- * The message.
+ * The group message.
  *
- * Short, because it is answered on a phone mid-task. Names the open work so the
- * reply can be a tap rather than a recall exercise, and never opens with a
- * reprimand - it is a check-in, not an audit.
+ * Addressed to them by handle, posted in ZAO Devz. Short, because it is
+ * answered on a phone mid-task; names the open work so the reply can be a tap
+ * rather than a recall exercise; and never opens with a reprimand - in a group,
+ * tone is the whole difference between a ritual and a summons.
  */
-export function renderAsk(openTitles: string[]): string {
-  const lines = ['What are you on right now?'];
+export function renderAsk(openTitles: string[], cfg: HeartbeatConfig = IMAN_DEFAULT): string {
+  const lines = [`${cfg.mentionHandle} what are you on right now?`];
   if (openTitles.length > 0) {
     lines.push('');
     lines.push('Your open ones:');
@@ -196,6 +219,12 @@ export function askButtons(openTitles: string[]): string[] {
 }
 
 /** What the asker sees. States the local time so silence reads correctly. */
+/**
+ * The silence alert - sent to ZAAL PRIVATELY, never to the group.
+ *
+ * A lead needs to know; a group does not need to watch someone be named for
+ * being quiet. Same information, chosen audience.
+ */
 export function renderSilenceAlert(cfg: HeartbeatConfig, quietHours: number, nowUtcMs: number): string {
   const theirHour = localHour(nowUtcMs, cfg.utcOffsetHours);
   return (


### PR DESCRIPTION
## Why

Zaal, in Telegram yesterday:

> "Why didn't I get anything update wise past 24 hours. **I asked every 4 hours when we doing work.**"

That expectation lived in his head and nowhere else. Nothing reminded Iman, nothing showed Zaal a heartbeat. So the gap stayed invisible until it was 24 hours wide - and then surfaced as a confrontation rather than a notification.

## The timezone is the actual mechanism

Iman wrote *"it's Midnight here"* at 6:06 PM Zaal-time, putting him ~6h ahead:

```
Zaal 09:00  ->  Iman 15:00    the standing sync, well placed
Zaal 14:00  ->  Iman 20:00    end of real overlap
Zaal 16:00  ->  Iman 22:00    Zaal's build window begins
Zaal 18:00  ->  Iman 00:00    Iman's midnight
```

**Zaal's most productive hours are exactly when Iman is offline.** The 2:54 PM "why no update" landed at 8:54 PM Iman's time; he replied 40 minutes later having "just got back online". Reading that as unresponsiveness is a timezone artifact, not a work-ethic one.

So every decision is made in the **teammate's** local hours. Iman gets asked at his 10:00, 14:00, 18:00.

## What it will not do

- **Never pings outside their working hours.** Tests assert silence at his midnight, 03:00, and both edges of the day.
- **Never interrupts someone visibly working** - recent activity suppresses the ask. The ping exists to make silence visible, not to collect a status report from someone already talking.
- **Reports silence at most once per working day.** A repeating alarm is one that gets muted.
- **Never treats a normal night as silence** - the single rule that keeps the alert meaningful.

The alert states the teammate's local time, so a reader can tell sleep from slacking without doing arithmetic.

## Evidence

| Check | Result |
|---|---|
| Unit tests | 27 pass - offset maths, slot scheduling, every suppression rule, both renderers |
| Full bot suite | 2176 tests pass |
| Typecheck | 0 non-test errors |

## Scope

**Pure module only.** The scheduler wiring is a separate change, deliberately - the schedule should be reviewed before anything DMs a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
