### PR TITLE
fix(agents): stop telling the CEO and researcher agents to monitor a retired partner

### DIFF
--- a/agents/ceo/HEARTBEAT.md
+++ b/agents/ceo/HEARTBEAT.md
@@ -24,7 +24,6 @@ Run this checklist on every heartbeat cycle. This covers local planning and orga
 - Review Respect leaderboard for governance health (`src/lib/respect/leaderboard.ts`)
 - Check partner platform status:
   - Incented campaigns: `incented.co/organizations/zabal`
-  - SongJam leaderboard: `songjam.space/zabal`
   - Empire Builder: ZABAL empire activity
 - Note any community issues, trending topics, or opportunities
 

--- a/agents/ceo/PERSONA.md
+++ b/agents/ceo/PERSONA.md
@@ -14,7 +14,7 @@ The ZAO is a 100+ member gated Farcaster community. Your job is to grow it to 20
 - **Chain:** Optimism (governance), Base (rewards/$ZABAL), Solana (WaveWarZ)
 - **Research:** 67 research docs in `research/` — start with `research/50-the-zao-complete-guide/`
 - **Config:** All branding, channels, contracts in `community.config.ts`
-- **Partners:** MAGNETIQ (Proof of Meet), SongJam (leaderboard), Empire Builder (token rewards), Incented (campaigns), Clanker ($ZABAL launcher)
+- **Partners:** MAGNETIQ (Proof of Meet), Empire Builder (token rewards), Incented (campaigns), Clanker ($ZABAL launcher)
 
 ## Memory and Planning
 

--- a/agents/ceo/SOUL.md
+++ b/agents/ceo/SOUL.md
@@ -14,7 +14,7 @@ You are Zaal's digital twin. You think like a founder who cares deeply about com
 - **Music is the mission.** Every decision should be filtered through: "Does this help independent artists?"
 - **Build in public.** Document everything. Every decision is content. Every mistake is a lesson to share.
 - **Respect is governance.** The weekly fractal meeting (Respect Game) is the heartbeat of the community. Protect it.
-- **Partners are family.** MAGNETIQ, SongJam, Empire Builder, Incented — these are collaborators, not vendors. Treat them accordingly.
+- **Partners are family.** MAGNETIQ, Empire Builder, Incented — these are collaborators, not vendors. Treat them accordingly.
 - **Forks are features.** ZAO OS is MIT-licensed and fork-friendly. Every community deserves its own OS.
 - Default to action over deliberation. Sprint on two-way decisions; deliberate on one-way ones.
 - Guard focus relentlessly. Reject low-impact work. Excessive priorities damage more than one wrong bet.

--- a/agents/ceo/TOOLS.md
+++ b/agents/ceo/TOOLS.md
@@ -69,7 +69,6 @@ npm run lint         # ESLint
 | Platform | URL | What |
 |----------|-----|------|
 | Incented | `incented.co/organizations/zabal` | Community campaigns |
-| SongJam | `songjam.space/zabal` | Mention leaderboard |
 | Empire Builder | `empirebuilder.world/profile/0x7234c...` | Token empire |
 | MAGNETIQ | `app.magnetiq.xyz` | Proof of Meet hub |
 | Clanker | `clanker.world` | $ZABAL token launcher |

--- a/agents/researcher/HEARTBEAT.md
+++ b/agents/researcher/HEARTBEAT.md
@@ -33,7 +33,7 @@ If no assigned tasks, scan for research opportunities:
 - Check if any research docs reference stale information (doc count, feature status)
 - Check if `community.config.ts` has changed since last scan (new features = need docs)
 - Check if `src/app/api/` has new routes not covered by research
-- Check if any partner platforms (MAGNETIQ, SongJam, Empire Builder, Incented, Clanker) have updates
+- Check if any partner platforms (MAGNETIQ, Empire Builder, Incented, Clanker) have updates
 - Check Farcaster ecosystem for new developments relevant to ZAO
 
 If you find something, create a subtask for yourself (with `parentId` and `goalId`).
@@ -64,7 +64,7 @@ On every 5th heartbeat, run a maintenance check:
 ## Research Priorities (Current)
 
 1. Any topic the CEO or Board assigns
-2. Partner platform updates (MAGNETIQ, SongJam, Empire Builder, Incented, Clanker)
+2. Partner platform updates (MAGNETIQ, Empire Builder, Incented, Clanker)
 3. Farcaster ecosystem changes (protocol updates, new clients, Neynar changes)
 4. Technology updates (Next.js, Supabase, XMTP, Wagmi/Viem)
 5. Competitive landscape (other music DAOs, social clients, creator tools)

--- a/agents/researcher/TOOLS.md
+++ b/agents/researcher/TOOLS.md
@@ -90,7 +90,6 @@ You have READ-ONLY access to the codebase plus web research:
 | Platform | URL | What to Watch |
 |----------|-----|--------------|
 | Incented | incented.co/organizations/zabal | New campaigns, protocol updates |
-| SongJam | songjam.space/zabal | Leaderboard changes, $SANG updates |
 | Empire Builder | empirebuilder.world | Empire features, Clanker integration |
 | MAGNETIQ | magnetiq.xyz | API release, POM updates |
 | Clanker | clanker.world | Protocol changes (now owned by Neynar) |


### PR DESCRIPTION
## What was wrong

SongJam was retired on 2026-07-31. **Six live references survived in the agent instruction files**, so both agents have been carrying a dead partner in their working context ever since:

- `agents/ceo/TOOLS.md` - a tools row pointing at `songjam.space/zabal`
- `agents/ceo/HEARTBEAT.md` - the same leaderboard, checked every cycle
- `agents/researcher/TOOLS.md` - listed as the source for "$SANG updates"
- `agents/researcher/HEARTBEAT.md` - named twice in the partner-platform check
- `agents/ceo/SOUL.md` and `PERSONA.md` - called it family

An agent told to check a dead partner every heartbeat either wastes the call or reports on it as though the relationship were live.

## Magnetiq deliberately kept

The original retirement note covered both, but that was **corrected**: the Magnetiq *platform* stays and is still the collectible rail - `collect.zabalgamez.com` redirects to it. Only the partnership ended. Every Magnetiq reference is untouched here.

$SANG went with SongJam, since it was defined solely as SongJam's token.

## Scope note

`agents/` now has **zero** SongJam references.

The `loops.house` hits found in the same sweep were **left alone on purpose** - they sit in dated research docs that record what was true at the time. Scrubbing history is not the same as removing live copy.

## How it was found

An authorised overnight sweep of the public repo estate for retired-brand references. Same sweep found `bettercallzaal/zabalbot` still searching Farcaster for `sang` and `songjam` in live code - that is a separate PR against that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9