### PR TITLE
fix: block reading $? after a pipeline - the rule alone did not work

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -149,6 +149,15 @@
             "statusMessage": "Typechecking before push..."
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$PROJECT_DIR/scripts/check-pipeline-exit.py\" --hook"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/scripts/__tests__/test_check_pipeline_exit.py
+++ b/scripts/__tests__/test_check_pipeline_exit.py
@@ -1,0 +1,128 @@
+"""Tests for check-pipeline-exit.py.
+
+The false-POSITIVE tests matter more than the true-positive ones. This check can
+block a command, so a rule that fires on ordinary `| head` usage would be worse
+than no check at all - it would train everyone to work around it
+(.claude/rules/noisy-signal-guard.md).
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check-pipeline-exit.py"
+
+_spec = importlib.util.spec_from_file_location("cpe", SCRIPT)
+cpe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cpe)
+
+
+# --- the three real incidents from 2026-08-09 -------------------------------
+
+def test_catches_the_lane_send_incident():
+    cmd = """~/bin/lane-send cowork "probe" 2>&1 | sed 's/^/  /'; echo "  exit=$?" """
+    assert cpe.check(cmd), "must catch the sed-swallows-status shape"
+
+
+def test_catches_the_secret_scan_incident():
+    cmd = (
+        "git diff --cached | grep -inE 'sk-ant-|ghp_' | head -5\n"
+        'echo "  scan exit=$? (1 = no matches, good)"'
+    )
+    assert cpe.check(cmd), "must catch status-read on the line after a pipeline"
+
+
+def test_catches_the_desktop_ssh_incident():
+    cmd = 'ssh ansuz "echo hi" 2>&1 | tail -1\nif [ $? -ne 0 ]; then echo down; fi'
+    assert cpe.check(cmd), "must catch a piped ssh reported as reachable"
+
+
+# --- must NOT fire on ordinary usage ----------------------------------------
+
+def test_ignores_a_plain_pipeline_with_no_status_read():
+    assert not cpe.check("cat file | grep foo | head -20")
+
+
+def test_ignores_status_read_with_no_pipeline():
+    assert not cpe.check('mycommand --flag\necho "exit=$?"')
+
+
+def test_ignores_pipefail():
+    cmd = 'set -o pipefail\ncurl -s url | tee /tmp/x\necho "exit=$?"'
+    assert not cpe.check(cmd)
+
+
+def test_ignores_explicit_pipestatus():
+    cmd = 'cmd | head -5\nrc=${PIPESTATUS[0]}\necho "$rc"'
+    assert not cpe.check(cmd)
+
+
+def test_ignores_logical_or_which_is_not_a_pipe():
+    assert not cpe.check('cmd_a || cmd_b\necho "exit=$?"')
+
+
+def test_ignores_a_pipe_char_inside_quotes():
+    cmd = """grep -E 'foo|bar' file\necho "exit=$?" """
+    assert not cpe.check(cmd), "a | inside a quoted regex is not a pipeline"
+
+
+def test_ignores_status_read_after_an_unpiped_command_further_down():
+    cmd = 'a | b\n\nsome_other_command\necho "exit=$?"'
+    assert not cpe.check(cmd), "the nearest preceding command is unpiped, so $? is its own"
+
+
+# --- CLI contract ------------------------------------------------------------
+
+def _run(args, stdin=""):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=stdin, capture_output=True, text=True,
+    )
+
+
+def test_cli_exits_2_and_explains_on_a_hit():
+    r = _run(["--command", 'cmd | head\necho "$?"'])
+    assert r.returncode == 2
+    assert "PIPESTATUS" in r.stderr and "pipefail" in r.stderr
+
+
+def test_cli_exits_0_on_clean_input():
+    assert _run(["--command", "echo hello"]).returncode == 0
+
+
+def test_hook_mode_reads_claude_code_payload():
+    payload = '{"tool_input": {"command": "cmd | tail\\necho $?"}}'
+    assert _run(["--hook"], stdin=payload).returncode == 2
+
+
+def test_hook_mode_never_blocks_on_unparseable_input():
+    assert _run(["--hook"], stdin="not json").returncode == 0, "a broken hook must not block work"
+
+
+def test_hook_mode_allows_empty_command():
+    assert _run(["--hook"], stdin='{"tool_input": {}}').returncode == 0
+
+
+# --- runnable without pytest --------------------------------------------------
+# This repo's test runner is vitest, so a pytest-only file would never execute in
+# CI - and a test that does not run is indistinguishable from one that passes.
+
+def _main() -> int:
+    tests = [(n, f) for n, f in sorted(globals().items())
+             if n.startswith("test_") and callable(f)]
+    failed = []
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as exc:
+            failed.append((name, str(exc) or "assertion failed"))
+        except Exception as exc:  # noqa: BLE001 - report, do not mask
+            failed.append((name, f"{type(exc).__name__}: {exc}"))
+    for name, why in failed:
+        print(f"FAIL {name}: {why}")
+    print(f"{len(tests) - len(failed)}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/scripts/check-pipeline-exit.py
+++ b/scripts/check-pipeline-exit.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""check-pipeline-exit.py - catch `$?` being read after a pipeline.
+
+WHY THIS EXISTS AS CODE AND NOT A RULE. `.claude/rules/silent-failure-guard.md`
+rule 1 already says this in plain English: "A pipeline's exit is the LAST
+command's. `curl | tee` reports `tee`." The rule was written on 2026-07-27 after
+a cron job reported success for seven weeks while 503ing every run.
+
+On 2026-08-09 the same bug happened THREE more times in one day, on two machines:
+
+  1. `~/bin/lane-send cowork probe 2>&1 | sed 's/^/  /'; echo "exit=$?"`
+     reported sed's status, so a refused send looked like a success.
+  2. A staged secret scan, `git diff --cached | grep -inE '...' | head -5`,
+     whose reported exit came from `head` - the scan could not have failed loudly.
+  3. The Windows desktop read `ssh ansuz ... | tail` as exit 0 and reported SSH
+     reachable. It was not; the host never authenticated.
+
+Three recurrences of a documented rule means the rule is not the mechanism.
+This is the mechanism.
+
+WHAT IT DOES NOT DO. It does not flag pipelines. Piping into `head`, `tail`,
+`sed`, or `jq` is normal and correct almost every time, and a check that fires on
+the normal case is one people learn to ignore (`.claude/rules/noisy-signal-guard.md`).
+It flags exactly one shape: reading `$?` when the status you get is a pipeline's
+last stage, with neither `pipefail` nor `PIPESTATUS` in sight.
+
+USAGE
+  check-pipeline-exit.py --command '<shell text>'   # exit 2 if the shape is found
+  check-pipeline-exit.py --hook                     # reads Claude Code hook JSON on stdin
+  check-pipeline-exit.py --scan <file> [...]        # lint committed shell scripts
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# `pipefail` makes a pipeline report the rightmost failure, and PIPESTATUS reads
+# a specific stage. Either one means the author already thought about this.
+SAFE_MARKERS = ("pipefail", "PIPESTATUS")
+
+# A real pipe, not `||`. Also skip `|&`, which is bash's stderr-pipe shorthand
+# but still a pipe - we WANT that flagged, so only `||` is excluded.
+_PIPE = re.compile(r"(?<!\|)\|(?!\|)")
+
+
+def _strip_quoted(line: str) -> str:
+    """Remove quoted spans so a literal '|' inside a string is not read as a pipe.
+
+    Deliberately simple: this is a heuristic guard, not a shell parser. It errs
+    toward removing too much, which produces false NEGATIVES (a missed warning)
+    rather than false POSITIVES (a bogus block). Given the check can block a
+    command, being quiet when unsure is the correct direction to be wrong in.
+    """
+    out, quote = [], None
+    for ch in line:
+        if quote:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
+def has_pipe(line: str) -> bool:
+    return bool(_PIPE.search(_strip_quoted(line)))
+
+
+def reads_status(line: str) -> bool:
+    """Does this line read `$?` - directly, or via ${PIPESTATUS[0]}-less checks."""
+    return "$?" in _strip_quoted(line) or "$?" in line
+
+
+def check(command: str) -> list[tuple[int, str]]:
+    """Return [(line_number, line)] for each unsafe read of `$?`.
+
+    A hit needs BOTH, within one logical step:
+      - `$?` is read, and
+      - the status it will receive comes from a pipeline - either the same line
+        pipes, or the closest preceding non-empty line does.
+    """
+    if any(marker in command for marker in SAFE_MARKERS):
+        return []
+
+    lines = command.split("\n")
+    hits: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        if not reads_status(line):
+            continue
+        if has_pipe(line):
+            hits.append((i + 1, line.strip()))
+            continue
+        # `cmd | head` on one line, `echo $?` on the next is the same bug spread
+        # over two lines - which is exactly how it was written all three times.
+        for prev in reversed(lines[:i]):
+            if prev.strip():
+                if has_pipe(prev):
+                    hits.append((i + 1, line.strip()))
+                break
+    return hits
+
+
+ADVICE = """The status you read there is the LAST stage of the pipeline, not the command you care about.
+
+  grep -q PATTERN file | head        -> $? is head's, which basically always succeeds
+
+Three ways out, best first:
+  1. Do not pipe when you need the status. Redirect to a file, check the status,
+     then read the file:   cmd > /tmp/out; rc=$?;  head /tmp/out
+  2. Read the stage you mean:        cmd | head;  rc=${PIPESTATUS[0]}
+  3. Turn on pipefail for the script: set -o pipefail
+
+See .claude/rules/silent-failure-guard.md rule 1."""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--command")
+    ap.add_argument("--hook", action="store_true")
+    ap.add_argument("--scan", nargs="*")
+    args = ap.parse_args()
+
+    if args.scan:
+        bad = 0
+        for path in args.scan:
+            try:
+                with open(path, encoding="utf-8", errors="ignore") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            for lineno, line in check(text):
+                bad += 1
+                print(f"{path}:{lineno}: reads $? after a pipeline: {line}")
+        if bad:
+            print(f"\n{bad} unsafe status read(s).\n{ADVICE}", file=sys.stderr)
+            return 1
+        return 0
+
+    command = args.command
+    if args.hook:
+        try:
+            payload = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0  # unparseable hook input must never block real work
+        command = (payload.get("tool_input") or {}).get("command", "")
+
+    if not command:
+        return 0
+
+    hits = check(command)
+    if not hits:
+        return 0
+
+    lines = "\n".join(f"  line {n}: {t}" for n, t in hits)
+    # Exit 2 is Claude Code's "block and show stderr to the model" contract. This
+    # blocks rather than warns because the failure mode is a SILENT wrong answer:
+    # the command appears to succeed, so a warning would be read after the wrong
+    # conclusion was already drawn.
+    print(f"Reading $? after a pipeline:\n{lines}\n\n{ADVICE}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`.claude/rules/silent-failure-guard.md` rule 1 already says this in plain English - *"A pipeline's exit is the LAST command's. `curl | tee` reports `tee`."* It was written 2026-07-27 after a cron job reported success for **seven weeks** while 503ing every run.

It happened three more times on 2026-08-09, on two machines:

1. `lane-send ... | sed ...; echo "exit=$?"` reported `sed`'s status, so a **refused** send read as a success.
2. A staged secret scan piped into `head`, so the reported exit came from `head`. That scan **could not have failed loudly.**
3. The Windows desktop read `ssh ansuz ... | tail` as exit 0 and reported SSH reachable. It was not - the host never authenticated. It caught itself mid-diagnosis.

**Three recurrences of a documented rule means the rule is not the mechanism.** Writing a fourth rule would have been the wrong response. This is the mechanism.

## What it flags, and what it deliberately does not

It flags exactly one shape: `$?` read when the status comes from a pipeline's last stage, with neither `pipefail` nor `PIPESTATUS` present.

It does **not** flag pipelines. Piping into `head`, `tail`, `sed`, or `jq` is normal and correct nearly every time, and a check that fires on the normal case is one people learn to route around (`noisy-signal-guard.md`).

## Measured before trusting it

| Check | Result |
|---|---|
| Real repo shell scripts | 70 scanned, **0 hits** |
| Fleet operator scripts (`~/bin`) | 88 scanned, **0 hits** |
| The three incidents above | all caught, in tests |
| Test suite | 15/15 |

The false-**positive** tests outnumber the true-positive ones on purpose, because this check can block a command. A quoted `|` inside a regex, `||`, `pipefail`, `PIPESTATUS`, and a status read after an unpiped command all pass through untouched.

## Two design calls worth reviewing

**It blocks rather than warns.** The failure mode is a silent *wrong answer* - the command appears to succeed, so a warning would arrive after the wrong conclusion had already been drawn. Unparseable hook input exits 0 and never blocks real work.

**Tests run without pytest** (`python3 scripts/__tests__/test_check_pipeline_exit.py`). This repo runs vitest, and a test that cannot run in CI is indistinguishable from one that passes - which is the same class of bug this PR is about.

Follow-up worth considering: wire `--scan` into CI so committed scripts are checked too. Not done here to keep the change scoped.
