### PR TITLE
fix(zoe): a failed notes read closed the task and wiped its notes

### DIFF
--- a/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
@@ -131,6 +131,29 @@ describe('applyBacklogAnswer - the answer follows the card, not the cursor', () 
     expect(patched).toHaveLength(1);
   });
 
+  /**
+   * Closing REPLACES `notes`, so it has to read them first. When that read
+   * fails there is nothing to preserve, and writing anyway replaced the whole
+   * note history with one grill line while telling Zaal "Closed."
+   */
+  it('does not close - or overwrite notes - when the notes read fails', async () => {
+    const failingRead = (async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PATCH') {
+        patched.push({ url: String(url), body: JSON.parse(String(init.body)) });
+        return { ok: true, status: 200 } as unknown as Response;
+      }
+      return { ok: false, status: 503, json: async () => [] } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const r = await applyBacklogAnswer('done', failingRead, OLD);
+
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain('503');
+    expect(patched).toHaveLength(0);
+    // Still unanswered, so the next tap retries instead of losing the card.
+    expect((await readState()).answered[OLD]).toBeUndefined();
+  });
+
   // A requeued verdict forgets the `answered` mark, so the task is answerable
   // the second time - but KEEPS `asked`, stamped, so it does not jump the queue.
   it('lets a requeued task be answered again when it returns', async () => {

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -228,7 +228,17 @@ export async function applyBacklogAnswer(
     const cur = await fetchImpl(`${c.root}/rest/v1/tasks?id=eq.${taskId}&select=notes`, {
       headers: c.headers,
     });
-    const rows = cur.ok ? ((await cur.json()) as Array<{ notes?: string }>) : [];
+    // Closing is a read-modify-write on a text column, and the PATCH below
+    // REPLACES `notes` wholesale. If the read fails we do not know what was in
+    // there, so writing anyway swaps the task's entire note history for one
+    // grill line - silently, because the PATCH still succeeds and Zaal is told
+    // "Closed." A 429 or a 5xx on the read is enough to do it.
+    //
+    // Fail closed instead: the card stays open and unanswered, so the next tap
+    // (or a typed answer) retries it. A close that has to be repeated is much
+    // cheaper than notes that cannot be recovered.
+    if (!cur.ok) return { ok: false, message: `could not read that task (${cur.status}) - not closing` };
+    const rows = (await cur.json()) as Array<{ notes?: string }>;
     const notes = `${(rows[0]?.notes || '').trim()}\n\n${verdictNote(v, new Date().toISOString().slice(0, 10))}`.trim();
     // 'done', never 'completed' - tasks.status has a CHECK constraint that 400s
     // on anything else, and the rejection reads as "nothing to close".


### PR DESCRIPTION
## What breaks without this

Closing a card from the Telegram backlog grill is a read-modify-write on the
task's `notes` column: read the current notes, append the grill line, PATCH the
whole string back. The read result was handled like this:

```ts
const cur = await fetchImpl(`${c.root}/rest/v1/tasks?id=eq.${taskId}&select=notes`, ...);
const rows = cur.ok ? ((await cur.json()) as Array<{ notes?: string }>) : [];
const notes = `${(rows[0]?.notes || '').trim()}\n\n${verdictNote(...)}`.trim();
```

A non-ok read (a 429 from Supabase, a 5xx, a rotated key returning 401) falls
through to `[]`, which is indistinguishable from "this task has no notes". The
PATCH then runs anyway and replaces the task's entire note history with a single
line:

```
GRILL 2026-08-09 (Telegram): confirmed done.
```

Nothing reports a problem. The PATCH succeeds, `applyBacklogAnswer` returns
`{ ok: true }`, and Zaal's phone says "Closed." The notes are gone, and the
board keeps no history to recover them from.

The exposure is not small: the grill drips a card every 2 minutes across a
~357-task board, and every "1 Done" or "4 Drop" tap goes through this path.
The notes are where a task's "why" lives - the context that made the task
worth keeping.

## The fix

Fail closed on the read. If we cannot see what is in `notes`, do not close the
task and do not write:

```ts
if (!cur.ok) return { ok: false, message: `could not read that task (${cur.status}) - not closing` };
```

The card stays unanswered, so the next tap (or a typed answer) retries it. A
close that has to be repeated costs one tap; notes that were overwritten cannot
be recovered.

Note the read returning `200 []` is a different case and is already harmless -
the row does not exist, so the PATCH matches zero rows and nothing is written.
Only the non-ok read destroys data, which is why the guard sits exactly there.

## Evidence

- New regression test `does not close - or overwrite notes - when the notes read fails`.
  Verified it FAILS on the unfixed source (`expected true to be false` - the old
  code returned ok and issued the PATCH) and passes with the fix.
- `npx vitest run src/zoe/__tests__/backlog-grill*.test.ts`: 51 passed (was 50).
- Full bot suite before: 2245 passed, 3 failed. After: 2246 passed, 3 failed.
  The 3 are pre-existing and unrelated - see "Other findings" below.
- `npx tsc --noEmit` in `bot/`: 37 errors before, 37 after, none in the touched
  files.

## Other findings from this audit, not fixed here (one PR only)

1. `bot/src/zoe/index.ts:3374` - the `bg:` callback handler is the only grill
   callback handler without `if (!isFromZaal(ctx)) return;`. Its siblings at
   3341, 3489 and 3393 all have it, and this one mutates the board (it can
   PATCH a task to `status: done` using a task id supplied in the callback
   data). I found no path by which a non-Zaal user receives a ZOE inline
   keyboard, so I am grading this hardening rather than a live hole - but the
   guard is one line and its absence looks like an oversight, not a decision.

2. `backlog-grill-runner.ts` close PATCH uses `Prefer: return=minimal`, which
   returns 204 whether or not a row matched. A tap on a card whose task has
   since left the board reports "Closed.", closes nothing, and marks the card
   answered so it never comes back. `Prefer: return=representation` plus a
   row-count check would make that honest.

3. `bot/` currently has 37 pre-existing `tsc --noEmit` errors, all in test
   files (`transcribe.test.ts`, `klearu.test.ts`, and others). `npm run
   typecheck` in `bot/` is therefore not a usable gate today.

4. The 3 local test failures (`trace.test.ts`, `transcribe.test.ts`,
   `farcaster/wiki.test.ts`) are Windows path-separator assumptions in the
   tests (`expected 'C:\Users\...' to contain '/traces/...'`), not repo
   defects. CI runs Linux and is unaffected. Flagging rather than "fixing",
   since changing them is churn against a green gate.

Autonomous repo audit run. PR only - no merge.

Generated with [Claude Code](https://claude.com/claude-code)
