### PR TITLE
fix(zoe): a skipped grill card came back as the NEXT card, forever

### DIFF
--- a/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
@@ -21,6 +21,7 @@ import {
   applyBacklogAnswer,
   outstandingCount,
   readState,
+  runBacklogGrillTick,
   writeState,
   type BacklogGrillState,
 } from '../backlog-grill-runner';
@@ -56,10 +57,11 @@ describe('outstandingCount - the backpressure signal', () => {
     expect(outstandingCount(s)).toBe(0);
   });
 
-  // A requeued task has its `asked` mark deleted so it comes round again -
-  // so it must not still count against the outstanding cap.
-  it('does not count a requeued task that was un-asked', () => {
-    const s = st({ asked: {}, answered: { a: { at: 'x', verdict: 'work' } } });
+  // A requeued task keeps its `asked` mark (that is what stops it jumping the
+  // queue), so the cap has to look past it - otherwise twenty skips would pin
+  // the outstanding count at 20 and the drip would stop for good.
+  it('does not count a task parked for requeue', () => {
+    const s = st({ asked: { a: { at: 'x', title: 'A', requeuedAt: 'y' } } });
     expect(outstandingCount(s)).toBe(0);
   });
 });
@@ -129,17 +131,82 @@ describe('applyBacklogAnswer - the answer follows the card, not the cursor', () 
     expect(patched).toHaveLength(1);
   });
 
-  // A requeued verdict forgets BOTH marks, so the task comes round again and is
-  // answerable the second time.
+  // A requeued verdict forgets the `answered` mark, so the task is answerable
+  // the second time - but KEEPS `asked`, stamped, so it does not jump the queue.
   it('lets a requeued task be answered again when it returns', async () => {
     await applyBacklogAnswer('skip', fakeFetch, OLD);
     const after = await readState();
-    expect(after.asked[OLD]).toBeUndefined();
+    expect(after.asked[OLD]?.requeuedAt).toBeTruthy();
     expect(after.answered[OLD]).toBeUndefined();
 
     await writeState({ ...after, asked: { ...after.asked, [OLD]: { at: 'y', title: 'Old' } } });
     const second = await applyBacklogAnswer('done', fakeFetch, OLD);
     expect(second.ok).toBe(true);
     expect(patched.some((p) => p.url.includes(`id=eq.${OLD}`))).toBe(true);
+  });
+});
+
+/**
+ * The bug this guards: cards go out oldest-first, so the card just skipped was
+ * the oldest one. Un-asking it made it the oldest UNASKED one too, and the next
+ * tick re-sent the same card - forever. Skip meant "show me this again in two
+ * minutes, and never show me anything else".
+ */
+describe('runBacklogGrillTick - a skipped card goes to the back, not the front', () => {
+  const rows = [
+    { id: 'a', title: 'Oldest', created_at: '2026-01-01T00:00:00Z' },
+    { id: 'b', title: 'Middle', created_at: '2026-02-01T00:00:00Z' },
+    { id: 'c', title: 'Newest', created_at: '2026-03-01T00:00:00Z' },
+  ];
+
+  const boardFetch = (async (url: string, init?: RequestInit) => {
+    if (init?.method === 'PATCH') return { ok: true, status: 200 } as unknown as Response;
+    if (String(url).includes('order=created_at.asc')) {
+      return { ok: true, status: 200, json: async () => rows } as unknown as Response;
+    }
+    return { ok: true, status: 200, json: async () => [{ notes: '' }] } as unknown as Response;
+  }) as unknown as typeof fetch;
+
+  const sent: string[] = [];
+  const tick = (now: number) =>
+    runBacklogGrillTick({
+      sendDM: async (text) => {
+        sent.push(text);
+      },
+      localHour: 10,
+      now,
+      fetchImpl: boardFetch,
+    });
+
+  beforeEach(async () => {
+    files.clear();
+    sent.length = 0;
+    process.env.COWORK_TRACKER_URL = 'https://tracker.test';
+    process.env.COWORK_TRACKER_KEY = 'k';
+  });
+
+  it('sends the next unseen task after a skip, then returns the skipped one last', async () => {
+    const t0 = Date.UTC(2026, 7, 9, 14, 0, 0);
+    const every = 2 * 60_000;
+
+    expect((await tick(t0)).title).toBe('Oldest');
+    await applyBacklogAnswer('skip', boardFetch, 'a');
+
+    // Before the fix this was 'Oldest' again - and every tick after it.
+    expect((await tick(t0 + every)).title).toBe('Middle');
+    expect((await tick(t0 + 2 * every)).title).toBe('Newest');
+    // Only now, with nothing unseen left, does the skipped one come round.
+    expect((await tick(t0 + 3 * every)).title).toBe('Oldest');
+  });
+
+  it('does not re-send a requeued card while unseen tasks remain', async () => {
+    const t0 = Date.UTC(2026, 7, 9, 14, 0, 0);
+    await tick(t0);
+    await applyBacklogAnswer('work', boardFetch, 'a');
+    const second = await tick(t0 + 2 * 60_000);
+
+    expect(second.sent).toBe(true);
+    expect(second.title).not.toBe('Oldest');
+    expect((await readState()).asked.a?.requeuedAt).toBeTruthy();
   });
 });

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -40,8 +40,14 @@ import {
 const STATE_PATH = join(homedir(), '.zao/zoe/backlog-grill-state.json');
 
 export interface BacklogGrillState {
-  /** taskId -> when we sent its card. Presence means "asked". */
-  asked: Record<string, { at: string; title: string }>;
+  /**
+   * taskId -> when we sent its card. Presence means "asked".
+   *
+   * `requeuedAt` marks one that was answered "work" or "skip" and is waiting to
+   * come round again. It stays IN `asked` so it is not treated as never-asked -
+   * see nextTask for why that distinction is the whole fix.
+   */
+  asked: Record<string, { at: string; title: string; requeuedAt?: string }>;
   /** taskId -> the verdict, once answered. */
   answered: Record<string, { at: string; verdict: string; note?: string }>;
   /** The card a bare "1" answers - the most recent one sent. */
@@ -64,9 +70,16 @@ export async function writeState(s: BacklogGrillState): Promise<void> {
   await fs.writeFile(STATE_PATH, JSON.stringify(s, null, 2), { mode: 0o600 });
 }
 
-/** How many cards are out and unanswered. This is the backpressure signal. */
+/**
+ * How many cards are out and unanswered. This is the backpressure signal.
+ *
+ * A requeued task is not outstanding: Zaal already answered it once, and it is
+ * parked at the back of the queue rather than sitting on his phone waiting. If
+ * it counted, twenty skips would permanently pin the cap and the drip would
+ * stop for good.
+ */
 export function outstandingCount(s: BacklogGrillState): number {
-  return Object.keys(s.asked).filter((id) => !s.answered[id]).length;
+  return Object.keys(s.asked).filter((id) => !s.answered[id] && !s.asked[id].requeuedAt).length;
 }
 
 interface BoardTask {
@@ -88,15 +101,23 @@ function cfg(): { root: string; headers: Record<string, string> } | null {
 }
 
 /**
- * The oldest open task not yet asked about.
+ * The next card: the oldest task never asked about, and only once those run
+ * out, the task requeued longest ago.
  *
  * Oldest first on purpose: a 36-day-old task is the one most likely to be dead,
  * and clearing the tail is where the board actually shrinks.
+ *
+ * The two-tier order is what makes "it comes back at the END of the queue" true.
+ * Cards go out oldest-first, so the card Zaal just skipped was by definition the
+ * oldest unasked one - simply un-asking it put it straight back at the FRONT and
+ * the next tick re-sent the same card, forever, and no other task could ever
+ * surface behind it. A requeued task therefore keeps its `asked` mark and waits
+ * behind every task that has not been seen at all.
  */
 async function nextTask(
   s: BacklogGrillState,
   fetchImpl: typeof fetch,
-): Promise<{ task: BoardTask; remaining: number } | null> {
+): Promise<{ task: BoardTask; remaining: number; unasked: number } | null> {
   const c = cfg();
   if (!c) return null;
   const url =
@@ -106,8 +127,14 @@ async function nextTask(
   if (!r.ok) return null;
   const rows = (await r.json()) as BoardTask[];
   const fresh = rows.filter((t) => !s.asked[t.id]);
-  if (fresh.length === 0) return null;
-  return { task: fresh[0], remaining: fresh.length };
+  const requeued = rows
+    .filter((t) => s.asked[t.id]?.requeuedAt && !s.answered[t.id])
+    .sort((a, b) =>
+      String(s.asked[a.id].requeuedAt).localeCompare(String(s.asked[b.id].requeuedAt)),
+    );
+  const queue = [...fresh, ...requeued];
+  if (queue.length === 0) return null;
+  return { task: queue[0], remaining: queue.length, unasked: fresh.length };
 }
 
 export interface GrillTickDeps {
@@ -145,7 +172,9 @@ export async function runBacklogGrillTick(
   });
   if (!gate.send) return { sent: false, reason: gate.reason };
 
-  const total = Object.keys(state.asked).length + next.remaining;
+  // `unasked`, not `remaining`: a requeued task is already inside `asked`, so
+  // counting the queue length here would count it twice in the "3/357" line.
+  const total = Object.keys(state.asked).length + next.unasked;
   const index = Object.keys(state.asked).length + 1;
   const why = (next.task.notes || '').split('\n')[0];
   const text = renderCard(
@@ -156,6 +185,8 @@ export async function runBacklogGrillTick(
 
   await deps.sendDM(text, verdictButtons(next.task.id));
 
+  // Rewritten wholesale, which clears any `requeuedAt`: it has now come round
+  // again, so it is an ordinary open card until it is answered a second time.
   state.asked[next.task.id] = { at: new Date(now).toISOString(), title: next.task.title };
   state.activeTaskId = next.task.id;
   state.lastSentMs = now;
@@ -221,11 +252,18 @@ export async function applyBacklogAnswer(
     verdict: v.key,
     note: v.note,
   };
-  // Requeued verdicts forget BOTH marks so the task comes round again as if it
-  // had never been asked - leaving the `answered` mark behind would make the
-  // second card un-answerable by the already-answered guard above.
+  // A requeued verdict forgets the `answered` mark - otherwise the guard above
+  // would refuse the second card - but KEEPS the `asked` mark, stamped with
+  // `requeuedAt`. Deleting `asked` outright made the task never-asked again, and
+  // since cards go out oldest-first it was the oldest never-asked task, so the
+  // next tick re-sent the very card he had just skipped and the queue never
+  // moved past it. nextTask now sends requeued tasks only after the unseen ones.
   if (v.requeue) {
-    delete state.asked[taskId];
+    state.asked[taskId] = {
+      at: state.asked[taskId]?.at ?? new Date().toISOString(),
+      title: state.asked[taskId]?.title ?? '',
+      requeuedAt: new Date().toISOString(),
+    };
     delete state.answered[taskId];
   }
   // Only the card in play stops being the card in play. Answering an older one


### PR DESCRIPTION
## What breaks without this

Press **5 Skip** (or **3 Work**) on a backlog grill card and that same card is the next card you get, two minutes later. Skip it again and you get it again. The queue never advances past it, so none of the other ~356 board tasks ever surface.

Concretely, in `applyBacklogAnswer`:

```ts
if (v.requeue) {
  delete state.asked[taskId];      // <- task is "never asked" again
  delete state.answered[taskId];
}
```

and in `nextTask`, cards go out oldest-first:

```ts
const fresh = rows.filter((t) => !s.asked[t.id]);   // order=created_at.asc
return { task: fresh[0], ... };
```

The card that was just skipped was, by definition, the oldest *asked* task - that is why it was sent. Deleting its `asked` mark makes it the oldest *unasked* task, so `fresh[0]` is the same task on the very next tick. The cron runs `*/2 * * * *`, so this is a two-minute loop, deterministic, not a race.

It also breaks the promise the reply makes. `"On it - it comes back at the end for confirmation"` and `"Skipped - it returns later"` both describe a task going to the **back** of the queue - the shape the module's own header calls out as "what turns the grill from sorting into progress". It went to the front, before any work could have happened.

## The fix

A requeued task keeps its `asked` mark, stamped `requeuedAt`. `nextTask` builds the queue as unseen-first, then requeued (oldest requeue first), so a requeued task returns only once there is nothing new left. Sending it clears the stamp, so it is an ordinary open card again until answered a second time.

Two invariants fall out of keeping the mark:

- `outstandingCount` skips requeued tasks - otherwise twenty skips would pin the cap at 20 and stop the drip for good.
- The card's `3/357` line counts *unasked* tasks rather than the whole queue, since a requeued task already sits inside `asked`.

## Evidence

**Proven:**
- The two new `runBacklogGrillTick` tests fail on the pre-fix code with `expected 'Oldest' to be 'Middle'` - the loop itself - and pass after. Verified by restoring `git show HEAD:bot/src/zoe/backlog-grill-runner.ts` and re-running.
- Full bot suite: `2248 passed / 3 failed` with this change, `2246 passed / 3 failed` on HEAD. Same 3 failures, all pre-existing and unrelated (`trace.test.ts`, `transcribe.test.ts`, `wiki.test.ts` - filesystem-path tests, this is a Windows box).
- `tsc --noEmit`: 37 errors with this change, 37 on HEAD, identical set. None mention `backlog-grill`; all are vitest `Mock<>` generic mismatches in unrelated test files.
- Test count went up (+2), no coverage dropped.

**Not verified:** nothing was run against the live tracker or the live bot - repo-only change, no deploy.

## Scope

Two files, both backlog-grill. No route, schema, dependency, or config touched.

## The rest of the audit (not fixed here, one PR only)

- `bot/src/zoe/index.ts:3374` - the `bg:` callback handler has no `isFromZaal(ctx)` check, unlike the `grill:*` handlers beside it. Graded **low**, not a live leak: the cards are DMs to Zaal, and Telegram only delivers a callback query from someone who can see the message. Worth a one-line guard for consistency with `pre-merge-security-and-suite.md`, not worth its own PR tonight.
- `bot/node_modules` was empty on this machine; `tsc`/`vitest` were installed before any of the numbers above were measured (`noisy-signal-guard.md`).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
