### PR TITLE
radar: revalidate doc 684 (new: circle_id FK unimplemented, Aug 15 deadline in 4 days)

### DIFF
--- a/research/_radar/2026-08-11.md
+++ b/research/_radar/2026-08-11.md
@@ -1,0 +1,1 @@
+ATTENTION: doc 684 (zaostock-task-tracking-circles-connection) - circle_id FK still absent from todos table; Aug 15 dry-run migration deadline is 4 days away - sources checked: bot/src/actions.ts, bot/src/circles.ts, scripts/stock-archive/2026-04-25-applied/stock-circles-v1-migration.sql (all via live repo grep, 2026-08-11)

--- a/research/events/684-zaostock-task-tracking-circles-connection/README.md
+++ b/research/events/684-zaostock-task-tracking-circles-connection/README.md
@@ -2,7 +2,7 @@
 topic: events
 type: decision
 status: research-complete
-last-validated: 2026-05-20
+last-validated: 2026-08-11
 superseded-by:
 related-docs: 609, 650, 662, 672, 677, 679, 682
 tier: QUICK
@@ -11,6 +11,10 @@ tier: QUICK
 # 684 — ZAOstock Task Tracking: The Fragmentation + Connecting It to the Six Circles
 
 > **Goal:** Answer "how are ZAOstock todos stored, and can we connect them to the cobuild six circles." Ground truth from code: todos live in three disconnected stores, none of which is linked to a circle. Recommend the FK + the canonical-store split.
+
+## Findings
+
+Updated 2026-08-11: Code re-verified against live repo. The primary recommendation (add `circle_id uuid REFERENCES circles(id)` to the `todos` table) remains **unimplemented**. `bot/src/actions.ts` `add_todo` has no `circle` field; `bot/src/circles.ts` uses `circle_id` only for `circle_members` (membership), not for todos. The `stock-circles-v1-migration.sql` (applied 2026-04-25) added `circle_id` to `stock_circle_members`, `stock_proposals`, and `stock_qa_log` — but NOT to `stock_todos`. The disconnect is unchanged. No external sources exist for this internal ZAO tooling topic. **ATTENTION: the "Before Aug 15 dry run" migration deadline from the Next Actions table is now 4 days away (2026-08-11 → Aug 15).**
 
 ## Key Decisions (recommendations first)
 
@@ -97,7 +101,8 @@ Correct behavior: a bulk-todo paste should result in the items added and one sho
 
 ## Sources
 
-- ZAOstock bot code: `bot/src/actions.ts` (`add_todo` -> `todos` table), `bot/src/status.ts` (`buildAllOpenTodos`, `buildStatus`), `bot/src/circles.ts` (six-circle commands), `bot/src/capture.ts` (`/gemba /idea /note`)
+- ZAOstock bot code: `bot/src/actions.ts` (`add_todo` -> `todos` table), `bot/src/status.ts` (`buildAllOpenTodos`, `buildStatus`), `bot/src/circles.ts` (six-circle commands), `bot/src/capture.ts` (`/gemba /idea /note`) — re-verified 2026-08-11
 - `Documents/cowork/data/actions.json` - cowork-zaodevz tracker shape, verified 2026-05-20
 - `Documents/iman/data/actions.json` - stale duplicate, `updatedAt 2026-05-06` vs cowork `2026-05-14`, verified 2026-05-20
 - Doc 609 (six circles), Doc 679 (cowork bot audit, finding A1 = bot code uncommitted)
+- `scripts/stock-archive/2026-04-25-applied/stock-circles-v1-migration.sql` — confirmed circle_id added to circle_members/proposals/qa_log but NOT todos, re-verified 2026-08-11


### PR DESCRIPTION
## Radar Revalidation — Doc 684

**Doc:** `research/events/684-zaostock-task-tracking-circles-connection/README.md`
**Last validated:** 2026-05-20 → **2026-08-11** (83 days stale)

---

### What was checked

Re-verified the doc's primary recommendation against the live codebase:

- `bot/src/actions.ts` — `add_todo` handler has no `circle` field or `circle_id` column reference
- `bot/src/circles.ts` — `circle_id` is used only for `circle_members` (membership), never for `todos`
- `scripts/stock-archive/2026-04-25-applied/stock-circles-v1-migration.sql` — `circle_id` was added to `stock_circle_members`, `stock_proposals`, and `stock_qa_log` in April, but **not to `stock_todos`**

External search found no relevant results (ZAOstock is a private internal event, not publicly indexed).

---

### Key finding — ATTENTION

The doc's primary recommendation (**add `circle_id uuid REFERENCES circles(id)` to the `todos` table**) is **still unimplemented** as of 2026-08-11.

The Next Actions table lists this migration as due **"Before Aug 15 dry run"** — that is **4 days from today**. The full chain (migration → write path in `actions.ts` → `/circle` read command → backfill) depends on this first step.

---

### Changes in this PR

1. `research/events/684-zaostock-task-tracking-circles-connection/README.md` — bumped `last-validated` to 2026-08-11, added Findings note with verification evidence and ATTENTION flag
2. `research/_radar/2026-08-11.md` — created daily radar log with ATTENTION prefix

---

**Do NOT merge without Zaal review.** This is a radar-only PR (no code changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSSZknuVpbymmtBypvpH8g)_