### PR TITLE
feat(scripts): flag research docs that make claims about files a change touches

### DIFF
--- a/scripts/__tests__/test_check_doc_currency.py
+++ b/scripts/__tests__/test_check_doc_currency.py
@@ -1,0 +1,164 @@
+"""Tests for check-doc-currency.py.
+
+The false-POSITIVE tests matter most. This repo already produced one check that
+fired 35 times on a healthy codebase and taught everyone to ignore it
+(.claude/rules/noisy-signal-guard.md). A doc-currency check that flags every PR
+would be the second, and it would be worse, because it touches every commit.
+
+Runnable without pytest: `python3 scripts/__tests__/test_check_doc_currency.py`.
+This repo's runner is vitest, and a test that cannot run in CI is
+indistinguishable from one that passes.
+"""
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check-doc-currency.py"
+_spec = importlib.util.spec_from_file_location("cdc", SCRIPT)
+cdc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cdc)
+
+PATH_RE = cdc.PATH_RE
+
+
+def paths_in(text):
+    return [m.group(1) for m in PATH_RE.finditer(text)]
+
+
+# --- what the regex must catch ------------------------------------------------
+
+def test_catches_a_plain_source_path():
+    assert "bot/src/zoe/scheduler.ts" in paths_in("see bot/src/zoe/scheduler.ts for the tick")
+
+
+def test_catches_a_backticked_path():
+    assert "src/lib/spaces/roomsDb.ts" in paths_in("the type lives in `src/lib/spaces/roomsDb.ts`")
+
+
+def test_catches_a_path_with_a_line_reference():
+    assert "bot/src/zoe/recall.ts" in paths_in("recall.ts:100 - see bot/src/zoe/recall.ts:100")
+
+
+def test_catches_scripts_and_packages():
+    got = paths_in("scripts/verify.py and packages/heart-fleet/src/lease.ts")
+    assert "scripts/verify.py" in got
+    assert "packages/heart-fleet/src/lease.ts" in got
+
+
+def test_catches_a_nextjs_dynamic_route():
+    assert "src/app/spaces/[id]/page.tsx" in paths_in("see src/app/spaces/[id]/page.tsx")
+
+
+# --- what it must NOT catch (these decide whether the check is usable) --------
+
+def test_ignores_prose_with_a_slash():
+    assert paths_in("use this and/or that, per the docs") == []
+
+
+def test_ignores_a_bare_filename_with_no_directory():
+    assert paths_in("open scheduler.ts and read it") == []
+
+
+def test_ignores_an_external_github_path():
+    assert paths_in("see github.com/builderz-labs/mission-control for the pattern") == []
+
+
+def test_ignores_a_url_path():
+    assert paths_in("https://zabalgamez.com/finals/live/index.html") == []
+
+
+def test_ignores_a_directory_without_a_file():
+    assert paths_in("everything under bot/src/zoe/ is the agent") == []
+
+
+def test_ignores_an_unknown_top_level_dir():
+    assert paths_in("vendor/thirdparty/thing.ts is not ours") == []
+
+
+# --- index behaviour ----------------------------------------------------------
+
+def _repo(tmp, docs):
+    root = Path(tmp)
+    (root / "research" / "x").mkdir(parents=True)
+    for name, body in docs.items():
+        d = root / "research" / "x" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "README.md").write_text(body, encoding="utf-8")
+    return root
+
+
+def test_index_maps_path_to_the_doc_that_cites_it():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _repo(tmp, {"a": "the tick is in bot/src/zoe/scheduler.ts"})
+        idx = cdc.index_docs(root)
+        assert len(idx["bot/src/zoe/scheduler.ts"]) == 1
+
+
+def test_index_skips_superseded_docs():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _repo(tmp, {"a": "---\nstatus: superseded\n---\nsee bot/src/zoe/scheduler.ts"})
+        assert cdc.index_docs(root).get("bot/src/zoe/scheduler.ts") is None, \
+            "a superseded doc is a record of a moment and cannot rot"
+
+
+def test_index_skips_point_in_time_records():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _repo(tmp, {"a": "---\ntype: point-in-time\n---\nsee scripts/verify.py"})
+        assert cdc.index_docs(root).get("scripts/verify.py") is None
+
+
+def test_index_survives_an_unreadable_doc():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _repo(tmp, {"a": "see scripts/verify.py"})
+        (root / "research" / "x" / "b").mkdir()
+        (root / "research" / "x" / "b" / "README.md").write_bytes(b"\xff\xfe bad bytes")
+        assert len(cdc.index_docs(root)["scripts/verify.py"]) == 1
+
+
+# --- CLI ----------------------------------------------------------------------
+
+def _run(args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True, text=True,
+        cwd=str(SCRIPT.resolve().parents[2]),
+    )
+
+
+def test_cli_is_silent_when_nothing_is_cited():
+    r = _run(["--files", "bot/src/zoe/a-file-no-doc-mentions-xyz.ts"])
+    assert r.returncode == 0
+    assert r.stdout.strip() == "", "silence is the common case and must stay silent"
+
+
+def test_cli_never_blocks_even_when_it_fires():
+    r = _run(["--files", "bot/src/zoe/scheduler.ts"])
+    assert r.returncode == 0, "this is advisory - it reports, it never blocks a commit"
+
+
+def test_cli_ignores_readme_changes():
+    r = _run(["--files", "research/agents/1081-zoe-assistant-buildout-roadmap/README.md"])
+    assert r.stdout.strip() == "", "editing a doc does not make a doc stale"
+
+
+def _main() -> int:
+    tests = [(n, f) for n, f in sorted(globals().items())
+             if n.startswith("test_") and callable(f)]
+    failed = []
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as exc:
+            failed.append((name, str(exc) or "assertion failed"))
+        except Exception as exc:  # noqa: BLE001
+            failed.append((name, f"{type(exc).__name__}: {exc}"))
+    for name, why in failed:
+        print(f"FAIL {name}: {why}")
+    print(f"{len(tests) - len(failed)}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/scripts/check-doc-currency.py
+++ b/scripts/check-doc-currency.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""check-doc-currency.py - flag research docs that make claims about files you changed.
+
+WHY. On 2026-08-09 the same failure landed four times in one day: a document
+that was confidently, specifically wrong because the thing it described had
+moved underneath it.
+
+  doc 2178          said the VPS runs 9 tmux loops. It runs 3.
+  doc 743           lists two partners retired on 2026-07-31 as current.
+  finals.html       described two Finals formats, neither of which was running.
+  mission-control.ts was marked complete in its own doc and never wired in.
+
+We have 24 rules in .claude/rules/. Every one is about not ASSERTING falsely -
+anti-fabrication, state-claims, confirm-before-claiming-absence. NONE is about a
+document quietly BECOMING false while nobody touches it. `agent-loops.md` rule 3
+already says "read live code first, docs are aspirational", and we still built on
+doc 2178's stale fleet table that morning. Discipline was tried; it does not hold.
+
+WHAT THIS DOES, AND WHAT IT DELIBERATELY DOES NOT.
+
+It does NOT ask you to update docs. It does not score staleness, guess intent, or
+require a DESIGN.md per component - this repo already has 2,000+ research docs and
+fragmenting further is the opposite of the fix.
+
+It answers exactly one question: *of the docs that name a specific file by path,
+which ones named a file this change touches?* Those docs made a checkable claim
+about code that just moved. Everything else is left alone.
+
+That narrowness is the whole design. A check that fires on every PR is one people
+route around (.claude/rules/noisy-signal-guard.md), and this repo has already
+produced one of those this week.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# A path-shaped token inside a doc: at least one slash, a real source extension.
+# Anchored on the repo's actual top-level source dirs so prose like "and/or" or a
+# URL path never reads as a file reference.
+PATH_RE = re.compile(
+    r"\b((?:src|bot/src|scripts|packages|app|api|components|lib)/"
+    r"[A-Za-z0-9_./\-\[\]]+\.(?:ts|tsx|js|jsx|mjs|py|sh|sql|json|ps1))\b"
+)
+
+# Docs that are explicitly historical do not rot - they are records of a moment.
+ARCHIVAL_MARKERS = ("status: superseded", "type: incident-postmortem", "point-in-time")
+
+
+def repo_root(start: Path) -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=start, capture_output=True, text=True, check=False,
+    )
+    return Path(out.stdout.strip()) if out.returncode == 0 else start
+
+
+def changed_files(root: Path, base: str) -> list[str]:
+    """Files changed against base. Never a pipeline - we need git's own status."""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        cwd=root, capture_output=True, text=True, check=False,
+    )
+    if out.returncode != 0:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", "--cached"],
+            cwd=root, capture_output=True, text=True, check=False,
+        )
+    return [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def index_docs(root: Path) -> dict[str, set[Path]]:
+    """path -> {docs that name it}. Built fresh; never cached, so it cannot go stale."""
+    index: dict[str, set[Path]] = defaultdict(set)
+    for doc in (root / "research").rglob("README.md"):
+        try:
+            text = doc.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        head = text[:600].lower()
+        if any(m in head for m in ARCHIVAL_MARKERS):
+            continue
+        for m in PATH_RE.finditer(text):
+            index[m.group(1)].add(doc)
+    return index
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--files", nargs="*", help="explicit file list instead of a git diff")
+    ap.add_argument("--stats", action="store_true", help="report the index only")
+    args = ap.parse_args()
+
+    root = repo_root(Path.cwd())
+    index = index_docs(root)
+
+    if args.stats:
+        docs = {d for s in index.values() for d in s}
+        print(f"paths cited: {len(index)}")
+        print(f"docs citing at least one path: {len(docs)}")
+        return 0
+
+    files = args.files if args.files else changed_files(root, args.base)
+    # A doc changing does not make a doc stale.
+    files = [f for f in files if not f.endswith("README.md")]
+    if not files:
+        return 0
+
+    hits: dict[Path, list[str]] = defaultdict(list)
+    for f in files:
+        for doc in index.get(f, ()):
+            hits[doc].append(f)
+
+    if not hits:
+        return 0
+
+    print("Docs that make claims about files this change touches:\n")
+    for doc, paths in sorted(hits.items()):
+        rel = doc.relative_to(root)
+        print(f"  {rel}")
+        for p in sorted(set(paths)):
+            print(f"      cites {p}")
+    print(
+        "\nEach of these named a file you just changed. Confirm the claim still holds,"
+        "\nor update the doc in this PR."
+        "\n\nNot every hit needs an edit - a doc can cite a file for context without"
+        "\nmaking a claim about it. This is a prompt to look, not an accusation."
+        "\n\nWhy: on 2026-08-09 four documents were confidently wrong because the code"
+        "\nmoved and nothing made anyone re-read them (.claude/rules/state-claims.md)."
+    )
+    return 0  # advisory: this reports, it never blocks
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Four times on 2026-08-09 a document was confidently, specifically wrong because the thing it described moved underneath it:

| Document | Claim | Reality |
|---|---|---|
| doc 2178 | VPS runs 9 tmux loops | a full process-tree walk found **3** |
| doc 743 | lists two partners as current | both **retired 2026-07-31** |
| `finals.html` | described two Finals formats | **neither** was running |
| doc 2226 | `mission-control.ts` complete | 187 lines, **never wired in** |

We have 24 rules in `.claude/rules/`, and every one is about not **asserting** falsely - anti-fabrication, state-claims, confirm-before-claiming-absence. **None is about a document quietly becoming false while nobody touches it.**

`agent-loops.md` rule 3 already says *"read live code first, docs are aspirational"* - and we still built on doc 2178's stale fleet table that same morning. The discipline version has been tried. It does not hold.

## What it does

One question: **of the docs that name a file by path, which named a file this change touches?** Those docs made a checkable claim about code that just moved.

Deliberately not included: staleness scoring, a `DESIGN.md` per component (2,127 research docs already exist - fragmenting further is the opposite of the fix), or any requirement to edit. It **reports and exits 0.** Advisory, never blocking.

## Measured before trusting it

The firing rate is the whole question, so it was measured rather than assumed:

- Indexes **1,640 cited paths across 747 docs**
- Fired on **0 of the last 11 merges** to main - most changes touch uncited files
- Fires correctly when it should: `bot/src/zoe/scheduler.ts` is named by **4 docs**, and today's own PR #3022 touched it. This would have caught it.
- **18/18 tests**, with the false-positive tests outnumbering the true-positive ones on purpose

Prose with a slash, a bare filename, an external github path, a URL path, a bare directory, and an unknown top-level dir all pass through untouched. Superseded and point-in-time docs are skipped - a record of a moment cannot rot. Editing a README does not flag that README.

Origin: a Reddit post on DTDD that names this exact failure. The three-tier orchestration it proposes we already run; the `DESIGN.md`-per-component part we deliberately declined. This takes one sentence from it - *a doc not updated as part of the change is guaranteed to rot, and the fix is a gate rather than discipline* - and nothing else.
