### PR TITLE
docs: session state 2026-08-11 (doc 2265) + fix the hook that blocked all Bash

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -129,7 +129,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$PROJECT_DIR\" && STAGED=$(git diff --cached --name-only --diff-filter=d | grep -E '\\.(ts|tsx)$' | tr '\\n' ' '); if [ -n \"$STAGED\" ]; then npx eslint --max-warnings 10 $STAGED 2>&1 | tail -20; fi",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && STAGED=$(git diff --cached --name-only --diff-filter=d | grep -E '\\.(ts|tsx)$' | tr '\\n' ' '); if [ -n \"$STAGED\" ]; then npx eslint --max-warnings 10 $STAGED 2>&1 | tail -20; fi",
             "statusMessage": "Linting staged files..."
           }
         ]
@@ -140,12 +140,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$PROJECT_DIR\" && bash .claude/skills/worksession/branch-guard.sh",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && bash .claude/skills/worksession/branch-guard.sh",
             "statusMessage": "Checking branch safety..."
           },
           {
             "type": "command",
-            "command": "cd \"$PROJECT_DIR\" && bash .claude/skills/worksession/typecheck-guard.sh",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && bash .claude/skills/worksession/typecheck-guard.sh",
             "statusMessage": "Typechecking before push..."
           }
         ]
@@ -155,7 +155,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$PROJECT_DIR/scripts/check-pipeline-exit.py\" --hook"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/check-pipeline-exit.py\" --hook"
           }
         ]
       }
@@ -178,7 +178,7 @@
           {
             "type": "command",
             "if": "Edit(src/**/*.ts)|Edit(src/**/*.tsx)|Write(src/**/*.ts)|Write(src/**/*.tsx)",
-            "command": "cd \"$PROJECT_DIR\" && npx eslint --fix \"$TOOL_ARG_FILE_PATH\" 2>/dev/null; exit 0",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && npx eslint --fix \"$TOOL_ARG_FILE_PATH\" 2>/dev/null; exit 0",
             "statusMessage": "Auto-formatting..."
           }
         ]
@@ -189,7 +189,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$PROJECT_DIR\" && BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [[ \"$BRANCH\" != ws/* ]]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"SessionStart\\\",\\\"additionalContext\\\":\\\"WARNING: You are on branch [$BRANCH], not a ws/ worksession branch. CLAUDE.md requires running /worksession at session start to create an isolated branch. Invoke /worksession NOW before doing any work.\\\"}}\"; fi",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [[ \"$BRANCH\" != ws/* ]]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"SessionStart\\\",\\\"additionalContext\\\":\\\"WARNING: You are on branch [$BRANCH], not a ws/ worksession branch. CLAUDE.md requires running /worksession at session start to create an isolated branch. Invoke /worksession NOW before doing any work.\\\"}}\"; fi",
             "statusMessage": "Checking worksession branch..."
           },
           {

--- a/research/infrastructure/2265-session-2026-08-11-state/README.md
+++ b/research/infrastructure/2265-session-2026-08-11-state/README.md
@@ -1,0 +1,119 @@
+---
+topic: infrastructure
+type: incident-postmortem
+status: research-complete
+last-validated: 2026-08-11
+related-docs: "2258, 2255, 2247"
+original-query: "Can u push all context to repo and then compact - preserve this session's verified state and errors before the context window is compacted"
+tier: STANDARD
+---
+
+# 2265 - Session state, 2026-08-11: what shipped, what is verified, what I got wrong
+
+> **Goal:** Carry this session's facts into the repo so the next session does not
+> re-derive them, and record the errors so they are not repeated.
+
+## Key decisions locked today
+
+| Decision | Detail |
+|---|---|
+| **Season 1 voting is retired** | The month-two ballot gauged opinion; it was never how finalists are chosen. `data/vote-candidates.json` status `closed`, `/vote` 307s to `/leaderboard`, no tallies render anywhere |
+| **Six finalists, three winners** | Two per track picked by Zaal. Three win, one per track. Never stated on the site before today |
+| **The prize is 500 USDC, split six ways** | Nothing else. The site had promised "top 8 share, top 16 get $ZABAL" - impossible with 6 finalists and 15 entrants |
+| **Points are awarded MANUALLY** | Zaal taps `/award`. Never build automatic accrual - see `feedback_points_are_awarded_manually` |
+| **Stale grill cards nag MORE, not less** | Zaal: "we need to clear old ones so always send them, keep reminding, the older the more frequent." Do NOT expire them |
+| **No submission is a "draft"** | Each entry is where that person is at. The shaming framing is cut everywhere |
+
+## Verified facts - do NOT re-derive these
+
+**The agent bus** (`~/.zao/private/zao-bus-server.js` on the VPS)
+- It is **HTTPS**, `https.createServer`, self-signed cert at `~/.zao/private/zao-bus-cert.pem`,
+  bound `127.0.0.1:8790`. The runbook saying `BUS_URL=http://...` is **WRONG** and produces
+  "Empty reply from server", which reads as a dead service. Use `curl -k https://`.
+- `/bus/health` requires auth (returns `{"error":"Unauthorized"}`), so it is useless as a probe.
+- Partners: zao, jim, brandon, sam. **Total messages: one**, `zao -> zao`, a self-test.
+  There is no swarm traffic to watch (task #74).
+
+**ZOE's Claude auth**
+- `~/.claude/.credentials.json` on the VPS carries an `expiresAt` of **2026-08-08T07:51 UTC**.
+  Expired three and a half days ago. There is **no ANTHROPIC_API_KEY** in `zao.env`, so ZOE runs
+  entirely on that OAuth session. Fix is interactive: `ssh vps`, `claude`, `/login`.
+- Both ZOE paths 401 - `decompose` (the bus) and `concierge` (replies). Every reply since Friday
+  got "Got it" and then silently failed. Nothing alerted anyone for 3.5 days.
+
+**The machines**
+| Node | Tailnet | State |
+|---|---|---|
+| macbook-air-3 | 100.81.77.87 | **sshd OFF (0 listeners on 22)**, sleeps, holds ALL 8 tmux lanes |
+| ansuz (Pi) | 100.117.191.11 | up |
+| desktop-h2ov6da | 100.72.152.63 | up |
+| srv1073120 | 100.121.237.35 | **UNIDENTIFIED - find out what this is** |
+| VPS srv1537940 | **NOT in tailnet** | 31.97.148.88, runs ZOE + the bus |
+
+The always-on box is unreachable privately; the sleeping laptop is on the tailnet but refuses
+connections. That inversion is the root of the "can't reach anything from Blink" problem.
+
+**Vendor lock-in, ranked by "is the only copy inside the vendor"**
+1. **Upstash KV** - was the emergency. Now exported nightly (PRs #615/#617/#618). Needs the
+   `ADMIN_KEY` repo secret, which Zaal set.
+2. **Paragraph** - 366 editions, alpha API, OAuth-bound. Same treatment would work.
+3. Vercel / Supabase / Neynar - rentable, data is portable.
+4. Anthropic - plan around the cap, not the exit.
+
+**Claude account switch** - lost on switch: every `claude_ai_*` connector (Gmail, Calendar,
+Drive, Slack, Linear, Notion, Dropbox, Canva, Calendly) plus **Paragraph**. Survives: Supabase,
+Serena, context7, Playwright, Dune, grep, Exa, GitHub.
+
+**Counts as of tonight**: 30 real projects (the 2 QA fixtures are now filtered), 15 on the
+points board, **32 recordings** (not 33 - see below), 55 keys in the KV backup.
+
+## Errors I made, so they are not repeated
+
+1. **Trusted a `count` field over the array it described.** `recordings/index.json` carried
+   `count: 33` while holding 32. That wrong number reached a published newsletter, the thread
+   and the kit. `edition-facts.sh` now counts the list and warns on disagreement.
+2. **Ran a Python script with `bash`.** `~/bin/zao-fetch-reddit.sh` is Python. It returned 0
+   bytes, I concluded Reddit was IP-blocked, and researched the wrong project for an hour.
+3. **`git add -A` twice**, sweeping unrelated files into PRs; then a `reset --hard` deleted
+   `AUGUST-LANE-BRIEF.md` after I had said it would survive. Recovered from the commit.
+4. **Committed to the wrong branch** - `ws/research-poidh-propagation`, the branch behind an
+   open PR - because `git checkout -b` failed silently and I did not check.
+5. **Declared a lane's prompt failed** after checking the pane 3 seconds in. It had landed.
+6. **A programmatic conflict resolution silently dropped a feature.** Resolving `zao-tracker`
+   took "theirs" for every block, but the block whose HEAD side was empty did not match the
+   pattern, dropping `REPO_SLUG="$repo"`. Zero conflict markers, clean `bash -n`, and `--repo`
+   would have silently done nothing. Caught only by tracing the flag end to end.
+
+The through-line: **a green check is not evidence.** Count the thing, do not read the label.
+
+## Also fixed tonight
+
+`.claude/settings.json` used `$PROJECT_DIR`, which Claude Code does not set. Six occurrences,
+all resolving empty. The unconditional Bash hook therefore ran `python3 "/scripts/..."`, failed,
+and **blocked every Bash call in this repo**. The other five hooks - commit linter, branch
+guard, typecheck guard, eslint auto-format, worksession check - had been failing silently for
+who knows how long. Now `$CLAUDE_PROJECT_DIR`. The pipeline guard it gates caught two real
+`$?`-after-pipeline bugs within minutes of coming back.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| `ssh vps` then `claude` then `/login` - revives ZOE, the grill and the bus | @Zaal | Task | 2026-08-12 |
+| Award Dee a point at `/award` - first real test, and it creates `points:tally` | @Zaal | Task | 2026-08-12 |
+| Merge zaal-dotfiles#17 (conflicts resolved, MERGEABLE) | @Zaal | PR | 2026-08-12 |
+| Post the thread, X post and 14 DMs - written, URL filled in | @Zaal | Outreach | 2026-08-12 |
+| Make the pinned TG message surface a ZOE 401 instead of a grill count | @Zaal | PR | 2026-08-14 |
+| Grill: remove buttons once answered; older cards nag more often (#91) | @Zaal | PR | 2026-08-14 |
+| Verify T3 Code, try `npx t3 connect` on the VPS (#90) | @Zaal | Research | 2026-08-14 |
+| Identify `srv1073120` on the tailnet | @Zaal | Task | 2026-08-15 |
+| Fix `zao-vault-log` - logs "0 shipped items" on a 20-PR day, or delete the cron | @Zaal | PR | 2026-08-15 |
+| Verify `zao-spend` cost arithmetic - reports ~10x the token maths | @Zaal | PR | 2026-08-15 |
+
+## Sources
+
+- 24 PRs merged in `ZAODEVZ/zabalgames` on 2026-08-11 (#598-#619).
+- Live reads of `/api/points`, `/api/submissions?feed=projects`, `/recordings/index.json`,
+  `/data/vote-candidates.json`, and the KV export, all 2026-08-11.
+- `~/.zao/handoffs/2026-08-11-research-brief.md` and `2026-08-11-mac-independence.md` - the
+  two lane briefs, carrying the same facts to the `zaoresearch` and `alwayson` lanes.

--- a/research/infrastructure/README.md
+++ b/research/infrastructure/README.md
@@ -123,3 +123,4 @@
 | 2251 | [The Graph for ZAO: not yet, and here is the exact trigger](./2251-the-graph-subgraphs-for-zao/) | STANDALONE | Decide whether ZAO should index its on-chain data with The Graph, |
 | 2263 | [The research library graduated, and the two calls are still open](./2263-zaoresearch-graduation-decision/) | STANDALONE | Answer IMan's two questions about the ZAOresearch migration, and verify the claims in the handover PDF against the live repos rather than accepting them. |
 | 2264 | [What has to change for the ecosystem to survive the Mac being offline](./2264-mac-offline-always-on-migration/) | STANDALONE | Decide, per capability, where it lives when the Mac is shut - based on an exhaustive inventory of what only exists on the Mac today, not on an assumption about what is missing. |
+| 2265 | [Session state, 2026-08-11: what shipped, what is verified, what I got wrong](./2265-session-2026-08-11-state/) | STANDARD | 2026-08-11 |


### PR DESCRIPTION
Two things that must not be lost to a compact.

## 1. The hook that blocked every Bash call

`.claude/settings.json` used `$PROJECT_DIR`, which Claude Code does not set - the real variable is `$CLAUDE_PROJECT_DIR`. Six occurrences, all resolving empty.

The unconditional Bash hook ran `python3 "/scripts/check-pipeline-exit.py"`, failed, and **blocked every Bash call in this repo**. The other five hooks - commit linter, branch guard, typecheck guard, eslint auto-format, worksession check - had been failing silently.

Approved explicitly by Zaal. Once restored, the pipeline guard **caught two real `$?`-after-pipeline bugs within minutes**.

## 2. Doc 2265 - session state

So the next session does not re-derive it:

- The agent bus is **HTTPS**, not HTTP. The runbook is wrong and its symptom reads as a dead service.
- **ZOE's Claude token expired 2026-08-08** with no API-key fallback. 3.5 days of silent 401s.
- The Mac has **sshd off** while the VPS is **not in the tailnet**.
- Vendor lock-in ranked by "is the only copy inside the vendor".
- **The six errors I made today**, including a conflict resolution that dropped a feature while showing zero conflict markers and passing a syntax check.

## Note on the PII hook

It blocked the first commit, reading the Unix timestamp `1786175499992` as a US phone number. Reported rather than bypassed. The raw value added nothing the date did not, so it is gone - but the scanner is worth tightening, because a 13-digit epoch is not a phone number and a check that cries wolf is one people learn to route around.