### PR TITLE
docs: CLAUDE.md was wrong about this repo, including about itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The pattern: **Monorepo as Lab.**
 - Sharing model: clone, no deps. Each graduate stands alone.
 - Research stays in ZAOOS forever - it's the institutional memory across every product.
 
-**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (spinning out to its own repo), agent stack (ZOE, the orchestrator), music player components, ~1,275 active research docs. 322 API routes, 296 components, 18 hooks. (Counts verified 2026-07-31 - see [Doc 836](research/infrastructure/836-zaoos-repo-estate-census/).)
+**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (spinning out to its own repo), agent stack (ZOE, the orchestrator), music player components, ~2,020 active research docs. 324 API routes, 296 components, 18 hooks. (Counts verified 2026-08-11 - see [Doc 836](research/infrastructure/836-zaoos-repo-estate-census/).)
 
 **Stack:** Next.js 16, React 19, Supabase (RLS), Neynar, XMTP, Stream.io, Wagmi/Viem, Tailwind v4, iron-session.
 
@@ -25,15 +25,15 @@ The pattern: **Monorepo as Lab.**
 
 | Directory | What | When to Read |
 |-----------|------|-------------|
-| `src/app/api/` | 322 route handlers across 55 domains | Working on backend |
+| `src/app/api/` | 324 route handlers across 62 domains | Working on backend |
 | `src/components/` | 296 components by feature | Working on UI |
-| `src/hooks/` | 20 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
-| `src/lib/` | Utils across 42 domains: auth, db, farcaster, music, publish, agents | Working on business logic |
+| `src/hooks/` | 18 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
+| `src/lib/` | Utils across 58 domains: auth, db, farcaster, music, publish, agents | Working on business logic |
 | `src/lib/agents/` | VAULT/BANKER/DEALER autonomous trading bots | Working on agents |
 | `src/lib/publish/` | Cross-platform posting (Farcaster, X, Bluesky) | Working on distribution |
 | `src/providers/` | Audio player, contexts | Working on player |
 | `community.config.ts` | All branding, channels, admin FIDs, contract addresses, nav | Forking or configuring |
-| `research/` | ~1,275 active research docs (see research/README.md) | Use grep, not bulk reads |
+| `research/` | ~2,020 active research docs (see research/README.md) | Use grep, not bulk reads |
 | `scripts/` | SQL migrations, wallet generation, webhook setup | DB or infra work |
 
 ## Quick Start


### PR DESCRIPTION
Every session loads `CLAUDE.md` first, so its numbers shape what an agent believes **before it reads a single file**. Five were stale, and one pair contradicted each other in the same document.

## The one that matters

It claimed **~1,275 active research docs**. There are **2,023**.

Being 59% low on the size of the research corpus feeds the exact failure this repo keeps hitting: an agent that thinks the corpus is smaller than it is reaches for *build it* instead of *search for it first*. That happened three times today, twice to me - I proposed building a research index and a ZOE capability map that already had homes, and earlier built a `/rename` command Claude Code already ships.

## The self-contradiction

The prose said **18 hooks**. The project-map table, six lines later, said **20 custom hooks**. There are 18.

## Measured 2026-08-11, by counting the tree

| | claimed | actual |
|---|---|---|
| research docs | ~1,275 | **2,023** (25 topic folders) |
| API routes | 322 | **324** |
| API domains | 55 | **62** |
| `src/lib` domains | 42 | **58** |
| hooks | 20 (table) | **18** |
| components | 296 | 296 - the one that held |

## How it was found

An authorised overnight sweep for claims the code contradicts. The verification date moves to today so the next drift is visible rather than silently inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nLSQNtRcd1iSt6nsZC6V9