### PR TITLE
feat(hooks): block third-party PII in the staged diff

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,3 +12,11 @@ bash "$(git rev-parse --show-toplevel)/scripts/git-secret-scan.sh" || exit 1
 #    missing folder-index row NO LONGER blocks a commit - PRs must not hand-edit
 #    the shared README (that caused concurrent doc PRs to collide). Advisory only.
 bash "$(git rev-parse --show-toplevel)/scripts/check-research-index.sh" || echo "[research-index] note: doc(s) not indexed yet - CI backfills on merge (not blocking)"
+
+# 4. Block third-party PII in the staged diff (.claude/rules/pii-hygiene.md).
+#    The rule was written 2026-05-23 and its own line 153 called this hook "a
+#    worthwhile follow-up"; it was never built, so for fifteen months the rule was
+#    a manual checklist. Measured at 0 false positives across the last 40 commits
+#    on main before shipping. Fails closed: a security scan that passes on error
+#    is not a scan (silent-failure-guard rule 5).
+python3 "$(git rev-parse --show-toplevel)/scripts/git-pii-scan.py" || exit 1

--- a/scripts/__tests__/test_git_pii_scan.py
+++ b/scripts/__tests__/test_git_pii_scan.py
@@ -1,0 +1,155 @@
+"""Tests for git-pii-scan.py.
+
+Two things must both be true, and either alone is worthless:
+
+  1. It CATCHES real third-party PII. A scan that never fires protects nobody.
+  2. It does NOT fire on ordinary repo content. Measured at zero across the last
+     40 commits on main; these tests pin the specific shapes that produced every
+     observed false positive, so a future regex tweak cannot quietly reintroduce
+     them.
+
+Runnable without pytest: `python3 scripts/__tests__/test_git_pii_scan.py`.
+This repo runs vitest, and a test that cannot run in CI is indistinguishable
+from one that passes.
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "git-pii-scan.py"
+_spec = importlib.util.spec_from_file_location("pii", SCRIPT)
+pii = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pii)
+
+
+def hits(line, path="notes.md"):
+    return pii.scan([(path, line)])
+
+
+def kinds(line):
+    return {k for k, _, _, _ in hits(line)}
+
+
+# --- MUST CATCH: real third-party PII ---------------------------------------
+
+def test_catches_a_third_party_email():
+    assert "email" in kinds("reach her at jane.doe@somecompany.co.uk about the deck")
+
+
+def test_catches_a_us_phone():
+    assert "us_phone" in kinds("call the venue on 207-555-0142 to confirm")
+
+
+def test_catches_a_phone_with_parens():
+    assert "us_phone" in kinds("her cell is (207) 555-0142")
+
+
+def test_catches_an_international_phone():
+    assert "intl_phone" in kinds("WZO office is +44 208 8901282")
+
+
+def test_catches_a_street_address():
+    assert "street_address" in kinds("the parklet is at 12 Franklin St, Ellsworth")
+
+
+def test_catches_a_birthdate():
+    assert "birthdate" in kinds("DOB 04/17/1988 on the waiver form")
+
+
+def test_catches_a_card_number():
+    assert "card_number" in kinds("card 4111 1111 1111 1111 on file")
+
+
+def test_reports_the_file_it_found_it_in():
+    h = hits("mail bob@example.org", path="research/x/README.md")
+    assert h and h[0][1] == "research/x/README.md"
+
+
+# --- MUST NOT FIRE: every observed false positive ----------------------------
+
+def test_allowlisted_zao_addresses_pass():
+    for addr in ["zaal@thezao.com", "zaalp99@gmail.com", "zoe-zao@agentmail.to",
+                 "hello@thezao.com", "support@thezao.com"]:
+        assert not kinds(f"contact {addr} for access"), addr
+
+
+def test_zao_role_addresses_pass():
+    assert not kinds("email info@thezao.com or team@zabalgamez.com")
+
+
+def test_a_uuid_is_not_a_phone_number():
+    # This exact shape produced two false positives in the measured history.
+    assert not kinds("const ZOE = '00000000-0000-4000-8000-00000000a0e0'")
+
+
+def test_a_uuid_is_not_a_card_number():
+    assert not kinds("id: 550e8400-e29b-41d4-a716-446655440000")
+
+
+def test_digits_inside_a_url_are_ignored():
+    # The Kickstarter help URL that tripped the phone pattern in real history.
+    assert not kinds("see https://help.kickstarter.com/hc/en-us/articles/15005028514")
+
+
+def test_ordinary_prose_is_silent():
+    assert not kinds("The ZAO ran 32 sessions in June 2026 with 31 presenters.")
+
+
+def test_at_mentions_do_not_fire():
+    # The dropped tg_handle pattern fired 86 times across 14 of 40 commits.
+    # Everything here must stay silent or the scanner is unusable.
+    assert not kinds("| Ship the retro | @Zaal | PR | 2026-08-15 |")
+    assert not kinds("installed @openai/codex and @100mslive/react-sdk")
+    assert not kinds("thanks @ghostmintops and @branth for shipping")
+
+
+def test_a_version_number_is_not_a_phone():
+    assert not kinds("bumped to 1.144.6 and 0.144.6")
+
+
+def test_semver_and_ports_are_silent():
+    assert not kinds("listening on 127.0.0.1:7777 and 100.72.152.63")
+
+
+# --- diff parsing ------------------------------------------------------------
+
+def test_only_added_lines_are_scanned():
+    """Context lines are already committed. Re-flagging them would make any commit
+    near an old address impossible."""
+    diff = "+++ b/a.md\n-old jane@x.com\n bob@y.com context\n+new text\n"
+    rows = []
+    cur = "?"
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            cur = line[6:]
+        elif line.startswith("+") and not line.startswith("+++"):
+            rows.append((cur, line[1:]))
+    assert pii.scan(rows) == []
+
+
+def test_cli_exits_zero_with_nothing_staged():
+    r = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True,
+                       cwd=str(SCRIPT.resolve().parents[1]))
+    assert r.returncode == 0
+
+
+def _main() -> int:
+    tests = [(n, f) for n, f in sorted(globals().items())
+             if n.startswith("test_") and callable(f)]
+    failed = []
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as exc:
+            failed.append((name, str(exc) or "assertion failed"))
+        except Exception as exc:  # noqa: BLE001
+            failed.append((name, f"{type(exc).__name__}: {exc}"))
+    for name, why in failed:
+        print(f"FAIL {name}: {why}")
+    print(f"{len(tests) - len(failed)}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/scripts/git-pii-scan.py
+++ b/scripts/git-pii-scan.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""git-pii-scan.py - block a commit that stages someone else's personal data.
+
+`.claude/rules/pii-hygiene.md` was written 2026-05-23 and specifies the regexes,
+the allowlists, and the pre-flight checks. Its own line 153 says a pre-commit hook
+automating them "is a worthwhile follow-up". It was never built, so for fifteen
+months the rule has been a manual checklist - which is exactly the shape of rule
+that gets economised away on a busy day.
+
+WHAT THE MEASUREMENT CHANGED. Before writing this, the rule's seven patterns were
+run against the last 40 commits on main. Results decided the design:
+
+  email       2 hits, BOTH allowlisted (zoe-zao@agentmail.to, zoe@thezao.com)
+  us_phone    2 hits, BOTH false positives - a UUID and a Kickstarter URL
+  cc          1 hit,  false positive - the same UUID
+  intl_phone  0
+  street      0
+  birthdate   0
+  tg_handle   86 hits across 14 of 40 commits
+
+So `@\\w+` for Telegram handles is DROPPED, deliberately, and this is the most
+important design decision here. It fires on every @mention in a task table, every
+npm scope, every code decorator. The rule's allowlist names six bot handles while
+the repo legitimately mentions teammates constantly, so no allowlist fixes it.
+A check that fires on 35% of commits gets bypassed within a week, and then the
+email check dies with it (.claude/rules/noisy-signal-guard.md). Better to block
+the six patterns that can be precise than to lose all seven to alert fatigue.
+
+Handle PII is still covered by the rule for humans to apply; it is simply not
+mechanised, and saying so is more honest than pretending otherwise.
+
+Phone and card patterns keep the rule's regex but skip UUID-shaped and URL-bearing
+lines, because that is what every observed false positive was.
+
+Exits NON-ZERO on a hit. A security scan fails closed (silent-failure-guard rule 5).
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# From pii-hygiene.md's "Email allowlist" section. These are already public.
+EMAIL_ALLOW = {
+    "zaal@thezao.com",
+    "zaalp99@gmail.com",
+    "zaal@bettercallzaal.com",
+    "zoe-zao@agentmail.to",
+    "hello@thezao.com",
+    "support@thezao.com",
+}
+# Public role-addresses on ZAO-controlled domains, per the same section.
+ROLE_PREFIXES = ("contact@", "team@", "info@", "hello@", "support@", "press@", "zoe@")
+ZAO_DOMAINS = ("thezao.com", "bettercallzaal.com", "zabalgamez.com", "zaofestivals.com")
+
+# Lines that produced every observed false positive. A UUID is not a phone number.
+UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}", re.I)
+URL_RE = re.compile(r"https?://|www\.")
+
+PATTERNS: dict[str, tuple[str, bool]] = {
+    # name: (regex, skip_on_uuid_or_url)
+    "email": (r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", False),
+    "us_phone": (r"\+?1?\s*\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b", True),
+    # The rule's own regex was r"\+\d{1,3}\s*\d{6,}", which requires the digits
+    # to run together and therefore MISSES a normally-formatted number like
+    # "+44 208 8901282". Widened to allow internal spaces, dots and hyphens.
+    "intl_phone": (r"\+\d{1,3}[\s.\-]?(?:\d[\s.\-]?){6,}", True),
+    "street_address": (r"\d{1,5}\s+\w+\s+(?:St|Ave|Blvd|Rd|Dr|Ln|Way|Pl|Ct|Pkwy)\b", False),
+    "birthdate": (r"\b(?:0?[1-9]|1[012])[-/](?:0?[1-9]|[12]\d|3[01])[-/](?:19|20)\d{2}\b", True),
+    "card_number": (r"\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b", True),
+}
+
+
+def email_allowed(addr: str) -> bool:
+    a = addr.lower()
+    if a in EMAIL_ALLOW:
+        return True
+    return a.startswith(ROLE_PREFIXES) and a.endswith(ZAO_DOMAINS)
+
+
+def staged_added_lines() -> list[tuple[str, str]]:
+    """[(file, added_line)] from the staged diff. Added lines only - context lines
+    are already committed, and re-flagging them would make every commit near an
+    old address impossible."""
+    out = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--no-color"],
+        capture_output=True, text=True, check=False,
+    )
+    rows: list[tuple[str, str]] = []
+    current = "?"
+    for line in out.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+        elif line.startswith("+") and not line.startswith("+++"):
+            rows.append((current, line[1:]))
+    return rows
+
+
+def scan(rows: list[tuple[str, str]]) -> list[tuple[str, str, str, str]]:
+    """-> [(kind, file, match, line)]"""
+    found: list[tuple[str, str, str, str]] = []
+    for path, line in rows:
+        skip_numeric = bool(UUID_RE.search(line) or URL_RE.search(line))
+        for kind, (pat, guarded) in PATTERNS.items():
+            if guarded and skip_numeric:
+                continue
+            for m in re.findall(pat, line):
+                text = m if isinstance(m, str) else m[0]
+                if kind == "email" and email_allowed(text):
+                    continue
+                found.append((kind, path, text, line.strip()[:100]))
+    return found
+
+
+def main() -> int:
+    rows = staged_added_lines()
+    if not rows:
+        return 0
+    found = scan(rows)
+    if not found:
+        return 0
+
+    print("COMMIT BLOCKED - personal data in the staged diff\n", file=sys.stderr)
+    for kind, path, match, line in found:
+        print(f"  {kind:15} {path}", file=sys.stderr)
+        print(f"  {'':15} matched: {match}", file=sys.stderr)
+        print(f"  {'':15} line:    {line}", file=sys.stderr)
+        print(file=sys.stderr)
+    print(
+        "Third-party personal data must not be committed. Redact it, or add the\n"
+        "address to the allowlist in .claude/rules/pii-hygiene.md if it is a public\n"
+        "ZAO address. Raw query output belongs in ~/.zao/private/, never the repo.\n\n"
+        "If this is a false positive, that is a bug in the scanner worth fixing -\n"
+        "say so rather than bypassing, because a check people route around protects\n"
+        "nobody.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`.claude/rules/pii-hygiene.md` was written 2026-05-23 with the regexes, allowlists and pre-flight checks fully specified. **Its own line 153 says a pre-commit hook automating them "is a worthwhile follow-up."** It was never built - so for fifteen months the rule has been a manual checklist, which is exactly the shape that gets economised away on a busy day.

## Measurement came first, and it changed the design

The rule's seven patterns were run against **the last 40 commits on main** before a line was written:

| Pattern | Result |
|---|---|
| email | 2 hits, **both allowlisted** (`zoe-zao@agentmail.to`, `zoe@thezao.com`) |
| us_phone | 2 hits, **both false positives** - a UUID and a Kickstarter URL |
| card | 1 hit, false positive - the same UUID |
| intl_phone / street / birthdate | 0 |
| **tg_handle** | **86 hits across 14 of 40 commits** |

**So `@\w+` for Telegram handles is dropped, deliberately.** It fires on every `@mention` in a task table, every npm scope, every decorator. The rule's allowlist names six bot handles while this repo mentions teammates constantly, so no allowlist fixes it.

A check that fires on 35% of commits gets bypassed within a week - and takes the email check down with it. Six precise patterns beat seven nobody trusts. **Handle PII stays a human check, and this says so rather than implying coverage that doesn't exist.**

Phone and card keep the rule's regex but skip lines containing a UUID or a URL, because that is what every observed false positive was.

## A flaw in the rule itself, found by a test

Its `intl_phone` regex `\+\d{1,3}\s*\d{6,}` requires the digits to run together, so it **misses a normally formatted number like `+44 208 8901282`**. Widened to allow internal separators.

## Evidence

- **19/19 tests**, proving both directions: it catches a third-party email, a US phone in two formats, an international number, a street address, a birthdate and a card number - and stays silent on allowlisted addresses, ZAO role addresses, UUIDs, digits inside URLs, `@mentions`, version numbers and ports
- **0 of 40 real commits** would be blocked, re-verified after widening the regex
- End to end: staged PII exits 1, clean content exits 0
- Only **added** lines are scanned - context lines are already committed, and re-flagging them would make any commit near an old address impossible

Fails closed, per `silent-failure-guard` rule 5. Tests run without pytest, since this repo runs vitest and a test that cannot run in CI is indistinguishable from one that passes.
