### PR TITLE
feat(zoe): failed work is parked, not deleted - and a silent success is fixed

### DIFF
--- a/bot/src/zoe/__tests__/work-park.test.ts
+++ b/bot/src/zoe/__tests__/work-park.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Failed work must survive the tick that failed it.
+ *
+ * Every test here names a way work used to vanish. The sharpest is the
+ * empty-output case: `reportFor` sits INSIDE `if (firstOutput.trim())`, so a
+ * research pass that returned nothing sent no message anywhere, deleted the
+ * item, charged it against the daily cap, and emitted a receipt saying
+ * `resultType: 'success'`. Silent, and recorded as a success.
+ *
+ * See doc 2272 for the spec and doc 2271 for the Peter comparison it came from.
+ */
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const receipts: Array<Record<string, unknown>> = [];
+const reported: string[] = [];
+let researchOutput = '';
+let dispatchThrows = false;
+let docResult: { ok: boolean; num?: number; prUrl?: string; error?: string } = { ok: true, num: 9999, prUrl: 'http://pr/1' };
+
+vi.mock('../dispatch', () => ({
+  dispatchPlan: vi.fn(async ({ hooks }: { hooks?: { onSubtaskDone?: (st: unknown, r: unknown) => Promise<void> } }) => {
+    if (dispatchThrows) throw new Error('dispatch exploded');
+    await hooks?.onSubtaskDone?.(
+      { worker: 'research-worker' },
+      { status: 'completed', output: researchOutput },
+    );
+  }),
+}));
+vi.mock('../research-doc', () => ({ commitResearchDoc: vi.fn(async () => docResult) }));
+vi.mock('../receipts', () => ({
+  emitReceipt: vi.fn(async (r: Record<string, unknown>) => {
+    receipts.push(r);
+    return true;
+  }),
+}));
+vi.mock('../verify-replan', () => ({
+  verifyReplanResearch: vi.fn(async (_goal: string, output: string) => ({ output, retries: 0 })),
+}));
+vi.mock('../../hermes/claude-cli', () => ({ callClaudeCli: vi.fn(async () => ({ text: 'ACCEPT' })) }));
+
+const { enqueueWork, runWorkTick, queueDepth, resumeParkedWork } = await import('../work-loop');
+const { parkedWork, foldRecords } = await import('../work-park');
+
+const deps = {
+  sendToZaal: async (t: string) => {
+    reported.push(t);
+    return true;
+  },
+  zaalTgId: 1,
+  repoDir: '/tmp',
+  currentDate: '2026-08-13',
+};
+
+describe('work-park', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'zoe-park-'));
+    process.env.ZOE_HOME = home;
+    receipts.length = 0;
+    reported.length = 0;
+    researchOutput = '';
+    dispatchThrows = false;
+    docResult = { ok: true, num: 9999, prUrl: 'http://pr/1' };
+  });
+  afterEach(async () => {
+    delete process.env.ZOE_HOME;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('THE SILENT PATH: empty research output parks, reports, and is NOT a success receipt', async () => {
+    await enqueueWork('a topic that yields nothing');
+    researchOutput = '';
+
+    await runWorkTick(deps);
+
+    // it left the active queue - that part was always correct
+    expect(await queueDepth()).toBe(0);
+
+    // ...but it is no longer gone
+    const parked = await parkedWork();
+    expect(parked).toHaveLength(1);
+    expect(parked[0].reason).toBe('empty-output');
+    expect(parked[0].stage).toBe('research');
+    expect(parked[0].item?.input).toBe('a topic that yields nothing');
+
+    // it now says something. previously: nothing at all.
+    expect(reported.join(' ')).toContain('no research output');
+
+    // and the receipt tells the truth. previously: resultType 'success'.
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].resultType).toBe('error');
+    expect(receipts[0].inputDigest).toBeTruthy();
+  });
+
+  it('a thrown tick parks the item instead of deleting it', async () => {
+    // The path doc 2271 named: the error was reported to Telegram, truncated to
+    // 120 chars, and the item was gone. The Telegram line scrolls away; the
+    // receipt carried no item id. Nothing could answer "what happened to it?".
+    await enqueueWork('a topic that explodes');
+    dispatchThrows = true;
+
+    await runWorkTick(deps);
+
+    expect(await queueDepth()).toBe(0); // still dequeued - that was always right
+    const parked = await parkedWork();
+    expect(parked).toHaveLength(1);
+    expect(parked[0].reason).toBe('error');
+    expect(parked[0].error).toContain('dispatch exploded'); // untruncated
+    expect(parked[0].item?.input).toBe('a topic that explodes');
+    expect(receipts[0].resultType).toBe('error');
+    expect(receipts[0].inputDigest).toBeTruthy(); // WHICH topic, not just "a tick"
+  });
+
+  it('a successful tick still reports success and parks nothing', async () => {
+    await enqueueWork('a topic that works');
+    researchOutput = 'real findings, long enough to matter';
+
+    await runWorkTick(deps);
+
+    expect(await queueDepth()).toBe(0);
+    expect(await parkedWork()).toHaveLength(0);
+    expect(receipts[0].resultType).toBe('success');
+  });
+
+  it('research that succeeded but failed to COMMIT keeps its output', async () => {
+    await enqueueWork('a topic whose doc will not land');
+    researchOutput = 'findings worth keeping';
+    docResult = { ok: false, error: 'git push rejected' };
+
+    await runWorkTick(deps);
+
+    const parked = await parkedWork();
+    expect(parked).toHaveLength(1);
+    expect(parked[0].reason).toBe('doc-failed');
+    expect(parked[0].output).toBe('findings worth keeping');
+    expect(receipts[0].resultType).toBe('error');
+  });
+
+  it('resume puts it back exactly once, and never twice', async () => {
+    await enqueueWork('parked then resumed');
+    researchOutput = '';
+    await runWorkTick(deps);
+    expect(await queueDepth()).toBe(0);
+
+    const id = (await parkedWork())[0].id;
+    const first = await resumeParkedWork(id, 'try it with the other source');
+    expect(first?.input).toBe('parked then resumed');
+    expect(await queueDepth()).toBe(1);
+
+    // a second resume of the same id must not duplicate the work
+    const second = await resumeParkedWork(id);
+    expect(second).toBeNull();
+    expect(await queueDepth()).toBe(1);
+
+    // and it is no longer listed as blocked
+    expect(await parkedWork()).toHaveLength(0);
+  });
+
+  it('the park file survives a corrupt line rather than losing every record', async () => {
+    await enqueueWork('one');
+    researchOutput = '';
+    await runWorkTick(deps);
+
+    const path = join(home, 'work-parked.jsonl');
+    const good = await readFile(path, 'utf8');
+    await (await import('node:fs/promises')).writeFile(path, `${good}{ not json\n`, 'utf8');
+
+    // throwing here would lose the whole file - the exact failure this prevents
+    expect(await parkedWork()).toHaveLength(1);
+  });
+});
+
+describe('the fold, which is where a naive implementation loses the payload', () => {
+  it('a later status-only append does NOT shed the item', () => {
+    // Peter retired latest-record-wins for exactly this: under it, appending
+    // {id, status} drops the `item` a resume needs, and the record becomes
+    // unusable while still looking present.
+    const folded = foldRecords([
+      { id: 'wk-1', status: 'blocked', item: { id: 'wk-1', kind: 'research', input: 'keep me', addedTs: 'x' } },
+      { id: 'wk-1', status: 'open' },
+    ]);
+    const rec = folded.get('wk-1');
+    expect(rec?.status).toBe('open');
+    expect(rec?.item?.input).toBe('keep me');
+  });
+
+  it('a later field overwrites', () => {
+    const folded = foldRecords([
+      { id: 'wk-2', status: 'blocked', error: 'first' },
+      { id: 'wk-2', status: 'blocked', error: 'second' },
+    ]);
+    expect(folded.get('wk-2')?.error).toBe('second');
+  });
+
+  it('an explicit null clears', () => {
+    const folded = foldRecords([
+      { id: 'wk-3', status: 'blocked', error: 'transient' },
+      { id: 'wk-3', status: 'blocked', error: null as unknown as string },
+    ]);
+    expect(folded.get('wk-3')?.error).toBeUndefined();
+  });
+
+  it('records for different ids do not bleed into each other', () => {
+    const folded = foldRecords([
+      { id: 'a', status: 'blocked', error: 'ea' },
+      { id: 'b', status: 'blocked' },
+    ]);
+    expect(folded.get('b')?.error).toBeUndefined();
+  });
+});
+
+describe('nothing resumes parked work on its own', () => {
+  it('runWorkTick never calls resumeWork or resumeParkedWork', () => {
+    // Asserted against SOURCE, not behaviour, because "nothing auto-resumes" is
+    // a property that only ever fails silently - a tick that quietly re-queued a
+    // deterministic failure would burn DAILY_CAP every day and look normal.
+    const src = readFileSync(fileURLToPath(new URL('../work-loop.ts', import.meta.url)), 'utf8');
+    const tickStart = src.indexOf('export async function runWorkTick');
+    const tickEnd = src.indexOf('export async function resumeParkedWork');
+    expect(tickStart, 'runWorkTick not found - update this test deliberately').toBeGreaterThan(-1);
+    expect(tickEnd, 'resumeParkedWork not found').toBeGreaterThan(tickStart);
+
+    const tickBody = src.slice(tickStart, tickEnd);
+    expect(tickBody).not.toMatch(/\bresumeWork\s*\(/);
+    expect(tickBody).not.toMatch(/\bresumeParkedWork\s*\(/);
+  });
+});

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -26,6 +26,7 @@ import { commitResearchDoc } from './research-doc';
 import { emitReceipt } from './receipts';
 import { callClaudeCli } from '../hermes/claude-cli';
 import { verifyReplanResearch } from './verify-replan';
+import { parkWork, resumeWork } from './work-park';
 import type { ZoeContext } from './types';
 
 const dir = (): string => process.env.ZOE_HOME || join(homedir(), '.zao', 'zoe');
@@ -214,6 +215,10 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
       };
 
       const firstOutput = await runResearch(item.input);
+      // The receipt used to say 'success' unconditionally, including when
+      // research returned nothing and when the doc failed to commit. It now
+      // reports what actually happened (doc 2272).
+      let resultType: 'success' | 'error' = 'success';
       if (firstOutput.trim()) {
         // Verify the result answers the goal; on a graded-incomplete verdict,
         // re-research (bounded) with the missing aspects fed back. Only commit
@@ -246,6 +251,25 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
             ? `Work-loop done: doc ${doc.num}${retries ? ` (verified, ${retries} replan${retries > 1 ? 's' : ''})` : ' (verified)'} -> ${doc.prUrl}`
             : `Work-loop: doc save failed - ${doc.error}`,
         ).catch(() => {});
+        if (!doc.ok) {
+          // Research that SUCCEEDED and merely failed to land was previously
+          // discarded exactly like research that never ran. Keep the output.
+          await parkWork(item, 'doc-failed', {
+            stage: 'commit',
+            error: doc.error ? String(doc.error) : 'doc save failed',
+            output: finalOutput,
+          });
+          resultType = 'error';
+        }
+      } else {
+        // THE SILENT PATH. reportFor lives inside the branch above, so an empty
+        // research result used to send nothing anywhere, delete the item, charge
+        // it against the daily cap, and emit a 'success' receipt. Park it, say so.
+        await parkWork(item, 'empty-output', { stage: 'research' });
+        resultType = 'error';
+        await reportFor(item, deps)(
+          `Work-loop: "${item.input.slice(0, 60)}" produced no research output - parked, not lost. Ask ZOE for parked work.`,
+        ).catch(() => {});
       }
       await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
       await bumpToday(deps.currentDate);
@@ -256,7 +280,10 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
         capability: 'research',
         tool: 'work-loop',
         action: 'work_tick',
-        resultType: 'success',
+        resultType,
+        // Without the item id the receipt trail can say a tick failed but never
+        // WHICH topic - the gap doc 2272 names.
+        inputDigest: item.id,
         evidenceUrl,
         approvalClass: 'auto',
       }).catch(() => {});
@@ -269,15 +296,37 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
         tool: 'work-loop',
         action: 'work_tick',
         resultType: 'error',
+        inputDigest: item.id,
         approvalClass: 'auto',
       }).catch(() => {});
       await reportFor(item, deps)(
         `Work-loop error: failed to process "${item.input.slice(0, 60)}..." - ${errMsg.slice(0, 120)}`,
       ).catch(() => {});
+      // Park BEFORE dequeuing. The comment below is still right - retrying a
+      // deterministic failure would burn DAILY_CAP forever - but dequeuing is
+      // not the same as deleting, and this used to do both (doc 2272).
+      await parkWork(item, 'error', { stage: 'unknown', error: errMsg });
       // Remove from queue even on error to avoid infinite retry loop
       await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
     }
   } finally {
     await releaseLock();
   }
+}
+
+/**
+ * Put a parked item back on the queue. **Operator-initiated only.**
+ *
+ * Nothing in this file calls it - not runWorkTick, not a drain, not boot. That
+ * is the property that keeps parking safe rather than a retry storm, and
+ * `work-park.test.ts` asserts it by reading this file as source.
+ */
+export async function resumeParkedWork(id: string, answer?: string): Promise<WorkItem | null> {
+  const item = await resumeWork(id, answer);
+  if (!item) return null;
+  const q = await readQueue();
+  if (q.some((x) => x.id === item.id)) return item; // already queued, do not duplicate
+  q.push(item);
+  await writeQueue(q);
+  return item;
 }

--- a/bot/src/zoe/work-park.ts
+++ b/bot/src/zoe/work-park.ts
@@ -1,0 +1,199 @@
+/**
+ * work-park.ts - failed work survives, and can be asked about afterwards.
+ *
+ * THE PROBLEM (doc 2271, spec in doc 2272)
+ * ----------------------------------------
+ * `work-loop.ts` deleted a failed item from the queue outright. Three paths, all
+ * ending in the same unconditional filter:
+ *
+ *   1. the tick threw          - reported to Telegram, then deleted
+ *   2. research returned ''    - NOT reported anywhere, deleted, and a receipt
+ *                                emitted saying resultType: 'success'
+ *   3. the doc failed to commit - research that succeeded but did not LAND was
+ *                                discarded exactly like research that never ran
+ *
+ * After any of them, "what happened to that topic?" had no answer. The receipt
+ * carries no item id and no error text; the Telegram line is truncated to 120
+ * characters and scrolls away; the queue entry is gone.
+ *
+ * WHY THIS PARKS INSTEAD OF RETRYING
+ * ----------------------------------
+ * The comment that guarded the old behaviour was RIGHT:
+ *
+ *     // Remove from queue even on error to avoid infinite retry loop
+ *
+ * Dequeuing is correct. Deleting the evidence is the bug. Retrying is how this
+ * breaks: an item that fails deterministically - a malformed topic, a revoked
+ * token, a permanently 404 URL - would burn DAILY_CAP every day forever and
+ * starve everything queued behind it. robertkeus/peter reaches the same
+ * conclusion from the other side: loopback counts reset each session, so a
+ * `blocked` task that re-enters on its own "retries the same wall unbounded".
+ *
+ * So a parked item costs nothing. The only thing that changes is that it can
+ * still be asked about, and an operator can put it back deliberately.
+ *
+ * WHY APPEND-ONLY JSONL, AND WHY FOLD-PER-ID
+ * ------------------------------------------
+ * Append-only because a crash midway through rewriting a file is precisely how
+ * you lose the thing you were trying to preserve. `runs.ts` already writes
+ * append-only JSONL under ~/.zao/zoe, so this is an established shape here.
+ *
+ * Fold-per-id rather than latest-record-wins. Peter documents that choice as a
+ * retirement of its own earlier design, because under latest-wins "every live
+ * run shed fields": a later status-only append silently drops the payload an
+ * earlier record carried. Here that would mean appending {id, status:'open'}
+ * erases the `item` a resume needs. So: later fields overwrite, absent fields
+ * inherit, and an explicit null clears.
+ */
+
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+// Type-only, so this does NOT create a runtime cycle with work-loop.ts.
+// The dependency runs one way at runtime: work-loop imports work-park, never
+// the reverse - which is also why resumeWork returns the item rather than
+// enqueueing it itself.
+import type { WorkItem } from './work-loop';
+
+/** Same resolver work-loop.ts uses, so both agree under ZOE_HOME in tests. */
+const dir = (): string => process.env.ZOE_HOME || join(homedir(), '.zao', 'zoe');
+const PARK = (): string => join(dir(), 'work-parked.jsonl');
+
+export type ParkReason =
+  /** The tick threw. */
+  | 'error'
+  /** Research returned an empty string - the silent path. */
+  | 'empty-output'
+  /** Research succeeded; the doc/PR did not land. */
+  | 'doc-failed'
+  /** A human has to answer before this can proceed. */
+  | 'needs-input';
+
+/** Where it died. "It failed" is not resumable; the stage is. */
+export type ParkStage = 'research' | 'verify' | 'commit' | 'unknown';
+
+export interface ParkRecord {
+  /** The work item's id. Records FOLD on this. */
+  id: string;
+  ts: string;
+  status: 'blocked' | 'open';
+  reason?: ParkReason;
+  /** The original item, so a resume needs nothing else. */
+  item?: WorkItem;
+  stage?: ParkStage;
+  /** Untruncated - the Telegram message is cut to 120 chars, this is not. */
+  error?: string;
+  /** For needs-input: re-asked verbatim on resume. */
+  question?: string;
+  /** The operator's answer, appended as its own record. */
+  answer?: string;
+  /** Research output worth keeping when only the COMMIT failed. */
+  output?: string;
+  attempts?: number;
+}
+
+/** A single appended line. Partial by design - the fold reassembles it. */
+type ParkAppend = Partial<ParkRecord> & { id: string };
+
+async function appendRecord(rec: ParkAppend): Promise<void> {
+  await fs.mkdir(dir(), { recursive: true });
+  await fs.appendFile(PARK(), `${JSON.stringify({ ts: new Date().toISOString(), ...rec })}\n`, 'utf8');
+}
+
+async function readLines(): Promise<ParkAppend[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(PARK(), 'utf8');
+  } catch {
+    return []; // no park file yet is a normal empty state, not an error
+  }
+  const out: ParkAppend[] = [];
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const rec = JSON.parse(t) as ParkAppend;
+      if (rec && typeof rec.id === 'string') out.push(rec);
+    } catch {
+      // One corrupt line must not hide every other parked item. Skipping it
+      // loses that record; throwing would lose the whole file, which is the
+      // failure this module exists to prevent.
+      continue;
+    }
+  }
+  return out;
+}
+
+/**
+ * Fold records per id, in file order.
+ *
+ * Later fields overwrite. Absent fields inherit. An explicit null clears.
+ * NOT latest-record-wins - see the header.
+ */
+export function foldRecords(records: ParkAppend[]): Map<string, ParkRecord> {
+  const byId = new Map<string, ParkRecord>();
+  for (const rec of records) {
+    const base = byId.get(rec.id) ?? ({ id: rec.id, ts: '', status: 'blocked' } as ParkRecord);
+    const merged: Record<string, unknown> = { ...base };
+    for (const [k, v] of Object.entries(rec)) {
+      if (v === null) delete merged[k];
+      else merged[k] = v;
+    }
+    byId.set(rec.id, merged as unknown as ParkRecord);
+  }
+  return byId;
+}
+
+/** Park a failed item. It leaves the active queue; it does not leave the record. */
+export async function parkWork(
+  item: WorkItem,
+  reason: ParkReason,
+  detail: { stage?: ParkStage; error?: string; question?: string; output?: string } = {},
+): Promise<void> {
+  const prior = (await parkedById()).get(item.id);
+  await appendRecord({
+    id: item.id,
+    status: 'blocked',
+    reason,
+    item,
+    stage: detail.stage ?? 'unknown',
+    ...(detail.error ? { error: detail.error } : {}),
+    ...(detail.question ? { question: detail.question } : {}),
+    ...(detail.output ? { output: detail.output } : {}),
+    attempts: (prior?.attempts ?? 0) + 1,
+  });
+}
+
+/** Park an item because a human has to answer something first. */
+export async function askHuman(item: WorkItem, question: string, stage: ParkStage = 'unknown'): Promise<void> {
+  await parkWork(item, 'needs-input', { stage, question });
+}
+
+async function parkedById(): Promise<Map<string, ParkRecord>> {
+  return foldRecords(await readLines());
+}
+
+/** Everything currently blocked, newest first. This is what answers "what failed?". */
+export async function parkedWork(): Promise<ParkRecord[]> {
+  return [...(await parkedById()).values()]
+    .filter((r) => r.status === 'blocked')
+    .sort((a, b) => (a.ts < b.ts ? 1 : -1));
+}
+
+/**
+ * Mark a parked item open and hand it back. **Operator-initiated only.**
+ *
+ * Returns the item so the CALLER re-enqueues it - which keeps the runtime
+ * dependency one-way (work-loop -> work-park) and, more importantly, means
+ * nothing inside this module can put work back into the queue by itself.
+ *
+ * Nothing calls this automatically. Not the tick, not the drain, not boot.
+ * `work-park.test.ts` asserts that by reading work-loop.ts as source, because
+ * "nothing auto-resumes" is a property that only ever fails silently.
+ */
+export async function resumeWork(id: string, answer?: string): Promise<WorkItem | null> {
+  const rec = (await parkedById()).get(id);
+  if (!rec || rec.status !== 'blocked' || !rec.item) return null;
+  await appendRecord({ id, status: 'open', ...(answer ? { answer } : {}) });
+  return rec.item;
+}


### PR DESCRIPTION
## Executive summary

`bot/src/zoe/work-loop.ts` deleted failed work. Doc 2271 (#3067) found it; doc 2272 (#3072, merged) specced the fix; this is the fix.

Three paths ended in the same unconditional `writeQueue(filter)`. After any of them, "what happened to that topic?" had no answer: the receipt carried no item id, the Telegram line was truncated to 120 characters and scrolled away, and the queue entry was gone.

## The path 2271 did not name, and it is the worst one

```ts
const firstOutput = await runResearch(item.input);
if (firstOutput.trim()) {
  // ... commitResearchDoc, reportFor(...)   <- the ONLY report is in here
}
await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
await bumpToday(deps.currentDate);
await emitReceipt({ ..., resultType: 'success', ... })
```

`reportFor` sits **inside** the `if`. When research returned an empty string: no doc, **no message anywhere**, item deleted, charged against the daily cap, and a receipt emitted saying **`success`**.

Silent, and recorded as a success - `silent-failure-guard.md`'s exact shape, inside the loop we point at when we talk about honesty.

## What changed

| Path | Before | After |
|---|---|---|
| the tick threw | reported (truncated), deleted | parked `error`, error text kept **untruncated** |
| research returned `''` | **silent**, deleted, receipt `success` | parked `empty-output`, reported, receipt `error` |
| doc failed to commit | reported, deleted, receipt `success` | parked `doc-failed`, **research output kept** |

Receipts now carry `inputDigest: item.id`, so the trail can say *which* topic failed rather than that *a tick* did.

## Park, not retry - the comment was right

```ts
// Remove from queue even on error to avoid infinite retry loop
```

That comment is correct and is kept. Dequeuing is right; **deleting the evidence was the bug.** The obvious "fix" - retry - is how this breaks: an item that fails deterministically (a malformed topic, a revoked token, a permanent 404) would burn `DAILY_CAP` every day and starve everything behind it. Peter reaches the same conclusion from the other side: loopback counts reset each session, so a `blocked` task that re-enters on its own "retries the same wall unbounded".

A parked item costs nothing. The only thing that changes is that it can be asked about.

`resumeParkedWork` is **operator-only**. Nothing calls it - not the tick, not a drain, not boot - and a test asserts that by reading `runWorkTick` as source, because "nothing auto-resumes" only ever fails silently.

## Why append-only JSONL, folded per id

Append-only because a crash midway through rewriting a file is exactly how you lose what you were preserving. `runs.ts` already writes append-only JSONL under `~/.zao/zoe`, so the shape is established here.

Records **fold** per id - later fields overwrite, absent inherit, explicit `null` clears - rather than latest-record-wins. Peter documents that choice as a retirement of its own earlier design, because under latest-wins "every live run shed fields". Here it would mean appending `{id, status:'open'}` erases the `item` a resume needs. There is a test for exactly that, and it fails under the naive implementation.

## Evidence

PROVEN by mutation, all restored afterwards:

| Mutation | Result |
|---|---|
| hardcode the receipt back to `resultType: 'success'` | 2 tests FAIL, including THE SILENT PATH |
| remove `parkWork` from the `catch` (the original delete) | throw-path test FAILS |
| fold -> latest-record-wins | fold test FAILS: `expected undefined to be 'keep me'` |

11 new tests. `tsc --noEmit` 0 errors. Full suite: **2357 passed, exit 0.**

**One honest note on that number.** An earlier full run of this same branch reported `2 failed | 2355 passed`, and I truncated the output with my own `tail`, so I cannot name which two. A clean re-run is 2357/2357 exit 0. My best hypothesis is interference: I was committing in a sibling worktree while that run was in flight, and worktrees share the git object store, so a test that shells out to git could have hit a moving target. That is a hypothesis, not a finding - the two failures are unidentified, and CI on this PR is the tiebreaker.

## Not in scope

- **`criteria[]` at filing** (doc 2272 decision 7) - right idea, but it changes the contract of every `enqueueWork` caller.
- **The doc 1527 DreamLoop port** - stuck at Phase 1 since July. This is the small change that removes the data loss, not the architecture that replaces the loop. If 1527 lands later, the park file is the state it needs anyway.
- **Pruning the park file** - nothing deletes from it. Deletion is Zaal's.
- **`bumpToday` behaviour** - unchanged. A failed tick still spent the money; changing that is a separate argument and should not ride along here.

## The organ

This is scar tissue. The loop could always heal from a failure by forgetting it, which looks like health and is actually amnesia - the same wound reopens and nobody can tell it is the same one. A scar is worse-looking and better: it holds a record of what happened at the exact place it happened.
