### PR TITLE
fix(tests): main is red - two PRs merged tonight collide

### DIFF
--- a/bot/src/zoe/__tests__/board-command-executor.test.ts
+++ b/bot/src/zoe/__tests__/board-command-executor.test.ts
@@ -17,6 +17,10 @@ const ctx: ExecContext = {
   taskTitle: 'ship the thing',
   commentId: 'comment-abc',
   commentContent: '@zoe make a new todo called zartizen ui cleanup and close this one',
+  // Authorization reads the ACCOUNT id, never the label (#2992). This test was
+  // written against the older shape that gated on displayName; both PRs were
+  // green alone and only collided once both were on main.
+  commentAuthorId: 'zaal',
   commentAuthor: 'Zaal',
 };
 
@@ -116,11 +120,35 @@ describe('authorization still gates everything', () => {
   it('a non-commander executes nothing and never queries', async () => {
     const { impl, calls } = makeFetch();
     const res = await executeBoardComment(
-      { ...ctx, commentAuthor: 'Iman' },
+      { ...ctx, commentAuthorId: 'iman', commentAuthor: 'Iman' },
       extract(CREATE_AND_CLOSE),
       impl,
     );
     expect(res).toBeNull();
     expect(calls).toHaveLength(0);
+  });
+
+  // The vulnerability #2992 closed: a display name is a field the user picks.
+  // Setting it to 'Zaal' must grant nothing.
+  it('a spoofed display name grants no authority', async () => {
+    const { impl, calls } = makeFetch();
+    const res = await executeBoardComment(
+      { ...ctx, commentAuthorId: 'iman', commentAuthor: 'Zaal' },
+      extract(CREATE_AND_CLOSE),
+      impl,
+    );
+    expect(res).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  // And the mirror: the right account works even when the label is unhelpful.
+  it('the right account is authorized whatever the label says', async () => {
+    const { impl } = makeFetch({ existingRows: [] });
+    const res = await executeBoardComment(
+      { ...ctx, commentAuthorId: 'zaal', commentAuthor: 'Zaal Panthaki' },
+      extract(CREATE_AND_CLOSE),
+      impl,
+    );
+    expect(res?.executed).toBe(2);
   });
 });


### PR DESCRIPTION
`board-command-executor.test.ts` has **4 failures on clean `origin/main` right now.** Neither PR that caused it is wrong.

| PR | What it did |
|---|---|
| #2992 | moved authorization off `displayName` onto `commentAuthorId` - reads the account and nothing else |
| #3000 | added replay-guard tests, written against the older shape that gated on `commentAuthor` |

Each was green on its own branch. Once both landed, the test's ctx carries no `commentAuthorId`, the executor **correctly refuses**, and all four assertions fail.

A merge-order hazard, not a defect - and invisible until both sit on main together, which is precisely when it blocks everyone else.

## The fix

Sets the account id in the test ctx, and turns one authorization test into three that pin the real security property:

- a non-commander **account** executes nothing
- a **spoofed display name** (`Zaal` on account `iman`) grants nothing - the vulnerability #2992 closed, which nothing covered
- the right account is authorized **even when the label is a full name** - the other half of that failure mode

## Evidence

Full bot suite: **175 files / 2235 tests green.** 0 non-test typecheck errors.

Verified by running it - after I claimed green on #3003 without reading the output and was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9