### PR TITLE
fix(zoe): the ack still swallows a board command - #2999 fixed only the reader

### DIFF
--- a/bot/src/zoe/__tests__/ack-does-not-answer-others.test.ts
+++ b/bot/src/zoe/__tests__/ack-does-not-answer-others.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The ack and the reply-finder are two different modules that both write as
+ * ZOE, so neither one alone can prove the #9246 thread is fixed. mention-answered.test.ts
+ * covers the reader with a HAND-WRITTEN ack; this covers the seam, by building
+ * the ack with the same function production uses and handing it to the same
+ * reader production uses.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildNotedAck, type BoardTask as AckTask } from '../task-teammate-ack';
+import {
+  findUnansweredMentions,
+  type BoardComment,
+  type BoardTask,
+} from '../task-comment-replies';
+
+/** The verbatim thread from board task #9246, 2026-08-08. */
+const IMAN = {
+  id: 'c1',
+  userId: 'iman',
+  displayName: 'Iman',
+  content: '@zaal https://github.com/ZAODEVZ/ZAOartizen/pull/19',
+};
+const ZAAL_COMMAND = {
+  id: 'c2',
+  userId: 'zaal',
+  displayName: 'Zaal',
+  content: '@iman done. @zoe make a new todo called zartizen ui cleanup and close this one',
+};
+
+const TASK: AckTask = { id: 't9246', legacy_id: '9246', title: 'ZAOartizen' };
+
+describe('a ZOE ack does not swallow someone else\'s @zoe command', () => {
+  it('the ack names the comment it acks', () => {
+    const ack = buildNotedAck(TASK, IMAN);
+    expect(ack.replyTo).toBe('c1');
+    expect(ack.userId).toBe('zoe');
+  });
+
+  it('leaves Zaal\'s command pending, even though the ack landed after it', () => {
+    // The exact live ordering: Iman comments, Zaal issues a command, then the
+    // ack of IMAN lands last. Without replyTo the command reads as answered and
+    // is dropped forever.
+    const thread: BoardComment[] = [IMAN, ZAAL_COMMAND, buildNotedAck(TASK, IMAN)];
+    const task = { id: 't9246', title: 'ZAOartizen', metadata: { comments: thread } } as BoardTask;
+
+    expect(findUnansweredMentions([task]).map((m) => m.comment.id)).toEqual(['c2']);
+  });
+
+  it('still answers the comment it was actually acking', () => {
+    // An ack of a teammate comment that itself tags @zoe does answer that one -
+    // the ack is a real response to it, and re-answering would double-post.
+    const mention = { ...IMAN, content: '@zoe can you look at PR/19' };
+    const thread: BoardComment[] = [mention, buildNotedAck(TASK, mention)];
+    const task = { id: 't9246', title: 'ZAOartizen', metadata: { comments: thread } } as BoardTask;
+
+    expect(findUnansweredMentions([task])).toEqual([]);
+  });
+});

--- a/bot/src/zoe/task-teammate-ack.ts
+++ b/bot/src/zoe/task-teammate-ack.ts
@@ -48,6 +48,12 @@ export interface BoardComment {
   content: string;
   createdAt?: string;
   editedAt?: string;
+  /**
+   * For a ZOE comment: the id of the comment it is answering. Mirrors the field
+   * in task-comment-replies.ts, which reads it to decide whether a @zoe mention
+   * is still waiting - see buildNotedAck.
+   */
+  replyTo?: string;
 }
 
 export interface BoardTask {
@@ -300,6 +306,32 @@ async function fetchCandidateTasks(fetchImpl: typeof fetch): Promise<BoardTask[]
   }
 }
 
+/**
+ * The "noted" ack comment for one teammate comment.
+ *
+ * `replyTo` is the load-bearing field, and it names the comment this ack is
+ * about. ZOE is not one writer: task-comment-replies.ts also posts as ZOE, and
+ * it decides whether a @zoe mention is still waiting by looking for a later
+ * ZOE-authored comment. An ack with no replyTo is read there as a generic
+ * answer to everything before it, so this ack of IMAN silently marked ZAAL's
+ * @zoe command answered - the #9246 thread. That command then never ran, with
+ * no error anywhere.
+ *
+ * Pure so the field is testable without a network or a disk write.
+ */
+export function buildNotedAck(task: BoardTask, comment: BoardComment): BoardComment {
+  const taskLabel = task.legacy_id ? `#${task.legacy_id}` : task.id;
+  const snippet = comment.content.replace(/\s+/g, ' ').trim().slice(0, 60);
+  return {
+    id: `zoe-ack-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    userId: ZOE_USER_ID,
+    displayName: ZOE_DISPLAY,
+    content: `Noted on ${taskLabel} - flagged to Zaal: "${snippet}". He will reply here.`,
+    createdAt: new Date().toISOString(),
+    replyTo: comment.id,
+  };
+}
+
 /** Append a "noted" ack to the task's metadata.comments. */
 async function postNotedAck(
   task: BoardTask,
@@ -309,15 +341,7 @@ async function postNotedAck(
   const base = process.env.COWORK_TRACKER_URL;
   const key = process.env.COWORK_TRACKER_KEY;
   if (!base || !key) return false;
-  const taskLabel = task.legacy_id ? `#${task.legacy_id}` : task.id;
-  const snippet = comment.content.replace(/\s+/g, ' ').trim().slice(0, 60);
-  const ack: BoardComment = {
-    id: `zoe-ack-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-    userId: ZOE_USER_ID,
-    displayName: ZOE_DISPLAY,
-    content: `Noted on ${taskLabel} - flagged to Zaal: "${snippet}". He will reply here.`,
-    createdAt: new Date().toISOString(),
-  };
+  const ack = buildNotedAck(task, comment);
   const metadata = { ...(task.metadata ?? {}) };
   const existing = Array.isArray(metadata.comments) ? (metadata.comments as BoardComment[]) : [];
   metadata.comments = [...existing, ack];


### PR DESCRIPTION
## Executive summary

PR #2999 fixed the half of the #9246 bug that reads. It did not fix the half that writes, so the bug is still live.

`findUnansweredMentions` (task-comment-replies.ts) now honours a `replyTo` field on a ZOE comment: a ZOE comment that names the mention it answers only answers that one. But ZOE is not one writer, and the module that actually produced the comment which broke #9246 - `postNotedAck` in `task-teammate-ack.ts` - never sets `replyTo`. A ZOE comment without it still falls into the legacy branch and is read as a generic answer to every `@zoe` mention before it.

Both loops run in the same scheduler tick (`scheduler.ts:666` replies, `scheduler.ts:698` ack), so the failing interleaving is not hypothetical - it is the ordinary case.

## What breaks without this

The verbatim thread from board task #9246, 2026-08-08:

```
[Iman] @zaal https://github.com/ZAODEVZ/ZAOartizen/pull/19
[Zaal] @iman done. @zoe make a new todo called zartizen ui cleanup and close this one
[ZOE]  Noted on #9246 - flagged to Zaal: "@zaal ...PR/19"      <- an ack of IMAN
```

That ack lands after Zaal's command. On the next tick `findUnansweredMentions` sees a later ZOE comment with no `replyTo`, takes the legacy branch (`task-comment-replies.ts:119`), and marks Zaal's command answered. The command never runs. No error, no log line, nothing to notice - the todo simply never appears.

## Evidence that the fix was incomplete

`mention-answered.test.ts:21` passes `'c1'` as the ack's `replyTo`:

```ts
c('c3', 'Noted - flagged to Zaal: "@zaal ...PR/19"', zoeUserId, 'c1'),
```

The test asserts against a hand-written ack that carries a field production never writes. It is green, and the bug is untouched. `grep -rn "replyTo" bot/src` confirms `task-comment-replies.ts` is the only producer.

## The change

- `task-teammate-ack.ts`: extract `buildNotedAck(task, comment)` (pure, so the field is testable with no network or disk) and stamp `replyTo: comment.id`. Add `replyTo?: string` to that module's `BoardComment`.
- New `__tests__/ack-does-not-answer-others.test.ts` covers the seam: it builds the ack with the same function production calls and hands it to the same reader production calls. The two existing test files each mock the other side, so neither could have caught this.

Third test pins the case that must NOT change: when the teammate comment itself tags `@zoe`, the ack does still answer it, so ZOE does not double-post.

## Verification

Run in `bot/` on this branch (Windows, `node_modules` restored with `npm install --no-save --ignore-scripts`):

- `vitest run` - **2227 passed, 3 failed**, vs **2224 passed, 3 failed** on `main`. +3 new tests, no regression.
- The 3 failures are identical before and after and are Windows-only path artifacts, not this change: `wiki.test.ts` writes `fid:1.json` (a colon is illegal in a Windows filename, so `readdir` returns nothing), plus the same shape in `trace.test.ts` and `transcribe.test.ts`. The bot runs on Linux. Flagged, not fixed - out of scope here.
- The new test was confirmed to FAIL without the fix: reverting the one line `replyTo: comment.id` turns 3 passed into 2 failed / 1 passed.
- `tsc --noEmit`: 106 output lines before and after, zero mentioning either changed file. The absolute count is phantom - several runtime deps (grammy, discord.js, supabase) are not installed in this audit checkout - so the honest claim is "unchanged, and clean in the touched files", not "clean".

## Anti-bloat

One new exported pure function, replacing an inline object literal at its only call site. No duplicated helper, no new dependency, no dead code, no unrelated edits. Diff is 33 insertions in one source file plus one test file.

## Also seen this run, not fixed here (one-PR rule)

1. **Windows-illegal wiki filenames.** `bot/src/zoe/farcaster/wiki.ts:290` derives a filename from an id containing `:` (`fid:1.json`). Harmless on the Linux VPS; it makes the suite un-runnable on the Windows desktop, which is where this audit runs. Same root as the two other Windows-only failures.
2. **An empty receipt falls through to a chat reply.** `task-comment-replies.ts:331` - if `executeBoardComment` returns a result whose `receipt` is `''`, `if (!ans)` sends it to `answerMention` instead, so board changes could be reported as a conversational answer. Narrow, and `renderReceipt` may never return empty; unverified.

Related: PR #3001 (`first-handler-wins.md`) states the rule this change enforces - "handled" must name what it handled, never authorship. This is that rule applied to the code it was written from.

Zaal merges, not the auditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
