### PR TITLE
fix(publish): a track title with a "<" in it is announced nowhere

### DIFF
--- a/src/lib/publish/__tests__/broadcast.test.ts
+++ b/src/lib/publish/__tests__/broadcast.test.ts
@@ -5,7 +5,12 @@ const mockPublishToTelegram = vi.hoisted(() => vi.fn());
 const mockPublishToDiscord = vi.hoisted(() => vi.fn());
 const mockBuildZaoEmbed = vi.hoisted(() => vi.fn());
 
-vi.mock('@/lib/publish/telegram', () => ({ publishToTelegram: mockPublishToTelegram }));
+// escapeHtml is deliberately NOT mocked — these tests exist to prove broadcast
+// really escapes, so the real implementation has to run.
+vi.mock('@/lib/publish/telegram', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../telegram')>();
+  return { publishToTelegram: mockPublishToTelegram, escapeHtml: actual.escapeHtml };
+});
 vi.mock('@/lib/publish/discord', () => ({
   publishToDiscord: mockPublishToDiscord,
   buildZaoEmbed: mockBuildZaoEmbed,
@@ -171,6 +176,39 @@ describe('castHash link appending', () => {
     const telegramCall = mockPublishToTelegram.mock.calls[0][0];
     expect(telegramCall.text).toContain('custom.site');
     expect(telegramCall.text).not.toContain('zaoos.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telegram HTML escaping — the text goes out with parse_mode HTML, so a raw
+// `<` in caller text makes the Bot API reject the WHOLE message (400 can't
+// parse entities) and the announcement is never posted.
+// ---------------------------------------------------------------------------
+
+describe('telegram HTML escaping', () => {
+  beforeEach(() => {
+    mockPublishToTelegram.mockResolvedValue({ success: true });
+    mockPublishToDiscord.mockResolvedValue({ success: true });
+  });
+
+  it('escapes < > and & in the caller text', async () => {
+    await broadcastToChannels({ text: 'New track approved: Love <3 by Simon & Garfunkel' });
+    const telegramCall = mockPublishToTelegram.mock.calls[0][0];
+    expect(telegramCall.text).toContain('Love &lt;3 by Simon &amp; Garfunkel');
+    expect(telegramCall.text).not.toContain('<3');
+  });
+
+  it('does not double-escape an ampersand into &amp;amp;', async () => {
+    await broadcastToChannels({ text: 'R&B' });
+    const telegramCall = mockPublishToTelegram.mock.calls[0][0];
+    expect(telegramCall.text).toContain('R&amp;B');
+    expect(telegramCall.text).not.toContain('&amp;amp;');
+  });
+
+  it('leaves the Discord text unescaped — Discord is markdown, not HTML', async () => {
+    await broadcastToChannels({ text: 'Love <3 & more' });
+    const discordCall = mockPublishToDiscord.mock.calls[0][0];
+    expect(discordCall.text).toBe('Love <3 & more');
   });
 });
 

--- a/src/lib/publish/__tests__/telegram.test.ts
+++ b/src/lib/publish/__tests__/telegram.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { escapeMarkdownV2, publishToTelegram } from '../telegram';
+import { escapeHtml, escapeMarkdownV2, publishToTelegram } from '../telegram';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,6 +57,25 @@ describe('escapeMarkdownV2', () => {
 
   it('leaves plain alphanumeric text unchanged', () => {
     expect(escapeMarkdownV2('HelloWorld123')).toBe('HelloWorld123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeHtml
+// ---------------------------------------------------------------------------
+
+describe('escapeHtml', () => {
+  it('escapes the three symbols the Bot API requires', () => {
+    expect(escapeHtml('a < b > c & d')).toBe('a &lt; b &gt; c &amp; d');
+  });
+
+  it('escapes the ampersand first so the escapes do not escape each other', () => {
+    expect(escapeHtml('<3')).toBe('&lt;3');
+    expect(escapeHtml('&')).toBe('&amp;');
+  });
+
+  it('leaves text with none of them unchanged', () => {
+    expect(escapeHtml('New track approved: Midnight')).toBe('New track approved: Midnight');
   });
 });
 

--- a/src/lib/publish/broadcast.ts
+++ b/src/lib/publish/broadcast.ts
@@ -8,7 +8,7 @@
  */
 
 import { buildZaoEmbed, publishToDiscord } from '@/lib/publish/discord';
-import { publishToTelegram } from '@/lib/publish/telegram';
+import { escapeHtml, publishToTelegram } from '@/lib/publish/telegram';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -75,9 +75,14 @@ export async function broadcastToChannels(options: BroadcastOptions): Promise<Br
     ? `\n\n[View on Farcaster](${farcasterLink}) · [Join ZAO OS](${pageUrl})`
     : `\n\n[Join ZAO OS](${pageUrl})`;
 
+  // Telegram is sent with parse_mode HTML and every caller passes PLAIN text,
+  // some of it user-supplied (a track title, an artist name). A raw `<` makes
+  // the Bot API reject the whole message with 400 `can't parse entities`, so a
+  // track called "Love <3" is announced nowhere at all. Only the caller's text
+  // needs escaping — linksSuffix is ours and carries no markup.
   const telegramPromise = hasTelegram
     ? publishToTelegram({
-        text: options.text + linksSuffix,
+        text: escapeHtml(options.text) + linksSuffix,
         imageUrl: options.imageUrl,
         parseMode: 'HTML',
         disablePreview: false,

--- a/src/lib/publish/telegram.ts
+++ b/src/lib/publish/telegram.ts
@@ -74,6 +74,20 @@ export function escapeMarkdownV2(text: string): string {
   return text.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
 }
 
+/**
+ * Escape text for Telegram HTML parse mode.
+ *
+ * The Bot API is explicit: "All <, > and & symbols that are not a part of a tag
+ * or an HTML entity must be replaced with the corresponding HTML entities."
+ * Sending them raw is not a rendering nit — the API rejects the WHOLE message
+ * with 400 `can't parse entities`, so the post never happens.
+ * Ampersand first, or the later escapes get escaped in turn.
+ * See: https://core.telegram.org/bots/api#html-style
+ */
+export function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 // ---------------------------------------------------------------------------
 // Publish
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What breaks without this

`broadcastToChannels` sends the Telegram message with `parse_mode: 'HTML'`
(`src/lib/publish/broadcast.ts:82`) but hands the Bot API the caller's text
verbatim (`:80`). Telegram's HTML mode is explicit that `<`, `>` and `&` that
are not part of a tag must be sent as entities; a raw `<` is not a rendering
nit, it makes the API reject the **entire message** with
`400 Bad Request: can't parse entities`.

Concretely, `src/app/api/music/submissions/review/route.ts:86-89` builds

```
`New track approved: ${trackLabel}`
```

where `trackLabel` is `submission.title` + `submission.artist` - both
user-submitted rows. Approve a track called `Love <3`, `<untitled>`, or
`a<b` and the Telegram announcement is never posted.

It is invisible on top of that: the call is fire-and-forget with
`.catch(logger.error)`, and `broadcastToChannels` never throws - it resolves
`{ telegram: { success: false, error } }`. So the `.catch` never fires, the
failed result is dropped, and nothing is logged. Green while broken.

## The fix

- `escapeHtml()` added to `src/lib/publish/telegram.ts`, next to the existing
  `escapeMarkdownV2()`. Ampersand first, so the escapes do not escape each other.
- Applied to `options.text` only in `broadcastToChannels`. The link suffix is
  ours and carries no markup; Discord is markdown, not HTML, and is untouched.

6 new tests: 3 unit tests on `escapeHtml`, 3 on broadcast (escapes the caller
text, does not double-escape `&`, leaves the Discord text alone). The broadcast
test's telegram mock now uses `importOriginal` so the real `escapeHtml` runs -
mocking it would make the test prove nothing.

## Verification - honest status

- `escapeHtml`'s logic verified directly in `node`: `a < b > c & d` ->
  `a &lt; b &gt; c &amp; d`, `<3` -> `&lt;3`, `R&B` -> `R&amp;B`, plain text
  unchanged.
- `npm run typecheck` and `vitest` were **NOT run**: the auditor's checkout has
  an empty `node_modules` (`ls node_modules | wc -l` = 0), and per
  `noisy-signal-guard.md` a toolchain that cannot resolve produces confident
  fake output rather than a verdict. Reporting that as green would be a vacuous
  pass. CI installs from the lockfile and is the real gate here.
- Test count goes 0 -> +6; no test removed.

## Other things this audit noticed, not fixed here (one PR per run)

1. `packages/publish/src/broadcast.ts` is a stale duplicate of
   `src/lib/publish/broadcast.ts` - same HTML bug, and it also predates the
   `channels` selector on the live copy (it always posts to both). It imports via
   the `@/` alias from inside a package. Worth deciding whether it is live or
   dead before fixing it in two places.
2. The swallowed broadcast failure described above (`.catch()` on a function
   that never rejects) is a separate one-line fix at the review route call site.
3. `truncate()` in `telegram.ts` runs after escaping and could in principle cut
   an entity in half when the text contains no spaces. Edge case, noted only.

Zaal merges. This branch was opened by the hourly repo auditor and merges nothing.

Generated with [Claude Code](https://claude.com/claude-code)
