### PR TITLE
fix(zoe): board commands authorize on a display name, not an account

### DIFF
--- a/bot/src/zoe/__tests__/board-commands.test.ts
+++ b/bot/src/zoe/__tests__/board-commands.test.ts
@@ -10,20 +10,23 @@ import {
 } from '../board-commands';
 
 describe('authorization - a comment box must not become a write API', () => {
-  it('Zaal may command', () => {
-    expect(isAuthorizedCommander('Zaal')).toBe(true);
+  // The board stamps Zaal's comments { userId: 'zaal', displayName: 'Zaal' }
+  // (task-teammate-ack.ts:601, :671), and userId is what every sibling module
+  // in this directory uses as identity. This gate reads the same field.
+  it('Zaal may command, matched on the account id', () => {
     expect(isAuthorizedCommander('zaal')).toBe(true);
+    expect(isAuthorizedCommander('Zaal')).toBe(true);
     expect(isAuthorizedCommander('  ZAAL  ')).toBe(true);
   });
 
   // Iman can still ASK @zoe anything - the reply path is untouched. He just
   // cannot mutate the board through a comment.
   it('a teammate may not command', () => {
-    expect(isAuthorizedCommander('Iman')).toBe(false);
-    expect(isAuthorizedCommander('Samantha')).toBe(false);
+    expect(isAuthorizedCommander('iman')).toBe(false);
+    expect(isAuthorizedCommander('samantha')).toBe(false);
   });
 
-  it('an unknown or missing name is never a commander', () => {
+  it('an unknown or missing id is never a commander', () => {
     expect(isAuthorizedCommander(undefined)).toBe(false);
     expect(isAuthorizedCommander(null)).toBe(false);
     expect(isAuthorizedCommander('')).toBe(false);
@@ -46,19 +49,47 @@ describe('tagsZoe', () => {
 
 describe('shouldExecute - all three gates', () => {
   it('runs for an authorized commander tagging zoe', () => {
-    expect(shouldExecute({ content: '@zoe close this', displayName: 'Zaal' }).execute).toBe(true);
+    const r = shouldExecute({ content: '@zoe close this', userId: 'zaal', displayName: 'Zaal' });
+    expect(r.execute).toBe(true);
   });
 
   it('does not run when zoe is not tagged', () => {
-    const r = shouldExecute({ content: 'close this please', displayName: 'Zaal' });
+    const r = shouldExecute({ content: 'close this please', userId: 'zaal', displayName: 'Zaal' });
     expect(r.execute).toBe(false);
     expect(r.reason).toContain('does not tag');
   });
 
   it('does not run for an unauthorized commenter, and says who', () => {
-    const r = shouldExecute({ content: '@zoe close this task', displayName: 'Iman' });
+    const r = shouldExecute({ content: '@zoe close this task', userId: 'iman', displayName: 'Iman' });
     expect(r.execute).toBe(false);
     expect(r.reason).toContain('Iman');
+  });
+
+  // The reason this gate moved off displayName. A display name is a profile
+  // field the user picks; the account id is not. Before this, the comment below
+  // executed - anyone who renamed themselves "Zaal" could create, reassign and
+  // close board tasks.
+  it('a teammate whose display name says Zaal still may not command', () => {
+    const r = shouldExecute({ content: '@zoe close this task', userId: 'iman', displayName: 'Zaal' });
+    expect(r.execute).toBe(false);
+    expect(r.reason).toContain('not an authorized commander');
+  });
+
+  it('refuses, rather than trusting the label, when there is no account behind the comment', () => {
+    const r = shouldExecute({ content: '@zoe close this task', displayName: 'Zaal' });
+    expect(r.execute).toBe(false);
+    expect(r.reason).toContain('no userId');
+  });
+
+  // And the inverse failure: a fuller display name must not stop the real Zaal
+  // from commanding, which is what keying on the label would have done.
+  it('a longer display name does not block the real commander', () => {
+    const r = shouldExecute({
+      content: '@zoe close this task',
+      userId: 'zaal',
+      displayName: 'Zaal Panthaki',
+    });
+    expect(r.execute).toBe(true);
   });
 });
 

--- a/bot/src/zoe/board-command-executor.ts
+++ b/bot/src/zoe/board-command-executor.ts
@@ -27,6 +27,9 @@ export interface ExecContext {
   taskTitle: string;
   commentId: string;
   commentContent: string;
+  /** The commenter's board ACCOUNT id. Authorization reads this and nothing else. */
+  commentAuthorId?: string | null;
+  /** The commenter's display name. Label only - never grants authority. */
   commentAuthor?: string | null;
 }
 
@@ -143,7 +146,11 @@ export async function executeBoardComment(
   extract: (prompt: string) => Promise<string | null>,
   fetchImpl: typeof fetch = fetch,
 ): Promise<ExecResult | null> {
-  const gate = shouldExecute({ content: ctx.commentContent, displayName: ctx.commentAuthor });
+  const gate = shouldExecute({
+    content: ctx.commentContent,
+    userId: ctx.commentAuthorId,
+    displayName: ctx.commentAuthor,
+  });
   if (!gate.execute) return null;
 
   let raw: unknown = null;

--- a/bot/src/zoe/board-commands.ts
+++ b/bot/src/zoe/board-commands.ts
@@ -48,13 +48,32 @@ const AUTHORIZED_COMMANDERS = new Set(['zaal']);
 /**
  * Is this commenter allowed to issue commands?
  *
- * Matched on the board's displayName, lowercased. Deliberately strict: an
- * unknown name is not a commander. A teammate tagging @zoe still gets an
- * ANSWER (that path is unchanged) - they just cannot mutate the board through
- * it, which stops a comment box from becoming an unauthenticated write API.
+ * Matched on the comment's `userId` - the board's stable account identity -
+ * NOT on `displayName`.
+ *
+ * WHY NOT displayName. It was, and that was an authorization check on a
+ * human-readable label. A board comment record carries both fields, and every
+ * sibling module in this directory already treats `userId` as the identity and
+ * `displayName` as decoration: task-comment-replies.ts recognises ZOE's own
+ * replies by `c.userId !== 'zoe'`, task-teammate-ack.ts tests
+ * `c.userId !== 'zaal'`, task-mention-notify.ts matches handles against
+ * `comment.userId`, and both of the comments this repo writes on Zaal's behalf
+ * are stamped `{ userId: 'zaal', displayName: 'Zaal' }`
+ * (task-teammate-ack.ts:601, :671). Only this gate reached for the label.
+ *
+ * That mismatch fails in both directions. A display name is a profile field a
+ * user picks, so anyone who can set theirs to "Zaal" (or "zaal", or " ZAAL ")
+ * inherits create/assign/close authority over the board - the comment box
+ * becoming a write API is exactly what this module says it prevents. And in the
+ * other direction, if the board renders a fuller name ("Zaal Panthaki"), the
+ * gate silently matches nobody and every board command falls through to a chat
+ * reply, which is the failure that looks like the feature was never built.
+ *
+ * A teammate tagging @zoe still gets an ANSWER - that path is untouched. They
+ * just cannot mutate the board through it.
  */
-export function isAuthorizedCommander(displayName?: string | null): boolean {
-  return AUTHORIZED_COMMANDERS.has((displayName || '').trim().toLowerCase());
+export function isAuthorizedCommander(userId?: string | null): boolean {
+  return AUTHORIZED_COMMANDERS.has((userId || '').trim().toLowerCase());
 }
 
 /** Does this comment address ZOE at all? */
@@ -150,15 +169,30 @@ function summarize(entry: unknown): string {
  *
  * Three gates, in order of cheapness. All must pass.
  */
-export function shouldExecute(comment: { content?: string; displayName?: string | null }): {
+export function shouldExecute(comment: {
+  content?: string;
+  /** The board account that wrote the comment. The ONLY thing authorization reads. */
+  userId?: string | null;
+  /** Label only - used to say who was refused. Never grants anything. */
+  displayName?: string | null;
+}): {
   execute: boolean;
   reason: string;
 } {
   const content = comment.content || '';
   if (!tagsZoe(content)) return { execute: false, reason: 'does not tag @zoe' };
-  if (!isAuthorizedCommander(comment.displayName)) {
+  if (!comment.userId) {
+    // Fail closed. A comment with no account behind it cannot be authorized by
+    // the name printed next to it, and refusing loudly beats executing on a
+    // label - the reply path still answers it.
+    return { execute: false, reason: 'comment carries no userId - refusing to authorize on a display name' };
+  }
+  if (!isAuthorizedCommander(comment.userId)) {
     // Still answerable by the existing reply path - just not executable.
-    return { execute: false, reason: `${comment.displayName || 'unknown'} is not an authorized commander` };
+    return {
+      execute: false,
+      reason: `${comment.displayName || comment.userId} is not an authorized commander`,
+    };
   }
   return { execute: true, reason: 'authorized' };
 }

--- a/bot/src/zoe/task-comment-replies.ts
+++ b/bot/src/zoe/task-comment-replies.ts
@@ -249,6 +249,10 @@ export async function runTaskCommentReplies(
           taskTitle: task.title,
           commentId: comment.id,
           commentContent: comment.content,
+          // userId is the identity this file already trusts (see tagsZoe above,
+          // which recognises ZOE's own comments by userId). displayName goes
+          // along only so a refusal can name who was refused.
+          commentAuthorId: comment.userId,
           commentAuthor: comment.displayName,
         },
         // Extraction is a small, mechanical transform - cheap model, no tools,


### PR DESCRIPTION
## Executive summary

The @zoe board-command executor merged today (#2989) decides who is allowed to
change the board by reading the comment's **display name**. A display name is a
profile field a user picks. The same comment record already carries `userId` -
the board account - and `userId` is what every other module in that directory
uses as identity.

This changes the gate to read `userId`, and to refuse rather than fall back to
the label when a comment has no account behind it. One-line policy change, plus
the tests that pin it.

## What breaks without this

`board-commands.ts:57` was:

```ts
export function isAuthorizedCommander(displayName?: string | null): boolean {
  return AUTHORIZED_COMMANDERS.has((displayName || '').trim().toLowerCase());  // Set(['zaal'])
}
```

fed from `task-comment-replies.ts:252` (`commentAuthor: comment.displayName`).

**Concretely:** a teammate on the ZAODEVZ board sets their display name to
`Zaal` (or `zaal`, or `  ZAAL  ` - it is trimmed and lowercased), comments
`@zoe make a todo called X, task it to me, and close this one`, and it executes.
Up to 5 commands per comment: create tasks, reassign tasks to anyone, and close
tasks. The account id on that same comment says `iman`, and nothing looks at it.

This is what `board-commands.ts:53` says the gate exists to prevent - "stops a
comment box from becoming an unauthenticated write API" - and it is the same
shape as the August anonymous-board leak (#2829): a service-role write path
(`COWORK_TRACKER_KEY`, RLS-bypassing) behind a check that does not actually
identify the caller.

**And the inverse failure, which is quieter.** If the board renders a fuller
name - `Zaal Panthaki`, or a handle - the set never matches, every board command
silently falls through to a chat reply, and the feature reads as if it was never
built. Same root cause: the wrong field.

## Why `userId` is the right field (all in-repo, all citable)

Every sibling module in `bot/src/zoe/` already treats `userId` as identity and
`displayName` as decoration:

- `task-comment-replies.ts:62` - recognises ZOE's own replies by `c.userId !== 'zoe'`
- `task-teammate-ack.ts:104-107` - `c.userId !== ZOE_USER_ID && c.userId !== 'zaal'`
- `task-mention-notify.ts:131` - matches handles against `comment.userId`
- `task-teammate-ack.ts:601` and `:671` - this repo writes Zaal's own board
  comments as `{ userId: 'zaal', displayName: 'Zaal' }`

So `'zaal'` is the correct value to match, and the authorized case keeps working
unchanged. Only this one gate reached for the label.

## The change

- `board-commands.ts` - `isAuthorizedCommander(userId)`; `shouldExecute` takes
  `userId` and fails closed when it is absent (a comment with no account cannot
  be authorized by the name printed next to it). `displayName` is kept purely so
  a refusal can name who was refused.
- `board-command-executor.ts` - `ExecContext.commentAuthorId`, passed to the gate.
- `task-comment-replies.ts` - passes `comment.userId` through.

No change to the reply path: a teammate tagging @zoe still gets an answer. No
change to the command allowlist, the per-comment cap, or the receipt.

## Evidence

- `npx tsc --noEmit -p tsconfig.ci.json` in `bot/` - **0 errors**
- Touched suites: `board-commands.test.ts` + `task-comment-replies.test.ts` -
  **41 passed** (38 before; 3 tests added, none removed)
- Full bot suite on this machine: 2149 passed, 3 failed. The 3 failures
  (`tick-lock`, `trace`, `transcribe`) reproduce identically with this change
  stashed - they are Windows path-separator assertions (`'\tmp\zoe-files'` vs
  `'/tmp/zoe-files'`), not a regression here, and CI on Linux is green for
  724b4a43e.

The added tests include the exact case that used to pass:

```ts
it('a teammate whose display name says Zaal still may not command', () => {
  const r = shouldExecute({ content: '@zoe close this task', userId: 'iman', displayName: 'Zaal' });
  expect(r.execute).toBe(false);
});
```

## Also seen this pass, not fixed here (one PR only)

Both are in code with no production callers yet, which is why neither displaced
this one:

1. **`src/lib/unlock/whop-bridge.ts:135` revokes on an RPC hiccup.** `syncGrant`
   returns `'revoke'` whenever `hasValidKey` is falsy, and `lock.ts:47` swallows
   every read failure into `return false`. Fail-closed is right for `grantOnKey`
   (deny access), but here it means a transient Base RPC outage tells the caller
   to deactivate a paying member's membership. It needs a third `'unknown'`
   outcome that changes nothing. No callers today.

2. **`bot/src/zoe/farcaster/wiki.ts:264/282/312` join an unsanitised id into a
   path.** `readWiki`/`writeWiki`/`deleteWiki` do `join(WIKI_HOME(), \`${id}.json\`)`
   with no containment check, and `deleteWiki` unlinks it. Also, entry ids are
   `fid:12345`, so the filename contains `:` - which is why
   `wiki.test.ts > lists all wiki entries` fails on Windows. Unwired today.
