### PR TITLE
feat(zoe): let the autonomous path say it ran, and keep it that way

### DIFF
--- a/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
+++ b/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
@@ -1,0 +1,124 @@
+/**
+ * featureRan coverage - the autonomous path must be able to say it ran.
+ *
+ * WHY
+ *
+ * state-claims.md: "you cannot conclude a feature did NOT run from the absence
+ * of log lines - unless you first prove it CAN log." Asked in August which of
+ * eight shipped features had executed in production, seven days of journald
+ * could not answer, because most of them contained no logging at all and the
+ * rest spoke only from inside a catch. Silence meant "nothing crashed", never
+ * "it ran".
+ *
+ * That gap matters most where nobody is watching. A feature Zaal triggers by
+ * hand announces itself by replying to him. A feature that runs on a scheduler
+ * at 4am does not, and its silence is indistinguishable from its death.
+ *
+ * So the rule this test enforces is narrow and stated: modules on the
+ * AUTONOMOUS path must contain a featureRan call. Not every module - a
+ * featureRan in all 127 would be the noise nobody greps, which
+ * noisy-signal-guard.md warns is the same as no signal at all.
+ *
+ * The list can shrink as well as grow: a declared module that loses its call
+ * fails here, so this cannot rot into a list that only ever gets longer.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { verifyReceipt } from '../bus-receipt';
+import { announcedFeatures, featureRan, resetAnnouncedForTest } from '../feature-ran';
+
+/**
+ * Modules that do work with no human watching. Each must announce on its
+ * success path.
+ *
+ * Deliberately NOT here: brief.ts and reflect.ts. They belong by the same rule,
+ * but their success paths were not read when this landed, and a featureRan
+ * placed in unread code would announce something other than what it claims.
+ * Follow-up, not an oversight.
+ */
+const AUTONOMOUS_FEATURES = [
+  'heart-run.ts',
+  'bonfire-retry.ts',
+  'receipts.ts',
+  'bus-upload.ts',
+  'bus-receipt.ts',
+  'afferent-digest.ts',
+  'recap.ts',
+];
+
+function sourceOf(file: string): string {
+  return readFileSync(fileURLToPath(new URL(`../${file}`, import.meta.url)), 'utf8');
+}
+
+/** A mention inside a comment is not a call. The swallow-registry test learned this the hard way. */
+function hasRealCall(source: string): boolean {
+  return source
+    .split('\n')
+    .filter((l) => {
+      const t = l.trim();
+      return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+    })
+    .some((l) => /\bfeatureRan\s*\(/.test(l));
+}
+
+describe('featureRan coverage on the autonomous path', () => {
+  it('every declared autonomous module calls featureRan outside a comment', () => {
+    const missing = AUTONOMOUS_FEATURES.filter((f) => !hasRealCall(sourceOf(f)));
+    expect(
+      missing,
+      `These run with nobody watching and cannot say they ran: ${missing.join(', ')}.\n` +
+        `Add featureRan() on the SUCCESS path - not at import time, which only proves\n` +
+        `the module loaded, the same empty proof a feature flag already gives.`,
+    ).toEqual([]);
+  });
+
+  it('the call is on the success path, not only inside a catch', () => {
+    // A module that speaks only when it fails tells you nothing when it works.
+    const catchOnly: string[] = [];
+    for (const f of AUTONOMOUS_FEATURES) {
+      const src = sourceOf(f);
+      const lines = src.split('\n');
+      const callLines = lines
+        .map((l, i) => ({ l, i }))
+        .filter(({ l }) => /\bfeatureRan\s*\(/.test(l) && !l.trim().startsWith('//'));
+      const allInCatch = callLines.every(({ i }) => {
+        // walk back to the nearest brace-opening construct
+        for (let j = i; j >= 0 && i - j < 25; j--) {
+          if (/\}\s*catch\s*\(/.test(lines[j])) return true;
+          if (/^\s*(export\s+)?(async\s+)?function\b/.test(lines[j])) return false;
+          if (/\btry\s*\{/.test(lines[j])) return false;
+        }
+        return false;
+      });
+      if (callLines.length > 0 && allInCatch) catchOnly.push(f);
+    }
+    expect(catchOnly, `featureRan only reachable from a catch block in: ${catchOnly.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('featureRan announces for real, not just in source', () => {
+  beforeEach(() => resetAnnouncedForTest());
+
+  it('verifyReceipt announces when called', () => {
+    expect(announcedFeatures()).not.toContain('bus-receipt-verify');
+    verifyReceipt({ messageId: 'm1', contentHash: 'abc' }, 'm1', 'abc');
+    expect(announcedFeatures()).toContain('bus-receipt-verify');
+  });
+
+  it('CANNOT_VERIFY still counts as having run - a real outcome is not a failure to execute', () => {
+    // The empty-hash case: '' === '' would have returned MATCH and proved nothing.
+    // It now returns CANNOT_VERIFY, and the verifier still ran.
+    const verdict = verifyReceipt({ messageId: 'm1', contentHash: '' }, 'm1', '');
+    expect(verdict).toBe('CANNOT_VERIFY');
+    expect(announcedFeatures()).toContain('bus-receipt-verify');
+  });
+
+  it('announces once per process, so a per-tick feature cannot flood the log', () => {
+    featureRan('demo-feature', 'first');
+    featureRan('demo-feature', 'second');
+    featureRan('demo-feature', 'third');
+    expect(announcedFeatures().filter((f) => f === 'demo-feature')).toHaveLength(1);
+  });
+});

--- a/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
+++ b/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
@@ -33,10 +33,12 @@ import { announcedFeatures, featureRan, resetAnnouncedForTest } from '../feature
  * Modules that do work with no human watching. Each must announce on its
  * success path.
  *
- * Deliberately NOT here: brief.ts and reflect.ts. They belong by the same rule,
- * but their success paths were not read when this landed, and a featureRan
- * placed in unread code would announce something other than what it claims.
- * Follow-up, not an oversight.
+ * brief.ts and reflect.ts were excluded on the first pass because their success
+ * paths had not been read, and a featureRan placed in unread code announces
+ * something other than what it claims. They have been read now: both return a
+ * string on BOTH paths - a real one, or a degraded stub - so each announces with
+ * a detail saying which, because "it ran" and "it worked" are different
+ * questions when a fallback still produces output.
  */
 const AUTONOMOUS_FEATURES = [
   'heart-run.ts',
@@ -46,6 +48,8 @@ const AUTONOMOUS_FEATURES = [
   'bus-receipt.ts',
   'afferent-digest.ts',
   'recap.ts',
+  'brief.ts',
+  'reflect.ts',
 ];
 
 function sourceOf(file: string): string {

--- a/bot/src/zoe/afferent-digest.ts
+++ b/bot/src/zoe/afferent-digest.ts
@@ -18,6 +18,7 @@ import { db } from '../supabase';
 import { emitReceipt } from './receipts';
 import { buildEpisode, promoteSubmission, queueConfigured, type BonfireSubmission } from './bonfire-queue';
 import { enqueueWrite } from './bonfire-retry';
+import { featureRan } from './feature-ran';
 
 export interface DigestResult {
   status: 'success' | 'error' | 'silent';
@@ -211,6 +212,10 @@ export async function persistDailyDigest(): Promise<DigestResult> {
       console.error('[zoe/afferent-digest] failed to emit digest receipt');
       return { status: 'error', message: 'receipt emit failed', receiptCount };
     }
+
+    // The digest receipt is the effect. Bonfire below is best-effort, so the
+    // feature has run by this point whether or not the graph write lands.
+    featureRan('afferent-digest', `${receiptCount} receipts`);
 
     // If Bonfire is configured, write an episode for long-term graph memory
     let bonfireSuccess = false;

--- a/bot/src/zoe/bonfire-retry.ts
+++ b/bot/src/zoe/bonfire-retry.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { ZOE_PATHS } from './memory';
 import { remember, containsSecret, bonfireConfigured } from './recall';
 import { containsPii, scanPii } from './pii';
+import { featureRan } from './feature-ran';
 
 /**
  * Resolved LAZILY, never at module load. This module is imported by
@@ -153,6 +154,15 @@ export async function flushQueue(path?: string, now: number = Date.now()): Promi
       `[zoe/bonfire-retry] ${remaining.length} still queued` +
         (stuck > 0 ? ` - ${stuck} have failed 5+ times, Bonfire may need a look` : ''),
     );
+  }
+
+  // Announce only when the queue actually moved. A flush that found nothing
+  // to do has not run in any sense worth reporting, and claiming otherwise
+  // would make the [zoe/ran] line mean 'the cron fired' rather than 'the
+  // feature worked' - which is the exact confusion this whole mechanism exists
+  // to remove.
+  if (sent > 0 || dropped > 0) {
+    featureRan('bonfire-retry', `sent ${sent}, dropped ${dropped}`);
   }
 
   return { sent, kept: remaining.length, dropped };

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -26,6 +26,7 @@ import { readTriageContext } from './memory';
 import { getRecentMeetingsForBrief } from './meetings';
 import type { ZoeTask } from './types';
 import { execSync } from 'node:child_process';
+import { featureRan } from './feature-ran';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
 
@@ -427,6 +428,12 @@ Output the brief now in the exact format from your system prompt.`;
     bare: false,
   });
 
+  // Both paths below return a string - a real brief, or the degraded stub. So
+  // "it ran" and "it worked" are different questions here, and the detail says
+  // which. guardEmpty already logs the degraded case at error level; this line
+  // is the one that proves the 5am scheduler reached this code at all.
+  const generated = result.text.trim().length >= EMPTY_GUARD_MIN;
+  featureRan('brief', generated ? 'generated' : 'degraded');
   return guardEmpty(result.text);
 }
 

--- a/bot/src/zoe/bus-receipt.ts
+++ b/bot/src/zoe/bus-receipt.ts
@@ -16,6 +16,7 @@
 
 import type { BusConfig } from './bus-send';
 import { busConfig, busConfigured, sendBusReply } from './bus-send';
+import { featureRan } from './feature-ran';
 
 /**
  * Result of verifying a receipt against what we sent. Three distinct outcomes
@@ -57,6 +58,9 @@ export function verifyReceipt(
   sentMessageId: string,
   sentContentHash: string,
 ): ReceiptVerificationResult {
+  // A pure function: being called IS running it, so announce at entry rather
+  // than per verdict. CANNOT_VERIFY is a real outcome, not a failure to run.
+  featureRan('bus-receipt-verify');
   // Both fields must be present and non-null to proceed.
   const hasMessageId = receipt.messageId !== null && receipt.messageId !== undefined;
   const hasContentHash = receipt.contentHash !== null && receipt.contentHash !== undefined;

--- a/bot/src/zoe/bus-upload.ts
+++ b/bot/src/zoe/bus-upload.ts
@@ -19,6 +19,7 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import type { BusConfig } from './bus-send';
 import { busConfig, busConfigured } from './bus-send';
+import { featureRan } from './feature-ran';
 
 export interface FileUploadResult {
   ok: boolean;
@@ -90,6 +91,7 @@ export async function uploadFileToBus(
     const fileId = data.id ? String(data.id) : undefined;
     const idDisplay = fileId ? ` (id ${fileId.slice(0, 8)})` : '';
 
+    featureRan('bus-upload', filename);
     return {
       ok: true,
       reply: `Uploaded ${filename}${idDisplay}.`,

--- a/bot/src/zoe/heart-run.ts
+++ b/bot/src/zoe/heart-run.ts
@@ -35,6 +35,7 @@
  */
 import { randomUUID } from 'node:crypto';
 import { deterministicResourceId } from '../../../packages/heart-fleet/src/index';
+import { featureRan } from './feature-ran';
 
 /** One row shape this module reads back - only the primary key is needed. */
 interface RunIdRow {
@@ -90,7 +91,10 @@ export async function ensureLeaseRun(
       .select('id')
       .eq('idempotency_key', idempotencyKey)
       .maybeSingle();
-    if (existing?.id) return existing.id as string;
+    if (existing?.id) {
+      featureRan('heart-run', kind);
+      return existing.id as string;
+    }
 
     const { data: created, error } = await client
       .from('agent_runs')
@@ -110,7 +114,10 @@ export async function ensureLeaseRun(
       })
       .select('id')
       .single();
-    if (!error && created?.id) return created.id as string;
+    if (!error && created?.id) {
+      featureRan('heart-run', kind);
+      return created.id as string;
+    }
 
     // A unique violation on idempotency_key means a sibling host created the row
     // between our read and our insert - re-read rather than fail.
@@ -119,7 +126,10 @@ export async function ensureLeaseRun(
       .select('id')
       .eq('idempotency_key', idempotencyKey)
       .maybeSingle();
-    if (raced?.id) return raced.id as string;
+    if (raced?.id) {
+      featureRan('heart-run', kind);
+      return raced.id as string;
+    }
 
     console.error(
       `[zoe/heart-run] could not ensure lease run for ${kind}:${key}: ${error?.message ?? 'unknown error'}`,

--- a/bot/src/zoe/recap.ts
+++ b/bot/src/zoe/recap.ts
@@ -18,6 +18,7 @@
  */
 import { callClaudeCliCapAware } from './models/cli-cap-aware';
 import { execSync } from 'node:child_process';
+import { featureRan } from './feature-ran';
 
 const RECAP_SYSTEM_PROMPT = `You are ZOE writing Zaal's nightly recap at 9pm EST.
 
@@ -133,7 +134,9 @@ Output the recap now in the exact format from your system prompt.`;
     bare: false,
   });
 
-  return guardEmpty(result.text);
+  const recap = guardEmpty(result.text);
+  if (recap) featureRan('recap');
+  return recap;
 }
 
 const EMPTY_GUARD_MIN = 50;

--- a/bot/src/zoe/receipts.ts
+++ b/bot/src/zoe/receipts.ts
@@ -15,6 +15,7 @@
 import { randomUUID } from 'node:crypto';
 import { db } from '../supabase';
 import { computeActionDigest } from './receipt-envelope';
+import { featureRan } from './feature-ran';
 
 /**
  * Resolve a run_id for a receipt. receipts.run_id is NOT NULL with an FK to
@@ -124,6 +125,7 @@ export async function emitReceipt(input: ReceiptInput): Promise<boolean> {
       return false;
     }
 
+    featureRan('receipts', input.capability);
     return true;
   } catch (err) {
     // Swallow all errors: network, parse, auth, etc. Receipts are best-effort.

--- a/bot/src/zoe/reflect.ts
+++ b/bot/src/zoe/reflect.ts
@@ -64,6 +64,7 @@ interface ReflectContext {
 }
 
 import { execSync } from 'node:child_process';
+import { featureRan } from './feature-ran';
 
 function loadReflectContext(repoDir: string): ReflectContext {
   let commits: string[] = [];
@@ -129,6 +130,9 @@ ${
   recordCall('reflect', result);
 
   const trimmed = result.text.trim();
+  // As in brief.ts: the canned three-question fallback is still a returned
+  // string, so the detail distinguishes a real reflection from the stub.
+  featureRan('reflect', trimmed.length < 60 ? 'degraded' : 'generated');
   if (trimmed.length < 60) {
     console.error('[zoe/reflect] empty reflection, length=', trimmed.length);
     return [


### PR DESCRIPTION
## Executive summary

ZOE has a mechanism for a feature to say it actually executed - `featureRan`, one line per feature per boot. It was being called in 12 of 127 modules, and three of those are its own infrastructure. So for roughly 118 modules, silence meant nothing at all: not "it worked", not "it failed", just quiet.

This puts it on the seven modules where the silence is most expensive, and adds a test so the coverage cannot quietly shrink again.

## Why this matters

`state-claims.md` already says you cannot conclude a feature did NOT run from missing log lines unless you first prove it CAN log. In August, asked which of eight shipped features had executed in production, seven days of journald could not answer - most of them contained no logging at all, and the rest spoke only from inside a `catch`. A week of work was untestable rather than broken.

The gap is worst where nobody is watching. A feature Zaal triggers by hand announces itself by replying to him. A feature that runs on a scheduler at 4am does not, and its silence is indistinguishable from its death.

## Before / after

BEFORE: `journalctl | grep '[zoe/ran]'` lists 9 real features. Whether the Heart ever took a lease, whether the Bonfire retry queue ever drained, whether a receipt was ever written - unanswerable without instrumenting first.

AFTER: the same grep answers all three.

## What changed, and where each call sits

| Module | Announces when |
|---|---|
| `heart-run` | the lease was ensured (all three id paths, including the raced one) |
| `bonfire-retry` | **only when the queue actually moved** |
| `receipts` | a receipt row was inserted |
| `bus-upload` | the bytes landed on the bus |
| `bus-receipt` | the verifier ran, including a `CANNOT_VERIFY` verdict |
| `afferent-digest` | the digest receipt was emitted |
| `recap` | a recap was produced and survived the empty guard |

Placement is the entire point, so two are deliberately conditional. `bonfire-retry` stays quiet on an empty queue: a flush that found nothing to do has not run in any sense worth reporting, and announcing anyway would make the line mean "the cron fired" rather than "the feature worked" - which is the exact confusion this mechanism exists to remove. `recap` announces only if the output passed the empty guard.

## brief.ts and reflect.ts - added after reading them

These two were excluded on the first pass, because their success paths had not been read and a `featureRan` placed in unread code announces something other than what it claims. They have been read now, and reading them changed the answer.

Both return a string on **both** paths - a real brief or reflection, or a degraded stub when the model comes back empty. So a single "it ran" line would have been true and useless: the 5am scheduler reaching the code and the brief actually being generated are different facts, and the degraded one is the one worth knowing about.

Each announces with a detail saying which - `generated` or `degraded`. `guardEmpty` already logs the degraded case at error level, so this is not a second alarm; it answers the separate question of whether the scheduler got there at all, which nothing could answer before.

Nine modules now, not seven.

And not every module gets one. `featureRan` in all 127 would be the noise nobody greps (`noisy-signal-guard.md`) - a signal that always fires is the same as no signal.

## Evidence

PROVEN:

| Check | Result |
|---|---|
| strip `featureRan` from `recap.ts` | coverage test FAILS, naming `recap.ts` |
| call `verifyReceipt` | `[zoe/ran] bus-receipt-verify` really prints |
| `CANNOT_VERIFY` verdict | still counts as having run - a real outcome is not a failure to execute |
| three calls, same feature | announces once, so a per-tick feature cannot flood the log |

`tsc --noEmit` 0 errors. 182 files / 2343 tests pass - 5 added, 0 broken.

The test also asserts the call is outside a comment and reachable outside a `catch`, because a module that speaks only when it fails tells you nothing when it works. The comment check exists because the sibling swallow-registry test was caught matching a token inside a comment.

NOT TESTED: no production run has happened yet. The proof that these announce in the live bot is the grep after the next deploy, not this PR.

## The organ

This is proprioception. The organism could always feel pain - every one of these modules logs on error. It could not feel ordinary motion, so a limb that had stopped moving felt exactly like a limb at rest. These are the stretch receptors: quiet, cheap, and only interesting when they go missing.

