### PR TITLE
fix(zoe): a board command re-ran every hour until its receipt posted

### DIFF
--- a/bot/src/zoe/__tests__/board-command-executor.test.ts
+++ b/bot/src/zoe/__tests__/board-command-executor.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The replay guard.
+ *
+ * Execution happens BEFORE the caller's freshness re-check and before the
+ * receipt that marks a comment answered is posted. Anything failing in that
+ * window - an 8s PATCH timeout, a concurrent app write, a restart - leaves the
+ * board already changed and the comment still unanswered, so the hourly cron
+ * re-runs it. `create_task` INSERTs, so that replay used to add a duplicate
+ * task every hour with nothing to stop it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeBoardComment, type ExecContext } from '../board-command-executor';
+
+const ctx: ExecContext = {
+  taskId: 'task-uuid-1',
+  taskTitle: 'ship the thing',
+  commentId: 'comment-abc',
+  commentContent: '@zoe make a new todo called zartizen ui cleanup and close this one',
+  commentAuthor: 'Zaal',
+};
+
+/** The extraction step the executor injects - fixed output, no model. */
+const extract = (json: unknown) => async () => JSON.stringify(json);
+
+const CREATE_AND_CLOSE = [
+  { action: 'create_task', title: 'zartizen ui cleanup' },
+  { action: 'close_task', taskRef: 'this' },
+];
+
+/**
+ * A fetch double that records calls and answers by URL shape.
+ * `existingRows` is what the legacy_source lookup finds.
+ */
+function makeFetch(opts: { existingRows?: unknown[]; lookupOk?: boolean } = {}) {
+  const calls: Array<{ url: string; method: string }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? 'GET';
+    calls.push({ url: u, method });
+    if (method === 'GET' && u.includes('legacy_source=eq.')) {
+      if (opts.lookupOk === false) return new Response('boom', { status: 500 });
+      return Response.json(opts.existingRows ?? []);
+    }
+    if (method === 'POST') return Response.json([{ id: 'new-uuid', legacy_id: '9247' }]);
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const creates = (calls: Array<{ url: string; method: string }>) =>
+  calls.filter((c) => c.method === 'POST' && c.url.includes('/tasks'));
+
+beforeEach(() => {
+  process.env.COWORK_TRACKER_URL = 'https://board.example';
+  process.env.COWORK_TRACKER_KEY = 'test-key';
+});
+
+afterEach(() => {
+  delete process.env.COWORK_TRACKER_URL;
+  delete process.env.COWORK_TRACKER_KEY;
+  vi.restoreAllMocks();
+});
+
+describe('replay guard', () => {
+  it('creates the task on the first run', async () => {
+    const { impl, calls } = makeFetch({ existingRows: [] });
+    const res = await executeBoardComment(ctx, extract(CREATE_AND_CLOSE), impl);
+    expect(creates(calls)).toHaveLength(1);
+    expect(res?.executed).toBe(2);
+  });
+
+  // The bug: without this guard the same comment re-created the task every
+  // hour for as long as the receipt failed to post.
+  it('creates nothing on a re-run of the same comment', async () => {
+    const { impl, calls } = makeFetch({ existingRows: [{ id: 'already-there' }] });
+    const res = await executeBoardComment(ctx, extract(CREATE_AND_CLOSE), impl);
+    expect(creates(calls)).toHaveLength(0);
+    expect(res?.receipt).toContain('already applied');
+    expect(res?.executed).toBe(0);
+  });
+
+  // A re-run must not re-apply the OTHER actions either - the guard runs before
+  // any of them, so a replay is a complete no-op, not a partial one.
+  it('does not re-close on a re-run', async () => {
+    const { impl, calls } = makeFetch({ existingRows: [{ id: 'already-there' }] });
+    await executeBoardComment(ctx, extract(CREATE_AND_CLOSE), impl);
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0);
+  });
+
+  // Fail closed. Running could duplicate; replying conversationally would mark
+  // the comment handled and lose the command. So: do nothing, retry next tick.
+  it('skips the tick when the lookup itself fails', async () => {
+    const { impl, calls } = makeFetch({ lookupOk: false });
+    const res = await executeBoardComment(ctx, extract(CREATE_AND_CLOSE), impl);
+    expect(res?.skipped).toBeTruthy();
+    expect(creates(calls)).toHaveLength(0);
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0);
+  });
+
+  // close/assign are idempotent under replay, so a comment with no create pays
+  // for no extra round-trip.
+  it('does not look up when the comment creates nothing', async () => {
+    const { impl, calls } = makeFetch();
+    const res = await executeBoardComment(
+      ctx,
+      extract([{ action: 'close_task', taskRef: 'this' }]),
+      impl,
+    );
+    expect(calls.filter((c) => c.url.includes('legacy_source=eq.'))).toHaveLength(0);
+    expect(res?.executed).toBe(1);
+  });
+});
+
+describe('authorization still gates everything', () => {
+  it('a non-commander executes nothing and never queries', async () => {
+    const { impl, calls } = makeFetch();
+    const res = await executeBoardComment(
+      { ...ctx, commentAuthor: 'Iman' },
+      extract(CREATE_AND_CLOSE),
+      impl,
+    );
+    expect(res).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/bot/src/zoe/board-command-executor.ts
+++ b/bot/src/zoe/board-command-executor.ts
@@ -33,7 +33,22 @@ export interface ExecContext {
 export interface ExecResult {
   executed: number;
   receipt: string;
+  /**
+   * Set when this tick deliberately did nothing and the comment must be tried
+   * again later. The caller must NOT fall through to the reply path on a
+   * skip: answering conversationally marks the comment as handled, which would
+   * throw the command away permanently.
+   */
   skipped?: string;
+}
+
+/**
+ * The `legacy_source` stamped on every task created from a comment.
+ *
+ * This doubles as the execution marker - see `alreadyExecuted`.
+ */
+export function commandSource(commentId: string): string {
+  return `zoe-command:${commentId}`;
 }
 
 function cfg(): { root: string; headers: Record<string, string> } | null {
@@ -63,6 +78,47 @@ async function resolveOwner(slug: string, fetchImpl: typeof fetch): Promise<stri
   }
 }
 
+/**
+ * Has this comment already been executed on an earlier tick?
+ *
+ * WHY THIS IS NEEDED. Execution runs BEFORE the caller's freshness re-check and
+ * before the receipt is posted, and the receipt is the only thing that marks a
+ * comment as handled. So any failure between the two - `postReply` timing out
+ * on its 8s AbortSignal, the row being PATCHed by the app in between, the
+ * process restarting - leaves the board already mutated and the comment still
+ * looking unanswered. The hourly cron then re-runs the whole comment.
+ *
+ * `close_task` and `assign_task` are idempotent under a replay (setting status
+ * to 'done' twice, or the same owner_id twice, changes nothing the second
+ * time). `create_task` is not: it INSERTs, so one transient failure produced a
+ * duplicate task every hour, forever, with no unique constraint to stop it.
+ *
+ * The marker is the `legacy_source` already written on every created task, so
+ * this needs no schema change - just a read of what the previous run left
+ * behind.
+ *
+ * Returns 'unknown' when the lookup itself fails, which the caller treats as
+ * "skip this tick and retry", never as "safe to run again".
+ */
+async function alreadyExecuted(
+  commentId: string,
+  fetchImpl: typeof fetch,
+): Promise<boolean | 'unknown'> {
+  const c = cfg();
+  if (!c) return 'unknown';
+  try {
+    const r = await fetchImpl(
+      `${c.root}/rest/v1/tasks?select=id&legacy_source=eq.${encodeURIComponent(commandSource(commentId))}&limit=1`,
+      { headers: c.headers },
+    );
+    if (!r.ok) return 'unknown';
+    const rows = (await r.json()) as unknown;
+    return Array.isArray(rows) && rows.length > 0;
+  } catch {
+    return 'unknown';
+  }
+}
+
 async function applyOne(
   cmd: BoardCommand,
   ctx: ExecContext,
@@ -84,7 +140,7 @@ async function applyOne(
       status: 'todo',
       owner_id: ownerId,
       notes: `${why}\n\nSource: @zoe command in a comment on task ${ctx.taskId}.`,
-      legacy_source: `zoe-command:${ctx.commentId}`,
+      legacy_source: commandSource(ctx.commentId),
       project: 'zaodevz',
     };
     try {
@@ -159,6 +215,29 @@ export async function executeBoardComment(
 
   const { commands, rejected, dropped } = parseCommands(raw);
   if (commands.length === 0 && rejected.length === 0) return null;
+
+  // Replay guard, and only where a replay actually costs something: create is
+  // the sole INSERT, so it is the sole action a re-run can duplicate. Checked
+  // before ANY action runs, so a replayed comment re-applies nothing at all.
+  if (commands.some((cmd) => cmd.action === 'create_task')) {
+    const done = await alreadyExecuted(ctx.commentId, fetchImpl);
+    if (done === 'unknown') {
+      // Fail closed. The comment stays unanswered, so the next tick retries it -
+      // whereas running now could duplicate, and falling through to a chat reply
+      // would mark it handled and lose the command outright.
+      return {
+        executed: 0,
+        receipt: '',
+        skipped: 'could not confirm whether this comment already ran; will retry',
+      };
+    }
+    if (done) {
+      return {
+        executed: 0,
+        receipt: 'already applied on an earlier run - nothing re-run.',
+      };
+    }
+  }
 
   featureRan('board-commands', `task ${ctx.taskId}`);
 

--- a/bot/src/zoe/task-comment-replies.ts
+++ b/bot/src/zoe/task-comment-replies.ts
@@ -242,6 +242,7 @@ export async function runTaskCommentReplies(
     // for the board to change. Only an authorized commander gets here; a
     // teammate tagging @zoe still falls straight through to the reply path.
     let ans: string | null = null;
+    let skip = false;
     try {
       const done = await executeBoardComment(
         {
@@ -269,11 +270,22 @@ export async function runTaskCommentReplies(
       );
       // The receipt IS the reply - so a board change is always visible in the
       // thread that caused it, never a silent mutation.
-      if (done) ans = done.receipt;
+      //
+      // A SKIP is not a reply. The executor sets it when it could not tell
+      // whether this comment already ran; answering conversationally would mark
+      // the comment handled and discard the command, so leave the comment
+      // untouched and let the next tick retry it.
+      if (done?.skipped) {
+        skip = true;
+        console.warn(`[zoe/board-commands] task ${task.id} skipped this tick: ${done.skipped}`);
+      } else if (done) {
+        ans = done.receipt;
+      }
     } catch (err) {
       console.warn('[zoe/board-commands] execution failed (falling back to a reply):', (err as Error)?.message);
     }
 
+    if (skip) continue;
     if (!ans) ans = await answerMention(task, comment, call);
     if (!ans) continue;
     // Re-fetch just before writing to shrink the window where a concurrent app


### PR DESCRIPTION
## Executive summary

A ZOE board command could run more than once. When Zaal comments "@zoe make a new todo called X and close this one", ZOE now changes the board and then posts a receipt back into the comment thread. That receipt is the only thing that marks the comment as handled. If posting it fails, the board has already changed but the comment still looks unanswered, so the hourly cron picks the same comment up again and re-runs it. `close` and `assign` do not care - setting a task to done twice changes nothing. `create` does: it inserts a new row every time, so one transient failure produced a duplicate task every hour, forever.

This adds a guard so a re-run does nothing at all.

## Why this matters

The window is not theoretical. Between the mutation and the receipt there are three ordinary ways to fail:

- `postReply` carries `AbortSignal.timeout(8000)` and returns `false` on a timeout (`task-comment-replies.ts:207`, `:212`).
- The pre-write freshness check `continue`s the loop if someone else replied in the meantime (`:285`) - the receipt is dropped, the board change is not.
- The process restarts mid-tick.

Nothing recovers from any of these. `fetchCandidateTasks` filters on `archived_at=is.null` only, not status, so a task ZOE just closed stays a candidate. The comment stays unanswered. The cron at `scheduler.ts:632` is `0 * * * *`.

There was no unique constraint and no dedupe: `legacy_source: zoe-command:<commentId>` was written on create and then read by nothing (`grep legacy_source` across `bot/src`, `src`, `scripts` - only the cockpit `handoff:`/`inbox:` prefixes have readers).

## Before / after

Before - `postReply` times out once on a "create a todo and close this" comment:

```
15:00  create task #9247, close #9246, receipt POST times out
16:00  comment still unanswered -> create task #9248, close #9246 again
17:00  create task #9249 ...
```

After: the second tick finds the `zoe-command:<commentId>` row from the first, applies nothing, and replies "already applied on an earlier run - nothing re-run." That reply marks the comment handled, so the loop terminates.

## The change

- `alreadyExecuted()` reads back the `legacy_source` marker the create already writes. No schema change.
- Checked once, before any action runs, so a replay is a complete no-op rather than a partial one.
- Only checked when the comment contains a `create_task`. `close`/`assign` are idempotent, so a comment that creates nothing pays for no extra round-trip.
- Fails closed. If the lookup itself errors, the tick is skipped and retried rather than re-run. The caller now honours that skip - previously any `null` from the executor fell through to `answerMention`, which posts a conversational reply, which marks the comment handled and discards the command permanently. That fall-through is why the guard could not simply return `null`.

## Evidence

Proven:

- 6 new tests in `bot/src/zoe/__tests__/board-command-executor.test.ts`. 3 of them fail against `origin/main` and pass with the fix (verified by checking out the pre-fix file and re-running): the duplicate create, the re-close, and the fail-closed skip.
- `npx tsc --noEmit -p tsconfig.ci.json` - exit 0, the gate added in #2986.
- Full bot suite: `3 failed | 2152 passed (2155)`. Baseline on the same machine with only the source fix reverted: the identical 3 failures. No regression, no test count drop.

Not verified:

- The 3 failing tests are pre-existing on this Windows machine and all three are path-separator artifacts (`trace`, `transcribe` expecting `/tmp/...` against `\tmp\...`; `wiki` writing `fid:123.json`, an illegal Windows filename). They are untouched by this PR. I did not confirm against a CI run.
- `biome check` does not apply - `bot/` is excluded by the root biome config.

## Scope

Three files, 219 insertions. No unrelated edits. Authorization, the action allowlist, the per-comment cap and the Zod validation are untouched - the executor still refuses anything the pure layer has not authorized, and the new test asserts a non-commander still executes nothing and issues zero queries.

## Also found, not fixed here (one PR per run)

1. `resolveOwner` builds `legacy_owner=ilike.${encodeURIComponent(slug)}` (`board-command-executor.ts`). PostgREST treats `*` in an `ilike` pattern as a wildcard, and `encodeURIComponent` does not escape `*`. An assignee slug of `*` would match an arbitrary team member, contradicting the "never guesses" contract directly above it. Low likelihood - the slug comes from the model reading Zaal's own comment - but the fix is to reject slugs outside `[a-z0-9._-]` in `CommandSchema`.

2. `isAuthorizedCommander` matches on the board's `displayName`, a string carried in `tasks.metadata.comments`, not on `userId`. If a board user can set their own display name to "zaal", they inherit command authority. Worth checking whether `displayName` is server-set; if it is not, this should key on `userId`.

3. The wiki test failure above is a genuine Windows portability issue - `writeWiki` puts a `:` in the filename. Irrelevant to the Linux VPS the bot runs on, but it means that suite cannot pass on Zaal's desktop.

Found by the hourly repo auditor. Do not merge without a read of the auth path (`pre-merge-security-and-suite.md`).
