### PR TITLE
fix(zoe): queue every failed Bonfire write, not just thread emits

### DIFF
--- a/bot/src/zoe/__tests__/bonfire-retry.test.ts
+++ b/bot/src/zoe/__tests__/bonfire-retry.test.ts
@@ -1,0 +1,129 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const remember = vi.fn();
+const bonfireConfigured = vi.fn(() => true);
+const containsSecret = vi.fn((_body: string) => false);
+const containsPii = vi.fn((_body: string) => false);
+const scanPii = vi.fn((_body: string) => [] as Array<{ kind: string }>);
+
+vi.mock('../recall', () => ({
+  remember: (...a: unknown[]) => remember(...a),
+  bonfireConfigured: () => bonfireConfigured(),
+  containsSecret: (b: string) => containsSecret(b),
+}));
+vi.mock('../pii', () => ({
+  containsPii: (b: string) => containsPii(b),
+  scanPii: (b: string) => scanPii(b),
+}));
+vi.mock('../memory', () => ({ ZOE_PATHS: { home: tmpdir() } }));
+
+const { enqueueWrite, flushQueue, loadQueue, saveQueue, MAX_AGE_DAYS } = await import('../bonfire-retry');
+
+let qp: string;
+
+beforeEach(async () => {
+  qp = join(await fs.mkdtemp(join(tmpdir(), 'bfq-')), 'q.json');
+  remember.mockReset();
+  bonfireConfigured.mockReturnValue(true);
+  containsSecret.mockReturnValue(false);
+  containsPii.mockReturnValue(false);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+const item = (name = 'ep-1') => ({ body: 'a body', name, sourceTag: 'zoe:test' });
+
+describe('enqueue', () => {
+  it('stamps queuedAt and starts attempts at 0', async () => {
+    await enqueueWrite(item(), qp);
+    const q = await loadQueue(qp);
+    expect(q).toHaveLength(1);
+    expect(q[0].attempts).toBe(0);
+    expect(Number.isNaN(Date.parse(q[0].queuedAt))).toBe(false);
+  });
+});
+
+describe('flush', () => {
+  it('sends and clears on success', async () => {
+    remember.mockResolvedValue({ ok: true });
+    await enqueueWrite(item(), qp);
+    expect(await flushQueue(qp)).toEqual({ sent: 1, kept: 0, dropped: 0 });
+    expect(await loadQueue(qp)).toHaveLength(0);
+  });
+
+  it('KEEPS a send failure - this is the whole point', async () => {
+    remember.mockResolvedValue({ ok: false, error: 'ECONNREFUSED' });
+    await enqueueWrite(item(), qp);
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 1, dropped: 0 });
+    expect(await loadQueue(qp)).toHaveLength(1);
+  });
+
+  it('counts attempts so a permanently stuck item is visible', async () => {
+    remember.mockResolvedValue({ ok: false, error: 'down' });
+    await enqueueWrite(item(), qp);
+    await flushQueue(qp);
+    await flushQueue(qp);
+    expect((await loadQueue(qp))[0].attempts).toBe(2);
+  });
+
+  it('DROPS a terminal skip rather than retrying it forever', async () => {
+    remember.mockResolvedValue({ ok: false, skipped: 'no-config' });
+    await enqueueWrite(item(), qp);
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 0, dropped: 1 });
+  });
+
+  it('drops an item whose body now trips the secret guard', async () => {
+    await enqueueWrite(item(), qp);
+    containsSecret.mockReturnValue(true);
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 0, dropped: 1 });
+    expect(remember).not.toHaveBeenCalled();
+  });
+
+  it('drops an item whose body now trips the PII guard', async () => {
+    await enqueueWrite(item(), qp);
+    containsPii.mockReturnValue(true);
+    scanPii.mockReturnValue([{ kind: 'email' }]);
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 0, dropped: 1 });
+    expect(remember).not.toHaveBeenCalled();
+  });
+
+  it('drops items older than the age cap', async () => {
+    const old = new Date(Date.now() - (MAX_AGE_DAYS + 1) * 86_400_000).toISOString();
+    await saveQueue([{ ...item(), queuedAt: old }], qp);
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 0, dropped: 1 });
+  });
+
+  it('keeps an item with an unparseable date rather than silently discarding it', async () => {
+    remember.mockResolvedValue({ ok: false, error: 'down' });
+    await saveQueue([{ ...item(), queuedAt: 'not-a-date' }], qp);
+    expect((await flushQueue(qp)).kept).toBe(1);
+  });
+
+  it('does nothing when Bonfire is not configured', async () => {
+    await enqueueWrite(item(), qp);
+    bonfireConfigured.mockReturnValue(false);
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 0, dropped: 0 });
+    expect(await loadQueue(qp)).toHaveLength(1);
+  });
+
+  it('handles a mixed queue without losing the failures', async () => {
+    remember
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, error: 'down' })
+      .mockResolvedValueOnce({ ok: false, skipped: 'empty' });
+    await enqueueWrite(item('a'), qp);
+    await enqueueWrite(item('b'), qp);
+    await enqueueWrite(item('c'), qp);
+    expect(await flushQueue(qp)).toEqual({ sent: 1, kept: 1, dropped: 1 });
+    expect((await loadQueue(qp))[0].name).toBe('b');
+  });
+
+  it('survives a corrupt queue file', async () => {
+    await fs.writeFile(qp, 'not json', 'utf8');
+    expect(await flushQueue(qp)).toEqual({ sent: 0, kept: 0, dropped: 0 });
+  });
+});

--- a/bot/src/zoe/afferent-digest.ts
+++ b/bot/src/zoe/afferent-digest.ts
@@ -17,6 +17,7 @@
 import { db } from '../supabase';
 import { emitReceipt } from './receipts';
 import { buildEpisode, promoteSubmission, queueConfigured, type BonfireSubmission } from './bonfire-queue';
+import { enqueueWrite } from './bonfire-retry';
 
 export interface DigestResult {
   status: 'success' | 'error' | 'silent';
@@ -233,6 +234,17 @@ export async function persistDailyDigest(): Promise<DigestResult> {
         bonfireSuccess = result.ok === true;
         if (!bonfireSuccess) {
           console.warn('[zoe/afferent-digest] bonfire promotion returned non-ok:', result);
+          // This used to end at the warning, and the digest was gone. Queue it so
+          // the graph catches up when Bonfire returns. A guard skip is terminal -
+          // re-sending it would trip the same guard forever.
+          if (!(result as { skipped?: string }).skipped) {
+            const ep = buildEpisode(submission);
+            await enqueueWrite({
+              body: ep.body,
+              name: ep.name,
+              sourceTag: 'zoe:afferent-digest',
+            }).catch(() => {});
+          }
         }
       } catch (err) {
         console.error('[zoe/afferent-digest] bonfire promotion failed:', (err as Error)?.message ?? err);

--- a/bot/src/zoe/bonfire-retry.ts
+++ b/bot/src/zoe/bonfire-retry.ts
@@ -1,0 +1,159 @@
+/**
+ * bonfire-retry.ts - a retry queue for EVERY Bonfire write, not just thread emits.
+ *
+ * Zaal, 2026-08-09, deciding the P1 in issues/507: when Bonfire is down, BUILD
+ * THE KV QUEUE - queue writes and replay on recovery, do not accept the loss.
+ *
+ * What was already true: thread-memory.ts had exactly this, working well, wired
+ * to a scheduler tick. What was not: it only covered thread transitions. The
+ * other writers dropped failures on the floor -
+ *
+ *   team-tracker.ts    a failed priorities mirror set `mirrored = false`, no retry
+ *   afferent-digest.ts a failed promotion logged console.warn and moved on
+ *
+ * The second one is the reason this is a P1 rather than housekeeping: that path
+ * promotes an APPROVED COMMUNITY SUBMISSION into the graph. A steward approves a
+ * member's work, Bonfire happens to be unreachable, and the submission vanishes
+ * into a warning nobody reads. The member is never told. That is silent data
+ * loss with a person on the other end of it.
+ *
+ * So this generalises the queue rather than adding a second one: same on-disk
+ * shape, same guards, same drain cadence, but keyed on an arbitrary sourceTag so
+ * any caller can use it. thread-memory keeps its own typed wrapper on top.
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from './memory';
+import { remember, containsSecret, bonfireConfigured } from './recall';
+import { containsPii, scanPii } from './pii';
+
+/**
+ * Resolved LAZILY, never at module load. This module is imported by
+ * team-tracker and afferent-digest, which are imported by dozens of test files
+ * that mock '../memory' without supplying ZOE_PATHS - reading ZOE_PATHS.home at
+ * module scope crashed 27 test files on import before this was a function.
+ * A module-scope side effect is a landmine for every future importer.
+ */
+function queueFile(): string {
+  return join(ZOE_PATHS.home, 'bonfire-retry-queue.json');
+}
+
+/** Bounded so a long outage cannot grow the file without limit. Oldest drop first. */
+export const MAX_QUEUE = 500;
+
+/** Past this, a write is stale enough that replaying it is noise, not recovery. */
+export const MAX_AGE_DAYS = 14;
+
+export interface QueuedWrite {
+  body: string;
+  name: string;
+  sourceTag: string;
+  queuedAt: string;
+  /** Attempts so far, so a permanently-failing item is visible rather than silent. */
+  attempts?: number;
+}
+
+export interface FlushResult {
+  sent: number;
+  kept: number;
+  /** Dropped because a guard now trips, or the item aged out. */
+  dropped: number;
+}
+
+export async function loadQueue(path?: string): Promise<QueuedWrite[]> {
+  try {
+    const raw = await fs.readFile(path ?? queueFile(), 'utf8');
+    const arr = JSON.parse(raw) as QueuedWrite[];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return []; // absent or corrupt - an empty queue, never a crash
+  }
+}
+
+export async function saveQueue(q: QueuedWrite[], path?: string): Promise<void> {
+  await fs.mkdir(ZOE_PATHS.home, { recursive: true });
+  // slice(-MAX_QUEUE) keeps the NEWEST. During a long outage the oldest writes
+  // are the ones most likely already superseded.
+  await fs.writeFile(path ?? queueFile(), JSON.stringify(q.slice(-MAX_QUEUE), null, 2), 'utf8');
+}
+
+/**
+ * Queue a failed Bonfire write.
+ *
+ * Only call this for a GENUINE send failure - network or HTTP. A guard skip
+ * (secret, PII, empty, no-config) is terminal: re-sending it would trip the same
+ * guard forever and the queue would never drain.
+ */
+export async function enqueueWrite(
+  item: Omit<QueuedWrite, 'queuedAt' | 'attempts'>,
+  path?: string,
+): Promise<void> {
+  const q = await loadQueue(path);
+  q.push({ ...item, queuedAt: new Date().toISOString(), attempts: 0 });
+  await saveQueue(q, path);
+}
+
+function agedOut(item: QueuedWrite, now: number): boolean {
+  const t = Date.parse(item.queuedAt);
+  if (Number.isNaN(t)) return false; // unparseable date: keep, do not silently discard
+  return now - t > MAX_AGE_DAYS * 86_400_000;
+}
+
+/**
+ * Replay queued writes. Call from a low-frequency scheduler tick.
+ *
+ * Re-scans every body before re-sending: content that trips a guard NOW is
+ * dropped rather than retried, because the guards are the last line before a
+ * secret or someone's phone number reaches a graph other agents can query.
+ */
+export async function flushQueue(path?: string, now: number = Date.now()): Promise<FlushResult> {
+  if (!bonfireConfigured()) return { sent: 0, kept: 0, dropped: 0 };
+  const q = await loadQueue(path);
+  if (q.length === 0) return { sent: 0, kept: 0, dropped: 0 };
+
+  const remaining: QueuedWrite[] = [];
+  let sent = 0;
+  let dropped = 0;
+
+  for (const item of q) {
+    if (agedOut(item, now)) {
+      dropped += 1;
+      console.warn(`[zoe/bonfire-retry] dropped after ${MAX_AGE_DAYS}d: ${item.name}`);
+      continue;
+    }
+    if (containsSecret(item.body)) {
+      dropped += 1;
+      console.warn(`[zoe/bonfire-retry] dropped - secret-shaped string in ${item.name}`);
+      continue;
+    }
+    if (containsPii(item.body)) {
+      const kinds = [...new Set(scanPii(item.body).map((m) => m.kind))].join(',');
+      dropped += 1;
+      console.warn(`[zoe/bonfire-retry] dropped - PII (${kinds}) in ${item.name}`);
+      continue;
+    }
+
+    const r = await remember({ body: item.body, name: item.name, sourceTag: item.sourceTag });
+    if (r.ok) {
+      sent += 1;
+    } else if (r.skipped) {
+      dropped += 1; // terminal - would fail identically forever
+    } else {
+      remaining.push({ ...item, attempts: (item.attempts ?? 0) + 1 });
+    }
+  }
+
+  await saveQueue(remaining, path);
+
+  // Say something when the queue is not draining. A queue that silently grows is
+  // the same failure as no queue at all, just slower to notice.
+  if (remaining.length > 0) {
+    const stuck = remaining.filter((i) => (i.attempts ?? 0) >= 5).length;
+    console.warn(
+      `[zoe/bonfire-retry] ${remaining.length} still queued` +
+        (stuck > 0 ? ` - ${stuck} have failed 5+ times, Bonfire may need a look` : ''),
+    );
+  }
+
+  return { sent, kept: remaining.length, dropped };
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -62,6 +62,7 @@ import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
+import { flushQueue } from './bonfire-retry';
 import { checkAndResend, readLastUserReplyAt } from './escalation';
 import { reconcileUntaggedTasks, getTaskStatusByIds, autoCloseFinishedTasks } from './team-tracker';
 import { ingestAllIdentities } from './fleet';
@@ -745,6 +746,14 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
 
         try {
           await flushEmitQueue();
+          // Same cadence, the other queue: every Bonfire writer that is not a
+          // thread transition (priorities mirror, afferent digest). Reports what
+          // it actually did, so a queue that never drains is visible rather than
+          // quietly growing.
+          const bf = await flushQueue();
+          if (bf.sent || bf.kept || bf.dropped) {
+            featureRan('bonfire-retry', `sent ${bf.sent}, kept ${bf.kept}, dropped ${bf.dropped}`);
+          }
         } catch (err) {
           console.warn('[zoe/scheduler] emit-queue flush failed (nbd):', (err as Error).message);
         }

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -24,6 +24,7 @@ import {
   type RepoFacts,
 } from './done-work-detector';
 import { remember } from './recall';
+import { enqueueWrite } from './bonfire-retry';
 
 export interface TeamTask {
   title: string;
@@ -569,9 +570,16 @@ export async function runTeamDigest(opts?: { mirrorToBonfire?: boolean }): Promi
     const ep = buildPrioritiesEpisode(tasks, members, new Date().toISOString());
     if (ep) {
       const r = await remember({ body: ep.body, name: ep.name, sourceTag: 'zoe:priorities' }).catch(
-        () => ({ ok: false }) as { ok: boolean },
+        () => ({ ok: false }) as { ok: boolean; skipped?: string },
       );
       mirrored = r.ok === true;
+      // A send failure used to end here, with `mirrored = false` and the episode
+      // gone. Queue it instead so the graph catches up when Bonfire returns. A
+      // guard SKIP is terminal and must not be queued - it would fail identically
+      // forever and the queue would never drain.
+      if (!mirrored && !(r as { skipped?: string }).skipped) {
+        await enqueueWrite({ body: ep.body, name: ep.name, sourceTag: 'zoe:priorities' }).catch(() => {});
+      }
     }
   }
   return { digest, taskCount: tasks.length, mirrored };


### PR DESCRIPTION
Your call on the P1 in issues/507 this morning: **build the KV queue, don't accept the loss.**

## What was already there, and what wasn't

`thread-memory.ts` already had this queue - working, guarded, wired to an hourly drain. It only covered thread transitions. The other two writers dropped failures on the floor:

| Writer | On a failed Bonfire write |
|---|---|
| `team-tracker.ts` | set `mirrored = false`, no retry |
| `afferent-digest.ts` | `console.warn`, moved on |

**The second one is why this is a P1.** That path promotes an *approved community submission* into the graph. A steward approves a member's work, Bonfire is briefly unreachable, and the submission vanishes into a warning nobody reads. The member is never told. That's silent data loss with a person on the other end of it.

So this **generalises the queue that already worked** rather than adding a second one - same on-disk shape, same guards, same drain tick, keyed on an arbitrary `sourceTag`.

## Behaviour worth reviewing

- **Terminal skips are dropped, never queued.** A no-config / secret / PII / empty result would trip the same guard forever and the queue would never drain.
- **Every body is re-scanned at flush time.** Content that trips a guard *now* is dropped rather than sent, because those guards are the last line before a secret or someone's phone number reaches a graph other agents can query.
- **Bounded at 500, aged out at 14 days.** A long outage can't grow the file without limit or replay writes that are long superseded.
- **Attempts are counted, and a stuck queue logs loudly.** A queue that silently grows is the same failure as no queue, just slower to notice.

## One bug caught in the writing

Resolving the queue path at **module scope** crashed **27 test files on import** - this module is pulled in by `team-tracker` and `afferent-digest`, and those tests mock `../memory` without supplying `ZOE_PATHS`. It's lazy now.

Worth stating plainly because it nearly shipped: the unit tests passed 12/12 while 27 other files were failing to load. Only the full suite caught it.

## Evidence

- Full suite **2274 passing across 178 files**, up from 2262 - the 12 new tests, no regressions
- `esbuild` bundles the real boot graph clean
- Typecheck **37 before, 37 after** - all pre-existing in `hermes/__tests__`, none mine
- Failure paths tested rather than assumed: send failure kept, terminal skip dropped, guard-trip-on-replay dropped, aged-out dropped, unparseable date kept, corrupt file survived, Bonfire-unconfigured no-ops without draining
