### PR TITLE
fix(tests): main is red - an unwritable-path test that only hangs on Linux

### DIFF
--- a/bot/src/hermes/__tests__/claude-health.test.ts
+++ b/bot/src/hermes/__tests__/claude-health.test.ts
@@ -128,10 +128,27 @@ describe('the health file', () => {
     expect(claudeBriefLines(await readClaudeHealth(path), T).alert).toBeNull();
   });
 
-  it('never throws when the path is unwritable', async () => {
-    // A health file that cannot be written must not break the call it observes.
-    await expect(recordClaudeOk(T, '/proc/definitely/not/writable.json')).resolves.toBeUndefined();
-  });
+  it(
+    'never throws when the path is unwritable',
+    async () => {
+      // A health file that cannot be written must not break the call it observes.
+      //
+      // The path has to be unwritable for the SAME reason on every platform.
+      // This used to be '/proc/definitely/not/writable.json', which fails
+      // instantly on macOS (no /proc at all) and hung past the 5s default on
+      // Linux CI - so the suite passed on every developer machine and left main
+      // red. A plain file used as a parent directory gives a deterministic
+      // ENOTDIR everywhere and returns immediately.
+      const blocker = join(dir, 'a-file-not-a-directory');
+      await (await import('node:fs/promises')).writeFile(blocker, 'x', 'utf8');
+
+      await expect(recordClaudeOk(T, join(blocker, 'claude-health.json'))).resolves.toBeUndefined();
+    },
+    // Deliberately tighter than the default. The property is that the writer
+    // gives up immediately on an unwritable path; if it ever starts blocking
+    // again, this must fail loudly rather than sit for five seconds first.
+    2000,
+  );
 
   it('survives a corrupt file rather than crashing the brief', async () => {
     await recordClaudeOk(T, path);


### PR DESCRIPTION
## Executive summary

**main is red, and has been since #3052 merged.** Bot Tests fails on every commit, so every PR opened since inherits a failing check. This fixes it.

The failing test is a good test with a bad choice of path. It asserts that a health file which cannot be written must not break the call it observes. To make the path unwritable it used `/proc/definitely/not/writable.json` - which means two different things on two platforms:

- **macOS**: `/proc` does not exist, so it fails instantly. Green on every developer machine.
- **Linux CI**: it sat past the 5-second default and timed out.

Passing locally and failing only in CI is the worst possible split, because the person who can reproduce it is nobody.

## Why this is urgent beyond the one test

A check that is always failing is a check everyone learns to merge past. That already happened: **#3059 was automerged with Bot Tests red.** The gate is not gating.

So the cost of leaving this is not one red X. It is that the next genuine Bot Tests failure will look exactly like this one and get merged the same way.

## The fix

A plain file used as a parent directory produces `ENOTDIR` on every platform. Measured: **0ms**.

```
mkdir failed fast: ENOTDIR 0ms
```

The suite already creates a temp dir per test with `afterEach` cleanup, so the blocker file needs no new teardown.

The timeout is also tightened from the 5s default to **2s**, deliberately. The property under test is that the writer gives up *immediately* on an unwritable path. If it ever starts blocking again, that should fail loudly rather than sit for five seconds and read like flake.

## Evidence

PROVEN:

| Check | Result |
|---|---|
| main CI run 31622382511, before any of today's work | FAILS on this exact test, 2338 tests |
| the fixed test locally | 15 pass |
| `ENOTDIR` timing probe | 0ms, deterministic |
| make `write()` rethrow instead of swallowing | test FAILS - it still tests the real property |

`tsc --noEmit` 0 errors. 182 files / 2346 tests pass.

The last row matters most: the easy way to "fix" a red test is to make it stop asserting. Rethrowing from `write()` still fails it, so the assertion is intact.

NOT VERIFIED: that this passes on Linux. I cannot run Linux here. The reasoning is that `ENOTDIR` on a regular-file parent is POSIX behaviour with no `/proc` special-casing, but the actual proof is this PR's own CI run.

## Not in scope

`Auto-merge safe PRs` merging a PR with a failing required check is a separate problem, and a real one. Flagged, not changed here - a gate change wants its own review.

## The organ

An immune response that fires constantly stops being information. The body did not have a new infection today; it had an alarm nobody could switch off, and so learned to ignore the alarm. Fixing the sensor matters more than the one thing it was pointed at.
