### PR TITLE
feat(zoe): wire the backlog grill - one board card every 2 minutes

### DIFF
--- a/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { outstandingCount, type BacklogGrillState } from '../backlog-grill-runner';
+
+const st = (over: Partial<BacklogGrillState> = {}): BacklogGrillState => ({
+  asked: {}, answered: {}, activeTaskId: null, lastSentMs: null, ...over,
+});
+
+describe('outstandingCount - the backpressure signal', () => {
+  it('is zero on a fresh state', () => {
+    expect(outstandingCount(st())).toBe(0);
+  });
+
+  it('counts cards sent but not answered', () => {
+    const s = st({ asked: { a: { at: 'x', title: 'A' }, b: { at: 'x', title: 'B' } } });
+    expect(outstandingCount(s)).toBe(2);
+  });
+
+  // This is what stops the pile becoming a wall he never opens.
+  it('drops back as he answers', () => {
+    const s = st({
+      asked: { a: { at: 'x', title: 'A' }, b: { at: 'x', title: 'B' } },
+      answered: { a: { at: 'x', verdict: 'done' } },
+    });
+    expect(outstandingCount(s)).toBe(1);
+  });
+
+  it('is zero once everything is answered', () => {
+    const s = st({
+      asked: { a: { at: 'x', title: 'A' } },
+      answered: { a: { at: 'x', verdict: 'keep' } },
+    });
+    expect(outstandingCount(s)).toBe(0);
+  });
+
+  // A requeued task has its `asked` mark deleted so it comes round again -
+  // so it must not still count against the outstanding cap.
+  it('does not count a requeued task that was un-asked', () => {
+    const s = st({ asked: {}, answered: { a: { at: 'x', verdict: 'work' } } });
+    expect(outstandingCount(s)).toBe(0);
+  });
+});

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -1,0 +1,219 @@
+/**
+ * backlog-grill-runner.ts - the IO half of the backlog grill.
+ *
+ * backlog-grill.ts is pure: it decides what a card looks like, how to read an
+ * answer, and whether another card is due. This file does the talking - reads
+ * the board, sends the card, records the verdict - and holds no policy of its
+ * own.
+ *
+ * WHAT THIS IS FOR
+ * Zaal, after clearing 24 board tasks in a terminal grill:
+ *   "start to slow grill me using telegram which is asking me a bunch of
+ *    questions each 2 mins adding a new one and ill just come though and go
+ *    though the whole queu just like today and knock them out with pressing
+ *    1,2,3,4,5 or typing in a reply"
+ *
+ * The board is at ~357 open. Nobody reads a 357-item list. Two cards at a time,
+ * five fixed answers, swept whenever he has a minute - that is the shape that
+ * actually moved 24 tasks in one sitting.
+ *
+ * WHY A SEPARATE STATE FILE FROM grill.ts
+ * grill.ts surfaces need-you decisions and PRs one at a time, and blocks until
+ * each is answered. This one deliberately does NOT block: cards pile up (capped)
+ * because the pile IS the queue Zaal sweeps. Sharing state would make each
+ * fight the other's cursor.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+  DRIP_DEFAULT,
+  parseVerdict,
+  renderCard,
+  shouldSendNext,
+  verdictButtons,
+  verdictNote,
+  type Verdict,
+} from './backlog-grill';
+
+const STATE_PATH = join(homedir(), '.zao/zoe/backlog-grill-state.json');
+
+export interface BacklogGrillState {
+  /** taskId -> when we sent its card. Presence means "asked". */
+  asked: Record<string, { at: string; title: string }>;
+  /** taskId -> the verdict, once answered. */
+  answered: Record<string, { at: string; verdict: string; note?: string }>;
+  /** The card a bare "1" answers - the most recent one sent. */
+  activeTaskId: string | null;
+  lastSentMs: number | null;
+}
+
+const EMPTY: BacklogGrillState = { asked: {}, answered: {}, activeTaskId: null, lastSentMs: null };
+
+export async function readState(): Promise<BacklogGrillState> {
+  try {
+    return { ...EMPTY, ...JSON.parse(await fs.readFile(STATE_PATH, 'utf8')) };
+  } catch {
+    return { ...EMPTY };
+  }
+}
+
+export async function writeState(s: BacklogGrillState): Promise<void> {
+  await fs.mkdir(join(homedir(), '.zao/zoe'), { recursive: true }).catch(() => {});
+  await fs.writeFile(STATE_PATH, JSON.stringify(s, null, 2), { mode: 0o600 });
+}
+
+/** How many cards are out and unanswered. This is the backpressure signal. */
+export function outstandingCount(s: BacklogGrillState): number {
+  return Object.keys(s.asked).filter((id) => !s.answered[id]).length;
+}
+
+interface BoardTask {
+  id: string;
+  title: string;
+  created_at?: string;
+  notes?: string;
+  legacy_id?: string;
+}
+
+function cfg(): { root: string; headers: Record<string, string> } | null {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return null;
+  return {
+    root: base.replace(/\/$/, ''),
+    headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+  };
+}
+
+/**
+ * The oldest open task not yet asked about.
+ *
+ * Oldest first on purpose: a 36-day-old task is the one most likely to be dead,
+ * and clearing the tail is where the board actually shrinks.
+ */
+async function nextTask(
+  s: BacklogGrillState,
+  fetchImpl: typeof fetch,
+): Promise<{ task: BoardTask; remaining: number } | null> {
+  const c = cfg();
+  if (!c) return null;
+  const url =
+    `${c.root}/rest/v1/tasks?status=eq.todo&archived_at=is.null` +
+    `&select=id,legacy_id,title,created_at,notes&order=created_at.asc&limit=200`;
+  const r = await fetchImpl(url, { headers: c.headers, cache: 'no-store' });
+  if (!r.ok) return null;
+  const rows = (await r.json()) as BoardTask[];
+  const fresh = rows.filter((t) => !s.asked[t.id]);
+  if (fresh.length === 0) return null;
+  return { task: fresh[0], remaining: fresh.length };
+}
+
+export interface GrillTickDeps {
+  sendDM: (text: string, buttons: { text: string; data: string }[][]) => Promise<unknown>;
+  /** Zaal's local hour, 0-23 - cards never go out at night. */
+  localHour: number;
+  now?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * One tick. Sends at most ONE card, or nothing.
+ *
+ * Returns what it did so the scheduler can log it - a silent tick that did
+ * nothing is indistinguishable from a broken one otherwise.
+ */
+export async function runBacklogGrillTick(
+  deps: GrillTickDeps,
+): Promise<{ sent: boolean; reason: string; title?: string }> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? Date.now();
+  if (!cfg()) return { sent: false, reason: 'tracker not configured' };
+
+  const state = await readState();
+  const next = await nextTask(state, fetchImpl);
+  if (!next) return { sent: false, reason: 'nothing left to ask about' };
+
+  const gate = shouldSendNext({
+    nowMs: now,
+    localHour: deps.localHour,
+    lastSentMs: state.lastSentMs,
+    outstanding: outstandingCount(state),
+    remainingInQueue: next.remaining,
+    cfg: DRIP_DEFAULT,
+  });
+  if (!gate.send) return { sent: false, reason: gate.reason };
+
+  const total = Object.keys(state.asked).length + next.remaining;
+  const index = Object.keys(state.asked).length + 1;
+  const why = (next.task.notes || '').split('\n')[0];
+  const text = renderCard(
+    { title: next.task.title, createdAt: next.task.created_at, why },
+    { index, total },
+    now,
+  );
+
+  await deps.sendDM(text, verdictButtons());
+
+  state.asked[next.task.id] = { at: new Date(now).toISOString(), title: next.task.title };
+  state.activeTaskId = next.task.id;
+  state.lastSentMs = now;
+  await writeState(state);
+  return { sent: true, reason: 'sent', title: next.task.title };
+}
+
+/**
+ * Apply an answer to the card currently in play.
+ *
+ * `raw` is whatever Zaal did - a tapped button's key, a bare "1", or a typed
+ * sentence. parseVerdict owns the interpretation; this only performs it.
+ */
+export async function applyBacklogAnswer(
+  raw: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: boolean; message: string }> {
+  const c = cfg();
+  if (!c) return { ok: false, message: 'tracker not configured' };
+  const state = await readState();
+  const taskId = state.activeTaskId;
+  if (!taskId) return { ok: false, message: 'no card is open' };
+
+  const v: Verdict | null = parseVerdict(raw);
+  if (!v) return { ok: false, message: 'could not read that answer' };
+
+  let message = '';
+  if (v.closesTask) {
+    const cur = await fetchImpl(`${c.root}/rest/v1/tasks?id=eq.${taskId}&select=notes`, {
+      headers: c.headers,
+    });
+    const rows = cur.ok ? ((await cur.json()) as Array<{ notes?: string }>) : [];
+    const notes = `${(rows[0]?.notes || '').trim()}\n\n${verdictNote(v, new Date().toISOString().slice(0, 10))}`.trim();
+    // 'done', never 'completed' - tasks.status has a CHECK constraint that 400s
+    // on anything else, and the rejection reads as "nothing to close".
+    const patch = await fetchImpl(`${c.root}/rest/v1/tasks?id=eq.${taskId}`, {
+      method: 'PATCH',
+      headers: { ...c.headers, Prefer: 'return=minimal' },
+      body: JSON.stringify({ status: 'done', notes }),
+    });
+    if (!patch.ok) return { ok: false, message: `close failed (${patch.status})` };
+    message = v.key === 'done' ? 'Closed.' : 'Dropped.';
+  } else if (v.key === 'work') {
+    message = v.note ? `On it: ${v.note.slice(0, 80)}` : 'On it - it comes back at the end for confirmation.';
+  } else if (v.key === 'skip') {
+    message = 'Skipped - it returns later.';
+  } else {
+    message = 'Kept open.';
+  }
+
+  state.answered[taskId] = {
+    at: new Date().toISOString(),
+    verdict: v.key,
+    note: v.note,
+  };
+  // Requeued verdicts forget the "asked" mark so the task comes round again.
+  if (v.requeue) delete state.asked[taskId];
+  state.activeTaskId = null;
+  await writeState(state);
+  return { ok: true, message };
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -38,6 +38,7 @@ import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { detectBuildIntent } from './build-intent';
+import { applyBacklogAnswer } from './backlog-grill-runner';
 import { parseBusReply } from './bus-bridge';
 import { replySubject, sendBusReply } from './bus-send';
 import { doneKeyboard, maybeKeyboard, runningKeyboard } from './dm-build-buttons';
@@ -1580,6 +1581,31 @@ bot.on('message:text', async (ctx) => {
         }
       } catch (e: unknown) {
         console.error('[zoe/grill] typed-answer capture failed:', (e as Error)?.message);
+      }
+    }
+
+    // BACKLOG GRILL typed answer. Deliberately placed AFTER the block above:
+    // the grill up there BLOCKS on its item, so if it has an open decision a
+    // bare "1" belongs to it. This only claims what that one declined.
+    //
+    // Guarded tightly, per first-handler-wins: it fires only when a backlog
+    // card is genuinely open AND the text is a bare 1-5 or one of the five
+    // words. Anything longer falls through to normal chat, so a sentence is
+    // never eaten - the "work on it with a typed brief" path lives on the
+    // buttons, not here, precisely so ordinary DM prose stays untouched.
+    if (!ctx.message.reply_to_message && /^\s*([1-5]|done|keep|work|drop|skip)\s*$/i.test(text)) {
+      try {
+        const { readState } = await import('./backlog-grill-runner');
+        const bgState = await readState();
+        if (bgState.activeTaskId) {
+          const r = await applyBacklogAnswer(text);
+          if (r.ok) {
+            await ctx.reply(r.message);
+            return;
+          }
+        }
+      } catch (e) {
+        console.error('[zoe/backlog-grill] typed answer failed:', (e as Error)?.message);
       }
     }
     // Thread context: when Zaal QUOTE-REPLIES a message, fold what he replied to
@@ -3340,6 +3366,23 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
 
 // #51 multi-choice: "Pick multiple" swaps the card's keyboard for toggle rows
 // ([x]/[ ] per option) + Send/Cancel. Single taps elsewhere stay instant.
+// BACKLOG GRILL taps. One handler for all five - the verdict is the suffix.
+bot.callbackQuery(/^bg:(done|keep|work|drop|skip)$/, async (ctx) => {
+  const key = (ctx.callbackQuery.data || '').slice(3);
+  try {
+    const r = await applyBacklogAnswer(key);
+    await ctx.answerCallbackQuery({ text: r.message.slice(0, 190) });
+    // Edit the card so an answered one cannot be answered twice, and so a
+    // scroll-back through the queue shows what was decided.
+    await ctx
+      .editMessageText(`${ctx.callbackQuery.message?.text || ''}\n\n-> ${r.message}`)
+      .catch(() => {});
+  } catch (e) {
+    await ctx.answerCallbackQuery({ text: 'That did not land - try again.' }).catch(() => {});
+    console.error('[zoe/backlog-grill] tap failed:', (e as Error)?.message);
+  }
+});
+
 bot.callbackQuery('grill:multi', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const active = await getActiveGrill();

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -54,6 +54,7 @@ import { surfaceZaostockApprovals } from './zaostock-approvals-surface';
 import { runOrchestratorTick, runNudgePing } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
 import { surfaceGrill } from './grill';
+import { runBacklogGrillTick } from './backlog-grill-runner';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
@@ -326,6 +327,52 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         } catch (err) {
           await releaseFire('morning-brief');
           console.error('[zoe/scheduler] morning brief failed:', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // BACKLOG GRILL. Every 2 minutes during Zaal's waking hours, drip ONE board
+  // task to his DM with the same five answers every time (1 done, 2 keep,
+  // 3 work on it, 4 drop, 5 skip).
+  //
+  // This is not the grill above. That one surfaces what NEEDS him - decisions,
+  // PRs - and waits for each answer. This one works the 357-task backlog, and
+  // deliberately lets cards pile up (capped at 20) because the pile IS the queue
+  // he sweeps. He cleared 24 in one sitting in a terminal doing exactly this.
+  //
+  // Every guard lives in backlog-grill.ts: nothing outside 06:00-22:00 his time,
+  // nothing once 20 are unanswered, nothing when the queue is empty. This cron
+  // only supplies the clock.
+  tasks.push(
+    cron.schedule(
+      '*/2 * * * *',
+      async () => {
+        try {
+          // Zaal is ET; the box is UTC. Computing his local hour here rather
+          // than assuming, because a card at 3am is how a feature gets muted.
+          const localHour = Number(
+            new Intl.DateTimeFormat('en-US', {
+              timeZone: 'America/New_York',
+              hour: 'numeric',
+              hour12: false,
+            }).format(new Date()),
+          );
+          const r = await runBacklogGrillTick({
+            localHour,
+            sendDM: (text, buttons) =>
+              opts.bot.api.sendMessage(opts.zaalTgId, text, {
+                reply_markup: {
+                  inline_keyboard: buttons.map((row) =>
+                    row.map((b) => ({ text: b.text, callback_data: b.data })),
+                  ),
+                },
+              }),
+          });
+          if (r.sent) console.log(`[zoe/backlog-grill] sent: ${r.title}`);
+        } catch (err) {
+          console.warn('[zoe/backlog-grill] tick failed (nbd):', (err as Error).message);
         }
       },
       { timezone: 'UTC' },


### PR DESCRIPTION
Supersedes #3003, which was branched before the red-main fix in #3004 and so carried four failing tests that were never its own. Rebased onto current main; force-push is blocked here, hence a fresh branch.

The pure module shipped this morning (#2998) and was wired to **nothing**, so the thing Zaal asked for most still could not run.

> "start to slow grill me using telegram which is asking me a bunch of questions each 2 mins adding a new one and ill just come though and go though the whole queu just like today and knock them out with **pressing 1,2,3,4,5** or typing in a reply"

## What this adds

- a **2-minute cron** dripping one open board task to his DM with five fixed answers, **oldest first** - the 36-day-old tasks are where the board actually shrinks
- a **tap handler** for the five buttons, which edits the card afterwards so an answered one cannot be answered twice
- a **typed handler** so a bare `1` works when his thumb beats the tap

## Ordering, because this is today's trap

`first-handler-wins.md` was written this evening after **three** bugs caused by two handlers reading the same input. A bare `1` is exactly that shape, so the placement is deliberate:

- the typed handler sits **after** the existing grill's typed-answer block. That grill *blocks* on its item, so if it has an open decision the `1` belongs to it.
- it fires only when a backlog card is genuinely open **and** the text is a bare 1-5 or one of the five words. A sentence falls through to normal chat untouched.
- the batch-answer guard requires a colon, so a bare number never reaches it.

## Guards stay in the pure module

Nothing outside 06:00-22:00 his local time. Nothing past 20 unanswered cards. Nothing when the queue is empty. The cron only supplies the clock - and computes his local hour explicitly rather than assuming, because a card at 3am is how a feature gets muted.

## Evidence

| Check | Result |
|---|---|
| Full bot suite | **176 files / 2240 tests green** - run after the rebase, output read this time |
| Typecheck | 0 non-test errors |

## Not deployed

This starts messaging a phone every two minutes. It wants a human to say go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
