### PR TITLE
fix(hooks): run typecheck before a commit, not before every Bash call

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -145,7 +145,7 @@
           },
           {
             "type": "command",
-            "command": "cd \"$PROJECT_DIR\" && npm run typecheck 2>&1 | tail -10",
+            "command": "cd \"$PROJECT_DIR\" && bash .claude/skills/worksession/typecheck-guard.sh",
             "statusMessage": "Typechecking before push..."
           }
         ]

--- a/.claude/skills/worksession/__tests__/test-typecheck-guard.sh
+++ b/.claude/skills/worksession/__tests__/test-typecheck-guard.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Tests for typecheck-guard.sh command scoping.
+#
+# The guard must fire on a commit and stay silent on everything else. It must
+# also never report a pass it did not earn: a missing toolchain says so out loud
+# rather than exiting quietly as though the check succeeded.
+#
+# Run: bash .claude/skills/worksession/__tests__/test-typecheck-guard.sh
+set -u
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/typecheck-guard.sh"
+PASS=0; FAIL=0
+
+# An empty PROJECT_DIR with no node_modules, so the guard reaches its
+# skip-and-say-so path instead of running a real multi-minute tsc.
+TMP=$(mktemp -d)
+export PROJECT_DIR="$TMP"
+
+fires() {  # fires <label> <should-run> <command>
+  local label="$1" want="$2" cmd="$3" out
+  out=$(CLAUDE_TOOL_INPUT_command="$cmd" bash "$GUARD" 2>&1 </dev/null)
+  local ran=no
+  case "$out" in *"TYPECHECK"*) ran=yes ;; esac
+  if [ "$ran" = "$want" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL $label: expected ran=$want got=$ran   (command: $cmd)"
+  fi
+}
+
+# --- MUST run on a commit ---
+fires "plain commit"          yes "git commit -m 'wip'"
+fires "commit with flags"     yes "git commit --amend"
+fires "commit in a chain"     yes "git add . && git commit -m 'x'"
+fires "commit with -C"        yes "git -C /some/repo commit -m 'x'"
+
+# --- MUST stay silent on everything else ---
+fires "ls"                    no  "ls -la"
+fires "git status"            no  "git status --short"
+fires "git push"              no  "git push origin HEAD"
+fires "npm test"              no  "npm run test"
+fires "word in a message"     no  "echo 'this commit was fine' > notes.txt"
+fires "a path named commit"   no  "cat docs/commit-style.md"
+
+# --- Missing toolchain must be LOUD, and must not claim a pass ---
+out=$(CLAUDE_TOOL_INPUT_command="git commit -m x" bash "$GUARD" 2>&1 </dev/null)
+case "$out" in
+  *"NOT a passing typecheck"*) PASS=$((PASS + 1)) ;;
+  *) FAIL=$((FAIL + 1)); echo "FAIL missing-toolchain: must say it verified nothing" ;;
+esac
+
+# --- stdin JSON form ---
+out=$(printf '{"tool_input":{"command":"git commit -m x"}}' | bash "$GUARD" 2>&1)
+case "$out" in
+  *TYPECHECK*) PASS=$((PASS + 1)) ;;
+  *) FAIL=$((FAIL + 1)); echo "FAIL stdin-json commit: should fire" ;;
+esac
+out=$(printf '{"tool_input":{"command":"ls -la"}}' | bash "$GUARD" 2>&1)
+if [ -z "$out" ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); echo "FAIL stdin-json ls: should be silent"; fi
+
+rmdir "$TMP" 2>/dev/null
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" = "0" ]

--- a/.claude/skills/worksession/typecheck-guard.sh
+++ b/.claude/skills/worksession/typecheck-guard.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Typecheck guard - run `npm run typecheck` before a COMMIT, not before every
+# shell command.
+#
+# WHY THIS EXISTS
+#
+# `npm run typecheck` was wired directly to the Bash PreToolUse hook, so a full
+# `tsc` ran before every single Bash call in this repo - before `ls`, before
+# `git status`, before `echo`. Two problems, and the second is the one that
+# actually costs you:
+#
+#   1. Cost. A full typecheck ahead of every command, most of which touch no
+#      TypeScript at all.
+#   2. Signal. It failed constantly (a machine with an unpopulated
+#      bot/node_modules produces hundreds of phantom errors), so its output
+#      became background noise and stopped being read. That is how a repo learns
+#      to measure "no NEW errors" instead of "no errors" - and three real bugs
+#      once sat inside that noise (.claude/rules/noisy-signal-guard.md).
+#
+# A typecheck is worth running when code is about to be COMMITTED. That is the
+# moment it protects. Same coverage, none of the per-command tax.
+#
+# Sibling of branch-guard.sh, which had the identical shape of bug.
+
+CMD="${CLAUDE_TOOL_INPUT_command:-}"
+if [ -z "$CMD" ] && [ ! -t 0 ]; then
+  STDIN=$(cat 2>/dev/null)
+  case "$STDIN" in
+    *'"command"'*)
+      CMD=$(printf '%s' "$STDIN" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)/\1/p' | head -1)
+      ;;
+    *) CMD="$STDIN" ;;
+  esac
+fi
+
+# Only a commit is this guard's business. Token boundaries are deliberate: a
+# loose match would count the word "commit" inside a message or a filename and
+# rebuild the same fires-on-everything problem in a new place.
+[ -z "$CMD" ] && exit 0
+if ! [[ "$CMD" =~ (^|[^[:alnum:]_.-])git([[:space:]]+(-[^[:space:]]+|[^[:space:]]+=[^[:space:]]*|/[^[:space:]]+))*[[:space:]]+commit([[:space:]]|$) ]]; then
+  exit 0
+fi
+
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# A missing toolchain is a FAIL, not a pass - a verifier that cannot run must
+# never fall through green (.claude/rules/silent-failure-guard.md rule 3). But
+# an unpopulated node_modules is an environment problem, not a code problem, and
+# blocking every commit on it would be its own noise. So: say so loudly, and let
+# the commit proceed rather than pretending the check passed.
+if [ ! -d node_modules/typescript ]; then
+  echo "TYPECHECK SKIPPED: node_modules/typescript is missing - run 'npm install'."
+  echo "This is NOT a passing typecheck. Nothing was verified."
+  exit 0
+fi
+
+OUT=$(npm run typecheck 2>&1)
+STATUS=$?
+if [ "$STATUS" != "0" ]; then
+  echo "TYPECHECK FAILED before commit:"
+  echo "$OUT" | tail -20
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## What changed

`npm run typecheck` moves off the per-Bash-call hook and behind a command-aware guard that only fires on a commit.

Follows #3030, which fixed the identical bug in `branch-guard.sh`. Same root cause: a check wired to **Bash** when it meant **a specific kind of Bash**.

## Why

A full `tsc` ran before **every single Bash call** in this repo. Before `ls`. Before `git status`. Before `echo`.

Two costs, and the second is the one that actually hurt:

1. **Cost.** Most commands touch no TypeScript at all, and every one of them waited for a full typecheck first.
2. **Signal.** It failed constantly - a machine with an unpopulated `bot/node_modules` produces hundreds of phantom errors - so its output became background noise and stopped being read. That is precisely how this repo learned to measure *"no NEW errors"* instead of *"no errors"*, and three real bugs once sat inside that noise. See `.claude/rules/noisy-signal-guard.md`, which was written about this exact failure.

A typecheck earns its cost at the moment code is about to be committed. That is when it protects something.

## Before / after

| | Before | After |
|---|---|---|
| `ls -la` | full `tsc` first | silent, instant |
| `git status` | full `tsc` first | silent, instant |
| `git commit -m "..."` | full `tsc` | full `tsc` - unchanged |
| `node_modules` missing | hundreds of phantom errors, ignored | says it verified NOTHING, loudly |

## The missing-toolchain case, deliberately

If `node_modules/typescript` is absent, the guard **states that nothing was verified** rather than exiting quietly as though it had passed (`.claude/rules/silent-failure-guard.md` rule 3: a missing verifier is a fail, not a pass).

It does not block the commit, because an unpopulated `node_modules` is an environment problem rather than a code problem, and blocking every commit on it would be its own noise. The line it prints cannot be mistaken for a green run:

```
TYPECHECK SKIPPED: node_modules/typescript is missing - run 'npm install'.
This is NOT a passing typecheck. Nothing was verified.
```

## Evidence

```
$ bash .claude/skills/worksession/__tests__/test-typecheck-guard.sh
13 passed, 0 failed
```

Commits fire (plain, `--amend`, chained behind `&&`, with `-C <path>`). `ls`, `git status`, `git push`, `npm test`, and the word "commit" appearing in a message or a filename all stay silent. The missing-toolchain path is asserted to announce itself rather than pass quietly.

Secret scan on the staged diff: clean, run as its own step. `.claude/settings.json` re-validated as parseable JSON after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9
