### PR TITLE
feat(zoe): the pinned brief can finally see a Claude 401

### DIFF
--- a/bot/src/hermes/__tests__/claude-health.test.ts
+++ b/bot/src/hermes/__tests__/claude-health.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The token was revoked for four days and nothing said so. These tests are the
+ * regression: every one of them describes a state the brief got wrong, or a way
+ * a naive fix would go wrong in the other direction.
+ *
+ * The token is valid again, so none of this can be tested against a live 401 -
+ * the state is constructed directly instead, which is also the only way to test
+ * "four days ago" without waiting four days.
+ */
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  claudeBriefLines,
+  readClaudeHealth,
+  recordClaudeFailure,
+  recordClaudeOk,
+  STALE_AFTER_MS,
+  type ClaudeHealth,
+} from '../claude-health';
+
+const T = 1_760_000_000_000; // fixed clock; nothing here may depend on the real one
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+const health = (over: Partial<ClaudeHealth> = {}): ClaudeHealth => ({
+  lastOkMs: null,
+  lastFailMs: null,
+  lastFailKind: null,
+  lastFailHint: null,
+  ...over,
+});
+
+describe('claudeBriefLines', () => {
+  it('alerts when the most recent observation is an auth failure', () => {
+    const r = claudeBriefLines(health({ lastOkMs: T - 5 * DAY, lastFailMs: T - 4 * DAY, lastFailKind: 'auth' }), T);
+    expect(r.alert).toContain('cannot reach Claude');
+    expect(r.alert).toContain('/login');
+    expect(r.status).toEqual(['claude', 'auth failed']);
+  });
+
+  it('THE INCIDENT: a four-day-old auth failure is still alerting', () => {
+    // Exactly the 2026-08-08 shape - the last success predates the revocation and
+    // every call since has 401'd. The old brief showed nothing at all here.
+    const r = claudeBriefLines(health({ lastOkMs: T - 6 * DAY, lastFailMs: T - 4 * DAY, lastFailKind: 'auth' }), T);
+    expect(r.alert).not.toBeNull();
+    expect(r.alert).toContain('4d ago');
+  });
+
+  it('CLEARS once a success is recorded after the failure - the alert can reach zero', () => {
+    const r = claudeBriefLines(health({ lastOkMs: T - MIN, lastFailMs: T - 4 * DAY, lastFailKind: 'auth' }), T);
+    expect(r.alert).toBeNull();
+    expect(r.status).toEqual(['claude', 'ok']);
+  });
+
+  it('does NOT claim health from the absence of failures', () => {
+    // Nothing observed at all. Silence is not evidence: this must not read "ok".
+    const r = claudeBriefLines(health(), T);
+    expect(r.alert).toBeNull();
+    expect(r.status).toEqual(['claude', 'not checked']);
+  });
+
+  it('stops claiming ok once the last success goes stale', () => {
+    const r = claudeBriefLines(health({ lastOkMs: T - (STALE_AFTER_MS + MIN) }), T);
+    expect(r.status[1]).toMatch(/^last ok /);
+  });
+
+  it('does NOT alert on staleness - a dead probe would make that permanent', () => {
+    // Nobody can clear a stale-based alert by acting, so it must stay a status.
+    const r = claudeBriefLines(health({ lastOkMs: T - 30 * DAY }), T);
+    expect(r.alert).toBeNull();
+  });
+
+  it('does not pull Zaal in for a rate limit', () => {
+    const r = claudeBriefLines(health({ lastOkMs: T - HOUR, lastFailMs: T - MIN, lastFailKind: 'rate_limit' }), T);
+    expect(r.alert).toBeNull();
+    expect(r.status).toEqual(['claude', 'rate_limit']);
+  });
+
+  it('treats an equal-timestamp tie as still failing, not recovered', () => {
+    const r = claudeBriefLines(health({ lastOkMs: T - HOUR, lastFailMs: T - HOUR, lastFailKind: 'auth' }), T);
+    expect(r.alert).toBeNull(); // lastFail is not GREATER than lastOk
+    expect(r.status).toEqual(['claude', 'ok']);
+  });
+});
+
+describe('the health file', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'zoe-health-'));
+    path = join(dir, 'nested', 'claude-health.json');
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reads as empty when the file does not exist', async () => {
+    expect(await readClaudeHealth(path)).toEqual(health());
+  });
+
+  it('round-trips a success', async () => {
+    await recordClaudeOk(T, path);
+    expect((await readClaudeHealth(path)).lastOkMs).toBe(T);
+  });
+
+  it('creates the directory it needs', async () => {
+    await recordClaudeOk(T, path);
+    expect(JSON.parse(await readFile(path, 'utf8')).lastOkMs).toBe(T);
+  });
+
+  it('keeps the last success when a failure lands, so recovery is detectable', async () => {
+    await recordClaudeOk(T - HOUR, path);
+    await recordClaudeFailure('auth', 'run /login', T, path);
+    const h = await readClaudeHealth(path);
+    expect(h.lastOkMs).toBe(T - HOUR);
+    expect(h.lastFailMs).toBe(T);
+    expect(h.lastFailKind).toBe('auth');
+    expect(claudeBriefLines(h, T).alert).not.toBeNull();
+  });
+
+  it('a later success clears the alert end to end', async () => {
+    await recordClaudeFailure('auth', 'run /login', T - HOUR, path);
+    await recordClaudeOk(T, path);
+    expect(claudeBriefLines(await readClaudeHealth(path), T).alert).toBeNull();
+  });
+
+  it('never throws when the path is unwritable', async () => {
+    // A health file that cannot be written must not break the call it observes.
+    await expect(recordClaudeOk(T, '/proc/definitely/not/writable.json')).resolves.toBeUndefined();
+  });
+
+  it('survives a corrupt file rather than crashing the brief', async () => {
+    await recordClaudeOk(T, path);
+    await (await import('node:fs/promises')).writeFile(path, '{ not json', 'utf8');
+    expect(await readClaudeHealth(path)).toEqual(health());
+  });
+});

--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { recordClaudeFailure, recordClaudeOk } from './claude-health';
 
 export interface ClaudeCliResult {
   text: string;
@@ -92,7 +93,29 @@ export function classifyClaudeError(text: string): { kind: ClaudeErrorKind; hint
   return { kind: 'unknown', hint: 'unclassified claude CLI failure - check logs' };
 }
 
-export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> {
+/**
+ * Every Claude call in the fleet funnels through here, which makes this the one
+ * place that can answer "is Claude actually reachable right now". Recording the
+ * outcome at the single spawn point means no caller has to remember to, and no
+ * new call path can silently escape the check - which is exactly how the
+ * 2026-08-08 token revocation went unseen for four days.
+ *
+ * Recording never throws (see claude-health.ts) and the original error is always
+ * rethrown unchanged, so this is observation only - it cannot alter behaviour.
+ */
+export async function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> {
+  try {
+    const result = await callClaudeCliInner(opts);
+    await recordClaudeOk();
+    return result;
+  } catch (err: unknown) {
+    if (err instanceof CliAuthError) await recordClaudeFailure('auth', err.hint);
+    else if (err instanceof CliError) await recordClaudeFailure(err.kind, err.hint);
+    throw err;
+  }
+}
+
+function callClaudeCliInner(opts: ClaudeCliOptions): Promise<ClaudeCliResult> {
   return new Promise((resolve, reject) => {
     const outputFormat = opts.outputFormat ?? 'json';
     const args: string[] = [
@@ -323,6 +346,7 @@ export async function checkClaudeAuth(cwd: string = '/home/zaal/zao-os'): Promis
       bare: true,
       outputFormat: 'text',
     });
+    // No record call here: this went through callClaudeCli, which already did it.
     return { ok: true };
   } catch (err) {
     if (err instanceof CliAuthError) {

--- a/bot/src/hermes/claude-health.ts
+++ b/bot/src/hermes/claude-health.ts
@@ -1,0 +1,139 @@
+/**
+ * claude-health.ts - did a Claude call actually succeed, and when?
+ *
+ * ZOE's Max-plan OAuth token was revoked on 2026-08-08. Every Claude call 401'd
+ * for four days and nothing surfaced it: the pinned brief kept showing a healthy
+ * grill count because it had no idea Claude existed. Zaal found out because the
+ * bot quietly stopped being useful.
+ *
+ * `checkClaudeAuth` in claude-cli.ts already existed and its docstring claimed
+ * "Used by: bot/src/zoe/index.ts onBotStart hook". It had NO callers. The
+ * healthcheck was built, documented as wired, and never wired - so this module
+ * is the missing half: somewhere for an outcome to be recorded, and something
+ * cheap for the brief to read.
+ *
+ * Two rules shape the whole design.
+ *
+ * SILENCE IS NOT EVIDENCE (`.claude/rules/state-claims.md`). Most scheduler ticks
+ * never call Claude, so "no 401s lately" proves nothing at all. Health is
+ * therefore only ever asserted from a POSITIVE recorded success. With no record
+ * we report "not checked", never "ok".
+ *
+ * THE INDICATOR MUST REACH ZERO (`.claude/rules/noisy-signal-guard.md`). Only an
+ * OBSERVED auth failure raises the alert, and the next recorded success clears
+ * it. Staleness is reported as status, never as an alert - if the probe itself
+ * stopped running, a stale-based alarm could never be cleared by anyone, and a
+ * permanent warning is not a warning.
+ *
+ * Writes are best-effort and never throw. A health file that cannot be written
+ * must not take down the call it was observing.
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { ClaudeErrorKind } from './claude-cli';
+
+/** Same convention as backlog-grill-state.json, which pinned-brief-runner reads directly. */
+export const CLAUDE_HEALTH_PATH = join(homedir(), '.zao/zoe/claude-health.json');
+
+export interface ClaudeHealth {
+  /** ms epoch of the last call that came back clean. */
+  lastOkMs: number | null;
+  /** ms epoch of the last call that failed. */
+  lastFailMs: number | null;
+  /** Why it failed, from classifyClaudeError. Only 'auth' is treated as actionable. */
+  lastFailKind: ClaudeErrorKind | null;
+  lastFailHint: string | null;
+}
+
+const EMPTY: ClaudeHealth = { lastOkMs: null, lastFailMs: null, lastFailKind: null, lastFailHint: null };
+
+/**
+ * A success older than this stops counting as proof of health. The probe runs
+ * hourly, so this is three missed probes - long enough not to flap, short
+ * enough that a dead probe is visible the same morning.
+ */
+export const STALE_AFTER_MS = 3 * 60 * 60 * 1000;
+
+export async function readClaudeHealth(path: string = CLAUDE_HEALTH_PATH): Promise<ClaudeHealth> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(path, 'utf8')) as Partial<ClaudeHealth>;
+    return {
+      lastOkMs: typeof parsed.lastOkMs === 'number' ? parsed.lastOkMs : null,
+      lastFailMs: typeof parsed.lastFailMs === 'number' ? parsed.lastFailMs : null,
+      lastFailKind: (parsed.lastFailKind as ClaudeErrorKind) ?? null,
+      lastFailHint: typeof parsed.lastFailHint === 'string' ? parsed.lastFailHint : null,
+    };
+  } catch {
+    return { ...EMPTY };
+  }
+}
+
+async function write(next: ClaudeHealth, path: string): Promise<void> {
+  try {
+    await fs.mkdir(dirname(path), { recursive: true });
+    await fs.writeFile(path, JSON.stringify(next, null, 2), 'utf8');
+  } catch {
+    /* best effort - never break the call being observed */
+  }
+}
+
+/** Record a clean Claude call. This is the ONLY thing that proves reachability. */
+export async function recordClaudeOk(nowMs: number = Date.now(), path: string = CLAUDE_HEALTH_PATH): Promise<void> {
+  const cur = await readClaudeHealth(path);
+  await write({ ...cur, lastOkMs: nowMs }, path);
+}
+
+/** Record a failed Claude call, keeping why. */
+export async function recordClaudeFailure(
+  kind: ClaudeErrorKind,
+  hint: string,
+  nowMs: number = Date.now(),
+  path: string = CLAUDE_HEALTH_PATH,
+): Promise<void> {
+  const cur = await readClaudeHealth(path);
+  await write({ ...cur, lastFailMs: nowMs, lastFailKind: kind, lastFailHint: hint || null }, path);
+}
+
+function ago(ms: number): string {
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return `${Math.max(mins, 1)}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.floor(hrs / 24)}d`;
+}
+
+/**
+ * Turn a health record into the two things the brief can show. Pure, so the
+ * whole decision is testable without a filesystem, a clock, or a live token.
+ *
+ * `alert` is for the needs-you list and is non-null ONLY when the most recent
+ * observation was an auth failure. It clears itself on the next success.
+ * `status` is the always-on line, and says "not checked" rather than "ok" when
+ * nothing has been observed.
+ */
+export function claudeBriefLines(
+  h: ClaudeHealth,
+  nowMs: number,
+  staleAfterMs: number = STALE_AFTER_MS,
+): { alert: string | null; status: [string, string] } {
+  const failing = h.lastFailMs !== null && (h.lastOkMs === null || h.lastFailMs > h.lastOkMs);
+
+  if (failing && h.lastFailKind === 'auth') {
+    return {
+      alert: `ZOE cannot reach Claude - auth failed ${ago(nowMs - (h.lastFailMs as number))} ago. Run \`claude\` then /login on the host.`,
+      status: ['claude', 'auth failed'],
+    };
+  }
+
+  // A non-auth failure (rate limit, timeout) is real but usually self-clearing,
+  // so it is reported without pulling Zaal in.
+  if (failing) return { alert: null, status: ['claude', `${h.lastFailKind ?? 'error'}`] };
+
+  if (h.lastOkMs === null) return { alert: null, status: ['claude', 'not checked'] };
+
+  const age = nowMs - h.lastOkMs;
+  if (age > staleAfterMs) return { alert: null, status: ['claude', `last ok ${ago(age)} ago`] };
+
+  return { alert: null, status: ['claude', 'ok'] };
+}

--- a/bot/src/zoe/__tests__/pinned-brief-runner.test.ts
+++ b/bot/src/zoe/__tests__/pinned-brief-runner.test.ts
@@ -18,9 +18,24 @@ vi.mock('node:os', async (importOriginal) => {
   return { ...actual, default: { ...actual, homedir: () => FAKE_HOME }, homedir: () => FAKE_HOME };
 });
 
+// gatherBrief shells out to `gh` twice. Failing them fast keeps this offline and
+// exercises the documented omit-rather-than-guess path.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    exec: (_cmd: string, _opts: unknown, cb?: (e: Error | null, o: string, e2: string) => void) => {
+      const done = typeof _opts === 'function' ? (_opts as typeof cb) : cb;
+      done?.(new Error('offline in tests'), '', '');
+      return undefined as never;
+    },
+  };
+});
+
 import { DRIP_DEFAULT } from '../backlog-grill';
 import { outstandingCount } from '../backlog-grill-runner';
-import { grillDepth } from '../pinned-brief-runner';
+import { gatherBrief, grillDepth } from '../pinned-brief-runner';
+import { CLAUDE_HEALTH_PATH } from '../../hermes/claude-health';
 
 const STATE_PATH = join(FAKE_HOME, '.zao/zoe/backlog-grill-state.json');
 
@@ -78,5 +93,50 @@ describe('grillDepth', () => {
 
   it('returns null when the state cannot be read, so the line is omitted', async () => {
     expect(await grillDepth()).toBeNull();
+  });
+});
+
+
+/**
+ * The regression for 2026-08-08: ZOE's OAuth token was revoked, every Claude call
+ * 401'd for four days, and the brief said nothing because it had no Claude line at
+ * all. These assert the line exists, that it alerts on a real observed failure,
+ * and - just as importantly - that it does not invent health when nothing is known.
+ */
+describe('gatherBrief surfaces Claude reachability', () => {
+  async function writeHealth(h: unknown): Promise<void> {
+    await fs.mkdir(dirname(CLAUDE_HEALTH_PATH), { recursive: true });
+    await fs.writeFile(CLAUDE_HEALTH_PATH, JSON.stringify(h), 'utf8');
+  }
+
+  beforeEach(async () => {
+    await fs.rm(CLAUDE_HEALTH_PATH, { force: true });
+  });
+
+  it('puts an auth failure in needs-you', async () => {
+    const now = new Date('2026-08-12T12:00:00.000Z');
+    await writeHealth({
+      lastOkMs: now.getTime() - 6 * 86400_000,
+      lastFailMs: now.getTime() - 4 * 86400_000,
+      lastFailKind: 'auth',
+      lastFailHint: 'run /login',
+    });
+    const brief = await gatherBrief(now);
+    expect(brief.needsYou.some((l) => l.includes('cannot reach Claude'))).toBe(true);
+    expect(brief.running).toContainEqual(['claude', 'auth failed']);
+  });
+
+  it('reports "not checked" rather than ok when nothing has been observed', async () => {
+    const brief = await gatherBrief(new Date('2026-08-12T12:00:00.000Z'));
+    expect(brief.running).toContainEqual(['claude', 'not checked']);
+    expect(brief.needsYou.some((l) => l.includes('Claude'))).toBe(false);
+  });
+
+  it('says ok, and raises nothing, after a recent success', async () => {
+    const now = new Date('2026-08-12T12:00:00.000Z');
+    await writeHealth({ lastOkMs: now.getTime() - 60_000, lastFailMs: null, lastFailKind: null, lastFailHint: null });
+    const brief = await gatherBrief(now);
+    expect(brief.running).toContainEqual(['claude', 'ok']);
+    expect(brief.needsYou.some((l) => l.includes('Claude'))).toBe(false);
   });
 });

--- a/bot/src/zoe/pinned-brief-runner.ts
+++ b/bot/src/zoe/pinned-brief-runner.ts
@@ -15,6 +15,7 @@ import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { claudeBriefLines, readClaudeHealth } from '../hermes/claude-health';
 import { DRIP_DEFAULT } from './backlog-grill';
 import { outstandingCount, type BacklogGrillState } from './backlog-grill-runner';
 import { renderPinnedBrief, syncPinnedBrief, type BriefInput, type PinDeps, type PinResult } from './pinned-brief';
@@ -63,10 +64,13 @@ export async function grillDepth(): Promise<number | null> {
 const REPO = 'bettercallzaal/ZAOOS';
 
 export async function gatherBrief(now: Date = new Date()): Promise<BriefInput> {
-  const [prsRaw, ciRaw, depth] = await Promise.all([
+  const [prsRaw, ciRaw, depth, health] = await Promise.all([
     sh(`gh api 'repos/${REPO}/pulls?state=open&per_page=100' --jq 'length'`),
     sh(`gh api 'repos/${REPO}/actions/runs?branch=main&per_page=1' --jq '.workflow_runs[0].conclusion // ""'`),
     grillDepth(),
+    // A file read, same cost class as the grill state. The brief must never call
+    // Claude itself - it runs every 5 minutes forever.
+    readClaudeHealth(),
   ]);
 
   const needsYou: string[] = [];
@@ -90,6 +94,15 @@ export async function gatherBrief(now: Date = new Date()): Promise<BriefInput> {
     running.push(['grill queue', depth >= cap ? `${depth} (at cap)` : String(depth)]);
     if (depth >= cap) needsYou.push(`Grill stuck at ${cap} - answer any card to restart it`);
   }
+
+  // Claude reachability. The whole point is that this line exists at all: when the
+  // OAuth token was revoked on 2026-08-08 the brief had nothing to say about Claude,
+  // so four days of total failure looked exactly like four days of working fine.
+  // `claudeBriefLines` only claims health from a recorded success, and only alerts
+  // on an observed auth failure - so it can reach zero when the token is fixed.
+  const claude = claudeBriefLines(health, now.getTime());
+  running.push(claude.status);
+  if (claude.alert) needsYou.push(claude.alert);
 
   const updatedLabel = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York',

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -56,6 +56,7 @@ import { surfaceNudges } from './nudge';
 import { surfaceGrill } from './grill';
 import { runBacklogGrillTick } from './backlog-grill-runner';
 import { runPinnedBriefTick } from './pinned-brief-runner';
+import { checkClaudeAuth } from '../hermes/claude-cli';
 import { withTickLock } from './tick-lock';
 import { featureRan } from './feature-ran';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
@@ -436,6 +437,36 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           featureRan('pinned-brief-tick', r.ran ? r.value.action : `lock ${r.reason}`);
         } catch (err) {
           console.warn('[zoe/pinned-brief] tick failed (nbd):', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Prove Claude is reachable, hourly, with an actual call.
+  //
+  // This is the positive half of the 401 fix. Recording outcomes inside
+  // callClaudeCli covers every real call, but a quiet ZOE makes no real calls -
+  // and "no failures recorded" is not evidence of health
+  // (`.claude/rules/state-claims.md`, silence is not evidence). So once an hour
+  // we spend one haiku call to establish the fact either way, and the pinned
+  // brief reads the result.
+  //
+  // checkClaudeAuth already existed in hermes/claude-cli.ts and its docstring
+  // claimed "Used by: bot/src/zoe/index.ts onBotStart hook". It had zero callers.
+  // This is that wiring, finally made real.
+  tasks.push(
+    cron.schedule(
+      '7 * * * *',
+      async () => {
+        try {
+          const r = await checkClaudeAuth();
+          featureRan('claude-auth-probe', r.ok ? 'ok' : `${r.kind ?? 'fail'}`);
+          if (!r.ok) console.warn(`[zoe/scheduler] claude auth probe failed: ${r.kind ?? 'unknown'} - ${r.hint ?? ''}`);
+        } catch (err) {
+          // The probe failing to RUN is different from Claude being down, and
+          // callClaudeCli has already recorded whatever it saw.
+          console.warn('[zoe/scheduler] claude auth probe threw:', (err as Error).message);
         }
       },
       { timezone: 'UTC' },


### PR DESCRIPTION
feat(zoe): the pinned brief can finally see a Claude 401

ZOE's Max-plan OAuth token was revoked on 2026-08-08. Every Claude call 401'd for
four days and the pinned brief showed a healthy grill count the whole time,
because it had no line about Claude at all. Zaal found out by noticing the bot had
quietly stopped being useful.

ROOT CAUSE, and it is not a missing feature. `checkClaudeAuth` already existed in
hermes/claude-cli.ts, correctly classified 401 as `kind: 'auth'`, and its docstring
said "Used by: bot/src/zoe/index.ts onBotStart hook". A grep for it across
bot/src returns exactly one line - its own definition. It was built, documented as
wired, and never wired. The classifier was fine; nothing was listening.

WHAT THIS ADDS

- `hermes/claude-health.ts` - a small record of the last Claude success and the
  last failure, at ~/.zao/zoe/claude-health.json. Writes are best-effort and never
  throw, so a health file that cannot be written can never break the call it is
  observing. `claudeBriefLines` is pure, so the whole decision is testable without
  a filesystem, a clock, or a live token.
- Recording wired into `callClaudeCli` itself rather than into each caller. Every
  Claude call in the fleet funnels through that one spawn point, so no existing
  caller had to be edited and no future call path can silently escape the check.
  The original error is always rethrown unchanged - this is observation only.
- An hourly `checkClaudeAuth` probe in the scheduler, which is the wiring the
  docstring already claimed. One haiku call an hour.
- The brief reads the health file (a file read, same cost class as the grill
  state) and adds a `claude` line.

THE TWO GUARDS, BOTH LOAD-BEARING

Silence is not evidence. Most scheduler ticks never call Claude, so "no 401s
lately" proves nothing. Health is only ever asserted from a POSITIVE recorded
success; with nothing recorded the brief says "not checked", never "ok". The
hourly probe exists precisely so an idle ZOE still produces that positive fact.

The indicator can reach zero. Only an OBSERVED auth failure raises the needs-you
alert, and the next recorded success clears it - the probe means recovery shows up
within the hour by itself. Staleness is reported as status, never as an alert:
if the probe itself stopped running, a stale-based alarm could not be cleared by
anyone, and a permanent warning is not a warning.

VERIFIED, absolute numbers not deltas

- 18 new tests, all passing. They include the incident shape itself (a four-day-old
  auth failure still alerting), the clearing case, the tie case, and two negative
  cases that would catch a naive fix: never claim ok from silence, never alert on
  staleness.
- Full suite 2302 passed / 180 files, up from 2284 (2299 measured before the last
  3 were added). vitest exit 0.
- tsc --noEmit: 37 errors, exactly as on main, none in any file touched here. The
  37 are the pre-existing vitest Mock generics, handled separately.
- esbuild bundles src/zoe/index.ts clean, exit 0 - tsc alone would not have caught
  a broken boot graph.
- The token is valid again as of 09:26 UTC so none of this could be tested against
  a live 401; every case is constructed state.

NOTE ON THE HANDOFF'S NUMBERS: it cited 2320 tests on main. This checkout measures
2284 before my changes. The 37 tsc errors matched exactly; the test count did not.
Flagging rather than quietly adopting either number.

bus-upload.ts, bus-receipt.ts and __tests__/bus-files.test.ts are untouched (PR #3051).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N3znCy4Xk7L8XDneB9Lnkf
