### PR TITLE
fix(scripts): gen-surface-map wrote Windows paths into a URL map, then crashed

### DIFF
--- a/scripts/agents/gen-surface-map.py
+++ b/scripts/agents/gen-surface-map.py
@@ -26,6 +26,17 @@ That combination is what `review` flags.
 
 `auth` remains INFERRED FROM SOURCE TEXT. It is a strong hint and an audit
 starting point, never a proof. Read the handler before you trust the label.
+
+ROUTE PATHS ARE ALWAYS POSIX, ON EVERY OS (the 2026-08-07 Windows fix)
+----------------------------------------------------------------------
+A URL path is not a filesystem path. Building one out of os.sep meant that
+running this script on Windows - now one of the always-on machines - wrote all
+324 routes as `\\api\\...`, which is not a URL and breaks every link in
+/surface. The `/cron/` fallback in auth_of() also cannot match a backslash path;
+today that changes no label (all 14 cron routes are caught earlier by their
+CRON_SECRET marker), but a cron route without that marker would silently be
+labelled `public`. The separator is normalised once, where the relative path is
+built, and everything downstream consumes that one posix string.
 """
 import json
 import os
@@ -34,7 +45,8 @@ import subprocess
 import sys
 
 ROOT = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], text=True).strip()
-API = os.path.join(ROOT, 'src', 'app', 'api')
+APP = os.path.join(ROOT, 'src', 'app')
+API = os.path.join(APP, 'api')
 OUT = os.path.join(ROOT, 'src', 'lib', 'surface-map.ts')
 SUFFIX_LEN = len('/route.ts')  # 9. Getting this wrong silently truncates every path.
 
@@ -112,10 +124,14 @@ def main():
             src = open(p, encoding='utf-8', errors='ignore').read()
         except OSError:
             continue
-        rel = p.replace(os.path.join(ROOT, 'src', 'app'), '')[:-SUFFIX_LEN]
+        # A URL path, not a filesystem path: posix separators on every OS.
+        rel = '/' + os.path.relpath(p, APP).replace(os.sep, '/')
+        rel = rel[:-SUFFIX_LEN]
         methods = [m for m in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')
                    if re.search(rf'export async function {m}\b', src)]
-        auth = auth_of(src, p)
+        # The route path, never the filesystem path - auth_of()'s `/cron/` test
+        # only matches a posix URL path.
+        auth = auth_of(src, rel)
         service_role = any(m in src for m in SERVICE_ROLE_MARKERS)
         rate_limited = any(m in src for m in RATELIMIT_MARKERS)
         # The one combination worth a human's eyes: no gate at all, yet holding a
@@ -164,11 +180,34 @@ export interface RouteEntry {{
 export const GENERATED_AT = '{stamp}';
 export const ROUTES: RouteEntry[] = {json.dumps(routes, indent=2)};
 """
-    open(OUT, 'w').write(body)
+    # LF and utf-8 explicitly: text mode on Windows would write CRLF and make
+    # every line of a 300-route file show up as changed.
+    with open(OUT, 'w', encoding='utf-8', newline='\n') as fh:
+        fh.write(body)
     # Format with the repo's own formatter so a regeneration never shows up as a
     # lint failure - the generator has to agree with biome, not fight it.
-    subprocess.run(['npx', 'biome', 'format', '--write', OUT],
-                   cwd=ROOT, capture_output=True)
+    #
+    # Two things went wrong with the old `npx biome ...` call:
+    #
+    #  1. npx is a .cmd on Windows, which CreateProcess will not run without a
+    #     shell, so it raised FileNotFoundError AFTER the file was written - a
+    #     traceback on top of a half-done job.
+    #  2. With node_modules absent, `npx biome` does not fail. It fetches the
+    #     unrelated public package named `biome` (0.3.3, not @biomejs/biome) and
+    #     runs THAT - exit 0, no formatting, and a stranger's code executed.
+    #
+    # So: run the repo's own installed binary by path, and if it is not there,
+    # say so instead of reaching for whatever the registry hands back.
+    bin_dir = os.path.join(ROOT, 'node_modules', '.bin')
+    biome = os.path.join(bin_dir, 'biome.cmd' if sys.platform == 'win32' else 'biome')
+    if os.path.exists(biome):
+        fmt = subprocess.run([biome, 'format', '--write', OUT], cwd=ROOT, capture_output=True)
+        if fmt.returncode != 0:
+            print(f'  WARNING: biome format exited {fmt.returncode} - '
+                  'the file is written but unformatted')
+    else:
+        print('  WARNING: @biomejs/biome is not installed (run `npm install`); '
+              'the file is written but UNFORMATTED - format it before committing')
 
     by_auth = {}
     for r in routes:


### PR DESCRIPTION
Running the documented command on Windows - `python3 scripts/agents/gen-surface-map.py`,
which CLAUDE-side convention says to run in the SAME PR as any route change -
produced a corrupt src/lib/surface-map.ts and then exited 1 with a traceback.

Three defects, all in this one script:

1. A URL path was built from a filesystem path. `p.replace(os.path.join(ROOT,
   'src','app'), '')` leaves os.sep, so all 324 routes were written as
   `\api\100ms\rooms` instead of `/api/100ms/rooms`. /surface renders those as
   links and doc 2245 quotes them; neither works with a backslash. Measured on
   this machine: 324 of 324 paths corrupted.

2. auth_of()'s `/cron/` fallback cannot match a backslash path. Today no label
   moves (all 14 cron routes are caught earlier by their CRON_SECRET marker), but
   a cron route without that marker would be labelled `public` on Windows and
   `cron` on Linux - the same input, two different security labels.

3. `subprocess.run(['npx', ...])` raised FileNotFoundError on Windows AFTER the
   file was written (npx is a .cmd, CreateProcess will not run it), so the run
   ended in a traceback on top of a half-done job. Worse, with node_modules
   absent `npx biome` does not fail at all: it fetches the unrelated public
   package named `biome` (0.3.3, not @biomejs/biome), runs it, formats nothing,
   and exits 0. Verified here - `npx biome --version` prints 0.3.3.

The fix normalises the separator once where the relative path is built, passes
that posix path to auth_of, writes with explicit utf-8 + LF, and runs the repo's
own node_modules/.bin/biome by path - warning loudly when it is absent rather
than executing whatever the registry hands back.

Verified: on Windows the fixed generator + `biome format` reproduces the
committed, Linux-generated src/lib/surface-map.ts byte-for-byte (empty git diff),
with identical counts: 324 routes, admin=68 cron=14 public=28 session=202
signed=10 token=2, 0 needing review. Exit 0, no traceback.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---

Found by the unattended repo auditor. The run was killed before it could push, so the branch sat in a temp worktree until now.

Generated with Claude Code
