### PR TITLE
fix(zoe): the pinned brief counted requeued grill cards, so it would pin a permanent false "stuck at 20"

### DIFF
--- a/bot/src/zoe/__tests__/pinned-brief-runner.test.ts
+++ b/bot/src/zoe/__tests__/pinned-brief-runner.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The queue depth the pinned brief reports must be the SAME number the grill
+ * gates on. The brief's own threshold text says "stuck at 20", so a depth
+ * computed differently from `outstandingCount` turns the brief into a permanent
+ * false alarm - the exact failure the grill's docstring warns about.
+ */
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FAKE_HOME = vi.hoisted(() => {
+  const base = (process.env.TMPDIR || process.env.TEMP || '/tmp').replace(/[\\/]+$/, '');
+  return `${base}/zoe-pinned-brief-runner-home`;
+});
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, default: { ...actual, homedir: () => FAKE_HOME }, homedir: () => FAKE_HOME };
+});
+
+import { DRIP_DEFAULT } from '../backlog-grill';
+import { outstandingCount } from '../backlog-grill-runner';
+import { grillDepth } from '../pinned-brief-runner';
+
+const STATE_PATH = join(FAKE_HOME, '.zao/zoe/backlog-grill-state.json');
+
+async function writeState(state: unknown): Promise<void> {
+  await fs.mkdir(dirname(STATE_PATH), { recursive: true });
+  await fs.writeFile(STATE_PATH, JSON.stringify(state), 'utf8');
+}
+
+const ts = '2026-08-09T12:00:00.000Z';
+
+describe('grillDepth', () => {
+  beforeEach(async () => {
+    await fs.rm(STATE_PATH, { force: true });
+  });
+
+  it('does not count a requeued card - it is parked, not waiting on him', async () => {
+    await writeState({
+      asked: {
+        open: { at: ts, title: 'still on his phone' },
+        requeued: { at: ts, title: 'answered work, comes back later', requeuedAt: ts },
+      },
+      // A requeue deletes its `answered` mark, so asked-minus-answered would be 2.
+      answered: {},
+      activeTaskId: null,
+      lastSentMs: null,
+    });
+    expect(await grillDepth()).toBe(1);
+  });
+
+  it('agrees with the grill own outstandingCount', async () => {
+    const state = {
+      asked: {
+        a: { at: ts, title: 'a' },
+        b: { at: ts, title: 'b', requeuedAt: ts },
+        c: { at: ts, title: 'c' },
+      },
+      answered: { c: { at: ts, verdict: 'done' } },
+      activeTaskId: null,
+      lastSentMs: null,
+    };
+    await writeState(state);
+    expect(await grillDepth()).toBe(outstandingCount(state));
+  });
+
+  it('twenty requeues do not fake the cap', async () => {
+    const asked: Record<string, { at: string; title: string; requeuedAt?: string }> = {};
+    for (let i = 0; i < DRIP_DEFAULT.maxOutstanding; i++) {
+      asked[`t${i}`] = { at: ts, title: `t${i}`, requeuedAt: ts };
+    }
+    await writeState({ asked, answered: {}, activeTaskId: null, lastSentMs: null });
+    const depth = await grillDepth();
+    expect(depth).toBe(0);
+    expect(depth).toBeLessThan(DRIP_DEFAULT.maxOutstanding);
+  });
+
+  it('returns null when the state cannot be read, so the line is omitted', async () => {
+    expect(await grillDepth()).toBeNull();
+  });
+});

--- a/bot/src/zoe/pinned-brief-runner.ts
+++ b/bot/src/zoe/pinned-brief-runner.ts
@@ -15,6 +15,8 @@ import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { DRIP_DEFAULT } from './backlog-grill';
+import { outstandingCount, type BacklogGrillState } from './backlog-grill-runner';
 import { renderPinnedBrief, syncPinnedBrief, type BriefInput, type PinDeps, type PinResult } from './pinned-brief';
 
 const run = promisify(exec);
@@ -31,14 +33,28 @@ async function sh(cmd: string): Promise<string | null> {
   }
 }
 
-/** How many grill cards are sent-but-unanswered. Reads the grill's own state. */
+/**
+ * How many grill cards are sent-but-unanswered. Reads the grill's own state.
+ *
+ * The count MUST be the grill's own `outstandingCount`, not a re-derivation.
+ * A task answered "work" or "skip" keeps its `asked` mark (stamped
+ * `requeuedAt`) and has its `answered` mark DELETED, so "asked minus answered"
+ * counts every requeue as an outstanding card. Since a requeue is never
+ * un-asked until it is answered a second time, that number only ever climbs -
+ * it crosses the cap on its own and then pins a permanent, false
+ * "Grill stuck at 20" in the one place the brief promises to be correct.
+ * The grill's own docstring warns about exactly this arithmetic.
+ */
 export async function grillDepth(): Promise<number | null> {
   try {
     const raw = await fs.readFile(join(homedir(), '.zao/zoe/backlog-grill-state.json'), 'utf8');
-    const d = JSON.parse(raw) as { asked?: Record<string, unknown>; answered?: Record<string, unknown> };
-    const asked = Object.keys(d.asked ?? {});
-    const answered = new Set(Object.keys(d.answered ?? {}));
-    return asked.filter((id) => !answered.has(id)).length;
+    const d = JSON.parse(raw) as Partial<BacklogGrillState>;
+    return outstandingCount({
+      asked: d.asked ?? {},
+      answered: d.answered ?? {},
+      activeTaskId: null,
+      lastSentMs: null,
+    });
   } catch {
     return null;
   }
@@ -68,8 +84,11 @@ export async function gatherBrief(now: Date = new Date()): Promise<BriefInput> {
   }
 
   if (depth !== null) {
-    running.push(['grill queue', depth >= 20 ? `${depth} (at cap)` : String(depth)]);
-    if (depth >= 20) needsYou.push('Grill stuck at 20 - answer any card to restart it');
+    // The cap comes from the grill's own config, so the brief can never claim
+    // "at cap" at a number the drip does not actually stop at.
+    const cap = DRIP_DEFAULT.maxOutstanding;
+    running.push(['grill queue', depth >= cap ? `${depth} (at cap)` : String(depth)]);
+    if (depth >= cap) needsYou.push(`Grill stuck at ${cap} - answer any card to restart it`);
   }
 
   const updatedLabel = new Intl.DateTimeFormat('en-US', {


### PR DESCRIPTION
## What breaks without this

The pinned brief (shipped ~3 hours ago in #3019) computes its own grill queue
depth instead of asking the grill. `pinned-brief-runner.ts` had:

```ts
const asked = Object.keys(d.asked ?? {});
const answered = new Set(Object.keys(d.answered ?? {}));
return asked.filter((id) => !answered.has(id)).length;
```

The grill deliberately does NOT define it that way, and says why in its own
docstring (`backlog-grill-runner.ts:74-83`):

> A requeued task is not outstanding: Zaal already answered it once, and it is
> parked at the back of the queue rather than sitting on his phone waiting.
> **If it counted, twenty skips would permanently pin the cap and the drip
> would stop for good.**

Answering a card `work` or `skip` keeps the `asked` mark (stamped `requeuedAt`)
and **deletes** the `answered` mark (`backlog-grill-runner.ts:271-274`). So under
"asked minus answered" every requeue is outstanding forever, and the number the
brief prints only ever climbs. Twenty skips is the ordinary lifetime of the
queue, not an edge case.

Once it crosses 20, the brief renders this, forever:

```
NEEDS YOU (1)
  Grill stuck at 20 - answer any card to restart it

RUNNING
  grill queue  20 (at cap)
```

The grill is **not** at the cap - the drip gates on `outstandingCount`, which
excludes requeues and is unaffected. So the one surface built specifically to be
correct at a glance ends up with a permanent, unclearable NEEDS YOU line about a
problem that does not exist. That is the exact shape `noisy-signal-guard.md` was
written about: a signal that cannot reach zero is a signal he stops reading, and
it sits above the real NEEDS YOU items.

## The fix

Call the grill's own `outstandingCount` rather than re-deriving it, and take the
threshold from `DRIP_DEFAULT.maxOutstanding` instead of a second hardcoded `20`,
so the brief can never say "at cap" at a number the drip does not stop at.
Null-on-unreadable is preserved, so a failed read still omits the line rather
than reporting a fabricated `0`.

26 insertions / 7 deletions in one function plus its call site, and a new test
file.

## Evidence (all run on this checkout, `bot/` deps installed fresh)

**Proven:**
- 4 new tests in `bot/src/zoe/__tests__/pinned-brief-runner.test.ts`. **3 of the
  4 fail on the pre-fix code** - the 20-requeue case returns `20` where `0` is
  correct - and all 4 pass after. Verified by stashing the source change and
  re-running.
- Full bot suite: **2263 passing**. The only 3 failures (`trace.test.ts`,
  `transcribe.test.ts`, `farcaster/wiki.test.ts` - all disk-path tests) fail
  **identically at HEAD without this change**, so they are pre-existing and
  Windows-local, not a regression from this PR.
- `tsc --noEmit`: 37 errors, the same 37 as HEAD, **0 of them in the touched
  files** (matches #3019's own stated baseline).
- `esbuild --bundle src/zoe/index.ts`: bundles, exit 0.

**Not tested:** the live pin itself. This changes only the number handed to the
pure renderer; `syncPinnedBrief` is untouched.

## Anti-bloat check

- Reused `outstandingCount` and `DRIP_DEFAULT` rather than writing a variant -
  removing a duplicate definition is the whole point of the change.
- No new dependency, no new module, no dead code, no unrelated edits.
- Diff is one function body, one call site, one new test file.

## Also seen this pass, not fixed here (one PR per audit run)

1. **3 tests fail on Windows** (`trace.test.ts`, `transcribe.test.ts`,
   `farcaster/wiki.test.ts`). Pre-existing, present at HEAD, and green in CI
   because CI is Linux - so this is a local-dev papercut, not a broken main.
   Worth a look only if anyone runs the suite on the desktop box.
2. **A transient edit failure re-sends a whole new pinned message.**
   `syncPinnedBrief` falls through to send-and-pin on ANY `editMessage` rejection
   (`pinned-brief.ts:154-159`). The comment assumes the cause is Zaal deleting
   the message, but a 429 or a network blip takes the same path, leaving a
   duplicate pin every 5 minutes until it recovers. Narrowing the fallback to
   Telegram's "message to edit not found" / "message can't be edited" would fix
   it. Left alone because it needs a judgement call about which error strings to
   match.
3. `PinState.lastText` is documented as "Hash of the last rendered text" but
   stores the full text. Cosmetic only; the comparison is correct either way.

Nothing else in the recent commits looked wrong.
