### PR TITLE
fix(webhooks): Alchemy replay double-credited on-chain Respect balances

### DIFF
--- a/src/app/api/webhooks/alchemy/__tests__/route.test.ts
+++ b/src/app/api/webhooks/alchemy/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import crypto from 'crypto';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // SIGNING_KEYS is evaluated at module load — must set env before import
@@ -12,19 +12,30 @@ vi.mock('@/lib/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
-const mockMaybeSingle = vi.hoisted(() => vi.fn().mockResolvedValue({ data: null }));
+const mockMaybeSingle = vi.hoisted(() => vi.fn());
 const mockIlike = vi.hoisted(() => vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle }));
 const mockSelect = vi.hoisted(() => vi.fn().mockReturnValue({ ilike: mockIlike }));
-const mockUpsert = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+// upsert(...).select('id') — the chain the route uses to learn whether the row
+// was actually inserted (first delivery) or ignored as a duplicate (replay).
+const mockUpsertSelect = vi.hoisted(() => vi.fn());
+const mockUpsert = vi.hoisted(() => vi.fn().mockReturnValue({ select: mockUpsertSelect }));
+const mockUpdateEq = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+const mockUpdate = vi.hoisted(() => vi.fn().mockReturnValue({ eq: mockUpdateEq }));
 const mockFrom = vi.hoisted(() =>
   vi.fn().mockImplementation((table: string) => {
     if (table === 'respect_transfers') return { upsert: mockUpsert };
-    return { select: mockSelect };
+    return { select: mockSelect, update: mockUpdate };
   }),
 );
 vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: { from: mockFrom } }));
 
 import { POST } from '../route';
+
+beforeEach(() => {
+  // Defaults: the transfer row inserts cleanly, and no member/user matches.
+  mockUpsertSelect.mockResolvedValue({ data: [{ id: 'transfer-1' }], error: null });
+  mockMaybeSingle.mockResolvedValue({ data: null });
+});
 
 afterEach(() => vi.clearAllMocks());
 
@@ -59,6 +70,13 @@ const ZOR_ACTIVITY_PAYLOAD = JSON.stringify({
   },
 });
 
+/** respect_members lookup hits first, then the users lookup. */
+function respectMemberFound() {
+  mockMaybeSingle
+    .mockResolvedValueOnce({ data: { id: 'member-1', onchain_og: 0, onchain_zor: 10 } })
+    .mockResolvedValueOnce({ data: null });
+}
+
 describe('POST /api/webhooks/alchemy', () => {
   it('returns 401 when HMAC signature does not match', async () => {
     const req = makeAlchemyRequest(EMPTY_PAYLOAD, 'wrong-signature-deadbeef');
@@ -83,7 +101,7 @@ describe('POST /api/webhooks/alchemy', () => {
     expect(body.ok).toBe(true);
     expect(mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({ token_type: 'zor_erc1155', tx_hash: '0xtxhash' }),
-      expect.any(Object),
+      expect.objectContaining({ ignoreDuplicates: true }),
     );
   });
 
@@ -95,5 +113,32 @@ describe('POST /api/webhooks/alchemy', () => {
     expect(res.status).toBe(200);
     expect(body.ok).toBe(true);
     expect(body.error).toBeDefined();
+  });
+
+  // Alchemy re-delivers anything it did not get a 2xx for, so the same signed
+  // payload can legitimately arrive twice. The balance must move exactly once.
+  describe('idempotency on re-delivery', () => {
+    it('credits the mint on the first delivery of a transfer', async () => {
+      respectMemberFound();
+      await POST(makeAlchemyRequest(ZOR_ACTIVITY_PAYLOAD));
+      expect(mockUpdate).toHaveBeenCalledWith({ onchain_zor: 15 });
+    });
+
+    it('does NOT credit again when the same transfer is re-delivered', async () => {
+      // Duplicate: ON CONFLICT DO NOTHING inserted nothing, so select returns [].
+      mockUpsertSelect.mockResolvedValue({ data: [], error: null });
+      respectMemberFound();
+      await POST(makeAlchemyRequest(ZOR_ACTIVITY_PAYLOAD));
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does NOT credit when the transfer row could not be recorded', async () => {
+      // No ledger row means the next delivery would look like the first one, so
+      // crediting here would double-count on the retry.
+      mockUpsertSelect.mockResolvedValue({ data: null, error: { message: 'db down' } });
+      respectMemberFound();
+      await POST(makeAlchemyRequest(ZOR_ACTIVITY_PAYLOAD));
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/api/webhooks/alchemy/route.ts
+++ b/src/app/api/webhooks/alchemy/route.ts
@@ -94,18 +94,51 @@ export async function POST(req: NextRequest) {
           ? parseInt(activity.blockNum, 16)
           : null;
 
-      await supabaseAdmin.from('respect_transfers').upsert(
-        {
-          tx_hash: txHash,
-          from_address: fromAddress,
-          to_address: toAddress,
-          token_type: tokenType,
-          amount,
-          block_number: blockNumber,
-          block_timestamp: payload?.createdAt || new Date().toISOString(),
-        },
-        { onConflict: 'tx_hash,to_address,token_type' },
-      );
+      // IDEMPOTENCY. Alchemy re-delivers any activity it did not get a 2xx for,
+      // and a function timeout looks exactly like that from its side, so the
+      // SAME transfer can arrive more than once. The UNIQUE(tx_hash, to_address,
+      // token_type) already de-duplicates the ledger row, but the balance credit
+      // below used to run on every delivery, so a replay added the mint amount to
+      // onchain_zor/onchain_og a second time and the inflated total never came
+      // back down (nothing reconciles these columns against the chain).
+      //
+      // `ignoreDuplicates` makes the insert a no-op on replay, and `.select()`
+      // then returns rows ONLY for a row we actually inserted. That turns the
+      // unique key the ledger already relies on into the answer to "have we
+      // credited this transfer before?".
+      const { data: insertedTransfer, error: transferError } = await supabaseAdmin
+        .from('respect_transfers')
+        .upsert(
+          {
+            tx_hash: txHash,
+            from_address: fromAddress,
+            to_address: toAddress,
+            token_type: tokenType,
+            amount,
+            block_number: blockNumber,
+            block_timestamp: payload?.createdAt || new Date().toISOString(),
+          },
+          { onConflict: 'tx_hash,to_address,token_type', ignoreDuplicates: true },
+        )
+        .select('id');
+
+      if (transferError) {
+        // Do NOT credit a transfer we failed to record. Without the ledger row
+        // the next delivery would look like the first one and credit it again -
+        // the exact double-count this guard exists to prevent.
+        logger.error('[alchemy-webhook] could not record transfer - balance NOT credited', {
+          txHash,
+          tokenType,
+          error: transferError,
+        });
+      }
+
+      const firstDelivery = !transferError && (insertedTransfer?.length ?? 0) > 0;
+      if (!transferError && !firstDelivery) {
+        logger.info(
+          `[alchemy-webhook] duplicate delivery for ${txHash.slice(0, 12)}... - already credited, not crediting again`,
+        );
+      }
 
       // Update respect_members on-chain balance for the recipient
       const { data: member } = await supabaseAdmin
@@ -114,7 +147,7 @@ export async function POST(req: NextRequest) {
         .ilike('wallet_address', toAddress)
         .maybeSingle();
 
-      if (member) {
+      if (member && firstDelivery) {
         const isMint = fromAddress === '0x0000000000000000000000000000000000000000';
         if (isMint) {
           const mintAmount = Number(amount) || 0;


### PR DESCRIPTION
Alchemy re-delivers any activity it did not get a 2xx for, and a function
timeout looks exactly like that from its side, so the same transfer can arrive
more than once.

The UNIQUE(tx_hash, to_address, token_type) constraint already de-duplicated
the ledger row in respect_transfers, so the ledger was fine. The balance credit
below it was not: it ran on every delivery, so a replay added the mint amount to
onchain_zor / onchain_og a second time. Nothing reconciles those columns against
the chain, so the inflated total never came back down.

The fix reuses the unique key the ledger already relies on as the answer to
"have we credited this transfer before?". `ignoreDuplicates: true` makes the
insert a no-op on replay, and `.select('id')` then returns rows only when a row
was actually inserted - so a non-empty result means first delivery.

A failed insert explicitly does NOT credit. Without the ledger row the next
delivery would look like a first delivery and credit it again, which is the
exact double-count this guard exists to prevent.

Found by the unattended repo auditor. Its run was killed before it could
commit, so the work sat uncommitted in a temp worktree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


Generated with Claude Code
