### PR TITLE
feat(zoe): make command routing ORDER assertable without booting the bot

### DIFF
--- a/bot/src/zoe/__tests__/command-routing-order.test.ts
+++ b/bot/src/zoe/__tests__/command-routing-order.test.ts
@@ -88,7 +88,7 @@ describe('isZoeCommand still behaves, now with one list instead of two', () => {
 describe('the declared order matches index.ts, so the two cannot drift', () => {
   it('every dispatched command appears in index.ts', () => {
     const missing = COMMAND_TABLE.filter((r) => r.indexToken !== null)
-      .filter((r) => !INDEX_SOURCE.includes(`${r.indexToken}.`))
+      .filter((r) => !INDEX_SOURCE.includes(r.indexToken as string))
       .map((r) => r.kind);
     expect(missing, `declared as dispatched in index.ts but not found there: ${missing.join(', ')}`).toEqual([]);
   });
@@ -98,7 +98,7 @@ describe('the declared order matches index.ts, so the two cannot drift', () => {
     const importBlockEnd = INDEX_SOURCE.indexOf("} from './commands'");
     const positions = COMMAND_TABLE.filter((r) => r.indexToken !== null).map((r) => ({
       kind: r.kind,
-      at: INDEX_SOURCE.indexOf(`${r.indexToken}.`, importBlockEnd > 0 ? importBlockEnd : 0),
+      at: INDEX_SOURCE.indexOf(r.indexToken as string, importBlockEnd > 0 ? importBlockEnd : 0),
     }));
 
     expect(
@@ -119,4 +119,41 @@ describe('the declared order matches index.ts, so the two cannot drift', () => {
         `index.ts: ${actual.join(' -> ')}`,
     ).toEqual(actual);
   });
+});
+
+describe('the substitution is safe: no two patterns claim the same input', () => {
+  // index.ts now asks classifyCommand ONCE and compares the answer, where it used
+  // to run four independent regex tests. Those are equivalent only while no two
+  // patterns match the same string. If two ever did, the TABLE's order would
+  // start deciding an outcome that four separate tests used to decide
+  // independently - a behaviour change hiding inside a refactor.
+  const corpus = [
+    '/focus',
+    '/focus on',
+    '/focus off',
+    '/audit',
+    '/budget',
+    '/budget detailed',
+    '/checkpoint shipped it',
+    'note: x',
+    'cc: x',
+    'claude: x',
+    'plan: x',
+    'decompose: x',
+    'queue: x',
+    'stop nudges',
+    'pause tips',
+    'resume nudges',
+    'build: a fix',
+    'ordinary prose about the day',
+    '',
+    '   ',
+  ];
+
+  for (const input of corpus) {
+    it(`at most one pattern claims ${JSON.stringify(input)}`, () => {
+      const hits = COMMAND_TABLE.filter((r) => r.pattern.test(input.trim())).map((r) => r.kind);
+      expect(hits.length, `ambiguous - claimed by: ${hits.join(', ')}`).toBeLessThanOrEqual(1);
+    });
+  }
 });

--- a/bot/src/zoe/__tests__/command-routing-order.test.ts
+++ b/bot/src/zoe/__tests__/command-routing-order.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Command routing order - assertable without booting the bot.
+ *
+ * index.ts routes positionally: ~153 early-return branches, no routing table,
+ * first match wins and returns. A broad matcher above a narrow one makes the
+ * narrow one unreachable and nothing reports an error, because the swallowing
+ * branch succeeds. That is the 2026-08-08 failure class
+ * (.claude/rules/first-handler-wins.md).
+ *
+ * Testing it directly is not possible: agent-loops.md rule 21 forbids importing
+ * index.ts in a test, since its top level boots a live poller that would collide
+ * with the running instance. So COMMAND_TABLE in commands.ts declares the order
+ * once, classifyCommand applies it, and the last test here asserts the declared
+ * order still matches the order in index.ts SOURCE - read as text, never
+ * imported. Two lists that can disagree is what this replaces.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { COMMAND_TABLE, classifyCommand, isZoeCommand } from '../commands';
+import { isCommandPrefixed } from '../tg-interactions';
+
+const INDEX_SOURCE = readFileSync(fileURLToPath(new URL('../index.ts', import.meta.url)), 'utf8');
+
+describe('classifyCommand routes verbatim input to the right command', () => {
+  const cases: Array<[string, string | null]> = [
+    ['/focus', 'focus-on'],
+    ['/focus on', 'focus-on'],
+    ['/focus off', 'focus-off'],
+    ['/audit', 'audit'],
+    ['/budget', 'budget'],
+    ['/budget detailed', 'budget'],
+    ['/checkpoint shipped the bus fix', 'checkpoint'],
+    ['note: remember the Artizen boost math', 'note'],
+    ['cc: same thing, other prefix', 'note'],
+    ['plan: ship the federation canary', 'plan'],
+    ['decompose: ship the federation canary', 'plan'],
+    ['queue: how do endowment LPs price', 'queue'],
+    ['stop nudges', 'nudge-toggle'],
+    ['resume tips', 'nudge-toggle'],
+    ['what did we ship today', null],
+    ['', null],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`${JSON.stringify(input)} -> ${expected ?? 'not a command'}`, () => {
+      expect(classifyCommand(input)).toBe(expected);
+    });
+  }
+
+  it('/focus off does not get eaten by /focus on', () => {
+    // Both patterns start with /focus. They are disjoint today because FOCUS_ON_RE
+    // is anchored, but that is a property worth asserting rather than assuming -
+    // an unanchored edit would silently make "/focus off" turn focus ON.
+    expect(classifyCommand('/focus off')).toBe('focus-off');
+  });
+
+  it('trims, because a phone keyboard adds whitespace', () => {
+    expect(classifyCommand('  /audit  ')).toBe('audit');
+  });
+});
+
+describe('build vocabulary must NOT be classified as a command here', () => {
+  // `build:` is lowercase letters plus a colon, the exact shape that the
+  // batch-answer guard ate in the 1/10 DM build incident. It is handled by
+  // isCommandPrefixed, not by this table, and must fall through so the build
+  // classifier can see it.
+  for (const input of ['build: a fix for the poller', 'fix: the ledger', 'ship: it']) {
+    it(`${JSON.stringify(input)} falls through classifyCommand`, () => {
+      expect(classifyCommand(input)).toBeNull();
+      expect(isCommandPrefixed(input)).toBe(true);
+    });
+  }
+});
+
+describe('isZoeCommand still behaves, now with one list instead of two', () => {
+  it('true for every kind in the table', () => {
+    const samples = ['/focus', '/focus off', '/audit', '/budget', '/checkpoint x', 'note: x', 'plan: x', 'queue: x', 'stop nudges'];
+    for (const s of samples) expect(isZoeCommand(s), s).toBe(true);
+  });
+
+  it('false for ordinary prose, so a reflection answer is not mistaken for a command', () => {
+    expect(isZoeCommand('had a good day, shipped the bus fix')).toBe(false);
+  });
+});
+
+describe('the declared order matches index.ts, so the two cannot drift', () => {
+  it('every dispatched command appears in index.ts', () => {
+    const missing = COMMAND_TABLE.filter((r) => r.indexToken !== null)
+      .filter((r) => !INDEX_SOURCE.includes(`${r.indexToken}.`))
+      .map((r) => r.kind);
+    expect(missing, `declared as dispatched in index.ts but not found there: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('COMMAND_TABLE order equals index.ts dispatch order', () => {
+    // Position of each token's first DISPATCH use, skipping the import block.
+    const importBlockEnd = INDEX_SOURCE.indexOf("} from './commands'");
+    const positions = COMMAND_TABLE.filter((r) => r.indexToken !== null).map((r) => ({
+      kind: r.kind,
+      at: INDEX_SOURCE.indexOf(`${r.indexToken}.`, importBlockEnd > 0 ? importBlockEnd : 0),
+    }));
+
+    expect(
+      positions.every((p) => p.at > 0),
+      `a dispatch site was not found: ${positions.filter((p) => p.at <= 0).map((p) => p.kind).join(', ')}`,
+    ).toBe(true);
+
+    const declared = positions.map((p) => p.kind);
+    const actual = [...positions].sort((a, b) => a.at - b.at).map((p) => p.kind);
+
+    expect(
+      declared,
+      'COMMAND_TABLE no longer matches the order index.ts dispatches in.\n' +
+        'One of them moved. Routing is positional, so a reordering can make a\n' +
+        'command unreachable with every other test still green - decide which\n' +
+        'order is correct and change both together, deliberately.\n' +
+        `declared: ${declared.join(' -> ')}\n` +
+        `index.ts: ${actual.join(' -> ')}`,
+    ).toEqual(actual);
+  });
+});

--- a/bot/src/zoe/__tests__/swallow-registry.test.ts
+++ b/bot/src/zoe/__tests__/swallow-registry.test.ts
@@ -136,38 +136,6 @@ const SWALLOW_REGISTRY: SwallowEntry[] = [
     excludes: [],
   },
   {
-    matcher: 'FOCUS_ON_RE.test(',
-    occurrences: 1,
-    why: 'Enables focus mode. Anchored slash-command pattern.',
-    returns: true,
-    broad: false,
-    excludes: [],
-  },
-  {
-    matcher: 'FOCUS_OFF_RE.test(',
-    occurrences: 1,
-    why: 'Disables focus mode and flushes the queued digest. Anchored slash-command pattern.',
-    returns: true,
-    broad: false,
-    excludes: [],
-  },
-  {
-    matcher: 'AUDIT_COMMAND_RE.test(',
-    occurrences: 1,
-    why: 'Runs the trust audit. Anchored slash-command pattern.',
-    returns: true,
-    broad: false,
-    excludes: [],
-  },
-  {
-    matcher: 'BUDGET_COMMAND_RE.test(',
-    occurrences: 1,
-    why: 'Reports spend and remaining headroom. Anchored slash-command pattern.',
-    returns: true,
-    broad: false,
-    excludes: [],
-  },
-  {
     matcher: '/res[ae]arch/i.test(',
     occurrences: 1,
     why: 'Paired with the URL test to decide whether an already-answered private research DM also gets committed as a numbered doc. Fire-and-forget, gates no return.',
@@ -235,7 +203,14 @@ describe('swallow registry: index.ts cannot grow a new user-text matcher silentl
   it('detects the matchers that are actually there (guards the detector itself)', () => {
     // If this drops to zero the detector broke and every other assertion below
     // would pass vacuously - a green test proving nothing.
-    expect(sites.length).toBeGreaterThanOrEqual(12);
+    //
+    // The floor was 12 and is now 10, because four command regexes
+    // (FOCUS_ON_RE, FOCUS_OFF_RE, AUDIT_COMMAND_RE, BUDGET_COMMAND_RE) moved out
+    // of index.ts into COMMAND_TABLE and are dispatched via classifyCommand.
+    // Lowering this number is how a broken detector would hide, so it is only
+    // ever moved together with a deliberate, named removal - never to make a
+    // red test go green.
+    expect(sites.length).toBeGreaterThanOrEqual(10);
   });
 
   it('every matcher in index.ts is declared in the registry', () => {

--- a/bot/src/zoe/commands.ts
+++ b/bot/src/zoe/commands.ts
@@ -55,7 +55,7 @@ export interface CommandRoute {
   kind: CommandKind;
   pattern: RegExp;
   /**
-   * The identifier index.ts uses at the dispatch site. Null when the command is
+   * The EXACT text index.ts uses at the dispatch site. Null when the command is
    * not dispatched through a named export there, which excludes it from the
    * order check below rather than pretending it has a position.
    */
@@ -86,14 +86,14 @@ export const COMMAND_TABLE: ReadonlyArray<CommandRoute> = [
   // Disjoint from every other pattern, so its position carries no risk. Kept
   // first to preserve exactly what isZoeCommand tested before this table.
   { kind: 'nudge-toggle', pattern: NUDGE_TOGGLE_RE, indexToken: null },
-  { kind: 'note', pattern: NOTE_PREFIX, indexToken: 'NOTE_PREFIX' },
-  { kind: 'queue', pattern: QUEUE_PREFIX, indexToken: 'QUEUE_PREFIX' },
-  { kind: 'focus-on', pattern: FOCUS_ON_RE, indexToken: 'FOCUS_ON_RE' },
-  { kind: 'focus-off', pattern: FOCUS_OFF_RE, indexToken: 'FOCUS_OFF_RE' },
-  { kind: 'checkpoint', pattern: CHECKPOINT_PREFIX, indexToken: 'CHECKPOINT_PREFIX' },
-  { kind: 'audit', pattern: AUDIT_COMMAND_RE, indexToken: 'AUDIT_COMMAND_RE' },
-  { kind: 'budget', pattern: BUDGET_COMMAND_RE, indexToken: 'BUDGET_COMMAND_RE' },
-  { kind: 'plan', pattern: PLAN_PREFIX, indexToken: 'PLAN_PREFIX' },
+  { kind: 'note', pattern: NOTE_PREFIX, indexToken: 'NOTE_PREFIX.exec' },
+  { kind: 'queue', pattern: QUEUE_PREFIX, indexToken: 'QUEUE_PREFIX.exec' },
+  { kind: 'focus-on', pattern: FOCUS_ON_RE, indexToken: "command === 'focus-on'" },
+  { kind: 'focus-off', pattern: FOCUS_OFF_RE, indexToken: "command === 'focus-off'" },
+  { kind: 'checkpoint', pattern: CHECKPOINT_PREFIX, indexToken: 'CHECKPOINT_PREFIX.exec' },
+  { kind: 'audit', pattern: AUDIT_COMMAND_RE, indexToken: "command === 'audit'" },
+  { kind: 'budget', pattern: BUDGET_COMMAND_RE, indexToken: "command === 'budget'" },
+  { kind: 'plan', pattern: PLAN_PREFIX, indexToken: 'PLAN_PREFIX.exec' },
 ];
 
 /**

--- a/bot/src/zoe/commands.ts
+++ b/bot/src/zoe/commands.ts
@@ -39,23 +39,87 @@ export const AUDIT_COMMAND_RE = /^\/audit$/i;
 /** `/budget` - check ZOE daily spend and remaining budget. */
 export const BUDGET_COMMAND_RE = /^\/budget(?:\s+detailed)?$/i;
 
+/** Every command index.ts dispatches by one of the patterns above. */
+export type CommandKind =
+  | 'nudge-toggle'
+  | 'note'
+  | 'queue'
+  | 'focus-on'
+  | 'focus-off'
+  | 'checkpoint'
+  | 'audit'
+  | 'budget'
+  | 'plan';
+
+export interface CommandRoute {
+  kind: CommandKind;
+  pattern: RegExp;
+  /**
+   * The identifier index.ts uses at the dispatch site. Null when the command is
+   * not dispatched through a named export there, which excludes it from the
+   * order check below rather than pretending it has a position.
+   */
+  indexToken: string | null;
+}
+
+/**
+ * THE ORDER IS THE CONTRACT.
+ *
+ * index.ts routes positionally across ~153 early-return branches with no
+ * routing table, so whichever branch matches first wins and returns. On
+ * 2026-08-08 that made ZOE's entire DM build vocabulary unreachable through
+ * its own documented syntax, and every test stayed green
+ * (.claude/rules/first-handler-wins.md).
+ *
+ * This table is that order, written down once and testable without importing
+ * index.ts - which agent-loops.md rule 21 forbids, because its top level boots
+ * a live poller. A companion test asserts this sequence still matches the
+ * sequence in index.ts source, so the two cannot drift apart silently.
+ *
+ * Sequence measured from index.ts dispatch sites, NOT copied from the previous
+ * body of isZoeCommand - which listed `plan` third while index.ts dispatches it
+ * last, after `budget`. That mismatch was invisible while the only consumer
+ * returned a boolean, and would have become a real routing bug the moment
+ * anything asked WHICH command a message is.
+ */
+export const COMMAND_TABLE: ReadonlyArray<CommandRoute> = [
+  // Disjoint from every other pattern, so its position carries no risk. Kept
+  // first to preserve exactly what isZoeCommand tested before this table.
+  { kind: 'nudge-toggle', pattern: NUDGE_TOGGLE_RE, indexToken: null },
+  { kind: 'note', pattern: NOTE_PREFIX, indexToken: 'NOTE_PREFIX' },
+  { kind: 'queue', pattern: QUEUE_PREFIX, indexToken: 'QUEUE_PREFIX' },
+  { kind: 'focus-on', pattern: FOCUS_ON_RE, indexToken: 'FOCUS_ON_RE' },
+  { kind: 'focus-off', pattern: FOCUS_OFF_RE, indexToken: 'FOCUS_OFF_RE' },
+  { kind: 'checkpoint', pattern: CHECKPOINT_PREFIX, indexToken: 'CHECKPOINT_PREFIX' },
+  { kind: 'audit', pattern: AUDIT_COMMAND_RE, indexToken: 'AUDIT_COMMAND_RE' },
+  { kind: 'budget', pattern: BUDGET_COMMAND_RE, indexToken: 'BUDGET_COMMAND_RE' },
+  { kind: 'plan', pattern: PLAN_PREFIX, indexToken: 'PLAN_PREFIX' },
+];
+
+/**
+ * Which command a DM is, or null if it is not one.
+ *
+ * First match wins, exactly as index.ts does it. Returning the KIND rather than
+ * a boolean is what makes routing order assertable: a test can state that
+ * `/focus off` reaches focus-off and not focus-on, in one line, with no bot.
+ */
+export function classifyCommand(text: string): CommandKind | null {
+  const trimmed = text.trim();
+  for (const route of COMMAND_TABLE) {
+    if (route.pattern.test(trimmed)) return route.kind;
+  }
+  return null;
+}
+
 /**
  * True if a DM is a recognized ZOE command. Such messages must bypass the
  * await-reflection pending capture (doc 770 H1): the evening reflection arms
  * a long-TTL pending, and a `plan:` sent in that window would otherwise be
  * swallowed as the reflection answer and never dispatched.
+ *
+ * Delegates to the table so there is ONE list of commands rather than two that
+ * can disagree - the duplication that hid the plan-ordering mismatch above.
  */
 export function isZoeCommand(text: string): boolean {
-  const trimmed = text.trim();
-  return (
-    NUDGE_TOGGLE_RE.test(trimmed) ||
-    NOTE_PREFIX.test(trimmed) ||
-    PLAN_PREFIX.test(trimmed) ||
-    QUEUE_PREFIX.test(trimmed) ||
-    FOCUS_ON_RE.test(trimmed) ||
-    FOCUS_OFF_RE.test(trimmed) ||
-    CHECKPOINT_PREFIX.test(trimmed) ||
-    AUDIT_COMMAND_RE.test(trimmed) ||
-    BUDGET_COMMAND_RE.test(trimmed)
-  );
+  return classifyCommand(text) !== null;
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -151,11 +151,8 @@ import {
   NOTE_PREFIX,
   PLAN_PREFIX,
   QUEUE_PREFIX,
-  FOCUS_ON_RE,
-  FOCUS_OFF_RE,
   CHECKPOINT_PREFIX,
-  AUDIT_COMMAND_RE,
-  BUDGET_COMMAND_RE,
+  classifyCommand,
   isZoeCommand,
 } from './commands';
 import { formatSpendStatus } from './cost-governance';
@@ -2208,15 +2205,22 @@ async function handlePrivateMessage(ctx: Context, text: string, brandContext?: s
     return;
   }
 
+  // Which command this is, decided ONCE by COMMAND_TABLE rather than by four
+  // independent regex tests whose relative order was only implied by where they
+  // happen to sit in this file. The branches below still run in the same order;
+  // the difference is that the order is now declared in commands.ts and asserted
+  // by a test, instead of being a property of line numbers in a 3700-line file.
+  const command = classifyCommand(text);
+
   // Hyperfocus guard: `/focus` or `/focus on` enables focus mode.
-  if (FOCUS_ON_RE.test(text.trim())) {
+  if (command === 'focus-on') {
     await startFocus();
     await ctx.reply('Focus mode ON. Non-urgent pings will queue until you send /focus off.');
     return;
   }
 
   // Hyperfocus guard: `/focus off` disables focus mode and sends queued digest.
-  if (FOCUS_OFF_RE.test(text.trim())) {
+  if (command === 'focus-off') {
     const queuedPings = await endFocus();
     const digest = buildFocusDigest(queuedPings);
     await ctx.reply('Focus mode OFF.\n\n' + digest);
@@ -2234,7 +2238,7 @@ async function handlePrivateMessage(ctx: Context, text: string, brandContext?: s
   }
 
   // Trust audit: `/audit` scans for fallen tasks/captures.
-  if (AUDIT_COMMAND_RE.test(text.trim())) {
+  if (command === 'audit') {
     if (!ctx.chatId) return;
     const progress = startProgressNarration(ctx, ctx.chatId, { first: 'Running audit...' });
     try {
@@ -2251,7 +2255,7 @@ async function handlePrivateMessage(ctx: Context, text: string, brandContext?: s
   }
 
   // Budget status: `/budget` shows today's spend and remaining headroom.
-  if (BUDGET_COMMAND_RE.test(text.trim())) {
+  if (command === 'budget') {
     const detailed = text.toLowerCase().includes('detailed');
     try {
       const budgetText = formatSpendStatus(detailed);


### PR DESCRIPTION
## Executive summary

`index.ts` decides what a message is by falling through ~153 early-return branches with no routing table. Whichever branch matches first, by line number, wins and returns. Routing order is load-bearing and nothing asserts it.

This declares the order once in `COMMAND_TABLE`, has `classifyCommand` return **which** command a message is, and then **wires index.ts to ask the table** instead of re-deriving the order from four independent regex tests.

## Why it could not be tested before

`agent-loops.md` rule 21 forbids importing `index.ts` in a test - its top level boots a live poller that would collide with the running instance. That is why no test imports it and why ordering has never been covered. This works around the constraint instead of fighting it: the table is importable, and the drift check reads `index.ts` as text.

`commands.ts` already existed for exactly this reason - its header says "extracted from index.ts so the routing predicates are unit-testable without importing index.ts". This extends that file rather than adding a second router.

## A real discrepancy this turned up

Measuring the order from `index.ts` rather than copying it from the old code found one:

- `isZoeCommand` tested **plan third**
- `index.ts` dispatches **plan last**, after `budget`

Harmless while the only consumer returned a boolean, since any match yields `true`. It becomes a live routing bug the moment anything asks *which* command a message is. `isZoeCommand` now delegates to the table, so there is one list instead of two that can silently disagree - which is how the mismatch survived.

## The substitution (added after #3059 merged)

The first version of this PR deliberately left `index.ts` untouched, because removing `FOCUS_ON_RE.test(` and friends would have failed the swallow registry's stale-entry check in #3059. **#3059 is merged, so both halves now land together**: the four regex constants leave `index.ts`, and their registry entries go with them.

```
- if (FOCUS_ON_RE.test(text.trim())) {
+ if (command === 'focus-on') {
```

with `const command = classifyCommand(text)` computed once above the block. The branches still run in the same sequence. What changed is that the sequence is declared and asserted rather than implied by line numbers.

**Equivalence is asserted, not assumed.** Four separate regex tests and one table lookup behave identically only while no two patterns match the same string. If two ever did, the table's *order* would start deciding an outcome that four independent tests used to decide separately - a behaviour change wearing a refactor's clothes. A new test asserts at most one pattern claims each of 20 inputs, including `build:` and bare prose.

The drift check survives the move: `indexToken` is now the exact dispatch text, so it follows each command from `FOCUS_ON_RE.test(` to `command === 'focus-on'` and still proves table order equals index.ts order.

## The registry caught its own floor

Removing four regex sites dropped the swallow detector's count from 14 to 10, below the minimum that stops the whole suite passing vacuously - so the test went red during this change, which is the detector working.

The floor moves to 10 **with the reason written next to it**. Lowering that number is precisely how a broken detector would hide, so it only ever moves alongside a deliberate, named removal.

## Evidence

PROVEN, all mutations restored:

| Check | Result |
|---|---|
| reorder `COMMAND_TABLE` (plan above focus-on) | FAILS, printing `declared:` vs `index.ts:` |
| widen `AUDIT_COMMAND_RE` to also match `/focus` | FAILS - `ambiguous - claimed by: focus-on, audit` |
| clean source | 45 pass in this file |
| existing `commands.test.ts` and `dm-build-unreachable.test.ts` | pass, unchanged |

`tsc --noEmit` 0 errors. **183 files / 2391 tests pass.**

NOT TESTED IN PRODUCTION: this changes live dispatch in `index.ts`. The disjointness proof is the argument that behaviour is unchanged; the confirmation is the bot running after merge.

## Scope

This covers the **command** region. A full extraction of all ~153 branches into a pure router is the correct end state and is much larger than one pass.

## The organ

Reflexes fire in a fixed order, and the order was not written anywhere in the body - it was a consequence of how the wiring grew. Now the order is written down, and the reflex arc reads it rather than rediscovering it each time.
