### PR TITLE
fix(hooks): branch-guard should only inspect pushes, not every Bash call

### DIFF
--- a/.claude/skills/worksession/__tests__/test-branch-guard.sh
+++ b/.claude/skills/worksession/__tests__/test-branch-guard.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Tests for branch-guard.sh command scoping.
+#
+# Both halves must hold. A guard that stops blocking pushes to main is worse
+# than the noise it replaced, and a guard that still fires on `ls` is the bug
+# this change exists to fix.
+#
+# Run: bash .claude/skills/worksession/__tests__/test-branch-guard.sh
+set -u
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/branch-guard.sh"
+PASS=0; FAIL=0
+
+# A throwaway repo on `main`, so the guard has something real to inspect and the
+# test never depends on which branch the developer happens to be on.
+TMP=$(mktemp -d)
+git init --quiet -b main "$TMP"
+git -C "$TMP" commit --allow-empty --quiet -m init
+export PROJECT_DIR="$TMP"
+
+check() {  # check <label> <expected-exit> <command-string>
+  local label="$1" want="$2" cmd="$3"
+  local got
+  CLAUDE_TOOL_INPUT_command="$cmd" bash "$GUARD" >/dev/null 2>&1 </dev/null
+  got=$?
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL $label: want exit $want, got $got   (command: $cmd)"
+  fi
+}
+
+# --- MUST still block: a real push to main ---
+check "push to main"            1 "git push origin main"
+check "push, no args"           1 "git push"
+check "push inside a chain"     1 "npm run build && git push origin HEAD"
+check "push with -C"            1 "git -C /some/repo push origin main"
+
+# --- MUST NOT fire: ordinary commands, which is every command but a push ---
+check "ls"                      0 "ls -la"
+check "cat a file"              0 "cat README.md"
+check "git status"              0 "git status --short"
+check "git commit"              0 "git commit -m 'wip'"
+check "git log"                 0 "git log --oneline -5"
+check "npm test"                0 "npm run test"
+check "a command saying push"   0 "echo 'remember to git-push later' > notes.txt"
+
+# --- Fail closed: unreadable input still guards ---
+CLAUDE_TOOL_INPUT_command="" bash "$GUARD" >/dev/null 2>&1 </dev/null
+if [ $? = 1 ]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL empty-command: guard should fail closed on main, not open"
+fi
+
+# --- stdin JSON form, the way Claude Code actually passes it ---
+printf '{"tool_input":{"command":"git push origin main"}}' | bash "$GUARD" >/dev/null 2>&1
+if [ $? = 1 ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); echo "FAIL stdin-json push: should block"; fi
+printf '{"tool_input":{"command":"ls -la"}}' | bash "$GUARD" >/dev/null 2>&1
+if [ $? = 0 ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); echo "FAIL stdin-json ls: should pass"; fi
+
+rm -rf "$TMP"
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = "0" ]

--- a/.claude/skills/worksession/branch-guard.sh
+++ b/.claude/skills/worksession/branch-guard.sh
@@ -1,7 +1,51 @@
 #!/bin/bash
-# Branch guard — runs before git push to catch parallel session conflicts
-# Warns if: pushing to main, branch is behind remote, or not on a ws/ branch
-# Works in both regular checkouts and git worktrees
+# Branch guard - runs before git push to catch parallel session conflicts.
+# Warns if: pushing to main, branch is behind remote, or not on a ws/ branch.
+# Works in both regular checkouts and git worktrees.
+#
+# WHY THE COMMAND CHECK EXISTS (added 2026-08-10)
+#
+# This script's job was always "before git push" - its first line said so - but
+# it was wired to the Bash PreToolUse hook, which fires on EVERY Bash call. So
+# on `main` it exited 1 before `ls`, before `cat`, before every command, and the
+# session filled with "PreToolUse:Bash hook error / Failed with non-blocking
+# status code: No stderr output". Two costs, both real:
+#
+#   1. A guard that fires on the normal case is a guard people learn to ignore,
+#      and it drowns the one time it fires for a real reason
+#      (.claude/rules/noisy-signal-guard.md).
+#   2. It ran `git fetch` every time, so every shell command in this repo paid a
+#      network round-trip before it started.
+#
+# The fix is to check WHAT is being run, not just which branch we are on. A
+# non-push command is none of this guard's business, so it exits 0 immediately.
+# The guard is not weakened: every push still gets the full check.
+
+# The hook passes the tool call as JSON on stdin; Claude Code also exports the
+# command as CLAUDE_TOOL_INPUT_command. Accept either, and if NEITHER is
+# available, fall through to guarding (fail closed - a guard that silently
+# disables itself when it cannot read its input is worse than a noisy one).
+CMD="${CLAUDE_TOOL_INPUT_command:-}"
+if [ -z "$CMD" ] && [ ! -t 0 ]; then
+  STDIN=$(cat 2>/dev/null)
+  case "$STDIN" in
+    *'"command"'*)
+      CMD=$(printf '%s' "$STDIN" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)/\1/p' | head -1)
+      ;;
+    *) CMD="$STDIN" ;;
+  esac
+fi
+
+# Only a push is this guard's business. An empty CMD means we could not read the
+# command at all, so we guard anyway rather than open the gate.
+# Token boundaries matter here: a loose match treats the string "git-push" in a
+# sentence as a push and re-creates the false-positive problem in miniature. The
+# optional flag group covers `git -C /repo push` and `git --git-dir=x push`.
+if [ -n "$CMD" ]; then
+  if ! [[ "$CMD" =~ (^|[^[:alnum:]_.-])git([[:space:]]+(-[^[:space:]]+|[^[:space:]]+=[^[:space:]]*|/[^[:space:]]+))*[[:space:]]+push([[:space:]]|$) ]]; then
+    exit 0
+  fi
+fi
 
 cd "$PROJECT_DIR" 2>/dev/null || exit 0
 
@@ -17,14 +61,6 @@ fi
 # Warn if not on a ws/ branch (might be a shared feature branch)
 if [[ "$BRANCH" != ws/* ]]; then
   echo "WARNING: Branch '$BRANCH' is not a work session branch (ws/*). Another terminal might be on this branch. Consider using /worksession to create an isolated branch."
-fi
-
-# Check if we're in a worktree (informational)
-TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
-COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
-if [ "$COMMON_DIR" != ".git" ] && [ "$COMMON_DIR" != "$(git rev-parse --git-dir 2>/dev/null)" ]; then
-  # We're in a linked worktree — good, isolated
-  :
 fi
 
 # Check if remote branch exists and we're behind


### PR DESCRIPTION
## What changed

`branch-guard.sh` now checks **what command is running** before doing anything. If it is not a `git push`, it exits 0 immediately.

## Why this matters

The script's own first line says "runs before git push". It was wired to the **Bash** PreToolUse hook, which fires on **every** Bash call. So on `main` it exited 1 before `ls`, before `cat`, before every command - and the session filled with:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: No stderr output
```

That is what surfaced this: a Claude lane working on the ZABAL standings emitted nine of those in a single turn.

Two costs, and the first is the serious one:

1. **A guard that fires on the normal case is a guard people learn to ignore.** The one signal that matters - a real push to `main` - was drowning in its own noise. This is `.claude/rules/noisy-signal-guard.md` exactly: a check that cannot reach zero is not a check.
2. **Every shell command in this repo paid a network round-trip**, because the guard ran `git fetch` each time.

## Before / after

| | Before | After |
|---|---|---|
| `ls -la` on main | exit 1, hook error, plus a `git fetch` | exit 0, silent, no network |
| `git push origin main` | exit 1, blocked | exit 1, blocked - unchanged |
| Command unreadable | n/a | exit 1, **fails closed** |

## Not weakened

Every push still gets the full check. When the command cannot be read at all, the guard runs anyway rather than opening the gate - a guard that silently disables itself when it cannot read its input would be worse than a noisy one.

Token boundaries are deliberate: a loose match counted the string `git-push` inside a sentence as a push, which would have rebuilt the same false-positive problem in miniature.

## Evidence

```
$ bash .claude/skills/worksession/__tests__/test-branch-guard.sh
14 passed, 0 failed
```

14 cases: real pushes (bare, chained behind `&&`, with `-C <path>`), ordinary commands that must stay silent (`ls`, `cat`, `git status`, `git commit`, `git log`, `npm test`), prose mentioning a push, the stdin-JSON form Claude Code actually sends, and the fail-closed path.

Secret scan on the staged diff: clean (case-insensitive, run as its own step).

## Still open, needs your call - not changed here

`.claude/settings.json` also runs **`npm run typecheck` as a Bash PreToolUse hook**, meaning a full `tsc` before every single shell command in this repo. I have not touched it, because narrowing a verification gate is your decision, not mine. Worth deciding where it belongs - pre-commit, or on Edit/Write, rather than per-command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
