### PR TITLE
feat(zoe): DreamNet federation canary - file upload and receipt ACK

### DIFF
--- a/bot/src/zoe/__tests__/bus-files.test.ts
+++ b/bot/src/zoe/__tests__/bus-files.test.ts
@@ -1,0 +1,577 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { uploadFileToBus, hashFile } from '../bus-upload';
+import { verifyReceipt, ackReceipt, type DreamNetReceipt } from '../bus-receipt';
+
+// Mock fetch and readFile globally so both modules can use them.
+const { fetchMock, readFileMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  readFileMock: vi.fn(),
+}));
+
+vi.stubGlobal('fetch', fetchMock);
+
+describe('uploadFileToBus', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+    readFileMock.mockReset();
+  });
+
+  it('uploads a file successfully and returns fileId + sha256', async () => {
+    const testBytes = Buffer.from('test file content');
+    readFileMock.mockResolvedValue(testBytes);
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'file-abc123def456' }),
+    });
+
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.fileId).toBe('file-abc123def456');
+    expect(result.sha256).toBeDefined();
+    expect(result.sha256).toHaveLength(64); // sha256 hex is 64 chars
+    expect(result.reply).toContain('test.sol');
+    expect(result.reply).toContain('file-abc'); // first 8 chars of ID in reply
+  });
+
+  it('computes the same sha256 locally as the module returns', async () => {
+    const testBytes = Buffer.from('deterministic test content');
+    readFileMock.mockResolvedValue(testBytes);
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'file-123' }),
+    });
+
+    const uploadResult = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    // Compute locally what we expect
+    const expectedHash = await hashFile('/tmp/test.sol', readFileMock);
+
+    expect(uploadResult.sha256).toBe(expectedHash);
+  });
+
+  it('returns CANNOT_UPLOAD when filename is empty', async () => {
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      '',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('empty_filename');
+    expect(result.reply).toContain('Filename cannot be empty');
+  });
+
+  it('returns unconfigured message when BUS_URL is not set', async () => {
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: '', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('unconfigured');
+    expect(result.reply).toContain('BUS_URL and BUS_TOKEN are not set');
+    expect(result.reply).toContain('test.sol');
+  });
+
+  it('returns unconfigured message when BUS_TOKEN is not set', async () => {
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: '' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('unconfigured');
+    expect(result.reply).toContain('BUS_URL and BUS_TOKEN are not set');
+  });
+
+  it('rejects upload with HTTP error status', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('test'));
+
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+    });
+
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('http 403');
+    expect(result.reply).toContain('Bus rejected');
+    expect(result.reply).toContain('403');
+  });
+
+  it('handles timeout gracefully', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('test'));
+
+    const abortErr = new Error('Aborted');
+    (abortErr as any).name = 'AbortError';
+    fetchMock.mockRejectedValue(abortErr);
+
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('timeout');
+    expect(result.reply).toContain('timed out');
+  });
+
+  it('handles network errors gracefully', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('test'));
+
+    fetchMock.mockRejectedValue(new Error('Connection refused'));
+
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('Connection refused');
+    expect(result.reply).toContain('Could not upload to the bus');
+  });
+
+  it('handles JSON parse error when response is not JSON', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('test'));
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new Error('Not JSON')),
+    });
+
+    const result = await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'token123' },
+      readFileMock,
+      fetchMock,
+    );
+
+    // Should still succeed - fileId will be undefined, but sha256 is there
+    expect(result.ok).toBe(true);
+    expect(result.sha256).toBeDefined();
+    expect(result.fileId).toBeUndefined();
+  });
+
+  it('includes Authorization header with Bearer token', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('test'));
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'file-123' }),
+    });
+
+    await uploadFileToBus(
+      '/tmp/test.sol',
+      'test.sol',
+      { url: 'https://bus.test', token: 'mytoken' },
+      readFileMock,
+      fetchMock,
+    );
+
+    const callArgs = fetchMock.mock.calls[0];
+    expect(callArgs[0]).toContain('/files/upload');
+    expect(callArgs[1]?.headers).toEqual({
+      'Content-Type': 'application/octet-stream',
+      Authorization: 'Bearer mytoken',
+    });
+  });
+
+  it('encodes filename in query parameter', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('test'));
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'file-123' }),
+    });
+
+    await uploadFileToBus(
+      '/tmp/test.sol',
+      'my special file.sol',
+      { url: 'https://bus.test', token: 'token' },
+      readFileMock,
+      fetchMock,
+    );
+
+    const callUrl = fetchMock.mock.calls[0][0];
+    expect(callUrl).toContain('name=');
+    expect(callUrl).toContain(encodeURIComponent('my special file.sol'));
+  });
+});
+
+describe('verifyReceipt', () => {
+  it('returns MATCH when contentHash and messageId both match', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'abc123def456789',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('MATCH');
+  });
+
+  it('returns MISMATCH when contentHash differs', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'wrong_hash',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('MISMATCH');
+  });
+
+  it('returns MISMATCH when messageId differs', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'wrong-id',
+      contentHash: 'abc123def456789',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('MISMATCH');
+  });
+
+  it('returns MISMATCH when both fields differ', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'wrong-id',
+      contentHash: 'wrong_hash',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('MISMATCH');
+  });
+
+  it('returns CANNOT_VERIFY when contentHash is missing', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('CANNOT_VERIFY');
+  });
+
+  it('returns CANNOT_VERIFY when messageId is missing', () => {
+    const receipt: DreamNetReceipt = {
+      contentHash: 'abc123def456789',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('CANNOT_VERIFY');
+  });
+
+  it('returns CANNOT_VERIFY when both fields are missing', () => {
+    const receipt: DreamNetReceipt = {};
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('CANNOT_VERIFY');
+  });
+
+  it('returns CANNOT_VERIFY when contentHash is null', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: null,
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('CANNOT_VERIFY');
+  });
+
+  it('returns CANNOT_VERIFY when messageId is null', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: null,
+      contentHash: 'abc123def456789',
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('CANNOT_VERIFY');
+  });
+
+  it('returns CANNOT_VERIFY when both are null', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: null,
+      contentHash: null,
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('CANNOT_VERIFY');
+  });
+
+  it('converts contentHash to string for comparison (number)', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 12345 as any, // simulate a numeric hash from an API
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', '12345');
+    expect(result).toBe('MATCH');
+  });
+
+  it('converts messageId to string for comparison (number)', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 123 as any, // simulate a numeric ID from an API
+      contentHash: 'abc123def456789',
+    };
+
+    const result = verifyReceipt(receipt, '123', 'abc123def456789');
+    expect(result).toBe('MATCH');
+  });
+
+  it('includes extra fields in receipt without affecting verification', () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'abc123def456789',
+      extraField: 'ignored',
+      anotherField: 42,
+      nested: { value: 'also ignored' },
+    };
+
+    const result = verifyReceipt(receipt, 'msg-123abc', 'abc123def456789');
+    expect(result).toBe('MATCH');
+  });
+});
+
+describe('ackReceipt', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('sends ACK for MATCH verification', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'ack-123' }),
+    });
+
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'abc123def456789',
+    };
+
+    const result = await ackReceipt(
+      receipt,
+      'receipt-msg-456',
+      'msg-123abc',
+      'abc123def456789',
+      { url: 'https://bus.test', token: 'token' },
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.verification).toBe('MATCH');
+    expect(result.reply).toContain('Sent to coordinator');
+  });
+
+  it('sends ACK for MISMATCH and reports the problem', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'ack-123' }),
+    });
+
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'wrong_hash',
+    };
+
+    const result = await ackReceipt(
+      receipt,
+      'receipt-msg-456',
+      'msg-123abc',
+      'abc123def456789',
+      { url: 'https://bus.test', token: 'token' },
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(true); // ACK itself succeeded
+    expect(result.verification).toBe('MISMATCH');
+    // Verify the ACK message contains the problem report
+    const sendCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/send'));
+    expect(sendCall).toBeDefined();
+    const sendBody = sendCall?.[1]?.body;
+    if (typeof sendBody === 'string') {
+      const parsed = JSON.parse(sendBody);
+      expect(parsed.body).toContain('MISMATCH');
+      expect(parsed.body).toContain('wrong_hash');
+    }
+  });
+
+  it('sends ACK for CANNOT_VERIFY and reports missing fields', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'ack-123' }),
+    });
+
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      // contentHash missing
+    };
+
+    const result = await ackReceipt(
+      receipt,
+      'receipt-msg-456',
+      'msg-123abc',
+      'abc123def456789',
+      { url: 'https://bus.test', token: 'token' },
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.verification).toBe('CANNOT_VERIFY');
+    // Verify the ACK message mentions missing fields
+    const sendCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/send'));
+    expect(sendCall).toBeDefined();
+    const sendBody = sendCall?.[1]?.body;
+    if (typeof sendBody === 'string') {
+      const parsed = JSON.parse(sendBody);
+      expect(parsed.body).toContain('CANNOT_VERIFY');
+      expect(parsed.body).toContain('Missing');
+    }
+  });
+
+  it('returns unconfigured when bus is not configured', async () => {
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'abc123def456789',
+    };
+
+    const result = await ackReceipt(
+      receipt,
+      'receipt-msg-456',
+      'msg-123abc',
+      'abc123def456789',
+      { url: '', token: '' },
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('unconfigured');
+    expect(result.reply).toContain('Bus not connected');
+  });
+
+  it('handles fetch error when sending ACK', async () => {
+    fetchMock.mockRejectedValue(new Error('Network error'));
+
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'abc123def456789',
+    };
+
+    const result = await ackReceipt(
+      receipt,
+      'receipt-msg-456',
+      'msg-123abc',
+      'abc123def456789',
+      { url: 'https://bus.test', token: 'token' },
+      fetchMock,
+    );
+
+    expect(result.ok).toBe(false);
+    // Error comes from sendBusReply catch block
+    expect(result.reply).toContain('Could not reach the bus');
+    // Still reports the verification result even though send failed
+    expect(result.verification).toBe('MATCH');
+  });
+
+  it('includes receipt message ID in ACK subject line', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'ack-123' }),
+    });
+
+    const receipt: DreamNetReceipt = {
+      messageId: 'msg-123abc',
+      contentHash: 'abc123def456789',
+    };
+
+    await ackReceipt(
+      receipt,
+      'abc12345-other-chars',
+      'msg-123abc',
+      'abc123def456789',
+      { url: 'https://bus.test', token: 'token' },
+      fetchMock,
+    );
+
+    const sendCall = fetchMock.mock.calls.find((call) => String(call[0]).includes('/send'));
+    expect(sendCall).toBeDefined();
+    const sendBody = sendCall?.[1]?.body;
+    if (typeof sendBody === 'string') {
+      const parsed = JSON.parse(sendBody);
+      expect(parsed.subject).toContain('ACK receipt');
+      // Subject should include the ID (first 8 chars: abc12345)
+      expect(parsed.subject).toContain('abc12345');
+    }
+  });
+});
+
+describe('hashFile', () => {
+  afterEach(() => {
+    readFileMock.mockReset();
+  });
+
+  it('computes sha256 of file contents', async () => {
+    const testBytes = Buffer.from('test content');
+    readFileMock.mockResolvedValue(testBytes);
+
+    const hash = await hashFile('/tmp/test.sol', readFileMock);
+
+    expect(hash).toHaveLength(64); // sha256 hex
+    expect(/^[a-f0-9]{64}$/.test(hash)).toBe(true); // valid hex
+  });
+
+  it('produces deterministic hashes', async () => {
+    const testBytes = Buffer.from('same content');
+    readFileMock.mockResolvedValue(testBytes);
+
+    const hash1 = await hashFile('/tmp/test1.sol', readFileMock);
+    const hash2 = await hashFile('/tmp/test2.sol', readFileMock);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different hashes for different content', async () => {
+    const bytes1 = Buffer.from('content1');
+    const bytes2 = Buffer.from('content2');
+
+    readFileMock.mockResolvedValueOnce(bytes1);
+    const hash1 = await hashFile('/tmp/test1.sol', readFileMock);
+
+    readFileMock.mockResolvedValueOnce(bytes2);
+    const hash2 = await hashFile('/tmp/test2.sol', readFileMock);
+
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/bot/src/zoe/__tests__/bus-files.test.ts
+++ b/bot/src/zoe/__tests__/bus-files.test.ts
@@ -235,6 +235,25 @@ describe('uploadFileToBus', () => {
   });
 });
 
+// The receipt can be perfect and the verify still prove nothing, if OUR side of
+// the comparison is empty. '' === '' is true, so an empty local hash would read
+// as MATCH - a check that passes because it never ran (agent-loops.md rule 30).
+describe('verifyReceipt - our own side must be present, or it is not a verify', () => {
+  const receipt: DreamNetReceipt = { messageId: 'msg-1', contentHash: 'abc123' };
+
+  it('an empty local hash is CANNOT_VERIFY, never MATCH', () => {
+    expect(verifyReceipt({ messageId: 'msg-1', contentHash: '' }, 'msg-1', '')).toBe('CANNOT_VERIFY');
+  });
+
+  it('an empty local messageId is CANNOT_VERIFY, never MATCH', () => {
+    expect(verifyReceipt({ messageId: '', contentHash: 'abc123' }, '', 'abc123')).toBe('CANNOT_VERIFY');
+  });
+
+  it('still MATCHes when both sides are genuinely present and equal', () => {
+    expect(verifyReceipt(receipt, 'msg-1', 'abc123')).toBe('MATCH');
+  });
+});
+
 describe('verifyReceipt', () => {
   it('returns MATCH when contentHash and messageId both match', () => {
     const receipt: DreamNetReceipt = {

--- a/bot/src/zoe/bus-receipt.ts
+++ b/bot/src/zoe/bus-receipt.ts
@@ -65,6 +65,16 @@ export function verifyReceipt(
     return 'CANNOT_VERIFY';
   }
 
+  // OUR OWN side must be present too. Comparing '' to '' is true, so an empty
+  // local hash would sail through as a MATCH while proving nothing whatsoever -
+  // the vacuous verify of agent-loops.md rule 30, where the check passes because
+  // it never actually ran. sha256 cannot return an empty string, so reaching
+  // here means a caller passed one, and that is a bug we must not launder into
+  // a green result.
+  if (!sentMessageId || !sentContentHash) {
+    return 'CANNOT_VERIFY';
+  }
+
   // Both fields are present. Check if they match what we sent (comparing as strings).
   const messageIdMatch = String(receipt.messageId) === sentMessageId;
   const contentHashMatch = String(receipt.contentHash) === sentContentHash;

--- a/bot/src/zoe/bus-receipt.ts
+++ b/bot/src/zoe/bus-receipt.ts
@@ -1,0 +1,176 @@
+/**
+ * bus-receipt.ts - ACK a DreamNet federation receipt and verify its hashes.
+ *
+ * Tenant-side receipt handling for the DreamNet federation canary. Given a
+ * receipt received from DreamNet (via the bus), this module:
+ *   1. Verifies the content hash matches what we computed locally
+ *   2. Verifies the message ID matches what we sent
+ *   3. ACKs the receipt back to the bus so DreamNet knows we got it
+ *
+ * All verification is PURE (no I/O). The result is a clear enum-like return
+ * value that distinguishes MATCH (everything verified), MISMATCH (a field has
+ * the wrong value), and CANNOT_VERIFY (a field is missing). Never reads a
+ * missing field as a match - that is the silent-failure-guard rule: a missing
+ * field must be CANNOT_VERIFY, never success.
+ */
+
+import type { BusConfig } from './bus-send';
+import { busConfig, busConfigured, sendBusReply } from './bus-send';
+
+/**
+ * Result of verifying a receipt against what we sent. Three distinct outcomes
+ * that never conflate.
+ */
+export type ReceiptVerificationResult = 'MATCH' | 'MISMATCH' | 'CANNOT_VERIFY';
+
+/**
+ * The shape of a DreamNet receipt as received over the bus. Only fields we
+ * care about for verification are required; others can be present but are not
+ * used here.
+ */
+export interface DreamNetReceipt {
+  messageId?: unknown;
+  contentHash?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Verify a receipt's content hash and message ID against what we sent.
+ *
+ * `sentMessageId` is the ID of the message we sent (the one that prompted
+ * DreamNet to send us this receipt). `sentContentHash` is the sha256 we
+ * computed locally over the exact bytes we uploaded. The receipt's fields
+ * must match both exactly.
+ *
+ * CRITICAL: a missing field is CANNOT_VERIFY, not a match. If the receipt has
+ * no contentHash, or if contentHash is null/undefined, returns CANNOT_VERIFY
+ * rather than treating it as success. This is anti-fabrication.md rule 2:
+ * never let a missing field read as a match.
+ *
+ * Returns:
+ *   - MATCH: receipt.messageId === sentMessageId AND receipt.contentHash === sentContentHash
+ *   - MISMATCH: both fields are present but at least one differs
+ *   - CANNOT_VERIFY: one or both fields are missing/undefined/null
+ */
+export function verifyReceipt(
+  receipt: DreamNetReceipt,
+  sentMessageId: string,
+  sentContentHash: string,
+): ReceiptVerificationResult {
+  // Both fields must be present and non-null to proceed.
+  const hasMessageId = receipt.messageId !== null && receipt.messageId !== undefined;
+  const hasContentHash = receipt.contentHash !== null && receipt.contentHash !== undefined;
+
+  if (!hasMessageId || !hasContentHash) {
+    return 'CANNOT_VERIFY';
+  }
+
+  // Both fields are present. Check if they match what we sent (comparing as strings).
+  const messageIdMatch = String(receipt.messageId) === sentMessageId;
+  const contentHashMatch = String(receipt.contentHash) === sentContentHash;
+
+  if (messageIdMatch && contentHashMatch) {
+    return 'MATCH';
+  }
+
+  return 'MISMATCH';
+}
+
+export interface AckReceiptResult {
+  ok: boolean;
+  /** Message to show Zaal or a handler. Always present. */
+  reply: string;
+  verification?: ReceiptVerificationResult;
+  reason?: string;
+}
+
+/**
+ * ACK a receipt back to the bus after verifying it. Sends a reply to the
+ * partner containing the verification result.
+ *
+ * `receiptMessageId` is the ID of the receipt message itself (what we are
+ * ACKing), not the ID of the message that prompted the receipt.
+ *
+ * Flow:
+ *   1. Verify the receipt's content hash and message ID match what we sent
+ *   2. Send an ACK back to the bus with the verification result
+ *   3. Return both the verification outcome and the send result
+ *
+ * If verification fails (MISMATCH or CANNOT_VERIFY), the ACK still sends
+ * (so DreamNet knows we received it), but the reply clearly states the problem.
+ */
+export async function ackReceipt(
+  receipt: DreamNetReceipt,
+  receiptMessageId: string,
+  sentMessageId: string,
+  sentContentHash: string,
+  cfg: BusConfig = busConfig(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<AckReceiptResult> {
+  if (!busConfigured(cfg)) {
+    return {
+      ok: false,
+      reason: 'unconfigured',
+      reply: 'Bus not connected - BUS_URL and BUS_TOKEN are not set, so this did not ACK.',
+    };
+  }
+
+  const verification = verifyReceipt(receipt, sentMessageId, sentContentHash);
+
+  let ackBody: string;
+  switch (verification) {
+    case 'MATCH':
+      ackBody = `Receipt verified. Content hash and message ID both match.`;
+      break;
+    case 'MISMATCH':
+      ackBody =
+        `Receipt verification FAILED - MISMATCH.\n` +
+        `Received contentHash: ${String(receipt.contentHash)}\n` +
+        `Sent contentHash: ${sentContentHash}\n` +
+        `Received messageId: ${String(receipt.messageId)}\n` +
+        `Sent messageId: ${sentMessageId}`;
+      break;
+    case 'CANNOT_VERIFY':
+      ackBody =
+        `Receipt verification FAILED - CANNOT_VERIFY.\n` +
+        `Missing or null fields in receipt.` +
+        (receipt.contentHash === undefined
+          ? ` contentHash is missing.`
+          : receipt.contentHash === null
+            ? ` contentHash is null.`
+            : '') +
+        (receipt.messageId === undefined
+          ? ` messageId is missing.`
+          : receipt.messageId === null
+            ? ` messageId is null.`
+            : '');
+      break;
+  }
+
+  try {
+    const sendResult = await sendBusReply(
+      {
+        to: 'coordinator',
+        subject: `ACK receipt ${String(receiptMessageId).slice(0, 8)}`,
+        body: ackBody,
+      },
+      cfg,
+      fetchImpl,
+    );
+
+    return {
+      ok: sendResult.ok,
+      reply: sendResult.reply,
+      verification,
+      reason: sendResult.reason,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'request failed';
+    return {
+      ok: false,
+      reply: `Could not send ACK: ${msg.slice(0, 120)}`,
+      verification,
+      reason: msg,
+    };
+  }
+}

--- a/bot/src/zoe/bus-upload.ts
+++ b/bot/src/zoe/bus-upload.ts
@@ -1,0 +1,126 @@
+/**
+ * bus-upload.ts - upload files to the DreamNet federation bus.
+ *
+ * Tenant-side file upload for the DreamNet federation canary. Wraps the bus
+ * `/files/upload` endpoint and computes a sha256 hash over the exact bytes
+ * sent - our own copy so the later verification against a receipt is
+ * meaningful (we trust our own hash more than a partner's report of what we sent).
+ *
+ * This is PURE except for the network call and file I/O. The hash computation
+ * happens locally before any send, and is returned alongside the bus response
+ * so the caller can verify a receipt's contentHash against it later.
+ *
+ * HONEST WHEN UNCONFIGURED. Like bus-send.ts, if BUS_URL / BUS_TOKEN are not
+ * set, this returns a clear message showing what would have been sent, rather
+ * than silently failing.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import type { BusConfig } from './bus-send';
+import { busConfig, busConfigured } from './bus-send';
+
+export interface FileUploadResult {
+  ok: boolean;
+  /** The message to show Zaal or a handler. Always present. */
+  reply: string;
+  /** Bus response ID, if upload succeeded. */
+  fileId?: string;
+  /** The sha256 hash we computed locally over the exact bytes sent. */
+  sha256?: string;
+  /** Set when upload failed or was impossible, for logs. */
+  reason?: string;
+}
+
+/**
+ * Upload a local file to the bus and return both the bus response and the
+ * sha256 hash computed locally. The hash is what makes verification meaningful:
+ * when a receipt arrives claiming a contentHash, we compare against our own
+ * hash, not what the partner claims to have received.
+ *
+ * `filePath` must be readable as binary. The file's full contents are hashed
+ * and sent; the hash is computed over exactly those bytes, so a receipt
+ * claiming a different hash proves tampering.
+ */
+export async function uploadFileToBus(
+  filePath: string,
+  filename: string,
+  cfg: BusConfig = busConfig(),
+  readFileImpl: typeof readFile = readFile,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FileUploadResult> {
+  if (!filename || filename.trim().length === 0) {
+    return { ok: false, reply: 'Filename cannot be empty.', reason: 'empty_filename' };
+  }
+
+  if (!busConfigured(cfg)) {
+    return {
+      ok: false,
+      reason: 'unconfigured',
+      reply:
+        'Bus not connected - BUS_URL and BUS_TOKEN are not set, so this did not upload.\n\n' +
+        `Would have uploaded ${filename} from ${filePath}\n\n` +
+        'Set both on the VPS and try again.',
+    };
+  }
+
+  try {
+    const fileBytes = await readFileImpl(filePath);
+    const sha256 = createHash('sha256').update(fileBytes).digest('hex');
+
+    const res = await fetchImpl(`${cfg.url!.replace(/\/$/, '')}/files/upload?name=${encodeURIComponent(filename)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        Authorization: `Bearer ${cfg.token}`,
+      },
+      body: fileBytes,
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        reason: `http ${res.status}`,
+        reply: `Bus rejected the upload (${res.status}). The file is safe - try again or check the bus.`,
+      };
+    }
+
+    const data = (await res.json().catch(() => ({}))) as { id?: string };
+    const fileId = data.id ? String(data.id) : undefined;
+    const idDisplay = fileId ? ` (id ${fileId.slice(0, 8)})` : '';
+
+    return {
+      ok: true,
+      reply: `Uploaded ${filename}${idDisplay}.`,
+      fileId,
+      sha256,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return {
+        ok: false,
+        reason: 'timeout',
+        reply: 'Upload timed out. The file is safe - try again.',
+      };
+    }
+    const msg = err instanceof Error ? err.message : 'request failed';
+    return {
+      ok: false,
+      reason: msg,
+      reply: `Could not upload to the bus: ${msg.slice(0, 120)}\n\nThe file is safe - try again.`,
+    };
+  }
+}
+
+/**
+ * Compute sha256 over a local file without uploading. Useful for testing or
+ * for pre-computing a hash before deciding whether to upload.
+ */
+export async function hashFile(
+  filePath: string,
+  readFileImpl: typeof readFile = readFile,
+): Promise<string> {
+  const fileBytes = await readFileImpl(filePath);
+  return createHash('sha256').update(fileBytes).digest('hex');
+}


### PR DESCRIPTION
## Executive Summary

ZOE can now upload a file to the partner bus and verify the receipt that comes back. This is our whole share of Brandon's federation canary, and it was blocked on one gap: `bus-send.ts` could only send text.

We are **not** building the gateway or the Spore adapter. Brandon was explicit - "do not create a second independent partner gateway beside the Federation Gateway." Those are his. Jim owes the Node implementation and API contract. Our tenant role in the canary is three steps: upload the `.sol` file, ACK the receipt, compare message IDs and content hashes.

## Why this matters

The canary is the first real trust exchange between ZAO and DreamNet. Everything downstream - Zoe, DreamNet and Zaal as sovereign tenants on one federation - depends on proving that a file can cross the boundary and come back provably unchanged.

The subtle part is **whose hash you believe.** We compute sha256 over the exact bytes we send, before they leave. When DreamNet's receipt arrives with its own hash, the comparison means something because our number was produced independently. Trusting the hash they hand back would make the check theater.

## Biological analogy

This is the Mouth and the Ear of the federation link. The Mouth speaks a file with a signature only we could have produced; the Ear listens for that same signature coming home. If what returns does not carry our mark, the organism refuses to swallow it.

## What is in the diff

| File | What |
|---|---|
| `bus-upload.ts` | Uploads a file to `POST /files/upload`, returns the bus response and the sha256 we computed over the bytes actually sent |
| `bus-receipt.ts` | `verifyReceipt()` - pure, returns `MATCH` / `MISMATCH` / `CANNOT_VERIFY`. Plus `ackReceipt()` |
| `__tests__/bus-files.test.ts` | 36 tests |

Network calls and file reads are injected, so the hashing and comparison logic is pure and testable with no network at all.

## The three-state result, and why it is three

`CANNOT_VERIFY` exists so that a missing field can never read as success. A receipt with no content hash is not a pass - it is an unanswerable question, and it says so.

**I hardened one case the first pass missed.** The original checked that the *receipt's* fields were present, but not its own. `'' === ''` is true, so an empty local hash would have returned `MATCH` while proving nothing whatsoever. That is precisely the vacuous verify in `agent-loops.md` rule 30 - a check that passes because it never ran. sha256 cannot return an empty string, so reaching that branch means a caller passed one, which is a bug we must not launder into a green result. Three tests cover the shapes that would have slipped through.

## Evidence

**Proven**

- Full bot suite: **2284 tests before, 2320 after** - 36 new, all passing, no drop
- Typecheck: **37 errors before, 37 after**, and **0 in any touched file**. Those 37 are pre-existing vitest `Mock<[...]>` mismatches in unrelated test files (tracked separately)
- `esbuild` bundles both new modules clean
- Secret scan of the staged diff: 0 matches. `BUS_TOKEN` is read from env only - never hardcoded, never logged, and the honest "bus not connected" message names the variable without ever printing a value

**Not tested**

Nothing has run against the live bus. There is no live counterpart yet - DreamNet's gateway and Jim's adapter do not exist on the other end. This ships the capability; the canary is the test.

## Deliberately not done

**No live wiring.** Nothing calls these yet - no handler, no scheduler. `bus-bridge.ts` set the precedent of keeping pure functions separate from live wiring so the wiring is its own reviewed step, and this follows it.

## Next

1. Brandon confirms the split and Jim sends the Node contract
2. Wire upload into a ZOE command
3. Run the canary with the Solidity file already sitting on the bus

## Translation layer

- **Engineer:** file upload with client-side hashing, and a three-state receipt verifier that refuses to guess.
- **Architect:** ZOE gains its tenant edge of the federation - the smallest possible surface, deliberately, since trust enforcement belongs at DreamNet's core.
- **Founder:** we can now prove a file crossed to a partner and came back untampered, which is the foundation every later exchange rests on.
- **Investor:** verifiable inter-org agent exchange, with the trust boundary owned by whoever should own it rather than duplicated on both sides.
