### PR TITLE
fix(bot): tsc from 37 errors to 0, and three of them were real

### DIFF
--- a/bot/src/hermes/__tests__/commands.test.ts
+++ b/bot/src/hermes/__tests__/commands.test.ts
@@ -14,6 +14,7 @@ vi.mock('../db', () => ({
 vi.mock('../runner', () => ({ dispatchHermesRun: vi.fn() }));
 
 import { cmdFix, cmdFixStatus, cmdZsEdit } from '../commands';
+import type { TeamMember } from '../../auth';
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -41,8 +42,10 @@ function makeCtx(text: string, fromId = 99999, role?: 'admin' | 'member') {
   };
 }
 
-const NON_ADMIN_MEMBER = { fid: 1, name: 'Alice', role: 'member' as const, telegram_id: 99999 };
-const ADMIN_MEMBER = { fid: 2, name: 'Bob', role: 'admin' as const, telegram_id: 88888 };
+// Shaped to TeamMember (src/auth.ts). These previously carried a `fid` field that
+// TeamMember has never had, and omitted id, scope and telegram_username.
+const NON_ADMIN_MEMBER: TeamMember = { id: 'm-1', name: 'Alice', scope: 'zao', role: 'member', telegram_id: 99999, telegram_username: 'alice' };
+const ADMIN_MEMBER: TeamMember = { id: 'm-2', name: 'Bob', scope: 'zao', role: 'admin', telegram_id: 88888, telegram_username: 'bob' };
 
 // ── cmdFix ────────────────────────────────────────────────────────────────────
 

--- a/bot/src/hermes/__tests__/critic.test.ts
+++ b/bot/src/hermes/__tests__/critic.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRunCmd = vi.hoisted(() => vi.fn());
 vi.mock('../git', () => ({ runCmd: mockRunCmd }));
@@ -17,8 +17,12 @@ import { runCritic } from '../critic';
 type CmdResult = { stdout: string; stderr: string; exitCode: number };
 const cmdOk = (stdout: string): CmdResult => ({ stdout, stderr: '', exitCode: 0 });
 
+// branchName is required by CritiqueInput and IS read by runCritic (critic.ts,
+// `branch: input.branchName` in the shadow-log line). It was missing here, so every
+// test below ran with branch: undefined - an input shape production cannot produce.
 const MOCK_INPUT = {
   workTreePath: '/tmp/wt',
+  branchName: 'ws/fix-greeting-typo',
   issueText: 'Fix the typo in greeting',
   filesChanged: ['src/greet.ts'],
 };

--- a/bot/src/hermes/__tests__/db.test.ts
+++ b/bot/src/hermes/__tests__/db.test.ts
@@ -70,7 +70,7 @@ describe('updateRun', () => {
     const update = vi.fn().mockReturnValue({ eq });
     mockDb.mockReturnValue({ from: vi.fn().mockReturnValue({ update }) });
 
-    await expect(updateRun('run-uuid-1', { status: 'done' })).rejects.toThrow(
+    await expect(updateRun('run-uuid-1', { status: 'ready' })).rejects.toThrow(
       'updateRun failed: update failed',
     );
   });

--- a/bot/src/zoe/__tests__/curator.test.ts
+++ b/bot/src/zoe/__tests__/curator.test.ts
@@ -8,7 +8,9 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 // Mock execSync before importing curator
-let mockExecSyncImpl = (cmd: string) => {
+// Annotated: without this the throwing default infers `(cmd: string) => never`,
+// and every test that swaps in a string-returning impl fails to typecheck.
+let mockExecSyncImpl: (cmd: string) => string = (_cmd: string) => {
   throw new Error('execSync not mocked');
 };
 

--- a/bot/src/zoe/__tests__/resume.test.ts
+++ b/bot/src/zoe/__tests__/resume.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCallClaudeCli = vi.hoisted(() => vi.fn());
 vi.mock('../../hermes/claude-cli', () => ({

--- a/bot/src/zoe/__tests__/tg-interactions.test.ts
+++ b/bot/src/zoe/__tests__/tg-interactions.test.ts
@@ -216,10 +216,10 @@ function makeDeps(
     isFromZaal: overrides.isFromZaal ?? true,
     zaalId: 123,
     reactions: {
-      unpin: vi.fn<[number, number], Promise<void>>().mockResolvedValue(undefined),
-      markDone: vi.fn<[string, 'done'], Promise<void>>().mockResolvedValue(undefined),
-      getTaskForMessage: overrides.getTaskForMessage ?? vi.fn<[number], Promise<string | null>>().mockResolvedValue(null),
-      ping: vi.fn<[string, string], Promise<void>>().mockResolvedValue(undefined),
+      unpin: vi.fn<(chatId: number, messageId: number) => Promise<void>>().mockResolvedValue(undefined),
+      markDone: vi.fn<(taskId: string, status: 'done') => Promise<void>>().mockResolvedValue(undefined),
+      getTaskForMessage: overrides.getTaskForMessage ?? vi.fn<(messageId: number) => Promise<string | null>>().mockResolvedValue(null),
+      ping: vi.fn<(queueName: string, reason: string) => Promise<void>>().mockResolvedValue(undefined),
     },
   };
 }

--- a/bot/src/zoe/__tests__/transcribe.test.ts
+++ b/bot/src/zoe/__tests__/transcribe.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockMkdir = vi.hoisted(() => vi.fn());
 const mockWriteFile = vi.hoisted(() => vi.fn());
-const mockReadFileSync = vi.hoisted(() => vi.fn(() => { throw new Error('ENOENT'); }));
+const mockReadFileSync = vi.hoisted(() => vi.fn<() => string>(() => { throw new Error('ENOENT'); }));
 const mockFetch = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', () => ({

--- a/bot/src/zoe/safety/__tests__/klearu.test.ts
+++ b/bot/src/zoe/safety/__tests__/klearu.test.ts
@@ -12,7 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Hoist so the fn reference is stable before vi.mock hoisting.
 const { makeSpawn } = vi.hoisted(() => {
   function makeSpawn(stdout: string, exitCode = 0) {
-    return vi.fn(() => ({
+    // rest signature so the vi.mock factory can forward its args through
+    return vi.fn((..._args: unknown[]) => ({
       stdout: {
         on: (event: string, cb: (d: Buffer) => void) => {
           if (event === 'data' && stdout) cb(Buffer.from(stdout));

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -193,7 +193,7 @@ export interface ConciergeResult {
 
 export type TaskOp =
   | { op: 'add'; task: Omit<ZoeTask, 'id' | 'created_at' | 'updated_at'> }
-  | { op: 'update'; id: string; patch: Partial<Pick<ZoeTask, 'status' | 'description' | 'priority' | 'notes'>> }
+  | { op: 'update'; id: string; patch: Partial<Pick<ZoeTask, 'title' | 'status' | 'description' | 'priority' | 'notes'>> }
   | { op: 'complete'; id: string; outcome?: string }
   | { op: 'defer'; id: string; reason?: string };
 


### PR DESCRIPTION
fix(bot): tsc from 37 errors to 0, and three of them were real

`./node_modules/.bin/tsc --noEmit` from bot/ reported 37 errors on main while all
tests passed. That gap is the actual damage: it forces everyone to measure "no NEW
errors" instead of "no errors", and a delta-based check cannot see a real error
that lands in one of the same files. Absolute count now 0, tsc exit 0.

THE HANDOFF'S DIAGNOSIS WAS PARTLY RIGHT. It said all 37 were `Mock<[...]>`
generic mismatches from a vitest bump. About 20 were. The rest were genuine drift
the noise had been hiding, which is precisely the argument for fixing the
instrument.

WHAT WAS ACTUALLY WRONG

1. vitest 3 changed `vi.fn`'s generics - one type param (the whole function type),
   not the old `<Args, Return>` pair. Four declarations in tg-interactions.test.ts
   used the old form; fixing those four cleared 16 errors.

2. `beforeEach` was used but never imported in critic.test.ts and resume.test.ts.
   It resolves at runtime through vitest globals, so the tests passed while the
   type layer was right to object.

3. Three throwing-default mocks inferred `=> never`, so every later
   `mockReturnValue`/reassignment with a real value was rejected
   (curator, transcribe). One zero-arg mock could not receive a forwarded
   `...unknown[]` (klearu). Annotated rather than cast.

THE THREE THAT WERE REAL BUGS, not type noise

4. `critic.test.ts` omitted `branchName` from its fixture, and `runCritic` READS it
   (`branch: input.branchName`, critic.ts). All six critic tests were running with
   `branch: undefined` - an input shape production cannot produce.

5. `commands.test.ts` fixtures carried a `fid` field that `TeamMember` has never
   had, and omitted the required `id`, `scope` and `telegram_username`. They were
   shaped to a type that no longer exists.

6. `ZoeTaskOp`'s update patch was typed
   `Partial<Pick<ZoeTask, 'status'|'description'|'priority'|'notes'>>`, excluding
   `title`. But `tasks.ts` merges with `{ ...t, ...op.patch }`, so title IS applied,
   and tasks.test.ts asserts exactly that and passes. The type was narrower than
   the behaviour, which blocked any caller from renaming a task through the
   documented op. Widened to match what the code does and the test proves.

   This is the one worth a second look on review: the alternative reading is that
   title updates should be forbidden and the runtime spread is the bug. I took the
   test as the specification.

7. `db.test.ts` passed `status: 'done'`, which is not a member of `HermesStatus`
   (pending | fixing | critiquing | ready | failed | escalated). The test only
   exercises the Supabase-error path so the value was incidental; changed to 'ready'.

VERIFIED, absolute numbers

- tsc --noEmit: 37 -> 0, exit 0. Stepwise: 37 -> 21 (vitest generics) -> 19
  (imports) -> 7 (fixtures) -> 3 (never/spread) -> 0.
- Full suite: 2302 passed / 180 files, vitest exit 0. Unchanged from before these
  fixes, which is the point - no behaviour was altered, only the contracts.
- esbuild bundles src/zoe/index.ts, exit 0.

One source file changed (`src/zoe/types.ts`, item 6). Everything else is tests.
bus-upload.ts, bus-receipt.ts and __tests__/bus-files.test.ts untouched (PR #3051).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N3znCy4Xk7L8XDneB9Lnkf
