### PR TITLE
fix(zoe): an answered grill card keeps its buttons, and an old one goes quiet

### DIFF
--- a/bot/src/zoe/__tests__/grill.test.ts
+++ b/bot/src/zoe/__tests__/grill.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   toQueue,
   pickNext,
+  askCooldownMs,
   formatGrill,
   parseOptions,
   matchTypedAnswer,
@@ -85,6 +86,71 @@ describe('pickNext', () => {
     const snoozed: GrillState = { ...emptyState, items: { a: { askedAt: '2026-07-25T00:00:00Z', status: 'snoozed', snoozeUntil: '2026-07-25T06:00:00Z' } } };
     expect(pickNext(queue, snoozed, now + 3600_000)).toBeNull(); // still snoozed
     expect(pickNext(queue, snoozed, Date.parse('2026-07-25T07:00:00Z'))?.key).toBe('a'); // snooze elapsed
+  });
+});
+
+// Zaal, 2026-08-11: "older cards must nag MORE frequently, not expire."
+describe('askCooldownMs - an older item nags harder', () => {
+  const H = 3600_000;
+  const D = 24 * H;
+
+  it('holds the 3h default for a fresh item', () => {
+    expect(askCooldownMs(0)).toBe(3 * H);
+    expect(askCooldownMs(6 * H)).toBe(3 * H);
+  });
+
+  it('shortens monotonically as the item ages, and never lengthens', () => {
+    const ages = [0, 12 * H, 1 * D, 2 * D, 3 * D, 6 * D, 7 * D, 30 * D];
+    const waits = ages.map(askCooldownMs);
+    for (let i = 1; i < waits.length; i++) expect(waits[i]).toBeLessThanOrEqual(waits[i - 1]);
+    expect(waits.at(-1)).toBeLessThan(waits[0]);
+  });
+
+  it('floors at 45m so a week-old item cannot arrive every tick', () => {
+    expect(askCooldownMs(7 * D)).toBe(45 * 60_000);
+    expect(askCooldownMs(365 * D)).toBe(45 * 60_000); // a year old is still floored
+  });
+});
+
+describe('pickNext - age drives the cooldown, and nothing ever expires', () => {
+  const queue = toQueue([task({ id: '1', legacy_id: 'a', title: 'A', priority: 'P0', next_owner: 'me' })], []);
+  const now = Date.parse('2026-08-11T12:00:00Z');
+  const H = 3600_000;
+  const D = 24 * H;
+
+  it('a week-old item re-surfaces after 1h where a fresh one would not', () => {
+    // Both were asked 1h ago. The only difference is when they were FIRST asked.
+    const asked = new Date(now - 1 * H).toISOString();
+    const fresh: GrillState = { ...emptyState, items: { a: { askedAt: asked, status: 'asked', firstAskedAt: asked } } };
+    const old: GrillState = {
+      ...emptyState,
+      items: { a: { askedAt: asked, status: 'asked', firstAskedAt: new Date(now - 8 * D).toISOString() } },
+    };
+    expect(pickNext(queue, fresh, now)).toBeNull(); // 1h into a 3h wait
+    expect(pickNext(queue, old, now)?.key).toBe('a'); // 1h into a 45m wait - overdue
+  });
+
+  it('an item unanswered for a month still surfaces - age never removes it', () => {
+    const s: GrillState = {
+      ...emptyState,
+      items: {
+        a: {
+          askedAt: new Date(now - 2 * H).toISOString(),
+          status: 'asked',
+          firstAskedAt: new Date(now - 30 * D).toISOString(),
+        },
+      },
+    };
+    expect(pickNext(queue, s, now)?.key).toBe('a');
+  });
+
+  it('falls back to askedAt for a state file written before firstAskedAt existed', () => {
+    const s: GrillState = {
+      ...emptyState,
+      items: { a: { askedAt: new Date(now - 1 * H).toISOString(), status: 'asked' } },
+    };
+    expect(pickNext(queue, s, now)).toBeNull(); // reads as new -> 3h default, still cooling
+    expect(pickNext(queue, s, now + 3 * H)?.key).toBe('a');
   });
 });
 

--- a/bot/src/zoe/grill.ts
+++ b/bot/src/zoe/grill.ts
@@ -48,6 +48,13 @@ export interface GrillItemState {
   snoozeUntil?: string;
   /** The one-click answer Zaal chose, if any. */
   answer?: string;
+  /**
+   * When this item was FIRST surfaced, never overwritten on a re-ask. `askedAt`
+   * moves every time the card is pushed, so it can only answer "how long since
+   * the last nudge" - it cannot answer "how long has this been unanswered",
+   * which is the question the cooldown needs (see askCooldownMs).
+   */
+  firstAskedAt?: string;
 }
 
 export interface GrillState {
@@ -189,6 +196,33 @@ export function multiKeyboard(
 const ASK_COOLDOWN_MS = 3 * 60 * 60 * 1000; // don't re-surface a still-open item within 3h
 const SNOOZE_MS = 6 * 60 * 60 * 1000;
 
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * How long to wait before re-surfacing a still-open item - SHORTER the longer it
+ * has gone unanswered.
+ *
+ * Zaal, 2026-08-11: "older cards must nag MORE frequently, not expire." The
+ * instinct to age an item out is exactly backwards. An item that has sat for a
+ * week is not less important than one raised this morning; it is the one thing
+ * demonstrably not getting done, and letting it go quiet is how it disappears.
+ * Nothing here ever removes an item - only `done` does that, and only Zaal
+ * produces a `done`.
+ *
+ * The floor is deliberate. A cooldown that keeps shrinking would eventually
+ * re-ask on every scheduler tick, and a card that arrives constantly is one that
+ * stops being read (`noisy-signal-guard.md`). 45m is the floor, and
+ * DAILY_PUSH_CAP still bounds the day at 5 unsolicited pushes regardless - so
+ * this changes WHICH item gets those five slots, not how many arrive.
+ */
+export function askCooldownMs(ageMs: number): number {
+  if (ageMs >= 7 * DAY_MS) return 45 * 60 * 1000;
+  if (ageMs >= 3 * DAY_MS) return 1.5 * HOUR_MS;
+  if (ageMs >= 1 * DAY_MS) return 2 * HOUR_MS;
+  return ASK_COOLDOWN_MS;
+}
+
 const DEFAULT_STATE: GrillState = { items: {}, activeKey: null, lastAskedAt: null };
 const stateFile = () => join(homedir(), '.zao', 'zoe', 'grill_state.json');
 
@@ -257,7 +291,13 @@ export function pickNext(queue: GrillItem[], state: GrillState, now: number): Gr
     if (!s) return item; // never asked
     if (s.status === 'done') continue;
     if (s.status === 'snoozed' && s.snoozeUntil && Date.parse(s.snoozeUntil) > now) continue;
-    if (s.status === 'asked' && now - Date.parse(s.askedAt) < ASK_COOLDOWN_MS) continue; // waiting on a reply, don't nag yet
+    if (s.status === 'asked') {
+      // Age is measured from the FIRST ask, not the last one. Falling back to
+      // askedAt keeps every pre-existing state file working - an item written
+      // before this field existed simply reads as new and gets the 3h default.
+      const age = now - Date.parse(s.firstAskedAt ?? s.askedAt);
+      if (now - Date.parse(s.askedAt) < askCooldownMs(age)) continue; // waiting on a reply, don't nag yet
+    }
     return item; // skipped / cooled-down / snooze-elapsed -> re-surface
   }
   return null;
@@ -397,7 +437,16 @@ export async function surfaceGrill(deps: SurfaceGrillDeps): Promise<{ sent: bool
   // Pin the new open question (silent) so it stays easy to find until answered.
   if (deps.pin && messageId) await deps.pin(messageId).catch(() => {});
 
-  state.items[item.key] = { askedAt: new Date(now).toISOString(), status: 'asked' };
+  // firstAskedAt survives every re-ask - it is what makes an old item nag harder.
+  // Writing the whole object fresh (rather than spreading the old one) is on
+  // purpose: a re-ask must clear a stale snoozeUntil/answer. Only the age carries.
+  const prior = state.items[item.key];
+  const askedAt = new Date(now).toISOString();
+  state.items[item.key] = {
+    askedAt,
+    status: 'asked',
+    firstAskedAt: prior?.firstAskedAt ?? prior?.askedAt ?? askedAt,
+  };
   state.activeKey = item.key;
   state.activeTitle = item.title;
   state.activeKind = item.kind;

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -1444,6 +1444,15 @@ bot.on('message:text', async (ctx) => {
           console.error('[zoe/grill] board resolve failed:', (e as Error)?.message),
         );
         await ctx.api.unpinChatMessage(zaalId, replyToId).catch(() => {});
+        // Strip the answered card's buttons. Zaal, 2026-08-11: "when I reply to
+        // these they don't remove the buttons." Both other resolve paths (the
+        // tap at grill:ans and the typed-answer capture in the DM path) already
+        // did this; only the reply path unpinned and left a live keyboard
+        // behind, so an answered card still read as open and re-tapping it
+        // re-answered an item that was already off the queue.
+        await ctx.api
+          .editMessageReplyMarkup(zaalId, replyToId, { reply_markup: { inline_keyboard: [] } })
+          .catch(() => {});
         await ctx.reply(`Resolved: ${gr.value}. Logged it and moved it off your plate.`);
         await surfaceGrill({ ...grillDeps(zaalId), bypassCap: true }).catch((e) =>
           console.error('[zoe/grill] advance failed:', (e as Error)?.message),


### PR DESCRIPTION
## Executive Summary

Two bugs Zaal hit on 2026-08-11, both in ZOE's grill - the DM that hands him one open decision at a time.

An answered card kept its buttons when he answered by REPLYING instead of tapping. And a card that had gone unanswered for a week was treated exactly like one raised an hour ago. This fixes both.

## Why this matters

The grill exists so decisions do not rot. Both bugs quietly worked against that.

The first made an answered question still look open - he had no way to tell, from the card, whether ZOE had heard him. The second is worse in slow motion: the cards that sit longest are the ones demonstrably not getting done, and the old behaviour asked about them exactly as often as about everything else, so they stayed buried under whatever arrived that morning.

## Before vs After

**Before**

- Reply to a card: unpinned, answer logged, buttons still live. Tapping one re-answered a resolved item.
- Every open card waited a flat 3h to come back, whether it was raised this morning or eight days ago.

**After**

- All three resolve paths (tap, typed answer, reply) clear the keyboard.
- The wait shortens with the card's age: 3h fresh, 2h after a day, 90m after three, 45m after a week - and floors there.

## Explain like I'm smart

The card carried two timestamps' worth of meaning in one field. `askedAt` moves every time ZOE pushes the card, so it can answer "how long since I last nudged you" but never "how long has this been sitting". A new field, `firstAskedAt`, survives the re-asks and holds the real age. The cooldown reads that instead.

## The one thing I deliberately did NOT do

I did not add expiry. The obvious-looking version of "handle old cards" is to age them out, and that is exactly backwards - it would make the ignored items disappear, which is the failure the grill exists to prevent. Nothing here removes an item. Only a `done` does, and only Zaal produces a `done`.

The floor is the other half of that judgement. A cooldown that keeps shrinking would eventually re-ask on every scheduler tick, and a card that arrives constantly is a card that stops being read (`noisy-signal-guard.md`). `DAILY_PUSH_CAP` is untouched at 5, so this changes **which** items get the day's five slots, not how many arrive.

## Evidence

**Proven**

- Full bot suite: **179 files, 2284 tests, all passing**
- Grill suite: **29 tests before, 35 after** - 6 new, written against the aging shapes from the report, including the migration case where an old state file has no `firstAskedAt`
- `esbuild` bundles `src/zoe/index.ts` clean at 800kb, so the boot graph resolves (tsc alone is not enough - `agent-loops.md` rule 1)
- Typecheck: **37 errors before, 37 after, none in the touched files**

**Not yet tested**

Neither fix has run against live Telegram. ZOE's Claude token expired 2026-08-08T07:51 UTC and it has no `ANTHROPIC_API_KEY` fallback, so the bot cannot make an API call at all until Zaal runs `ssh vps` -> `claude` -> `/login`. The logic is covered by unit tests; the Telegram API calls are not.

## Risks

The 37 pre-existing typecheck errors are all vitest `Mock<[...]>` generic mismatches in test files, present on main before this branch. They are noise that could hide a real error in the same files - worth a separate fix, flagged rather than swept in here (`noisy-signal-guard.md`: do not adapt to a loud check, fix it).

## Next

- Zaal: `ssh vps` -> `claude` -> `/login`, then answer a card by replying and confirm the buttons clear
- Separate PR: the 37 Mock type errors

## Translation layer

- **Engineer:** one missing `editMessageReplyMarkup`, and a constant replaced by a function of item age.
- **Architect:** the grill's state now distinguishes "when did I last speak" from "how long has this been open" - two different questions that one field was answering badly.
- **Founder:** the decisions that have been ignored longest now get asked about most often, and an answered question looks answered.
- **Investor:** the queue self-prioritises toward what is actually stuck, without adding volume.
