### PR TITLE
feat(zoe): backlog grill - drip the board to Telegram, answered by a number

### DIFF
--- a/bot/src/zoe/__tests__/backlog-grill.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DRIP_DEFAULT,
+  parseVerdict,
+  renderCard,
+  shouldSendNext,
+  verdictButtons,
+  verdictNote,
+  VERDICTS,
+} from '../backlog-grill';
+
+describe('parseVerdict - a thumb at a traffic light', () => {
+  it.each([
+    ['1', 'done'],
+    ['2', 'keep'],
+    ['3', 'work'],
+    ['4', 'drop'],
+    ['5', 'skip'],
+  ])('a bare "%s" is %s', (reply, key) => {
+    expect(parseVerdict(reply)?.key).toBe(key);
+  });
+
+  it.each(['1.', '1)', '1 -', ' 1 '])('tolerates punctuation and spacing: %s', (reply) => {
+    expect(parseVerdict(reply)?.key).toBe('done');
+  });
+
+  it('accepts the word instead of the number', () => {
+    expect(parseVerdict('done')?.key).toBe('done');
+    expect(parseVerdict('drop')?.key).toBe('drop');
+    expect(parseVerdict('work on it')?.key).toBe('work');
+  });
+
+  // "1" and "1 but ask iman first" mean different things, and the second is the
+  // more valuable message. Never discard the words.
+  it('keeps what he typed alongside the number', () => {
+    const v = parseVerdict('1 but check with iman first');
+    expect(v?.key).toBe('done');
+    expect(v?.note).toBe('but check with iman first');
+  });
+
+  // A sentence is a richer answer than a digit. Dropping it because it did not
+  // start with a number would be the wrong call.
+  it('treats free text as work-on-it with the text as the brief', () => {
+    const v = parseVerdict('actually split this into two and do the first half');
+    expect(v?.key).toBe('work');
+    expect(v?.note).toContain('split this into two');
+  });
+
+  it('returns null for nothing', () => {
+    expect(parseVerdict('')).toBeNull();
+    expect(parseVerdict('   ')).toBeNull();
+  });
+
+  it('ignores a number outside 1-5 as a choice', () => {
+    const v = parseVerdict('9');
+    expect(v?.key).toBe('work');
+    expect(v?.note).toBe('9');
+  });
+});
+
+describe('the verdict shape', () => {
+  // A task is never done because work STARTED. It comes back for confirmation.
+  it('work and skip go back in the queue', () => {
+    expect(parseVerdict('3')?.requeue).toBe(true);
+    expect(parseVerdict('5')?.requeue).toBe(true);
+  });
+
+  it('done, keep and drop do not requeue', () => {
+    for (const r of ['1', '2', '4']) expect(parseVerdict(r)?.requeue).toBe(false);
+  });
+
+  it('only done and drop close the task', () => {
+    expect(parseVerdict('1')?.closesTask).toBe(true);
+    expect(parseVerdict('4')?.closesTask).toBe(true);
+    expect(parseVerdict('2')?.closesTask).toBe(false);
+    expect(parseVerdict('3')?.closesTask).toBe(false);
+  });
+
+  it('the five never reorder - the numbers are muscle memory', () => {
+    expect(VERDICTS.map((v) => v.key)).toEqual(['done', 'keep', 'work', 'drop', 'skip']);
+  });
+});
+
+describe('renderCard', () => {
+  const task = { title: 'Fix Fractal documentation', createdAt: '2026-07-07T00:00:00Z' };
+  const now = Date.parse('2026-08-08T00:00:00Z');
+
+  it('shows position so the sweep has an end in sight', () => {
+    expect(renderCard(task, { index: 3, total: 320 }, now)).toContain('3/320');
+  });
+
+  it('shows the age - a 32-day-old task deserves a different answer', () => {
+    expect(renderCard(task, { index: 1, total: 10 }, now)).toContain('open 32d');
+  });
+
+  it('lists all five options', () => {
+    const out = renderCard(task, { index: 1, total: 10 }, now);
+    for (const v of VERDICTS) expect(out).toContain(`${v.n}. ${v.label}`);
+  });
+
+  it('includes a real why', () => {
+    const out = renderCard({ ...task, why: 'Audit written in doc 1306 but bios still dead' }, { index: 1, total: 5 }, now);
+    expect(out).toContain('bios still dead');
+  });
+
+  // 13 of Iman's 20 open tasks carry this exact boilerplate. It costs a line
+  // and says nothing.
+  it('never shows the boilerplate note', () => {
+    const out = renderCard(
+      { ...task, why: 'Action item captured from forwarded email. Reply to Claude in next session if blocked' },
+      { index: 1, total: 5 },
+      now,
+    );
+    expect(out).not.toContain('Reply to Claude');
+  });
+
+  it('survives a task with no date or why', () => {
+    expect(() => renderCard({ title: 'bare' }, { index: 1, total: 1 }, now)).not.toThrow();
+  });
+});
+
+describe('verdictButtons', () => {
+  it('offers all five as taps', () => {
+    const flat = verdictButtons().flat();
+    expect(flat).toHaveLength(5);
+    for (const v of VERDICTS) expect(flat.some((b) => b.text.startsWith(String(v.n)))).toBe(true);
+  });
+});
+
+describe('shouldSendNext - a pile is the feature, a flood is not', () => {
+  const base = { nowMs: 1_000_000_000, localHour: 12, lastSentMs: null, outstanding: 0, remainingInQueue: 100 };
+
+  it('sends when due', () => {
+    expect(shouldSendNext(base).send).toBe(true);
+  });
+
+  it('waits out the interval', () => {
+    const r = shouldSendNext({ ...base, lastSentMs: base.nowMs - 30_000 });
+    expect(r.send).toBe(false);
+    expect(r.reason).toContain('too soon');
+  });
+
+  it('sends once the interval has passed', () => {
+    expect(shouldSendNext({ ...base, lastSentMs: base.nowMs - 3 * 60_000 }).send).toBe(true);
+  });
+
+  // Unbounded, the pile becomes a wall he never opens.
+  it('stops adding when too many are unanswered', () => {
+    const r = shouldSendNext({ ...base, outstanding: DRIP_DEFAULT.maxOutstanding });
+    expect(r.send).toBe(false);
+    expect(r.reason).toContain('catch up');
+  });
+
+  it('resumes once he has cleared some', () => {
+    expect(shouldSendNext({ ...base, outstanding: 5 }).send).toBe(true);
+  });
+
+  it.each([3, 23, 0])('stays quiet at %s:00 local', (localHour) => {
+    expect(shouldSendNext({ ...base, localHour }).send).toBe(false);
+  });
+
+  it('stops when the queue is empty', () => {
+    const r = shouldSendNext({ ...base, remainingInQueue: 0 });
+    expect(r.send).toBe(false);
+    expect(r.reason).toContain('empty');
+  });
+});
+
+describe('verdictNote - every change explains itself', () => {
+  it('records what was chosen', () => {
+    expect(verdictNote(parseVerdict('1')!, '2026-08-08')).toContain('confirmed done');
+    expect(verdictNote(parseVerdict('4')!, '2026-08-08')).toContain('dropped');
+  });
+
+  it('quotes what he typed', () => {
+    const note = verdictNote(parseVerdict('1 ask iman to verify')!, '2026-08-08');
+    expect(note).toContain('ask iman to verify');
+  });
+
+  it('never claims done for a drop', () => {
+    expect(verdictNote(parseVerdict('4')!, '2026-08-08')).not.toContain('confirmed done');
+  });
+});

--- a/bot/src/zoe/backlog-grill.ts
+++ b/bot/src/zoe/backlog-grill.ts
@@ -1,0 +1,219 @@
+/**
+ * backlog-grill.ts - drip the board backlog to Zaal's phone, one card every
+ * couple of minutes, answered by pressing a number.
+ *
+ * WHAT ALREADY EXISTS (extend, never rebuild)
+ * ------------------------------------------
+ * grill.ts already DMs Zaal one item at a time, keeps state so nothing repeats,
+ * pins the open question, renders buttons, and matches a typed answer. None of
+ * that is rebuilt here. Three things were missing for what Zaal asked for:
+ *
+ *   1. SOURCE. grill.ts pulls from the cockpit - decisions that need him, PRs to
+ *      review, blocked items. It has no path to the 356-task board backlog,
+ *      which is where the actual pile is.
+ *   2. OPTIONS. parseOptions() reads choices OUT of a title ("1: intro / 2: map").
+ *      A backlog task has no options in its title; it needs the same five
+ *      verdicts every time, so the answer becomes muscle memory.
+ *   3. CADENCE. The grill cron is every 2 hours. Zaal asked for one added every
+ *      couple of minutes so a queue builds and he sweeps it in one pass.
+ *
+ * WHY FIVE FIXED VERDICTS
+ * ----------------------
+ * The terminal grill today proved the shape: 24 tasks reviewed, 9 closed, in
+ * minutes, because every question had the same small set of answers. Zaal:
+ * "ill just come though and go though the whole queu just like today and knock
+ * them out with pressing 1,2,3,4,5 or typign in a reply."
+ *
+ * So the options never change per card. 1 is always done, 3 is always work-on-it.
+ * You stop reading the options after the first few cards, which is the entire
+ * point - the bottleneck is his attention, not the interface.
+ *
+ * WHY "WORK ON IT" IS ONE OF THE FIVE
+ * ----------------------------------
+ * Also from today: sending a task to be worked mid-grill, and having it come
+ * back at the END of the queue for confirmation, is what turns the grill from
+ * sorting into progress. A task never gets marked done because work STARTED -
+ * it re-enters the queue and is confirmed by a human, which is why `requeue` is
+ * part of the verdict shape rather than an afterthought.
+ */
+
+/** The five, in the order they are pressed. Stable - do not reorder. */
+export const VERDICTS = [
+  { n: 1, key: 'done', label: 'Done - close it' },
+  { n: 2, key: 'keep', label: 'Keep open' },
+  { n: 3, key: 'work', label: 'Work on it now' },
+  { n: 4, key: 'drop', label: 'Drop it' },
+  { n: 5, key: 'skip', label: 'Skip for now' },
+] as const;
+
+export type VerdictKey = (typeof VERDICTS)[number]['key'];
+
+export interface Verdict {
+  key: VerdictKey;
+  /** Anything Zaal typed instead of, or alongside, a number. */
+  note?: string;
+  /** Does this go back in the queue for a later confirmation? */
+  requeue: boolean;
+  /** Does this change the board now? */
+  closesTask: boolean;
+}
+
+/**
+ * Read an answer.
+ *
+ * Accepts a bare number, the word, or free text. Free text is never discarded -
+ * it becomes the note, because "1" and "1 but ask iman first" mean different
+ * things and the second one is the more valuable message.
+ *
+ * A bare number is deliberately the fastest path: it is what a thumb does at a
+ * traffic light.
+ */
+export function parseVerdict(reply: string): Verdict | null {
+  const raw = (reply || '').trim();
+  if (!raw) return null;
+
+  // A leading number, optionally followed by anything else.
+  const m = /^([1-5])\b[\s.:)-]*(.*)$/s.exec(raw);
+  if (m) {
+    const v = VERDICTS.find((x) => x.n === Number(m[1]));
+    if (v) return build(v.key, m[2].trim() || undefined);
+  }
+
+  // The word itself: "done", "keep", "drop", "skip", "work on it".
+  const lower = raw.toLowerCase();
+  for (const v of VERDICTS) {
+    if (lower === v.key || lower.startsWith(`${v.key} `)) {
+      return build(v.key, raw.slice(v.key.length).trim() || undefined);
+    }
+  }
+  if (/^work on it/i.test(lower)) return build('work', raw.slice(10).trim() || undefined);
+
+  // Anything else is a real instruction. Treat it as "work on it" with the
+  // typed text as the brief - a sentence is a richer answer than a number, and
+  // dropping it because it did not start with a digit would be the wrong call.
+  return build('work', raw);
+}
+
+function build(key: VerdictKey, note?: string): Verdict {
+  return {
+    key,
+    note,
+    // Work re-enters the queue: a task is never done because work STARTED.
+    requeue: key === 'work' || key === 'skip',
+    closesTask: key === 'done' || key === 'drop',
+  };
+}
+
+/**
+ * The card.
+ *
+ * One task, its age, its why if it has one, and the five options. Age is shown
+ * because a 36-day-old task and a 2-day-old one deserve different answers, and
+ * that is invisible from a title.
+ */
+export function renderCard(
+  task: { title: string; createdAt?: string; why?: string | null },
+  position: { index: number; total: number },
+  now = Date.now(),
+): string {
+  const lines: string[] = [];
+  lines.push(`${position.index}/${position.total}`);
+  lines.push('');
+  lines.push(task.title.slice(0, 200));
+
+  if (task.createdAt) {
+    const days = Math.floor((now - Date.parse(task.createdAt)) / 86400_000);
+    if (Number.isFinite(days) && days >= 0) {
+      lines.push(`open ${days}d`);
+    }
+  }
+  const why = (task.why || '').trim();
+  // The boilerplate note is worse than nothing - it takes up a line and says
+  // nothing. 13 of Iman's 20 open tasks carry it; do not put it on a card.
+  if (why && !/Reply to Claude in next session/i.test(why)) {
+    lines.push('');
+    lines.push(why.slice(0, 180));
+  }
+  lines.push('');
+  for (const v of VERDICTS) lines.push(`${v.n}. ${v.label}`);
+  return lines.join('\n');
+}
+
+/** Buttons, always - a number is faster to tap than to type. */
+export function verdictButtons(): { text: string; data: string }[][] {
+  return [
+    [
+      { text: '1 Done', data: 'bg:done' },
+      { text: '2 Keep', data: 'bg:keep' },
+      { text: '3 Work', data: 'bg:work' },
+    ],
+    [
+      { text: '4 Drop', data: 'bg:drop' },
+      { text: '5 Skip', data: 'bg:skip' },
+    ],
+  ];
+}
+
+export interface DripConfig {
+  /** Minutes between cards. Zaal asked for ~2. */
+  everyMinutes: number;
+  /** Most unanswered cards allowed to pile up before we stop adding. */
+  maxOutstanding: number;
+  /** Local hours (Zaal's) in which cards may be sent. */
+  startHour: number;
+  endHour: number;
+}
+
+/**
+ * A pile is fine; a flood is not.
+ *
+ * Zaal wants a queue to sweep, so outstanding cards are the FEATURE - but
+ * unbounded they become a wall he never opens, and a check nobody reads is
+ * worth nothing. 20 is roughly one sweep's worth at the pace he cleared them
+ * today.
+ */
+export const DRIP_DEFAULT: DripConfig = {
+  everyMinutes: 2,
+  maxOutstanding: 20,
+  startHour: 6,
+  endHour: 22,
+};
+
+export interface DripInput {
+  nowMs: number;
+  /** Zaal's local hour, 0-23. */
+  localHour: number;
+  lastSentMs: number | null;
+  outstanding: number;
+  remainingInQueue: number;
+  cfg?: DripConfig;
+}
+
+export function shouldSendNext(input: DripInput): { send: boolean; reason: string } {
+  const cfg = input.cfg ?? DRIP_DEFAULT;
+  if (input.remainingInQueue <= 0) return { send: false, reason: 'queue empty' };
+  if (input.localHour < cfg.startHour || input.localHour >= cfg.endHour) {
+    return { send: false, reason: `outside ${cfg.startHour}-${cfg.endHour}` };
+  }
+  if (input.outstanding >= cfg.maxOutstanding) {
+    return { send: false, reason: `${input.outstanding} already unanswered - let him catch up` };
+  }
+  const since = input.lastSentMs === null ? Infinity : input.nowMs - input.lastSentMs;
+  if (since < cfg.everyMinutes * 60_000) {
+    return { send: false, reason: 'too soon since the last card' };
+  }
+  return { send: true, reason: 'due' };
+}
+
+/** What gets written into the task's notes, so every close explains itself. */
+export function verdictNote(v: Verdict, date: string): string {
+  const base = {
+    done: 'confirmed done',
+    keep: 'still wanted - kept open',
+    work: 'sent to be worked on',
+    drop: 'dropped - not doing it',
+    skip: 'skipped for now',
+  }[v.key];
+  const note = v.note ? ` Zaal added: "${v.note}"` : '';
+  return `GRILL ${date} (Telegram): ${base}.${note}`;
+}


### PR DESCRIPTION
## Why

Zaal, after clearing 24 board tasks in a terminal grill today:

> "start to slow grill me using telegram which is asking me a bunch of questions each 2 mins adding a new one and ill just come though and go though the whole queu just like today and knock them out with **pressing 1,2,3,4,5** or typing in a reply"

## What already existed - three gaps, not a rebuild

`grill.ts` already DMs one item at a time, keeps state so nothing repeats, pins the open question, renders buttons, and matches typed answers. **None of that is reimplemented.** What was missing:

| Gap | Detail |
|---|---|
| **Source** | grill.ts pulls from the cockpit. It has no path to the 356-task board backlog, which is where the pile is. |
| **Options** | `parseOptions()` reads choices *out of* a title. A backlog task has none - it needs the same five verdicts every time. |
| **Cadence** | The grill cron is every 2 hours. This needs ~2 minutes. |

## Why the five never change

**1 is always done. 3 is always work-on-it.** You stop reading the options after a few cards, which is the entire point - the bottleneck is attention, not interface. Today's terminal grill proved it: 24 reviewed, 9 closed, in minutes.

## Why "work on it" requeues

Also proven today: sending a task to be worked mid-grill and having it come back at the **end** of the queue for confirmation is what turns the grill from sorting into progress. A task is never done because work *started* - so `requeue` is part of the verdict shape, not an afterthought.

## Typed replies are not second-class

`1` and `1 but check with iman first` mean different things, and the second is the more valuable message - so the words are kept as a note. A bare sentence with no number reads as work-on-it with the sentence as the brief.

## Guards

- **20 outstanding cards max.** The pile is the feature; unbounded it becomes a wall nobody opens.
- **Nothing between 22:00 and 06:00.**
- Every verdict writes a note explaining itself, and a drop records as "dropped - not doing it", never as done.

## Evidence

| Check | Result |
|---|---|
| Unit tests | 37 pass - every parse path, requeue semantics, card rendering, drip guards |
| Full bot suite | 2186 tests pass |
| Typecheck | 0 non-test errors |

## Scope

Pure module. Scheduler wiring is separate, so the cadence gets reviewed before anything messages a phone every two minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9