### PR TITLE
fix(publish): composing to one channel posted to both

### DIFF
--- a/src/app/api/publish/compose/__tests__/route.test.ts
+++ b/src/app/api/publish/compose/__tests__/route.test.ts
@@ -128,6 +128,21 @@ describe('POST /api/publish/compose', () => {
     expect(json.data.results[0].detail).toContain('failed');
   });
 
+  it('broadcasts ONLY to the channel that was selected', async () => {
+    mocks.broadcastToChannels.mockResolvedValue({
+      telegram: { success: true },
+      discord: { success: false, error: 'Discord not selected' },
+    });
+    const res = await POST(req({ text: 'post', platforms: ['telegram'], dryRun: false }));
+    // The load-bearing assertion: Discord is explicitly opted OUT, not left to
+    // the helper's both-channels default.
+    expect(mocks.broadcastToChannels).toHaveBeenCalledWith(
+      expect.objectContaining({ channels: { telegram: true, discord: false } }),
+    );
+    const json = await res.json();
+    expect(json.data.results.map((r: { platform: string }) => r.platform)).toEqual(['telegram']);
+  });
+
   it('400s on an empty platform list or empty text', async () => {
     expect((await POST(req({ text: 'hi', platforms: [] }))).status).toBe(400);
     expect((await POST(req({ text: '', platforms: ['x'] }))).status).toBe(400);

--- a/src/app/api/publish/compose/route.ts
+++ b/src/app/api/publish/compose/route.ts
@@ -189,7 +189,19 @@ export async function POST(req: NextRequest) {
           }
         }
       } else {
-        const b = await broadcastToChannels({ text, imageUrl, castHash: castHash ?? undefined });
+        // Pass the selection through. broadcastToChannels defaults to BOTH
+        // channels, so calling it because EITHER was ticked used to publish to
+        // both - an irreversible send to a public channel the admin did not
+        // select, and one this response never reported.
+        const b = await broadcastToChannels({
+          text,
+          imageUrl,
+          castHash: castHash ?? undefined,
+          channels: {
+            telegram: platforms.includes('telegram'),
+            discord: platforms.includes('discord'),
+          },
+        });
         if (platforms.includes('telegram')) {
           results.push({
             platform: 'telegram',

--- a/src/lib/publish/__tests__/broadcast.test.ts
+++ b/src/lib/publish/__tests__/broadcast.test.ts
@@ -62,6 +62,43 @@ describe('platform guards', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Channel selection - a send is irreversible, so an unselected channel must
+// never receive anything even when it is fully configured.
+// ---------------------------------------------------------------------------
+
+describe('channel selection', () => {
+  it('does not post to Discord when only Telegram is selected', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    const result = await broadcastToChannels({
+      text: 'hi',
+      channels: { telegram: true, discord: false },
+    });
+    expect(mockPublishToTelegram).toHaveBeenCalled();
+    expect(mockPublishToDiscord).not.toHaveBeenCalled();
+    expect(result.discord).toEqual({ success: false, error: 'Discord not selected' });
+  });
+
+  it('does not post to Telegram when only Discord is selected', async () => {
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    const result = await broadcastToChannels({
+      text: 'hi',
+      channels: { telegram: false, discord: true },
+    });
+    expect(mockPublishToDiscord).toHaveBeenCalled();
+    expect(mockPublishToTelegram).not.toHaveBeenCalled();
+    expect(result.telegram).toEqual({ success: false, error: 'Telegram not selected' });
+  });
+
+  it('omitting channels still posts to both (existing callers unchanged)', async () => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+    await broadcastToChannels({ text: 'hi' });
+    expect(mockPublishToTelegram).toHaveBeenCalled();
+    expect(mockPublishToDiscord).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Both succeed
 // ---------------------------------------------------------------------------
 

--- a/src/lib/publish/broadcast.ts
+++ b/src/lib/publish/broadcast.ts
@@ -27,6 +27,17 @@ export interface BroadcastOptions {
   castHash?: string;
   /** Direct URL to link to (overrides default ZAO OS link). */
   url?: string;
+  /**
+   * Which channels to attempt. Omitted (or an omitted key) means BOTH, which is
+   * the historical behavior every existing caller relies on.
+   *
+   * This exists because "broadcast" is only the right default when the caller
+   * genuinely wants every channel. /api/publish/compose lets an admin tick
+   * Telegram and Discord independently, and calling this helper because EITHER
+   * was ticked posted to BOTH — an irreversible send to a public channel nobody
+   * selected, and one the response never mentioned.
+   */
+  channels?: { telegram?: boolean; discord?: boolean };
 }
 
 export interface BroadcastResult {
@@ -41,13 +52,16 @@ export interface BroadcastResult {
 /**
  * Publish a message to Telegram and Discord channels in parallel.
  *
+ * - Only attempts a channel the caller selected (default: both).
  * - Only attempts Telegram if TELEGRAM_BOT_TOKEN is set.
  * - Only attempts Discord if DISCORD_WEBHOOK_URL is set.
  * - Never throws — returns results for both platforms.
  */
 export async function broadcastToChannels(options: BroadcastOptions): Promise<BroadcastResult> {
-  const hasTelegram = !!process.env.TELEGRAM_BOT_TOKEN;
-  const hasDiscord = !!process.env.DISCORD_WEBHOOK_URL;
+  const wantsTelegram = options.channels?.telegram ?? true;
+  const wantsDiscord = options.channels?.discord ?? true;
+  const hasTelegram = wantsTelegram && !!process.env.TELEGRAM_BOT_TOKEN;
+  const hasDiscord = wantsDiscord && !!process.env.DISCORD_WEBHOOK_URL;
 
   // Build links to append
   const farcasterLink = options.castHash
@@ -68,7 +82,10 @@ export async function broadcastToChannels(options: BroadcastOptions): Promise<Br
         parseMode: 'HTML',
         disablePreview: false,
       })
-    : Promise.resolve({ success: false, error: 'Telegram not configured' });
+    : Promise.resolve({
+        success: false,
+        error: wantsTelegram ? 'Telegram not configured' : 'Telegram not selected',
+      });
 
   const discordPromise = hasDiscord
     ? publishToDiscord({
@@ -84,7 +101,10 @@ export async function broadcastToChannels(options: BroadcastOptions): Promise<Br
             ]
           : undefined,
       })
-    : Promise.resolve({ success: false, error: 'Discord not configured' });
+    : Promise.resolve({
+        success: false,
+        error: wantsDiscord ? 'Discord not configured' : 'Discord not selected',
+      });
 
   const [telegramResult, discordResult] = await Promise.allSettled([
     telegramPromise,


### PR DESCRIPTION
broadcastToChannels attempted Telegram and Discord purely on whether each was
configured, ignoring what the caller asked for. /api/publish/compose lets an
admin tick Telegram and Discord independently, and called this helper when
EITHER was ticked - so selecting one posted to both.

That is an irreversible send to a public channel nobody selected, and the
response never mentioned the extra post, so there was no signal it had happened.

BroadcastOptions gains an optional `channels` field. An omitted field, or an
omitted key inside it, still means both, so every existing caller keeps its
current behavior. A channel the caller did not select reports "not selected"
rather than "not configured", so the two cases stay distinguishable in logs.

Found by the unattended repo auditor. Its run was killed before it could
commit, so the work sat uncommitted in a temp worktree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


Generated with Claude Code
