### PR TITLE
ci: make main's real state observable, and name why push CI stops on bot merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,36 @@
 name: CI
 
+# WHY THIS HAS A SCHEDULE AND A DISPATCH, NOT JUST push + pull_request
+#
+# `push: [main]` looks like it covers merges. It does not cover the merges we
+# actually do most of. GitHub does not start a workflow run for a push made with
+# the automatic GITHUB_TOKEN - a deliberate anti-recursion rule - and
+# docs-automerge.yml merges with `GH_TOKEN: ${{ github.token }}`. So every
+# auto-merged PR lands on main and CI never runs on the result.
+#
+# Measured 2026-08-12: PR #3057 was merged by a user and got CI on main. The next
+# four (#3059, #3062, #3064, #3066) were merged by github-actions[bot] and got
+# ZERO runs between them. The last main commit that did run CI, f90e3ce, FAILED -
+# so main sat red-then-unknown while every PR opened afterwards showed green,
+# because a PR check tests the branch head and never the merge result.
+#
+# The schedule below means main's true state is never more than a day stale even
+# when nothing but the bot merges, and workflow_dispatch means anyone asking "is
+# main actually green right now" can get an answer instead of an inference.
+#
+# This does not fix the cause. The cause is the token, and fixing it needs a PAT
+# or GitHub App token in docs-automerge.yml - see the note there.
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # 06:40 UTC daily. Offset from the estate-health and backup jobs so a red
+    # main is its own signal rather than one line inside a busy morning.
+    - cron: '40 6 * * *'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,6 +59,11 @@ jobs:
       # pre-existing backlog is worked down, this is non-blocking: it reports
       # issues on touched files without failing CI. Flip continue-on-error to
       # false to make it enforcing. See research doc 887 / loop-zaoos-fixes.
+      # On the schedule/dispatch runs this diffs main against itself and so lints
+      # nothing. That is harmless rather than a hidden pass: the step is already
+      # continue-on-error, so it has never been the thing that fails CI. The
+      # blocking checks on those runs are Typecheck, test, bot-test and build,
+      # all of which are absolute rather than diff-scoped.
       - name: Lint (biome, changed files)
         continue-on-error: true
         run: npm run ci:lint:changed

--- a/.github/workflows/docs-automerge.yml
+++ b/.github/workflows/docs-automerge.yml
@@ -134,6 +134,24 @@ jobs:
           done <<< "$newdirs"
           echo "collision=$collision" >> "$GITHUB_OUTPUT"
 
+      # KNOWN GAP - this merge produces a main commit that CI never runs on.
+      #
+      # GitHub does not start a workflow run for a push made with the automatic
+      # GITHUB_TOKEN (anti-recursion). `github.token` below IS that token, so the
+      # squash-merge this step performs lands on main silently: ci.yml's
+      # `push: [main]` trigger never fires. Measured 2026-08-12 - four consecutive
+      # bot-merged commits (#3059, #3062, #3064, #3066) with zero runs between them,
+      # while the user-merged #3057 immediately before got its run normally.
+      #
+      # The gate itself is still real: --auto holds the merge until the PR's
+      # required checks pass. What is missing is verification of the MERGE RESULT,
+      # which is a different tree from the branch head that was checked.
+      #
+      # THE FIX needs a token whose pushes do trigger workflows - a fine-grained
+      # PAT or a GitHub App installation token in a repo secret, swapped in for
+      # `github.token` on this step only. That is a Zaal action because it means
+      # creating and storing a credential. Until then, ci.yml carries a daily
+      # schedule + workflow_dispatch so main's real state stays observable.
       - name: Enable auto-merge (squash)
         if: |
           (steps.classify.outputs.category == 'docs' && steps.collide.outputs.collision != 'true') ||


### PR DESCRIPTION
## The finding

`ci.yml` has `push: branches: [main]`, so merges look covered. They are not.

**GitHub does not start a workflow run for a push made with the automatic `GITHUB_TOKEN`** — a deliberate anti-recursion rule. `docs-automerge.yml:143` merges with `GH_TOKEN: ${{ github.token }}`. So every auto-merged PR lands on main and CI never runs on the result.

The discriminator is exactly who merged:

| PR | merged_by | runs on the resulting main commit |
|---|---|---|
| #3057 | `bettercallzaal` (User) | 1 — CI, **failure** |
| #3059 | `github-actions[bot]` | **0** |
| #3062 | `github-actions[bot]` | **0** |
| #3064 | `github-actions[bot]` | **0** |
| #3066 | `github-actions[bot]` | **0** |

Last push-event run of any kind: **08-12T17:23 UTC**. Latest `pull_request` run: **08-13T02:34 UTC** — nine hours later. Actions is enabled, all five workflows are `active`, `ci.yml` was unchanged across the gap. It is the token, not an outage.

**Why this is worse than four missing runs:** the last main commit that did run CI *failed*. Main went red and then went dark. Every PR opened afterwards showed green, because a PR check tests the branch head — never the merge result. #3062's own commit message records the same thing from the other side: "#3059 was in fact automerged with Bot Tests red."

## Is main actually healthy

Yes. Run at `origin/main` = `4947e82f` in a clean worktree, absolute numbers, not a delta:

```
npm ci                                 rc=0   239 packages
npx tsc --noEmit -p tsconfig.ci.json   rc=0   0 errors
npm test                               rc=0   182 test files passed (182)
                                              2346 tests passed (2346)
```

Zero failure markers in the output. (40 lines match "fail" — all expected stderr from tests exercising error paths, e.g. `[wiki] fetchNeynarUserProfile(999999) failed: Neynar API error`.)

**Platform caveat, and why it turns out not to bite:** I ran darwin/node v22.23.1; CI runs ubuntu-latest. The failure on f90e3ce was a test that only hung on Linux, so a macOS pass would normally prove little. But #3062 fixed it by *removing the platform divergence* — it replaced `/proc/definitely/not/writable.json` (instant failure on macOS, hang past the 5s default on Linux) with a plain file used as a parent directory, giving deterministic `ENOTDIR` everywhere, plus a 2000 ms timeout so a regression fails loudly instead of sitting. `claude-health.test.ts` ran here: 15 tests, passed, 230 ms.

So main is green — it just could not be *shown* to be, which is the actual defect.

## What this PR changes

Two files, comments and trigger config only, no job logic touched.

- **`ci.yml`** — adds `workflow_dispatch` so "is main green right now" is answerable on demand, and a `schedule` at 06:40 UTC so main is never more than a day stale even when only the bot merges. Offset from the estate-health and backup jobs so a red main reads as its own signal.
- **`docs-automerge.yml`** — documents the gap at the merge step itself, with the measurement and the real fix, so it is found there rather than rediscovered.

All four jobs run on the scheduled trigger (`build` gates on `needs`, not an `if`). The one diff-scoped step, `ci:lint:changed`, lints nothing on a schedule run — noted inline, and harmless because it is already `continue-on-error: true` and has never been the step that fails CI. The blocking checks on those runs are Typecheck, test, bot-test and build, all absolute.

## What this does NOT fix

**The cause.** Making bot merges trigger CI needs a token whose pushes do trigger workflows — a fine-grained PAT or a GitHub App installation token in a repo secret, swapped in for `github.token` on that one step. That means creating and storing a credential, so it is Zaal's call, not something to slip into a CI PR. Until it is done, auto-merged commits still land unverified; the schedule just means we find out within a day instead of never.

Also worth deciding separately: `--auto` gates on the PR's checks, which is the branch head. If merge-result verification is wanted before the merge rather than after, that is a merge-queue question.
