### PR TITLE
fix(zoe): the grill tick was silent when it declined

### DIFF
--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -55,6 +55,7 @@ import { runOrchestratorTick, runNudgePing } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
 import { surfaceGrill } from './grill';
 import { runBacklogGrillTick } from './backlog-grill-runner';
+import { featureRan } from './feature-ran';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
@@ -370,6 +371,11 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
                 },
               }),
           });
+          // Announce the FIRST tick after a boot whatever it decided, so a
+          // quiet morning is legible: 'outside 6-22' and 'queue empty' are very
+          // different from a cron that never fired, and without this they look
+          // identical (state-claims.md - silence is not evidence).
+          featureRan('backlog-grill', r.sent ? 'sending' : r.reason);
           if (r.sent) console.log(`[zoe/backlog-grill] sent: ${r.title}`);
         } catch (err) {
           console.warn('[zoe/backlog-grill] tick failed (nbd):', (err as Error).message);


### PR DESCRIPTION
Shipped the grill cadence tonight and walked straight into the trap documented in `state-claims.md` the same day.

The tick only logs when it **sends**. Outside the 06:00-22:00 window it declines silently - indistinguishable from a cron that never fired.

Concretely: it merged at **22:58 ET**, outside the window, so the first card lands at 06:00. If none arrives, "no cards" is unreadable - a dead cron, an empty queue, and working-as-designed all look identical.

`featureRan` now announces the first tick after each boot with whatever it decided. Once per process, so a decline every two minutes doesn't become the noise nobody greps.

In the meantime I verified the cron registered by a different route: the scheduler reports **23 cron tasks**, up from 22 at the previous boot.

**176 files / 2240 tests green**, 0 non-test typecheck errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
