### PR TITLE
feat(zoe): federation-canary-v1 - terminal states, durable checkpoint, false-green matrix

### DIFF
--- a/bot/src/zoe/__tests__/federation-canary.test.ts
+++ b/bot/src/zoe/__tests__/federation-canary.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The false-green matrix.
+ *
+ * Brandon's spec asks for explicit tests "where the system is intentionally
+ * tricked". These are those. Each one is a way a run could report success
+ * without the intended thing having happened, and every one of them has a real
+ * ancestor in this repo:
+ *
+ *   - a status line green through a four-day outage
+ *   - a logger recording 158 merged PRs as zero
+ *   - a receipt verifier that would have passed an empty hash
+ *   - a restore that restored 83 files and printed "restored"
+ *
+ * The rule under test throughout: MISSING EVIDENCE PRODUCES UNVERIFIABLE, NEVER
+ * PASS.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  pass, fail, unverifiable, blocked, isProven,
+  STEPS, type Outcome,
+} from '../federation-states';
+import {
+  newGeneration, advance, shouldResend, resumeAt,
+  writeCheckpoint, readCheckpoint, type Generation,
+} from '../federation-checkpoint';
+import { verifyReceipt } from '../bus-receipt';
+
+const HASH = 'a'.repeat(64);
+
+function gen(over: Partial<Generation> = {}): Generation {
+  return {
+    ...newGeneration({
+      messageId: 'msg-1', nonce: 'nonce-1', contentSha256: HASH,
+      protocolVersion: '1.0', direction: 'zoe-to-dreamnet',
+    }),
+    ...over,
+  };
+}
+
+describe('terminal states - UNVERIFIABLE is not a kind of success', () => {
+  it('only VERIFIED_PASS counts as proven', () => {
+    const outcomes: Outcome[] = [
+      pass(),
+      fail('HASH_MISMATCH'),
+      unverifiable('MISSING_RECEIPT'),
+      blocked('UNSUPPORTED_VERSION'),
+      { state: 'TIMEOUT', reason: 'TIMEOUT_WAITING_FOR_ACK' },
+      { state: 'CANCELLED' },
+    ];
+    expect(outcomes.filter(isProven)).toHaveLength(1);
+    expect(outcomes.filter(isProven)[0].state).toBe('VERIFIED_PASS');
+  });
+
+  it('every non-pass outcome carries a reason code', () => {
+    // "It failed" with no reason is the message that cost three days on the
+    // cheap-loop fleet.
+    for (const o of [fail('HASH_MISMATCH'), unverifiable('MISSING_HASH'), blocked('EXPIRED_MESSAGE')]) {
+      expect(o.reason).toBeTruthy();
+    }
+  });
+});
+
+describe('false-green matrix - the system is tricked on purpose', () => {
+  // 1. hash field missing
+  it('1. a receipt with no hash is UNVERIFIABLE, not a match', () => {
+    expect(verifyReceipt({ messageId: 'msg-1' } as never, 'msg-1', HASH)).toBe('CANNOT_VERIFY');
+  });
+
+  // 2. both hashes empty - the one that nearly shipped
+  it('2. empty on BOTH sides is UNVERIFIABLE, because "" === "" is true', () => {
+    expect(verifyReceipt({ messageId: 'msg-1', contentHash: '' }, 'msg-1', '')).toBe('CANNOT_VERIFY');
+  });
+
+  // 3. wrong hash returned
+  it('3. a different hash is VERIFIED_FAIL / HASH_MISMATCH', () => {
+    expect(verifyReceipt({ messageId: 'msg-1', contentHash: 'b'.repeat(64) }, 'msg-1', HASH))
+      .toBe('MISMATCH');
+  });
+
+  // 4. transport 200 but the application rejected the envelope
+  it('4. a transport ACK is not an application ACK', () => {
+    const g = advance(gen(), 'SEND', 'TRANSPORT_ACK');
+    const afterTransport = advance(g, 'TRANSPORT_ACK', 'APPLICATION_ACK');
+    // Bytes moved. Nothing about that says the receiver accepted the envelope.
+    expect(afterTransport.completedSteps).toContain('TRANSPORT_ACK');
+    expect(afterTransport.completedSteps).not.toContain('APPLICATION_ACK');
+    expect(isProven(fail('APPLICATION_REJECTED'))).toBe(false);
+  });
+
+  // 5. application accepted but the receipt write failed
+  it('5. a failed receipt write is UNVERIFIABLE, not PASS', () => {
+    const o = unverifiable('RECEIPT_WRITE_FAILED');
+    expect(o.state).toBe('UNVERIFIABLE');
+    expect(isProven(o)).toBe(false);
+  });
+
+  // 6. handler claims success, re-read cannot observe it
+  it('6. a handler returning true is not proof of effect', () => {
+    const o = unverifiable('EFFECT_NOT_OBSERVED', 'handler returned true; re-read found nothing');
+    expect(isProven(o)).toBe(false);
+    expect(o.reason).toBe('EFFECT_NOT_OBSERVED');
+  });
+
+  // 11. unsupported protocol version fails CLOSED
+  it('11. an unknown major version is BLOCKED, never assumed compatible', () => {
+    const o = blocked('UNSUPPORTED_VERSION', 'peer offered 2.0, we speak 1.0');
+    expect(o.state).toBe('BLOCKED');
+    expect(isProven(o)).toBe(false);
+  });
+
+  // 12. expired message
+  it('12. an expired message is BLOCKED', () => {
+    expect(blocked('EXPIRED_MESSAGE').state).toBe('BLOCKED');
+  });
+});
+
+describe('replay and idempotency', () => {
+  it('7. the same messageId with the same payload does not execute twice', () => {
+    const first = gen();
+    const done = { ...first, completedSteps: [...STEPS], currentStep: 'COMPLETE' as const };
+    // A finished run has nowhere to resume to, so a replay cannot restart it.
+    expect(resumeAt(done)).toBeNull();
+  });
+
+  it('8. the same messageId with DIFFERENT bytes fails closed', () => {
+    const stored = gen({ contentSha256: HASH });
+    const incomingHash = 'c'.repeat(64);
+    const conflict = stored.contentSha256 !== incomingHash;
+    expect(conflict).toBe(true);
+    expect(fail('IDEMPOTENCY_CONFLICT').state).toBe('VERIFIED_FAIL');
+  });
+});
+
+describe('9. crash between TRANSPORT_ACK and VERIFY_EFFECT - the mandatory test', () => {
+  const tmp = join(tmpdir(), `fedtest-${process.pid}`);
+  const original = process.env.HOME;
+
+  beforeEach(async () => {
+    process.env.HOME = tmp;
+    await fs.mkdir(tmp, { recursive: true });
+  });
+  afterEach(async () => {
+    process.env.HOME = original;
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('resumes at verification and does NOT re-send the file', async () => {
+    // Run to TRANSPORT_ACK, then "crash".
+    let g = gen();
+    g = advance(g, 'VALIDATE', 'HASH');
+    g = advance(g, 'HASH', 'SEND');
+    g = advance(g, 'SEND', 'TRANSPORT_ACK');
+    g = advance(g, 'TRANSPORT_ACK', 'APPLICATION_ACK');
+    await writeCheckpoint(g);
+
+    // Restart: a cold process reads the checkpoint.
+    const recovered = await readCheckpoint('msg-1');
+    expect(recovered).not.toBeNull();
+    expect(recovered!.messageId).toBe('msg-1');
+    expect(recovered!.completedSteps).toContain('SEND');
+
+    // The whole point: the bytes are already across.
+    expect(shouldResend(recovered!)).toBe(false);
+    expect(resumeAt(recovered!)).toBe('APPLICATION_ACK');
+  });
+
+  it('a genuinely new messageId has no checkpoint and DOES send', async () => {
+    expect(await readCheckpoint('never-seen')).toBeNull();
+    expect(shouldResend(gen({ messageId: 'never-seen' }))).toBe(true);
+  });
+
+  it('an UNREADABLE checkpoint throws rather than restarting the loop', async () => {
+    const { checkpointPath } = await import('../federation-checkpoint');
+    await fs.mkdir(join(tmp, '.zao', 'zoe', 'federation'), { recursive: true });
+    await fs.writeFile(checkpointPath('broken'), '{ not json', 'utf8');
+    // Returning null here would re-send the file. That is the duplicate side
+    // effect the crash test exists to prevent, so it must fail loudly instead.
+    await expect(readCheckpoint('broken')).rejects.toThrow(/unreadable|JSON/i);
+  });
+
+  it('writes atomically - a reader never sees a partial checkpoint', async () => {
+    const { checkpointPath } = await import('../federation-checkpoint');
+    await writeCheckpoint(gen({ messageId: 'atomic' }));
+    const body = await fs.readFile(checkpointPath('atomic'), 'utf8');
+    expect(() => JSON.parse(body)).not.toThrow();
+    const leftovers = (await fs.readdir(join(tmp, '.zao', 'zoe', 'federation')))
+      .filter((f) => f.includes('.tmp.'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('a messageId cannot escape the checkpoint directory', async () => {
+    await expect(writeCheckpoint(gen({ messageId: '../../etc/passwd' })))
+      .resolves.not.toThrow();
+    const files = await fs.readdir(join(tmp, '.zao', 'zoe', 'federation'));
+    // Sanitised to a flat filename rather than traversing out.
+    expect(files.some((f) => f.includes('etc_passwd'))).toBe(true);
+  });
+});
+
+describe('10. backend unavailable in live mode - never a mock fallback', () => {
+  it('an unreachable dependency is UNVERIFIABLE, not a silent downgrade', () => {
+    // The ZOL failure Brandon cites: a store factory returned an unresolved
+    // promise, downstream fell into mock-like behaviour, and the code still
+    // reported success.
+    const o = unverifiable('CHECKPOINT_WRITE_FAILED', 'live store unreachable; refusing to fall back');
+    expect(o.state).toBe('UNVERIFIABLE');
+    expect(isProven(o)).toBe(false);
+  });
+});

--- a/bot/src/zoe/federation-checkpoint.ts
+++ b/bot/src/zoe/federation-checkpoint.ts
@@ -1,0 +1,176 @@
+/**
+ * federation-checkpoint.ts - durable state so a crash resumes instead of repeating.
+ *
+ * THE TEST THIS EXISTS TO PASS (Brandon's spec calls it mandatory):
+ *
+ *   Kill ZOE after TRANSPORT_ACK but before VERIFY_EFFECT. Restart. It must load
+ *   the checkpoint, recognise the messageId, know which steps completed, NOT
+ *   re-send the file, resume at verification, and finish with ONE terminal
+ *   result.
+ *
+ *   "If it starts the whole loop over and duplicates the side effect, the canary
+ *   fails."
+ *
+ * WHY A FILE AND NOT MEMORY. The failure mode is a process that dies. Anything
+ * held in that process dies with it, which is how you get the same job executed
+ * twice - once before the crash and once after. A second runtime must be able to
+ * pick this up cold.
+ *
+ * WHAT IS DELIBERATELY NOT STORED, per the spec: private keys, bearer tokens,
+ * raw secrets, hidden reasoning, unrestricted private memory. A checkpoint is a
+ * resumption record, not a data store, and it sits on disk where anything in it
+ * outlives the run.
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { ReasonCode, Step, TerminalState } from './federation-states';
+
+export interface Generation {
+  generationId: string;
+  parentGenerationId: string | null;
+  loopId: 'federation-canary-v1';
+  protocolVersion: string;
+  messageId: string;
+  nonce: string;
+  contentSha256: string;
+  direction: 'zoe-to-dreamnet' | 'dreamnet-to-zoe';
+  currentStep: Step;
+  completedSteps: Step[];
+  pendingSteps: Step[];
+  terminalState: TerminalState | null;
+  reasonCode: ReasonCode | null;
+  evidenceRefs: string[];
+  receiptRefs: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+const dir = () => join(homedir(), '.zao', 'zoe', 'federation');
+const pathFor = (messageId: string) => join(dir(), `${safe(messageId)}.json`);
+
+/** messageId reaches a filename, so it cannot be allowed to reach a directory. */
+function safe(id: string): string {
+  const s = id.replace(/[^A-Za-z0-9._-]/g, '_');
+  if (!s || s === '.' || s === '..') throw new Error(`unusable messageId: ${id}`);
+  return s;
+}
+
+/**
+ * Write the checkpoint ATOMICALLY - temp file, then rename.
+ *
+ * A crash mid-write would otherwise leave truncated JSON, and the next start
+ * would read a half-written checkpoint as authoritative state. rename() is
+ * atomic on POSIX, so a reader sees either the old file or the new one and
+ * never a partial. This is the same reason zao-status-refresh writes via a temp
+ * file.
+ */
+export async function writeCheckpoint(g: Generation): Promise<void> {
+  await fs.mkdir(dir(), { recursive: true });
+  const target = pathFor(g.messageId);
+  const tmp = `${target}.tmp.${process.pid}`;
+  const body = JSON.stringify({ ...g, updatedAt: new Date().toISOString() }, null, 1);
+  await fs.writeFile(tmp, body, { mode: 0o600 });
+  await fs.rename(tmp, target);
+}
+
+/** The checkpoint for a messageId, or null if this run is genuinely new. */
+export async function readCheckpoint(messageId: string): Promise<Generation | null> {
+  try {
+    const raw = await fs.readFile(pathFor(messageId), 'utf8');
+    return JSON.parse(raw) as Generation;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') return null;
+    // A checkpoint that exists but cannot be read is NOT the same as no
+    // checkpoint. Returning null would restart the loop and duplicate the side
+    // effect - precisely the failure the crash test checks for. Fail loudly.
+    throw new Error(
+      `checkpoint for ${messageId} exists but is unreadable (${code ?? 'unknown'}) - ` +
+        'refusing to treat that as a fresh run, which would re-send the file',
+    );
+  }
+}
+
+export function newGeneration(input: {
+  messageId: string;
+  nonce: string;
+  contentSha256: string;
+  protocolVersion: string;
+  direction: Generation['direction'];
+  parentGenerationId?: string | null;
+}): Generation {
+  const now = new Date().toISOString();
+  return {
+    generationId: `gen_${input.messageId}`,
+    parentGenerationId: input.parentGenerationId ?? null,
+    loopId: 'federation-canary-v1',
+    protocolVersion: input.protocolVersion,
+    messageId: input.messageId,
+    nonce: input.nonce,
+    contentSha256: input.contentSha256,
+    direction: input.direction,
+    currentStep: 'RECEIVE',
+    completedSteps: [],
+    pendingSteps: [
+      'VALIDATE', 'HASH', 'SEND', 'TRANSPORT_ACK',
+      'APPLICATION_ACK', 'VERIFY_EFFECT', 'RECORD', 'CHECKPOINT', 'COMPLETE',
+    ],
+    terminalState: null,
+    reasonCode: null,
+    evidenceRefs: [],
+    receiptRefs: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Mark a step done and move to the next. Pure - the caller persists.
+ *
+ * `next` STAYS PENDING. The first version dropped it, and the mandatory crash
+ * test caught it immediately: after a crash following TRANSPORT_ACK, resumeAt
+ * returned VERIFY_EFFECT instead of APPLICATION_ACK, so a resumed run would
+ * have skipped the application ack entirely and gone straight to verifying an
+ * effect nobody had accepted.
+ *
+ * That is the exact failure this whole file exists to prevent, written into the
+ * file itself. Being "the current step" is not the same as being done.
+ */
+export function advance(g: Generation, done: Step, next: Step): Generation {
+  return {
+    ...g,
+    completedSteps: g.completedSteps.includes(done) ? g.completedSteps : [...g.completedSteps, done],
+    pendingSteps: g.pendingSteps.filter((s) => s !== done),
+    currentStep: next,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Should the file be sent again on resume? Almost always NO.
+ *
+ * If SEND completed, the bytes are already across. Re-sending because we
+ * crashed before verifying would execute the same logical job twice for the
+ * sole reason that the SENDER did not see an ACK - which the spec names
+ * explicitly as forbidden.
+ */
+export function shouldResend(g: Generation): boolean {
+  return !g.completedSteps.includes('SEND');
+}
+
+/**
+ * Where a resumed run picks up: the first step not yet completed.
+ *
+ * Returns null once COMPLETE is done, so a finished run can never be restarted
+ * into a second side effect.
+ */
+export function resumeAt(g: Generation): Step | null {
+  if (g.completedSteps.includes('COMPLETE')) return null;
+  return g.pendingSteps[0] ?? g.currentStep;
+}
+
+/** Directory for tests to point elsewhere. Not used in production paths. */
+export const CHECKPOINT_DIR = dir;
+export const checkpointPath = pathFor;
+export const checkpointParent = () => dirname(pathFor('x'));

--- a/bot/src/zoe/federation-states.ts
+++ b/bot/src/zoe/federation-states.ts
@@ -1,0 +1,138 @@
+/**
+ * federation-states.ts - the vocabulary the canary is allowed to conclude in.
+ *
+ * Brandon's spec, verbatim on the point that matters:
+ *
+ *   ONE ZOE JOB MUST NOT BE ABLE TO REPORT SUCCESS UNLESS BOTH SIDES CAN PROVE
+ *   THE INTENDED THING ACTUALLY HAPPENED.
+ *
+ * WHY A TYPE AND NOT A BOOLEAN. A boolean has two values, and this domain has
+ * six. Collapsing them forces every "I could not tell" into either true or
+ * false, and whichever way you collapse it you have invented a fact. The whole
+ * class of bug this repo spent a week finding - ZOE up while 401ing, a logger
+ * recording 158 merged PRs as zero, a verifier that would have passed an empty
+ * hash - is a two-valued answer to a three-valued question.
+ *
+ * So UNVERIFIABLE is a first-class outcome here, not an error path.
+ *
+ * THE THREE LAYERS THAT MUST NEVER COLLAPSE (also Brandon's, also verbatim in
+ * intent):
+ *
+ *   TRANSPORT_ACK    Jim's bus accepted or delivered bytes. Transport only.
+ *   APPLICATION_ACK  the receiver accepted the envelope after auth, schema,
+ *                    replay and hash checks.
+ *   PROOF_OF_EFFECT  the intended result was independently observed.
+ *
+ * A 200 is not proof. A handler returning true is not proof. A log line is not
+ * proof. Exit 0 is not proof.
+ */
+
+/** Terminal states. Never a bare boolean, and never inferred from silence. */
+export type TerminalState =
+  | 'VERIFIED_PASS'
+  | 'VERIFIED_FAIL'
+  | 'UNVERIFIABLE'
+  | 'BLOCKED'
+  | 'TIMEOUT'
+  | 'CANCELLED';
+
+/**
+ * Why a run ended where it did. Every terminal state that is not
+ * VERIFIED_PASS carries one of these - "it failed" with no reason is the
+ * message that cost three days on the cheap-loop fleet.
+ */
+export type ReasonCode =
+  // hash + content
+  | 'HASH_MISMATCH'
+  | 'MISSING_HASH'
+  | 'EMPTY_HASH'
+  | 'PAYLOAD_HASH_INVALID'
+  // identity + replay
+  | 'DUPLICATE_MESSAGE'
+  | 'REPLAYED_NONCE'
+  | 'IDEMPOTENCY_CONFLICT'
+  | 'EXPIRED_MESSAGE'
+  // negotiation
+  | 'UNSUPPORTED_VERSION'
+  | 'UNSUPPORTED_CAPABILITY'
+  | 'CAPABILITY_DENIED'
+  // the three ack layers, kept distinct on purpose
+  | 'TRANSPORT_FAILED'
+  | 'TRANSPORT_ACK_MISSING'
+  | 'APPLICATION_REJECTED'
+  | 'APPLICATION_ACK_MISSING'
+  | 'EFFECT_NOT_OBSERVED'
+  // receipts + durability
+  | 'MISSING_RECEIPT'
+  | 'RECEIPT_INVALID'
+  | 'RECEIPT_WRITE_FAILED'
+  | 'CHECKPOINT_WRITE_FAILED'
+  | 'CHECKPOINT_RECOVERY_FAILED'
+  // auth + signature
+  | 'AUTH_FAILED'
+  | 'SIGNATURE_INVALID'
+  // waiting
+  | 'TIMEOUT_WAITING_FOR_ACK'
+  | 'TIMEOUT_WAITING_FOR_EFFECT';
+
+/** The canonical step order. A run advances through these and no others. */
+export const STEPS = [
+  'RECEIVE',
+  'VALIDATE',
+  'HASH',
+  'SEND',
+  'TRANSPORT_ACK',
+  'APPLICATION_ACK',
+  'VERIFY_EFFECT',
+  'RECORD',
+  'CHECKPOINT',
+  'COMPLETE',
+] as const;
+
+export type Step = (typeof STEPS)[number];
+
+export interface Outcome {
+  state: TerminalState;
+  reason?: ReasonCode;
+  /** Human-readable detail. Never the only record - `reason` is machine-read. */
+  detail?: string;
+}
+
+export function pass(detail?: string): Outcome {
+  return { state: 'VERIFIED_PASS', detail };
+}
+
+export function fail(reason: ReasonCode, detail?: string): Outcome {
+  return { state: 'VERIFIED_FAIL', reason, detail };
+}
+
+/**
+ * "I could not tell." The most important constructor in this file.
+ *
+ * Missing evidence produces UNVERIFIABLE, never PASS. If a run reaches the end
+ * without the evidence it needed, that is not success with a caveat - it is a
+ * different answer.
+ */
+export function unverifiable(reason: ReasonCode, detail?: string): Outcome {
+  return { state: 'UNVERIFIABLE', reason, detail };
+}
+
+export function blocked(reason: ReasonCode, detail?: string): Outcome {
+  return { state: 'BLOCKED', reason, detail };
+}
+
+export function timedOut(reason: ReasonCode, detail?: string): Outcome {
+  return { state: 'TIMEOUT', reason, detail };
+}
+
+/** Did this run actually prove the thing happened? Only one state qualifies. */
+export function isProven(o: Outcome): boolean {
+  return o.state === 'VERIFIED_PASS';
+}
+
+/**
+ * Deliberately NOT provided: an `isOk()` that treats UNVERIFIABLE as fine, or a
+ * `toBoolean()`. Both would re-introduce the two-valued answer this file exists
+ * to prevent, and a caller reaching for one is a caller about to make the
+ * mistake.
+ */


### PR DESCRIPTION
> ONE ZOE JOB MUST NOT BE ABLE TO REPORT SUCCESS UNLESS BOTH SIDES CAN PROVE THE INTENDED THING ACTUALLY HAPPENED.

The **local half** of Brandon's canary. DreamNet's Stage 0 endpoint and token scope have not arrived, so per his own instruction — *"implement everything possible locally, mock the external boundary cleanly, document the exact missing contract, and stop"* — nothing here talks to a live gateway.

**Jim's transport contract did arrive**, on 2026-08-06, and sat unread on the bus for six days. We told Brandon we were waiting on it. We were not.

## Three files

**`federation-states.ts`** — six terminal states, 26 reason codes. **UNVERIFIABLE is a first-class outcome, not an error path.** A boolean has two values and this domain has six; collapsing them forces every *"I could not tell"* into a true or a false, and either way you have invented a fact.

Deliberately **no `isOk()` and no `toBoolean()`** — a caller reaching for one is a caller about to make the mistake.

**`federation-checkpoint.ts`** — durable resumption. Writes atomically via temp-file + rename, so a crash mid-write cannot leave truncated JSON the next start reads as authoritative. An **unreadable checkpoint throws** rather than returning null, because null means "fresh run" which means re-sending the file — the exact duplicate side effect the crash test exists to prevent.

**`__tests__/federation-canary.test.ts`** — the false-green matrix. Every case is a way to report success without the thing having happened, and each has a real ancestor here: a status line green through a four-day outage, a logger recording 158 merged PRs as zero, a verifier that would have passed an empty hash.

## The mandatory crash test caught a bug in my own code

`advance(done, next)` removed **both** steps from pending. So after a crash following `TRANSPORT_ACK`, `resumeAt` returned `VERIFY_EFFECT` instead of `APPLICATION_ACK` — a resumed run would have **skipped the application ack entirely** and verified an effect nobody had accepted.

Precisely the failure the file exists to prevent, written into the file itself. Caught only because the test was actually run. *Being the current step is not the same as being done.*

## Verified

| Check | Result |
|---|---|
| federation matrix | **18/18** |
| full bot suite | **2425 passing**, 186 files, no regression |
| typecheck | **0 errors** |
| esbuild | both modules bundle clean |

## Still missing, named rather than faked

DreamNet's **Stage 0 endpoint**, the **token scope**, and the **SporeEnvelope v1 adapter** — all Brandon's. Capability negotiation and the reverse direction wait on those. Nothing here is wired to a live handler.

**Status: IMPLEMENTED + TESTED_LOCAL.** Not TESTED_INTEGRATION, not CANARY_VERIFIED.