### PR TITLE
feat(zoe): one pinned message that is always current

### DIFF
--- a/bot/src/zoe/__tests__/pinned-brief.test.ts
+++ b/bot/src/zoe/__tests__/pinned-brief.test.ts
@@ -1,0 +1,167 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  renderPinnedBrief,
+  syncPinnedBrief,
+  readPinState,
+  type BriefInput,
+  type PinDeps,
+} from '../pinned-brief';
+
+const BASE: BriefInput = {
+  needsYou: ['ZOE login revoked - ssh vps, claude, /login'],
+  running: [
+    ['ZOE', 'up'],
+    ['PRs', '0'],
+  ],
+  changed: ['relay stopped losing messages'],
+  updatedLabel: '08:24',
+};
+
+let statePath: string;
+
+beforeEach(async () => {
+  statePath = join(await fs.mkdtemp(join(tmpdir(), 'pin-')), 'pinned-brief.json');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function deps(over: Partial<PinDeps> = {}): PinDeps {
+  return {
+    sendMessage: vi.fn(async () => ({ message_id: 42 })),
+    pinMessage: vi.fn(async () => undefined),
+    editMessage: vi.fn(async () => undefined),
+    statePath,
+    ...over,
+  };
+}
+
+describe('renderPinnedBrief', () => {
+  it('puts NEEDS YOU first, because it is the only actionable block', () => {
+    const text = renderPinnedBrief(BASE);
+    expect(text.indexOf('NEEDS YOU')).toBeLessThan(text.indexOf('RUNNING'));
+    expect(text.startsWith('NEEDS YOU')).toBe(true);
+  });
+
+  it('counts the needs-you items so the count is readable without counting', () => {
+    expect(renderPinnedBrief({ ...BASE, needsYou: ['a', 'b', 'c'] })).toContain('NEEDS YOU (3)');
+  });
+
+  it('says he is clear rather than rendering an empty heading', () => {
+    const text = renderPinnedBrief({ ...BASE, needsYou: [] });
+    expect(text).toContain('nothing - you are clear');
+  });
+
+  it('aligns the running column so values line up on a phone', () => {
+    const text = renderPinnedBrief({
+      ...BASE,
+      running: [
+        ['ZOE', 'up'],
+        ['grill queue', '20'],
+      ],
+    });
+    // Scope to the RUNNING block. Filtering the whole text on "up" also catches
+    // the "updated ..." footer, which is not part of the aligned column.
+    const running = text.split('\n\n').find((b) => b.startsWith('RUNNING')) ?? '';
+    const cols = running
+      .split('\n')
+      .slice(1)
+      .map((l) => l.search(/(up|20)/));
+    expect(cols.length).toBe(2);
+    expect(new Set(cols).size).toBe(1);
+  });
+
+  it('drops CHANGED first when over budget, never the actionable blocks', () => {
+    const text = renderPinnedBrief({
+      ...BASE,
+      changed: Array.from({ length: 400 }, (_, i) => `a very long changed line number ${i}`),
+    });
+    expect(text).toContain('NEEDS YOU');
+    expect(text).toContain('RUNNING');
+    expect(text).not.toContain('CHANGED');
+  });
+
+  it('never exceeds the Telegram 4096 limit', () => {
+    const text = renderPinnedBrief({
+      ...BASE,
+      needsYou: Array.from({ length: 500 }, (_, i) => `needs you item ${i} with plenty of text`),
+    });
+    expect(text.length).toBeLessThanOrEqual(4096);
+  });
+});
+
+describe('syncPinnedBrief', () => {
+  it('sends and pins on the first run, and remembers the id', async () => {
+    const d = deps();
+    const r = await syncPinnedBrief('hello', d);
+    expect(r).toEqual({ action: 'pinned', messageId: 42 });
+    expect(d.pinMessage).toHaveBeenCalledWith(42);
+    expect(await readPinState(statePath)).toEqual({ messageId: 42, lastText: 'hello' });
+  });
+
+  it('edits the SAME message on the next run rather than sending a new one', async () => {
+    const d = deps();
+    await syncPinnedBrief('first', d);
+    const r = await syncPinnedBrief('second', d);
+    expect(r).toEqual({ action: 'edited', messageId: 42 });
+    expect(d.sendMessage).toHaveBeenCalledTimes(1);
+    expect(d.editMessage).toHaveBeenCalledWith(42, 'second');
+  });
+
+  it('skips the API entirely when nothing changed', async () => {
+    const d = deps();
+    await syncPinnedBrief('same', d);
+    const r = await syncPinnedBrief('same', d);
+    expect(r).toEqual({ action: 'unchanged', messageId: 42 });
+    expect(d.editMessage).not.toHaveBeenCalled();
+  });
+
+  it('re-pins when the message was deleted, rather than going silent', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const d = deps({
+      editMessage: vi.fn(async () => {
+        throw new Error('Bad Request: message to edit not found');
+      }),
+      sendMessage: vi.fn(async () => ({ message_id: 99 })),
+    });
+    await syncPinnedBrief('first', d);
+    const r = await syncPinnedBrief('second', d);
+    expect(r).toEqual({ action: 'pinned', messageId: 99 });
+    expect(await readPinState(statePath)).toEqual({ messageId: 99, lastText: 'second' });
+  });
+
+  it('keeps the message when only the PIN fails - readable beats discarded', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const d = deps({
+      pinMessage: vi.fn(async () => {
+        throw new Error('not enough rights');
+      }),
+    });
+    const r = await syncPinnedBrief('hello', d);
+    expect(r).toEqual({ action: 'pinned', messageId: 42 });
+    expect(await readPinState(statePath)).toEqual({ messageId: 42, lastText: 'hello' });
+  });
+
+  it('reports failure loudly when the send itself fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const d = deps({
+      sendMessage: vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    });
+    const r = await syncPinnedBrief('hello', d);
+    expect(r).toEqual({ action: 'failed', reason: 'network down' });
+  });
+
+  it('survives a corrupt state file by re-pinning', async () => {
+    await fs.mkdir(join(statePath, '..'), { recursive: true });
+    await fs.writeFile(statePath, 'not json at all', 'utf8');
+    const d = deps();
+    const r = await syncPinnedBrief('hello', d);
+    expect(r.action).toBe('pinned');
+  });
+});

--- a/bot/src/zoe/pinned-brief-runner.ts
+++ b/bot/src/zoe/pinned-brief-runner.ts
@@ -1,0 +1,94 @@
+/**
+ * pinned-brief-runner.ts - gather real state and keep the pinned brief current.
+ *
+ * The render lives in pinned-brief.ts (pure, fully tested). This is the impure
+ * half: it asks the box what is true and hands the result over.
+ *
+ * Every source here is CHEAP and LOCAL to the VPS - a file read and one `gh`
+ * call. Nothing here may become slow enough to matter, because it runs on a
+ * timer forever. If a source fails, its line is OMITTED rather than guessed:
+ * a brief that invents "main green" while CI is red is worse than a brief that
+ * says nothing about CI (anti-fabrication.md rule 5).
+ */
+import { exec } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { renderPinnedBrief, syncPinnedBrief, type BriefInput, type PinDeps, type PinResult } from './pinned-brief';
+
+const run = promisify(exec);
+
+/** Anything slower than this is not worth a pinned brief being late for. */
+const CMD_TIMEOUT_MS = 8000;
+
+async function sh(cmd: string): Promise<string | null> {
+  try {
+    const { stdout } = await run(cmd, { timeout: CMD_TIMEOUT_MS });
+    return stdout.trim();
+  } catch {
+    return null; // omitted, never guessed
+  }
+}
+
+/** How many grill cards are sent-but-unanswered. Reads the grill's own state. */
+export async function grillDepth(): Promise<number | null> {
+  try {
+    const raw = await fs.readFile(join(homedir(), '.zao/zoe/backlog-grill-state.json'), 'utf8');
+    const d = JSON.parse(raw) as { asked?: Record<string, unknown>; answered?: Record<string, unknown> };
+    const asked = Object.keys(d.asked ?? {});
+    const answered = new Set(Object.keys(d.answered ?? {}));
+    return asked.filter((id) => !answered.has(id)).length;
+  } catch {
+    return null;
+  }
+}
+
+const REPO = 'bettercallzaal/ZAOOS';
+
+export async function gatherBrief(now: Date = new Date()): Promise<BriefInput> {
+  const [prsRaw, ciRaw, depth] = await Promise.all([
+    sh(`gh api 'repos/${REPO}/pulls?state=open&per_page=100' --jq 'length'`),
+    sh(`gh api 'repos/${REPO}/actions/runs?branch=main&per_page=1' --jq '.workflow_runs[0].conclusion // ""'`),
+    grillDepth(),
+  ]);
+
+  const needsYou: string[] = [];
+  const running: Array<[string, string]> = [['ZOE', 'up']];
+
+  if (prsRaw !== null && /^\d+$/.test(prsRaw)) {
+    const n = Number(prsRaw);
+    running.push(['open PRs', String(n)]);
+    if (n >= 5) needsYou.push(`${n} PRs open - review or merge`);
+  }
+
+  if (ciRaw) {
+    running.push(['main', ciRaw === 'success' ? 'green' : ciRaw]);
+    if (ciRaw !== 'success') needsYou.push(`main is ${ciRaw} - CI needs a look`);
+  }
+
+  if (depth !== null) {
+    running.push(['grill queue', depth >= 20 ? `${depth} (at cap)` : String(depth)]);
+    if (depth >= 20) needsYou.push('Grill stuck at 20 - answer any card to restart it');
+  }
+
+  const updatedLabel = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: false,
+  }).format(now);
+
+  return { needsYou, running, changed: [], updatedLabel: `${updatedLabel} ET` };
+}
+
+export interface BriefTickDeps extends Omit<PinDeps, 'statePath'> {
+  statePath?: string;
+  /** Injected in tests so the gather step stays offline. */
+  gather?: (now?: Date) => Promise<BriefInput>;
+}
+
+export async function runPinnedBriefTick(deps: BriefTickDeps): Promise<PinResult> {
+  const input = await (deps.gather ?? gatherBrief)();
+  return syncPinnedBrief(renderPinnedBrief(input), deps);
+}

--- a/bot/src/zoe/pinned-brief.ts
+++ b/bot/src/zoe/pinned-brief.ts
@@ -1,0 +1,180 @@
+/**
+ * pinned-brief.ts - ONE pinned Telegram message that is always the current state.
+ *
+ * WHY THIS EXISTS. Zaal (2026-08-09): "can we stop making artifacts, they just
+ * get lost, i havent really looked at a single one, if it not a quick glance
+ * its hard to get to it."
+ *
+ * The measured pattern across every surface we have built: he answers what
+ * ARRIVES (11 of 14 grill cards) and ignores what he must NAVIGATE to (hosted
+ * pages, the cockpit, research docs - all near zero). So the fix is not a better
+ * page. It is a surface that costs nothing to reach.
+ *
+ * A pinned message is the only "page" in Telegram: it sits at the top of the
+ * chat behind one tap, it is always in the same place, and it never scrolls
+ * away behind tool output. The Bot API confirms a bot may pin in a private chat
+ * with no admin rights: "In private chats and channel direct messages chats, all
+ * non-service messages can be pinned."
+ *
+ * NOT mission-control.ts. That module renders the step-journal - a severity
+ * ranked feed of what agents are DOING. This renders what he asked for instead:
+ * what needs him, what is running, and what changed. Outcomes, not process.
+ *
+ * Content rules (brand.md + the DreamNet standard, scaled down):
+ *   - NEEDS YOU first, because it is the only block that requires action.
+ *   - Every needs-you line says what to DO, not what is broken.
+ *   - No PR numbers, no diffs, no mechanism. He asked for results, not method.
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { featureRan } from './feature-ran';
+
+/** Telegram's hard cap is 4096. Leave headroom so a long line can never 400. */
+const RENDER_BUDGET = 3800;
+
+/** Where the pinned message id lives, so we EDIT rather than re-send forever.
+ *  Same directory the backlog grill uses for its state. */
+export const PIN_STATE_PATH = join(homedir(), '.zao/zoe/pinned-brief.json');
+
+export interface PinState {
+  messageId: number;
+  /** Hash of the last rendered text, so an unchanged brief skips the edit. */
+  lastText: string;
+}
+
+export interface BriefInput {
+  /** Things only Zaal can clear. Each line is an instruction, not a complaint. */
+  needsYou: string[];
+  /** Live fleet state: short label -> short value. */
+  running: Array<[string, string]>;
+  /** What changed since the last brief, in plain language. */
+  changed: string[];
+  /** Rendered into the footer so a stale pin is visibly stale. */
+  updatedLabel: string;
+}
+
+/**
+ * Render the pinned text. Deterministic and pure - the tests pin this exactly,
+ * because the whole value of the surface is that it looks the same every time
+ * and he can find the one line he needs without reading.
+ */
+export function renderPinnedBrief(input: BriefInput): string {
+  const blocks: string[] = [];
+
+  if (input.needsYou.length > 0) {
+    const lines = input.needsYou.map((l) => `  ${l}`);
+    blocks.push([`NEEDS YOU (${input.needsYou.length})`, ...lines].join('\n'));
+  } else {
+    blocks.push('NEEDS YOU\n  nothing - you are clear');
+  }
+
+  if (input.running.length > 0) {
+    const width = Math.max(...input.running.map(([k]) => k.length));
+    const lines = input.running.map(([k, v]) => `  ${k.padEnd(width)}  ${v}`);
+    blocks.push(['RUNNING', ...lines].join('\n'));
+  }
+
+  if (input.changed.length > 0) {
+    blocks.push(['CHANGED', ...input.changed.map((l) => `  ${l}`)].join('\n'));
+  }
+
+  blocks.push(`updated ${input.updatedLabel}`);
+
+  let text = blocks.join('\n\n');
+  if (text.length > RENDER_BUDGET) {
+    // Drop CHANGED before anything else: NEEDS YOU and RUNNING are actionable,
+    // history is not. Truncating the actionable half to preserve history would
+    // be exactly backwards.
+    const trimmed = [blocks[0], blocks[1], blocks[blocks.length - 1]].filter(Boolean);
+    text = trimmed.join('\n\n');
+  }
+  return text.length <= 4096 ? text : `${text.slice(0, 4090)}\n...`;
+}
+
+export async function readPinState(path: string = PIN_STATE_PATH): Promise<PinState | null> {
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<PinState>;
+    if (typeof parsed.messageId === 'number') {
+      return { messageId: parsed.messageId, lastText: typeof parsed.lastText === 'string' ? parsed.lastText : '' };
+    }
+  } catch {
+    // no state yet, or corrupt - either way we send a fresh pin
+  }
+  return null;
+}
+
+export async function writePinState(state: PinState, path: string = PIN_STATE_PATH): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(path, JSON.stringify(state), 'utf8');
+}
+
+export interface PinDeps {
+  sendMessage: (text: string) => Promise<{ message_id: number }>;
+  pinMessage: (messageId: number) => Promise<unknown>;
+  editMessage: (messageId: number, text: string) => Promise<unknown>;
+  statePath?: string;
+}
+
+export type PinResult =
+  | { action: 'pinned'; messageId: number }
+  | { action: 'edited'; messageId: number }
+  | { action: 'unchanged'; messageId: number }
+  | { action: 'failed'; reason: string };
+
+/**
+ * Pin once, then edit that same message forever.
+ *
+ * Three cases, in order of how often they happen:
+ *   unchanged - the text is identical, so skip the API call entirely. Telegram
+ *               rejects a no-op edit with "message is not modified" anyway, and
+ *               a pointless edit re-marks the message as changed on his phone.
+ *   edited    - normal path.
+ *   pinned    - first run, or the message was deleted and the edit 400'd. We
+ *               re-send and re-pin rather than going silent, because a brief
+ *               that quietly stops updating is worse than no brief: it shows
+ *               stale state as if it were current.
+ */
+export async function syncPinnedBrief(text: string, deps: PinDeps): Promise<PinResult> {
+  const statePath = deps.statePath ?? PIN_STATE_PATH;
+  const existing = await readPinState(statePath);
+
+  if (existing && existing.lastText === text) {
+    featureRan('pinned-brief', 'unchanged');
+    return { action: 'unchanged', messageId: existing.messageId };
+  }
+
+  if (existing) {
+    try {
+      await deps.editMessage(existing.messageId, text);
+      await writePinState({ messageId: existing.messageId, lastText: text }, statePath);
+      featureRan('pinned-brief', `edited ${existing.messageId}`);
+      return { action: 'edited', messageId: existing.messageId };
+    } catch (error: unknown) {
+      // Fall through to a fresh pin. The usual cause is Zaal deleting or
+      // unpinning the message, which should heal itself, not stop the feature.
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[zoe/pinned-brief] edit failed, re-pinning: ${msg}`);
+    }
+  }
+
+  try {
+    const sent = await deps.sendMessage(text);
+    try {
+      await deps.pinMessage(sent.message_id);
+    } catch (error: unknown) {
+      // The message exists and is readable even unpinned - degraded, not broken,
+      // so say so loudly and keep the id rather than throwing the brief away.
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[zoe/pinned-brief] sent but pin failed: ${msg}`);
+    }
+    await writePinState({ messageId: sent.message_id, lastText: text }, statePath);
+    featureRan('pinned-brief', `pinned ${sent.message_id}`);
+    return { action: 'pinned', messageId: sent.message_id };
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[zoe/pinned-brief] send failed: ${msg}`);
+    return { action: 'failed', reason: msg };
+  }
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -55,6 +55,7 @@ import { runOrchestratorTick, runNudgePing } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
 import { surfaceGrill } from './grill';
 import { runBacklogGrillTick } from './backlog-grill-runner';
+import { runPinnedBriefTick } from './pinned-brief-runner';
 import { withTickLock } from './tick-lock';
 import { featureRan } from './feature-ran';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
@@ -390,6 +391,50 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (r.sent) console.log(`[zoe/backlog-grill] sent: ${(r as { title?: string }).title}`);
         } catch (err) {
           console.warn('[zoe/backlog-grill] tick failed (nbd):', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // THE PINNED BRIEF. Zaal (2026-08-09): "can we stop making artifacts, they
+  // just get lost... if it not a quick glance its hard to get to it."
+  //
+  // Measured: he answers what ARRIVES (11 of 14 grill cards) and ignores what he
+  // must NAVIGATE to (hosted pages, the cockpit, docs - all near zero). So this
+  // is not another page. It is ONE message, pinned in his DM, edited in place
+  // forever - always the same spot, one tap, never scrolling away.
+  //
+  // Every 5 minutes: cheap (a file read plus one gh call), and it skips the API
+  // entirely when nothing changed, so a quiet hour costs nothing and never
+  // re-marks the message as changed on his phone.
+  tasks.push(
+    cron.schedule(
+      '*/5 * * * *',
+      async () => {
+        try {
+          const r = await withTickLock(
+            join(ZOE_PATHS.home, 'pinned-brief.tick.lock'),
+            async () =>
+              runPinnedBriefTick({
+                sendMessage: async (text) => {
+                  const m = await opts.bot.api.sendMessage(opts.zaalTgId, text);
+                  return { message_id: m.message_id };
+                },
+                pinMessage: (messageId) =>
+                  // disable_notification: the brief updating is not an event he
+                  // needs alerting to - the whole point is that it is quietly
+                  // always correct when he looks.
+                  opts.bot.api.pinChatMessage(opts.zaalTgId, messageId, {
+                    disable_notification: true,
+                  }),
+                editMessage: (messageId, text) =>
+                  opts.bot.api.editMessageText(opts.zaalTgId, messageId, text),
+              }),
+          );
+          featureRan('pinned-brief-tick', r.ran ? r.value.action : `lock ${r.reason}`);
+        } catch (err) {
+          console.warn('[zoe/pinned-brief] tick failed (nbd):', (err as Error).message);
         }
       },
       { timezone: 'UTC' },


### PR DESCRIPTION
Zaal: *"can we stop making artifacts, they just get lost, i havent really looked at a single one, if it not a quick glance its hard to get to it."*

## The research, before the build

Measured across every surface we have shipped:

| Surface | Requires him to | Engagement |
|---|---|---|
| Grill cards in the DM | nothing, it arrives | **11 of 14 answered** |
| Terminal status line | nothing, it is just there | live |
| Artifacts / hosted pages | open a link, load a page | zero, his own account |
| The cockpit | navigate to it | *"I never used the cockpit"* |
| Research docs | find and open them | near zero |

**He responds to what arrives; he does not navigate.** Every durable thing we have built that lives somewhere he must go has approximately zero engagement. So the constraint is not "make a better page" - it is *never make him go anywhere*.

A pinned message is the only "page" Telegram has: top of the chat, one tap, same spot every time, never scrolls behind tool output. Confirmed against the Bot API spec that this needs no admin rights - *"In private chats and channel direct messages chats, all non-service messages can be pinned."*

## Why not mission-control.ts

`mission-control.ts` already exists - 187 lines, doc 2226, task #73, marked **completed**. Two findings:

1. **It was never wired.** No import in `index.ts` or `scheduler.ts`, and its own header says the pin call site was left as "a later, reviewed insertion." `pinChatMessage` is called **zero** times in the codebase; `unpinChatMessage` four times.
2. **It renders the wrong thing.** It is a severity-ranked feed of what agents are *doing* - which is the "how it worked" he explicitly asked us to stop sending.

So this renders outcomes instead: what needs him, what is running, what changed.

## What it looks like

```
NEEDS YOU (3)
  ZOE login revoked - ssh vps, then claude, then /login
  Grill stuck at 20 - answer any card to restart it
  OpenRouter dry - $10 tops it up

RUNNING
  ZOE          up
  open PRs     0
  main         green
  grill queue  20 (at cap)

updated 08:24 ET
```

## Behaviour worth reviewing

- **Unchanged text skips the API entirely.** A quiet hour costs nothing, and it never re-marks the message as changed on his phone.
- **A deleted message re-pins itself** rather than going quiet. A brief that silently stops updating is worse than no brief, because it shows stale state as if it were current.
- **A failed source is omitted, never guessed.** A brief claiming "main green" while CI is red is worse than one that says nothing about CI.
- **NEEDS YOU renders first and survives truncation**; CHANGED is dropped first. Truncating the actionable half to preserve history would be backwards.

## Evidence

- Full bot suite **2262 passing** across 177 files, up from 2249 - the 13 new tests, no regressions
- `esbuild` bundles the real boot graph clean, since tsc alone does not catch a boot crash
- Typecheck adds **zero** new errors: 37 before, 37 after, all pre-existing in `hermes/__tests__`
- Failure paths are tested, not assumed: deleted message, pin-refused, send-failed, corrupt state file

Separately worth noting: those 37 pre-existing typecheck errors are invisible to CI, which passes. Not touched here.
