### PR TITLE
feat(zoe): instrument nine silent features, and fix the check that was lying

### DIFF
--- a/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
+++ b/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
@@ -50,6 +50,17 @@ const AUTONOMOUS_FEATURES = [
   'recap.ts',
   'brief.ts',
   'reflect.ts',
+  // Added by the 2026-08-14 audit. Every one was ERR-ONLY or SILENT: it spoke
+  // only when it failed, or not at all, so its silence meant nothing.
+  'work-loop.ts',
+  'orchestrator-tick.ts',
+  'repo-improver.ts',
+  'error-remediation.ts',
+  'backlog-grill-runner.ts',
+  'trust-audit.ts',
+  'dispatch.ts',
+  'proactive.ts',
+  'team-tracker.ts',
 ];
 
 function sourceOf(file: string): string {
@@ -80,23 +91,51 @@ describe('featureRan coverage on the autonomous path', () => {
 
   it('the call is on the success path, not only inside a catch', () => {
     // A module that speaks only when it fails tells you nothing when it works.
+    //
+    // The first version of this walked backwards to the nearest `} catch (` and
+    // called that enclosing. That is wrong whenever a catch has already CLOSED
+    // above the line - the shape `try { ...; try{}catch{}; HERE } finally {}` -
+    // and the 2026-08-14 audit found it mislabelling three success-path calls in
+    // orchestrator-tick, repo-improver and error-remediation. Track brace depth.
+    //
+    // Known limit, found by mutating this test rather than by reasoning about
+    // it: a SINGLE-LINE `try { ... } catch { featureRan(...) }` is not detected,
+    // because the scan only reads preceding lines and the catch opener is on the
+    // call's own line. Real code does not write it that way, and widening the
+    // scan to the current line would misread a call that merely follows a closed
+    // catch on one line. Stated rather than left as a surprise.
+    const insideCatch = (lines: string[], idx: number): boolean => {
+      let depth = 0;
+      const catchDepths: number[] = [];
+      for (let j = 0; j < idx; j++) {
+        const line = lines[j];
+        const s = line.trim();
+        if (s.startsWith('//') || s.startsWith('*')) continue;
+        let opensCatch = /\bcatch\s*(\([^)]*\))?\s*\{/.test(line);
+        for (const ch of line) {
+          if (ch === '{') {
+            depth++;
+            if (opensCatch) {
+              catchDepths.push(depth);
+              opensCatch = false;
+            }
+          } else if (ch === '}') {
+            if (catchDepths.length && catchDepths[catchDepths.length - 1] === depth) catchDepths.pop();
+            depth--;
+          }
+        }
+      }
+      return catchDepths.length > 0;
+    };
+
     const catchOnly: string[] = [];
     for (const f of AUTONOMOUS_FEATURES) {
-      const src = sourceOf(f);
-      const lines = src.split('\n');
-      const callLines = lines
+      const lines = sourceOf(f).split('\n');
+      const callIdx = lines
         .map((l, i) => ({ l, i }))
-        .filter(({ l }) => /\bfeatureRan\s*\(/.test(l) && !l.trim().startsWith('//'));
-      const allInCatch = callLines.every(({ i }) => {
-        // walk back to the nearest brace-opening construct
-        for (let j = i; j >= 0 && i - j < 25; j--) {
-          if (/\}\s*catch\s*\(/.test(lines[j])) return true;
-          if (/^\s*(export\s+)?(async\s+)?function\b/.test(lines[j])) return false;
-          if (/\btry\s*\{/.test(lines[j])) return false;
-        }
-        return false;
-      });
-      if (callLines.length > 0 && allInCatch) catchOnly.push(f);
+        .filter(({ l }) => /\bfeatureRan\s*\(/.test(l) && !l.trim().startsWith('//') && !l.startsWith('import'))
+        .map(({ i }) => i);
+      if (callIdx.length > 0 && callIdx.every((i) => insideCatch(lines, i))) catchOnly.push(f);
     }
     expect(catchOnly, `featureRan only reachable from a catch block in: ${catchOnly.join(', ')}`).toEqual([]);
   });

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -27,6 +27,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { featureRan } from './feature-ran';
 import {
   DRIP_DEFAULT,
   parseVerdict,
@@ -191,6 +192,9 @@ export async function runBacklogGrillTick(
   state.activeTaskId = next.task.id;
   state.lastSentMs = now;
   await writeState(state);
+  // Only the SENT path. A tick that declined to send has not run in any sense
+  // worth reporting, and saying otherwise makes the line mean 'the cron fired'.
+  featureRan('backlog-grill', next.task.title.slice(0, 60));
   return { sent: true, reason: 'sent', title: next.task.title };
 }
 

--- a/bot/src/zoe/dispatch.ts
+++ b/bot/src/zoe/dispatch.ts
@@ -27,6 +27,7 @@ import {
   type WorkerResult,
 } from './workers';
 import { recordRun, newRunId, type RunRecord } from './runs';
+import { featureRan } from './feature-ran';
 
 const DEFAULT_PLAN_BUDGET_USD = Number(process.env.ZOE_PLAN_BUDGET_USD ?? 5);
 
@@ -355,5 +356,8 @@ export async function dispatchPlan(args: DispatchPlanArgs): Promise<DispatchRepo
     }
   }
 
+  // Completion only. A plan paused for an approval gate has not finished, and
+  // announcing there would report a wait as a result.
+  featureRan('dispatch', 'plan completed');
   return finish('completed');
 }

--- a/bot/src/zoe/error-remediation.ts
+++ b/bot/src/zoe/error-remediation.ts
@@ -24,6 +24,7 @@ import type { HermesRepoTarget } from '../hermes/types';
 import { db } from '../supabase';
 import { dispatchHermesRun } from '../hermes/runner';
 import { emitReceipt } from './receipts';
+import { featureRan } from './feature-ran';
 
 export interface AppError {
   id: string;
@@ -153,6 +154,7 @@ export async function runErrorRemediationTick(deps: RemediationDeps): Promise<st
       `Error ${tag} (${target}${next.brand ? `, brand ${next.brand}` : ''}): diagnosed -> fixed -> ${prLabel} open${result.prUrl ? ` ${result.prUrl}` : ''}. Ready for your merge.`,
     );
     mcEmit('error-remediation', 'zoe', 5, `error ${tag} fixed -> ${result.prUrl ?? 'PR open'}`);
+    featureRan('error-remediation', 'auto-fixed');
     return `fixed -> ${result.prUrl ?? 'pr'}`;
   }
 
@@ -161,6 +163,7 @@ export async function runErrorRemediationTick(deps: RemediationDeps): Promise<st
     `Error ${tag} (${target}) - pipeline could not auto-fix (${result.kind}): ${result.reason}. Needs you.`,
   );
   mcEmit('error-remediation', 'zoe', 8, `error ${tag} NEEDS ZAAL (${result.kind}): ${result.reason}`);
+  featureRan('error-remediation', `escalated: ${result.kind}`);
   return `escalated (${result.kind})`;
 }
 

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -42,6 +42,7 @@ import { armPendingAnswer } from './pending-answers';
 import { startNudge, stopNudge, markPinged, dueTracks, nudgeLadderEnabled } from './nudge-ladder';
 import { refillOpenThings, clearOpenThing, topicFromQid, type TopicOpenThingState } from './always-open-topics';
 import { topicNameForThread } from './topic-router';
+import { featureRan } from './feature-ran';
 
 const ORCHESTRATOR_STATE_PATH = (): string =>
   join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator-state.json');
@@ -676,6 +677,9 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
         console.error('[zoe/orchestrator] refillOpenThings failed:', (err as Error)?.message);
       }
     }
+    // The tick reached the end of its work without throwing. Placed before the
+    // finally so a lock release on the error path cannot masquerade as a run.
+    featureRan('orchestrator-tick');
   } finally {
     await releaseLock();
   }

--- a/bot/src/zoe/proactive.ts
+++ b/bot/src/zoe/proactive.ts
@@ -28,6 +28,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { ZOE_PATHS } from './memory';
+import { featureRan } from './feature-ran';
 import {
   listLiveThreads,
   nextEscalationAction,
@@ -355,6 +356,7 @@ export async function runReasoningTick(deps: ReasoningTickDeps = {}): Promise<Pr
     considered: candidates.length,
     unacked,
   });
+  featureRan('proactive', `spoke: ${best.threadId ?? 'thread'}`);
   return {
     speak: true,
     message: best.message,

--- a/bot/src/zoe/repo-improver.ts
+++ b/bot/src/zoe/repo-improver.ts
@@ -24,6 +24,7 @@
 import { z } from 'zod';
 import { mcEmit } from './mission-control';
 import type { HermesRepoTarget } from '../hermes/types';
+import { featureRan } from './feature-ran';
 
 /** The repos the scout rotates through. hermesTarget=null => surface-only (no auto-fix target yet). */
 export interface ScoutRepo {
@@ -195,6 +196,7 @@ export async function runRepoImproverScout(deps: ScoutDeps): Promise<string> {
     run_id: null,
   });
   mcEmit('repo-improver', 'scout', 4, `proposed improvement: ${target.repo} - ${finding.area}`);
+  featureRan('repo-improver-scout', `${target.repo} - ${finding.area}`);
   return `proposed: ${target.repo} - ${finding.area}`;
 }
 

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -25,6 +25,7 @@ import {
 } from './done-work-detector';
 import { remember } from './recall';
 import { enqueueWrite } from './bonfire-retry';
+import { featureRan } from './feature-ran';
 
 export interface TeamTask {
   title: string;
@@ -747,6 +748,11 @@ export async function autoCloseFinishedTasks(
         refused.push(`${patch.status} on ${v.title.slice(0, 50)}`);
       }
     }
+    // The scan completed and wrote whatever it decided to write. `closed` is the
+    // effect; a scan that closed nothing still RAN, and that is the distinction
+    // this line exists to make - previously the whole module was silent, so a
+    // dead auto-close and a quiet one looked identical.
+    featureRan('auto-close', `${closed} closed, ${deferred} deferred`);
     return {
       ok: refused.length === 0,
       scanned: rows.length,

--- a/bot/src/zoe/trust-audit.ts
+++ b/bot/src/zoe/trust-audit.ts
@@ -18,6 +18,7 @@ import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { ZoeTask } from './types';
+import { featureRan } from './feature-ran';
 
 export interface AuditFinding {
   type: 'capture' | 'task';
@@ -170,6 +171,7 @@ export async function runAudit(recentShippedPRs: string[] = [], now: number = Da
     summary = `Trust audit found ${findings.length} potential gaps: ${captures} old captures, ${tasks} stuck tasks. Review details.`;
   }
 
+  featureRan('trust-audit', `${findings.length} findings`);
   return {
     scannedAt: new Date(now).toISOString(),
     findings,

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -28,6 +28,7 @@ import { callClaudeCli } from '../hermes/claude-cli';
 import { verifyReplanResearch } from './verify-replan';
 import { parkWork, resumeWork } from './work-park';
 import type { ZoeContext } from './types';
+import { featureRan } from './feature-ran';
 
 const dir = (): string => process.env.ZOE_HOME || join(homedir(), '.zao', 'zoe');
 const QUEUE = (): string => join(dir(), 'work-queue.json');
@@ -273,6 +274,9 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
       }
       await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
       await bumpToday(deps.currentDate);
+      // A tick reached the end of an item. resultType distinguishes a committed
+      // doc from a parked failure - both are 'it ran', only one is 'it worked'.
+      featureRan('work-loop', resultType);
       // Receipt so the afferent digest (R1) sees the work-loop's output, not just
       // repo-improver. Best-effort - never let a receipt failure break the tick.
       await emitReceipt({


### PR DESCRIPTION
## Executive summary

Audited **all 127 modules** in `bot/src/zoe/`, classifying each by whether it can say it ran: on the **SUCCESS** path, only inside a **catch**, or **nothing at all**. Then instrumented the nine highest-value silent ones.

| | before | after |
|---|---:|---:|
| SUCCESS (announces on the success path) | 21 | **30** |
| CATCH-ONLY (speaks only when it fails) | 0 | 0 |
| ERR-ONLY (no featureRan; only `console.error`) | 41 | 37 |
| SILENT (no logging statement of any kind) | 64 | 59 |
| n/a (no exported function) | 1 | 1 |

**64 modules had no logging statement of any kind.** For those, silence meant nothing at all - not "it worked", not "it failed". A module that speaks only when it fails tells you nothing when it works, and a silent one cannot be told from a dead one.

`tsc --noEmit` 0 errors. **185 files / 2407 tests pass, exit 0.** No poller entrypoint was imported or restarted at any point - the audit reads source as text and the tests mock the dispatch layer.

## The check itself was wrong, and that is the most important finding

The catch-detection in the coverage test from #3060 walked backwards to the nearest `} catch (` and called that enclosing. That is wrong whenever a catch has already **closed** above the line - the ordinary shape:

```ts
try {
  ...
  try { ... } catch { ... }
  featureRan('x');        // <- reported as catch-only. It is not.
} finally { ... }
```

It mislabelled three of the calls in this very PR - `orchestrator-tick`, `repo-improver`, `error-remediation` - as catch-only. It now tracks brace depth.

That bug would have inverted the test's whole purpose: reporting good placements as bad, and training whoever hit it to ignore the check. A check that is wrong in the direction of false alarms is the one people learn to skip.

Proven by mutation, both restored:

| Mutation | Result |
|---|---|
| move a call inside a multi-line `catch` | FAILS: `only reachable from a catch block in: trust-audit.ts` |
| delete a call entirely | FAILS: `cannot say they ran: dispatch.ts` |

**A known limit is now written into the test**, and I found it by mutating rather than by reasoning: a *single-line* `try { ... } catch { featureRan(...) }` is not detected, because the scan only reads preceding lines. Real code does not write it that way, and widening the scan would misread a call that merely follows a closed catch. Stated rather than left as a surprise.

## What was instrumented, and where

| module | announces when |
|---|---|
| `work-loop` | a tick finished an item - detail says committed doc or parked failure |
| `orchestrator-tick` | the tick completed without throwing |
| `repo-improver-scout` | an improvement was proposed |
| `error-remediation` | auto-fixed, **or** escalated - both are real outcomes |
| `backlog-grill` | **only** the sent path |
| `trust-audit` | the scan produced findings |
| `dispatch` | a plan **completed** - not one paused for an approval gate |
| `proactive` | **only** when it decides to speak |
| `auto-close` | the board scan wrote what it decided to |

Three are deliberately conditional, because "it ran" and "it worked" are different questions. `backlog-grill` stays quiet when it declines to send; `dispatch` does not announce a plan paused for approval; `proactive` does not announce a tick that chose silence. Without those guards the line would mean "the cron fired", which is the confusion this mechanism exists to remove.

## Not instrumented, on purpose

`teammate-heartbeat.ts` and `done-work-detector.ts` export **only pure helpers** - their runner lives in `scheduler.ts`, which already announces. A call inside them would announce a helper, not a feature.

The coverage list grows 9 -> 18 modules, so none of this can shrink back silently.

## The full table

<details>
<summary>All 127 modules, after instrumentation</summary>

| module | lines | exports | verdict | evidence |
|---|---:|---:|---|---|
| `scheduler.ts` | 1374 | 1 | **SUCCESS** | `scheduler.ts:392, scheduler.ts:437, scheduler.ts:464` |
| `team-tracker.ts` | 769 | 19 | **SUCCESS** | `team-tracker.ts:755` |
| `orchestrator-tick.ts` | 687 | 5 | **SUCCESS** | `orchestrator-tick.ts:682` |
| `brief.ts` | 451 | 2 | **SUCCESS** | `brief.ts:436` |
| `proactive.ts` | 394 | 13 | **SUCCESS** | `proactive.ts:359` |
| `dispatch.ts` | 364 | 3 | **SUCCESS** | `dispatch.ts:361` |
| `work-loop.ts` | 337 | 4 | **SUCCESS** | `work-loop.ts:279` |
| `backlog-grill-runner.ts` | 289 | 5 | **SUCCESS** | `backlog-grill-runner.ts:197` |
| `repo-improver.ts` | 289 | 11 | **SUCCESS** | `repo-improver.ts:199` |
| `afferent-digest.ts` | 272 | 1 | **SUCCESS** | `afferent-digest.ts:218` |
| `board-command-executor.ts` | 266 | 2 | **SUCCESS** | `board-command-executor.ts:249` |
| `error-remediation.ts` | 260 | 7 | **SUCCESS** | `error-remediation.ts:157, error-remediation.ts:166` |
| `tick-lock.ts` | 249 | 3 | **SUCCESS** | `tick-lock.ts:182` |
| `trust-audit.ts` | 213 | 2 | **SUCCESS** | `trust-audit.ts:174` |
| `bus-receipt.ts` | 191 | 2 | **SUCCESS** | `bus-receipt.ts:63` |
| `mission-control.ts` | 188 | 4 | **SUCCESS** | `mission-control.ts:106` |
| `receipts.ts` | 188 | 2 | **SUCCESS** | `receipts.ts:128` |
| `pinned-brief.ts` | 181 | 4 | **SUCCESS** | `pinned-brief.ts:144, pinned-brief.ts:152, pinned-brief.ts:173` |
| `guardrails.ts` | 173 | 6 | **SUCCESS** | `guardrails.ts:75` |
| `live-status.ts` | 171 | 1 | **SUCCESS** | `live-status.ts:158` |
| `bonfire-retry.ts` | 170 | 4 | **SUCCESS** | `bonfire-retry.ts:165` |
| `build-intent.ts` | 169 | 1 | **SUCCESS** | `build-intent.ts:107` |
| `heart-run.ts` | 166 | 2 | **SUCCESS** | `heart-run.ts:95, heart-run.ts:118, heart-run.ts:130` |
| `recap.ts` | 152 | 1 | **SUCCESS** | `recap.ts:138` |
| `reflect.ts` | 152 | 1 | **SUCCESS** | `reflect.ts:135` |
| `memory-git.ts` | 145 | 6 | **SUCCESS** | `memory-git.ts:73` |
| `bus-bridge.ts` | 142 | 7 | **SUCCESS** | `bus-bridge.ts:46` |
| `bus-upload.ts` | 129 | 2 | **SUCCESS** | `bus-upload.ts:94` |
| `dm-build-session.ts` | 127 | 12 | **SUCCESS** | `dm-build-session.ts:56` |
| `feature-ran.ts` | 62 | 3 | **SUCCESS** | `feature-ran.ts:40` |

| `task-teammate-ack.ts` | 722 | 12 | **ERR-ONLY** | `task-teammate-ack.ts:251` |
| `daily-note.ts` | 579 | 5 | **ERR-ONLY** | `daily-note.ts:110` |
| `workers.ts` | 477 | 3 | **ERR-ONLY** | `workers.ts:453 (console.error, 1 total; no console.log)` |
| `concierge.ts` | 431 | 2 | **ERR-ONLY** | `concierge.ts:152` |
| `always-open-topics.ts` | 421 | 14 | **ERR-ONLY** | `always-open-topics.ts:275` |
| `curator.ts` | 377 | 11 | **ERR-ONLY** | `curator.ts:104` |
| `events.ts` | 363 | 5 | **ERR-ONLY** | `events.ts:357 (console.error, 1 total; no console.log)` |
| `task-comment-replies.ts` | 352 | 4 | **ERR-ONLY** | `task-comment-replies.ts:213` |
| `calendar.ts` | 345 | 3 | **ERR-ONLY** | `calendar.ts:217 (console.error, 2 total; no console.log)` |
| `recall.ts` | 345 | 8 | **ERR-ONLY** | `recall.ts:100` |
| `approvals.ts` | 337 | 8 | **ERR-ONLY** | `approvals.ts:332 (console.error, 1 total; no console.log)` |
| `learn.ts` | 326 | 6 | **ERR-ONLY** | `learn.ts:230 (console.error, 1 total; no console.log)` |
| `discord.ts` | 310 | 1 | **ERR-ONLY** | `discord.ts:106` |
| `threads.ts` | 303 | 19 | **ERR-ONLY** | `threads.ts:148 (console.error, 1 total; no console.log)` |
| `sidequests.ts` | 266 | 8 | **ERR-ONLY** | `sidequests.ts:139 (console.error, 4 total; no console.log)` |
| `extractors.ts` | 257 | 4 | **ERR-ONLY** | `extractors.ts:165 (console.error, 2 total; no console.log)` |
| `advisors.ts` | 239 | 8 | **ERR-ONLY** | `advisors.ts:229 (console.error, 1 total; no console.log)` |
| `heart-canary.ts` | 218 | 3 | **ERR-ONLY** | `heart-canary.ts:93` |
| `task-mention-notify.ts` | 212 | 5 | **ERR-ONLY** | `task-mention-notify.ts:203` |
| `repo-improver-io.ts` | 193 | 1 | **ERR-ONLY** | `repo-improver-io.ts:113` |
| `transcribe.ts` | 190 | 5 | **ERR-ONLY** | `transcribe.ts:61 (console.error, 1 total; no console.log)` |
| `tasks.ts` | 187 | 4 | **ERR-ONLY** | `tasks.ts:42 (console.error, 2 total; no console.log)` |
| `inbox-ingest.ts` | 186 | 2 | **ERR-ONLY** | `inbox-ingest.ts:125` |
| `nudge.ts` | 167 | 3 | **ERR-ONLY** | `nudge.ts:164` |
| `thread-memory.ts` | 164 | 3 | **ERR-ONLY** | `thread-memory.ts:82 (console.error, 3 total; no console.log)` |
| `trace.ts` | 146 | 5 | **ERR-ONLY** | `trace.ts:143 (console.error, 1 total; no console.log)` |
| `preflight.ts` | 130 | 4 | **ERR-ONLY** | `preflight.ts:120` |
| `thread-ops.ts` | 130 | 3 | **ERR-ONLY** | `thread-ops.ts:108 (console.error, 1 total; no console.log)` |
| `meetings.ts` | 129 | 1 | **ERR-ONLY** | `meetings.ts:125 (console.error, 1 total; no console.log)` |
| `brand-brain.ts` | 123 | 4 | **ERR-ONLY** | `brand-brain.ts:77 (console.error, 4 total; no console.log)` |
| `build-candidate.ts` | 115 | 3 | **ERR-ONLY** | `build-candidate.ts:108 (console.error, 1 total; no console.log)` |
| `runs.ts` | 93 | 3 | **ERR-ONLY** | `runs.ts:62 (console.error, 1 total; no console.log)` |
| `brief-veto.ts` | 88 | 3 | **ERR-ONLY** | `brief-veto.ts:84 (console.error, 1 total; no console.log)` |
| `turn-queue.ts` | 86 | 4 | **ERR-ONLY** | `turn-queue.ts:76 (console.error, 1 total; no console.log)` |
| `env.ts` | 84 | 1 | **ERR-ONLY** | `env.ts:77` |
| `discord-webhook.ts` | 71 | 2 | **ERR-ONLY** | `discord-webhook.ts:50 (console.error, 2 total; no console.log)` |
| `user-errors.ts` | 58 | 1 | **ERR-ONLY** | `user-errors.ts:54 (console.error, 1 total; no console.log)` |
| `memory.ts` | 897 | 22 | **SILENT** | `memory.ts:442` |
| `grill.ts` | 576 | 18 | **SILENT** | `no logging statement of any kind` |
| `tg-interactions.ts` | 515 | 11 | **SILENT** | `no logging statement of any kind` |
| `decompose.ts` | 461 | 4 | **SILENT** | `no logging statement of any kind` |
| `reflexion.ts` | 367 | 5 | **SILENT** | `no logging statement of any kind` |
| `types.ts` | 297 | 2 | **SILENT** | `no logging statement of any kind` |
| `relay-bridge.ts` | 262 | 12 | **SILENT** | `no logging statement of any kind` |
| `board-commands.ts` | 259 | 5 | **SILENT** | `no logging statement of any kind` |
| `receipt-envelope.ts` | 244 | 5 | **SILENT** | `no logging statement of any kind` |
| `teammate-heartbeat.ts` | 235 | 7 | **SILENT** | `no logging statement of any kind` |
| `backlog-grill.ts` | 231 | 5 | **SILENT** | `no logging statement of any kind` |
| `work-park.ts` | 200 | 5 | **SILENT** | `no logging statement of any kind` |
| `task-classifier.ts` | 199 | 4 | **SILENT** | `no logging statement of any kind` |
| `inbox-triage.ts` | 194 | 5 | **SILENT** | `no logging statement of any kind` |
| `fleet-health.ts` | 181 | 3 | **SILENT** | `no logging statement of any kind` |
| `bonfire-queue.ts` | 170 | 8 | **SILENT** | `no logging statement of any kind` |
| `done-work-detector.ts` | 170 | 5 | **SILENT** | `no logging statement of any kind` |
| `nudge-ladder.ts` | 167 | 9 | **SILENT** | `no logging statement of any kind` |
| `cost-governance.ts` | 165 | 5 | **SILENT** | `no logging statement of any kind` |
| `crm.ts` | 161 | 2 | **SILENT** | `no logging statement of any kind` |
| `research-dedupe.ts` | 159 | 4 | **SILENT** | `no logging statement of any kind` |
| `groups.ts` | 158 | 9 | **SILENT** | `no logging statement of any kind` |
| `pending-decisions.ts` | 158 | 4 | **SILENT** | `no logging statement of any kind` |
| `escalation.ts` | 146 | 4 | **SILENT** | `no logging statement of any kind` |
| `golden-eval.ts` | 145 | 3 | **SILENT** | `no logging statement of any kind` |
| `focus-guard.ts` | 144 | 7 | **SILENT** | `no logging statement of any kind` |
| `pii.ts` | 143 | 3 | **SILENT** | `no logging statement of any kind` |
| `verify-replan.ts` | 140 | 5 | **SILENT** | `no logging statement of any kind` |
| `identities.ts` | 135 | 4 | **SILENT** | `no logging statement of any kind` |
| `ping-lifecycle.ts` | 135 | 4 | **SILENT** | `no logging statement of any kind` |
| `cost-ledger.ts` | 132 | 3 | **SILENT** | `no logging statement of any kind` |
| `pinned-brief-runner.ts` | 127 | 3 | **SILENT** | `no logging statement of any kind` |
| `telegram-routing.ts` | 127 | 2 | **SILENT** | `no logging statement of any kind` |
| `commands.ts` | 126 | 2 | **SILENT** | `no logging statement of any kind` |
| `message-context.ts` | 125 | 4 | **SILENT** | `no logging statement of any kind` |
| `nudges.ts` | 121 | 6 | **SILENT** | `no logging statement of any kind` |
| `bus-send.ts` | 112 | 4 | **SILENT** | `no logging statement of any kind` |
| `zaostock-approvals-surface.ts` | 106 | 1 | **SILENT** | `no logging statement of any kind` |
| `session-checkpoint.ts` | 105 | 4 | **SILENT** | `no logging statement of any kind` |
| `loops-status.ts` | 100 | 6 | **SILENT** | `no logging statement of any kind` |
| `call-budget.ts` | 94 | 3 | **SILENT** | `no logging statement of any kind` |
| `topic-router.ts` | 91 | 2 | **SILENT** | `no logging statement of any kind` |
| `watcher.ts` | 91 | 3 | **SILENT** | `no logging statement of any kind` |
| `relay.ts` | 90 | 3 | **SILENT** | `no logging statement of any kind` |
| `research-doc.ts` | 88 | 1 | **SILENT** | `no logging statement of any kind` |
| `zol-queue.ts` | 85 | 2 | **SILENT** | `no logging statement of any kind` |
| `fleet.ts` | 82 | 2 | **SILENT** | `no logging statement of any kind` |
| `dm-build-pending.ts` | 80 | 5 | **SILENT** | `no logging statement of any kind` |
| `tg-chunk.ts` | 80 | 2 | **SILENT** | `no logging statement of any kind` |
| `handoffs-surface.ts` | 79 | 1 | **SILENT** | `no logging statement of any kind` |
| `outbox.ts` | 76 | 4 | **SILENT** | `no logging statement of any kind` |
| `resume.ts` | 69 | 3 | **SILENT** | `no logging statement of any kind` |
| `questions.ts` | 68 | 3 | **SILENT** | `no logging statement of any kind` |
| `drafts.ts` | 66 | 6 | **SILENT** | `no logging statement of any kind` |
| `guardrail-adapters.ts` | 66 | 1 | **SILENT** | `no logging statement of any kind` |
| `button-bar.ts` | 51 | 1 | **SILENT** | `no logging statement of any kind` |
| `topics.ts` | 50 | 3 | **SILENT** | `no logging statement of any kind` |
| `pending-answers.ts` | 43 | 4 | **SILENT** | `no logging statement of any kind` |
| `dm-build-buttons.ts` | 35 | 3 | **SILENT** | `no logging statement of any kind` |
| `index.ts` | 3698 | 0 | **(n/a)** | `no exported function` |

</details>

Two classifier caveats, stated so the table is not over-read: `feature-ran.ts` counts its own definition, and `index.ts` falls to `(n/a)` because the export regex only matches `export function` - it is 3,698 lines and exports differently.

## What is still silent

37 ERR-ONLY and 59 SILENT modules remain. Most are helpers, formatters and pure data where a `featureRan` would be the noise nobody greps (`noisy-signal-guard.md`). The table is the inventory for deciding the next batch - it is not a claim that the remaining 96 all need one.

## The organ

Proprioception again, extended. #3060 gave nine limbs stretch receptors. This audit is the map of which limbs still have none - and it also found that the instrument used to check for receptors was itself misreading three healthy ones as numb.
