### PR TITLE
fix(zoe): a ZOE reply to one comment silently marked every other one answered

### DIFF
--- a/bot/src/zoe/__tests__/mention-answered.test.ts
+++ b/bot/src/zoe/__tests__/mention-answered.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { findUnansweredMentions, type BoardComment, type BoardTask } from '../task-comment-replies';
+
+const ZOE = '00000000-0000-4000-8000-00000000z0e0'.replace('z0e', 'a0e');
+
+function task(comments: BoardComment[]): BoardTask {
+  return { id: 't1', title: 'Todo 08/08/26', metadata: { comments } } as BoardTask;
+}
+const c = (id: string, content: string, userId?: string, replyTo?: string): BoardComment => ({
+  id, content, userId, displayName: userId ? 'ZOE' : 'Zaal', replyTo,
+});
+
+describe('findUnansweredMentions - the #9246 bug', () => {
+  // The exact thread that failed live on 2026-08-08. ZOE's ack of IMAN landed
+  // after Zaal's command and marked it answered, so the command never ran.
+  it('a ZOE ack of someone ELSE does not answer Zaal\'s command', () => {
+    const zoeUserId = findZoeId();
+    const t = task([
+      c('c1', '@zaal https://github.com/ZAODEVZ/ZAOartizen/pull/19'),
+      c('c2', '@iman done. @zoe make a new todo called zartizen ui cleanup and close this one'),
+      c('c3', 'Noted - flagged to Zaal: "@zaal ...PR/19"', zoeUserId, 'c1'),
+    ]);
+    const out = findUnansweredMentions([t]);
+    expect(out.map((x) => x.comment.id)).toEqual(['c2']);
+  });
+
+  it('a tagged reply DOES answer the comment it names', () => {
+    const z = findZoeId();
+    const t = task([
+      c('c1', '@zoe what is the status'),
+      c('c2', 'Here is the status', z, 'c1'),
+    ]);
+    expect(findUnansweredMentions([t])).toEqual([]);
+  });
+
+  // Without this, every historical @zoe mention would read as unanswered and
+  // ZOE would flood old threads re-answering all of them.
+  it('a legacy untagged ZOE reply still counts, so old threads stay quiet', () => {
+    const z = findZoeId();
+    const t = task([
+      c('c1', '@zoe what is the status'),
+      c('c2', 'Here is the status', z),
+    ]);
+    expect(findUnansweredMentions([t])).toEqual([]);
+  });
+
+  it('an unanswered mention is still found', () => {
+    const t = task([c('c1', '@zoe please close this')]);
+    expect(findUnansweredMentions([t]).map((x) => x.comment.id)).toEqual(['c1']);
+  });
+
+  it('a comment that does not tag zoe is never queued', () => {
+    const t = task([c('c1', '@zaal look at this')]);
+    expect(findUnansweredMentions([t])).toEqual([]);
+  });
+
+  it('handles several mentions in one thread independently', () => {
+    const z = findZoeId();
+    const t = task([
+      c('c1', '@zoe first question'),
+      c('c2', 'answer to first', z, 'c1'),
+      c('c3', '@zoe second question'),
+    ]);
+    expect(findUnansweredMentions([t]).map((x) => x.comment.id)).toEqual(['c3']);
+  });
+
+  it('survives a task with no comments', () => {
+    expect(findUnansweredMentions([{ id: 't', title: 'x', metadata: {} } as BoardTask])).toEqual([]);
+  });
+});
+
+/** ZOE_USER_ID is module-private; recover it from observed behaviour. */
+function findZoeId(): string {
+  // A reply from this id must satisfy the legacy branch (answers everything).
+  for (const candidate of [ZOE, 'zoe', 'ZOE']) {
+    const t = task([c('c1', '@zoe q'), c('c2', 'a', candidate)]);
+    if (findUnansweredMentions([t]).length === 0) return candidate;
+  }
+  throw new Error('could not determine ZOE_USER_ID from behaviour');
+}

--- a/bot/src/zoe/task-comment-replies.ts
+++ b/bot/src/zoe/task-comment-replies.ts
@@ -30,6 +30,14 @@ export interface BoardComment {
   content: string;
   createdAt?: string;
   editedAt?: string;
+  /**
+   * For a ZOE comment: the id of the comment it is answering.
+   *
+   * Added 2026-08-08. Without it, "has this been answered?" could only ask
+   * "is there ANY later ZOE comment", which is wrong whenever two ZOE modules
+   * write to the same thread - see findUnansweredMentions.
+   */
+  replyTo?: string;
 }
 
 export interface BoardTask {
@@ -68,6 +76,31 @@ function tagsZoe(c: BoardComment): boolean {
  * ZOE-authored comment (userId === 'zoe') appearing later in the ordered
  * comments array. Pure + exported for unit testing.
  */
+/**
+ * Which @zoe comments are still waiting on ZOE.
+ *
+ * THE BUG THIS FIXES (found live, 2026-08-08)
+ * -----------------------------------------
+ * This used to treat ANY later ZOE comment as an answer:
+ *
+ *   comments.slice(i + 1).some((later) => later.userId === ZOE_USER_ID)
+ *
+ * ZOE is not one writer. task-teammate-ack also posts as ZOE, acknowledging a
+ * teammate's comment. On task #9246 the thread ran:
+ *
+ *   [Iman] @zaal <PR link>
+ *   [Zaal] @zoe ... make a new todo ... and close this one
+ *   [ZOE]  Noted - flagged to Zaal: "<Iman's comment>"     <- ack of IMAN
+ *
+ * That ack landed after Zaal's command, so his command was marked answered by a
+ * message that had nothing to do with it. It would never have been processed -
+ * silently, forever, with no error anywhere.
+ *
+ * Now a ZOE comment answers a specific mention only when it says so. Legacy ZOE
+ * comments carry no replyTo, so they still count as a generic answer - without
+ * that, every historical @zoe mention would suddenly read as unanswered and ZOE
+ * would flood old threads re-answering them.
+ */
 export function findUnansweredMentions(
   tasks: BoardTask[],
 ): Array<{ task: BoardTask; comment: BoardComment }> {
@@ -77,7 +110,14 @@ export function findUnansweredMentions(
     for (let i = 0; i < comments.length; i++) {
       const c = comments[i];
       if (!tagsZoe(c)) continue;
-      const answered = comments.slice(i + 1).some((later) => later.userId === ZOE_USER_ID);
+      const answered = comments.slice(i + 1).some((later) => {
+        if (later.userId !== ZOE_USER_ID) return false;
+        // Tagged reply: only counts for the comment it names.
+        if (later.replyTo) return later.replyTo === c.id;
+        // Untagged = written before this fix. Keep the old meaning so old
+        // threads stay quiet rather than all reopening at once.
+        return true;
+      });
       if (!answered) out.push({ task, comment: c });
     }
   }
@@ -180,6 +220,7 @@ async function postReply(
   task: BoardTask,
   answer: string,
   fetchImpl: typeof fetch,
+  replyTo?: string,
 ): Promise<boolean> {
   const base = process.env.COWORK_TRACKER_URL;
   const key = process.env.COWORK_TRACKER_KEY;
@@ -190,6 +231,7 @@ async function postReply(
     displayName: ZOE_DISPLAY,
     content: answer,
     createdAt: new Date().toISOString(),
+    replyTo,
   };
   const metadata = { ...(task.metadata ?? {}) };
   const existing = Array.isArray(metadata.comments) ? (metadata.comments as BoardComment[]) : [];
@@ -283,7 +325,7 @@ export async function runTaskCommentReplies(
       (m) => m.comment.id === comment.id,
     );
     if (!stillUnanswered) continue;
-    if (await postReply(fresh, ans, fetchImpl)) answered++;
+    if (await postReply(fresh, ans, fetchImpl, comment.id)) answered++;
   }
 
   if (answered > 0) {


### PR DESCRIPTION
## Found by watching the board-command feature fail on its first real run

Task #9246, live:

```
[Iman] @zaal https://github.com/ZAODEVZ/ZAOartizen/pull/19
[Zaal] @iman done. @zoe ... make a new todo ... and close this one
[ZOE]  Noted - flagged to Zaal: "@zaal ...PR/19"      <- an ack of IMAN
```

## Root cause

`findUnansweredMentions` treated **any** later ZOE comment as an answer:

```js
comments.slice(i + 1).some((later) => later.userId === ZOE_USER_ID)
```

But ZOE is not one writer. `task-teammate-ack` also posts as ZOE. Its acknowledgement of *Iman's* comment landed after Zaal's command and marked that command answered - **by a message with nothing to do with it**.

Zaal's command would never have run. No error, no log, no retry - the queue simply stopped containing it. The board-command feature shipped hours earlier was working correctly and would have looked broken forever.

## The fix

A ZOE reply now records which comment it answers, and answered-ness checks that id rather than mere authorship.

Legacy ZOE comments carry no `replyTo` and still count as a generic answer, **on purpose**: without that, every historical `@zoe` mention would read as unanswered and ZOE would flood old threads re-answering all of them. That path is tested.

## Why this keeps happening

**Second bug today in the same family** - a message consumed by an adjacent handler that had no business consuming it. This morning the batch-answer parser ate `build:` before the build classifier could see it.

Both were invisible because the swallowing path returns success. Worth naming as a pattern: **when two handlers read the same input, the first to claim it wins silently.**

## Evidence

| Check | Result |
|---|---|
| Regression tests | 7 pass, built on the exact #9246 thread |
| Legacy-quiet path | tested - merging this does not wake old threads |
| Full bot suite | 2156 tests pass |
| Typecheck | 0 non-test errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9