### PR TITLE
fix(backlog-grill): a 12h cap window, and a re-ask tier, so the count can reach zero

### DIFF
--- a/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
@@ -64,6 +64,46 @@ describe('outstandingCount - the backpressure signal', () => {
     const s = st({ asked: { a: { at: 'x', title: 'A', requeuedAt: 'y' } } });
     expect(outstandingCount(s)).toBe(0);
   });
+
+  /**
+   * The 2026-08-09 jam, reproduced. Twenty cards sent over two days pinned the
+   * cap and the drip stopped for five days, because the only thing that could
+   * lower the count was Zaal answering cards buried a week deep in Telegram.
+   *
+   * The requirement Zaal set: this number must be able to reach ZERO on its
+   * own. A flag that can never clear is a flag nobody reads.
+   */
+  describe('the 12h cap window - the count has to be able to reach zero', () => {
+    const NOW = Date.UTC(2026, 7, 14, 14, 0, 0);
+    const hoursAgo = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
+
+    it('counts a card sent inside the window', () => {
+      const s = st({ asked: { a: { at: hoursAgo(11), title: 'A' } } });
+      expect(outstandingCount(s, NOW)).toBe(1);
+    });
+
+    it('releases the slot once the card is older than 12h', () => {
+      const s = st({ asked: { a: { at: hoursAgo(13), title: 'A' } } });
+      expect(outstandingCount(s, NOW)).toBe(0);
+    });
+
+    // The whole point: twenty stale cards no longer latch the gate shut.
+    it('falls from 20 to 0 as a day-old pile ages out, with nothing answered', () => {
+      const asked: BacklogGrillState['asked'] = {};
+      for (let i = 0; i < 20; i++) asked[`t${i}`] = { at: hoursAgo(30), title: `T${i}` };
+      const s = st({ asked });
+
+      expect(outstandingCount(s, NOW - 20 * 3_600_000)).toBe(20); // 10h old: all held
+      expect(outstandingCount(s, NOW)).toBe(0); // 30h old: all released
+      expect(Object.keys(s.asked)).toHaveLength(20); // released from the CAP, not the queue
+    });
+
+    // Between flooding him and holding a slot, holding the slot is the safe error.
+    it('counts a card whose timestamp cannot be parsed', () => {
+      const s = st({ asked: { a: { at: 'not-a-date', title: 'A' } } });
+      expect(outstandingCount(s, NOW)).toBe(1);
+    });
+  });
 });
 
 /**
@@ -231,5 +271,56 @@ describe('runBacklogGrillTick - a skipped card goes to the back, not the front',
     expect(second.sent).toBe(true);
     expect(second.title).not.toBe('Oldest');
     expect((await readState()).asked.a?.requeuedAt).toBeTruthy();
+  });
+
+  /**
+   * An asked-but-unanswered card matched neither tier - `fresh` excludes it
+   * (it is in `asked`), `requeued` excludes it (no `requeuedAt`). So it went out
+   * exactly ONCE, ever, and scrolling past it lost it for good while it went on
+   * holding a cap slot. Twenty of those froze the drip for five days.
+   */
+  it('re-sends an unanswered card once its ladder cooldown has elapsed', async () => {
+    const t0 = Date.UTC(2026, 7, 9, 14, 0, 0);
+    const every = 2 * 60_000;
+
+    await tick(t0);
+    await tick(t0 + every);
+    await tick(t0 + 2 * every);
+
+    // All three seen, none answered. Six minutes in, the ladder's 3h fresh rung
+    // is doing its job - re-asking here would be nagging, not surfacing.
+    expect((await tick(t0 + 3 * every)).reason).toBe('nothing left to ask about');
+
+    // 4h in, every card is past that rung. Before this change the queue stayed
+    // empty here for ever, and these three cards were unreachable.
+    const again = await tick(t0 + 4 * 3_600_000);
+    expect(again.sent).toBe(true);
+    expect(again.title).toBe('Oldest'); // longest since its last card leads
+  });
+
+  // Age drives the ladder, so it has to survive the re-send that answers it.
+  it('keeps firstAskedAt across a re-send so the ladder can climb', async () => {
+    const t0 = Date.UTC(2026, 7, 9, 14, 0, 0);
+    await tick(t0);
+    const first = (await readState()).asked.a?.firstAskedAt;
+    expect(first).toBe(new Date(t0).toISOString());
+
+    await tick(t0 + 4 * 3_600_000);
+    const after = (await readState()).asked.a;
+    expect(after?.firstAskedAt).toBe(first); // never overwritten
+    expect(after?.at).not.toBe(first); // but the last-sent stamp moved
+  });
+
+  // The 324 never-seen tasks are the pile Zaal wants moving. A re-ask tier in
+  // front of them would just starve them behind a different twenty.
+  it('sends every unseen task before any re-ask, however overdue', async () => {
+    const t0 = Date.UTC(2026, 7, 9, 14, 0, 0);
+    await tick(t0);
+
+    // A week later 'Oldest' is deep into the 45m rung - it still waits.
+    const week = t0 + 7 * 86_400_000;
+    expect((await tick(week)).title).toBe('Middle');
+    expect((await tick(week + 2 * 60_000)).title).toBe('Newest');
+    expect((await tick(week + 4 * 60_000)).title).toBe('Oldest');
   });
 });

--- a/bot/src/zoe/__tests__/pinned-brief-runner.test.ts
+++ b/bot/src/zoe/__tests__/pinned-brief-runner.test.ts
@@ -44,7 +44,13 @@ async function writeState(state: unknown): Promise<void> {
   await fs.writeFile(STATE_PATH, JSON.stringify(state), 'utf8');
 }
 
-const ts = '2026-08-09T12:00:00.000Z';
+// An hour ago, not a fixed calendar date. The depth is time-relative now - a
+// card stops holding a cap slot once it is older than DRIP_DEFAULT.capWindowMs -
+// so a hardcoded timestamp would quietly age past the window and leave every
+// assertion below passing or failing for the wrong reason.
+const ts = new Date(Date.now() - 3_600_000).toISOString();
+/** Older than the cap window: sent, never answered, long since scrolled past. */
+const stale = new Date(Date.now() - 5 * 86_400_000).toISOString();
 
 describe('grillDepth', () => {
   beforeEach(async () => {
@@ -78,6 +84,21 @@ describe('grillDepth', () => {
     };
     await writeState(state);
     expect(await grillDepth()).toBe(outstandingCount(state));
+  });
+
+  /**
+   * The phone-side twin of the 2026-08-09 jam. Twenty cards sent days ago and
+   * never answered pinned the terminal's "grill JAMMED 20/20" AND this brief's
+   * "stuck at 20" for five days. The brief promises to be the one correct
+   * surface, so it has to release them too.
+   */
+  it('does not count cards that aged out of the cap window', async () => {
+    const asked: Record<string, { at: string; title: string }> = {};
+    for (let i = 0; i < DRIP_DEFAULT.maxOutstanding; i++) {
+      asked[`t${i}`] = { at: stale, title: `t${i}` };
+    }
+    await writeState({ asked, answered: {}, activeTaskId: null, lastSentMs: null });
+    expect(await grillDepth()).toBe(0);
   });
 
   it('twenty requeues do not fake the cap', async () => {

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -36,6 +36,11 @@ import {
   verdictNote,
   type Verdict,
 } from './backlog-grill';
+// IMPORTED, never copied. There is exactly one re-ask ladder and grill.ts owns
+// it. The last time this policy got a second implementation - the status line's
+// inline copy of outstandingCount - the copy silently drifted from the original
+// and painted a jam over a healthy grill. Import it or leave it alone.
+import { askCooldownMs } from './grill';
 
 const STATE_PATH = join(homedir(), '.zao/zoe/backlog-grill-state.json');
 
@@ -46,8 +51,15 @@ export interface BacklogGrillState {
    * `requeuedAt` marks one that was answered "work" or "skip" and is waiting to
    * come round again. It stays IN `asked` so it is not treated as never-asked -
    * see nextTask for why that distinction is the whole fix.
+   *
+   * `at` moves on every send, so it answers "how long since the last card" and
+   * nothing else. `firstAskedAt` is stamped once and never overwritten, because
+   * the ladder needs "how long has this gone unanswered" - the same split
+   * grill.ts documents on GrillItemState. A record written before this field
+   * existed falls back to `at`, which for a card that has never been re-sent is
+   * the same instant.
    */
-  asked: Record<string, { at: string; title: string; requeuedAt?: string }>;
+  asked: Record<string, { at: string; title: string; requeuedAt?: string; firstAskedAt?: string }>;
   /** taskId -> the verdict, once answered. */
   answered: Record<string, { at: string; verdict: string; note?: string }>;
   /** The card a bare "1" answers - the most recent one sent. */
@@ -71,15 +83,41 @@ export async function writeState(s: BacklogGrillState): Promise<void> {
 }
 
 /**
- * How many cards are out and unanswered. This is the backpressure signal.
+ * How many cards are IN FRONT OF HIM right now. This is the backpressure signal.
  *
- * A requeued task is not outstanding: Zaal already answered it once, and it is
- * parked at the back of the queue rather than sitting on his phone waiting. If
- * it counted, twenty skips would permanently pin the cap and the drip would
- * stop for good.
+ * Three things do not count, all for the same reason - none of them is sitting
+ * on his phone waiting for a thumb:
+ *
+ *  - answered: he dealt with it.
+ *  - requeued: he answered it once and it is parked at the back of the queue.
+ *    If it counted, twenty skips would permanently pin the cap.
+ *  - older than `capWindowMs`: sent days ago and long since scrolled past.
+ *
+ * That last one is the 2026-08-09 jam. Twenty cards sent over two days pinned
+ * the cap at 20 and the drip stopped for five days, because the only thing that
+ * could lower the count was Zaal answering cards he could no longer find. A
+ * backpressure signal that cannot fall on its own is not backpressure, it is a
+ * latch - and `grill JAMMED 20/20` printed unchanged on every lane until nobody
+ * read it.
+ *
+ * Aging out of the CAP is not aging out of the QUEUE. The card stays in `asked`
+ * forever and comes back through nextTask's re-ask tier, sooner the older it
+ * gets. Nothing here deletes anything.
  */
-export function outstandingCount(s: BacklogGrillState): number {
-  return Object.keys(s.asked).filter((id) => !s.answered[id] && !s.asked[id].requeuedAt).length;
+export function outstandingCount(
+  s: BacklogGrillState,
+  now = Date.now(),
+  capWindowMs = DRIP_DEFAULT.capWindowMs,
+): number {
+  return Object.keys(s.asked).filter((id) => {
+    if (s.answered[id] || s.asked[id].requeuedAt) return false;
+    const sentAt = Date.parse(s.asked[id].at);
+    // An undateable `at` counts. We cannot prove the card has gone quiet, and
+    // between flooding him and holding a slot, holding the slot is the safe
+    // error.
+    if (!Number.isFinite(sentAt)) return true;
+    return now - sentAt < capWindowMs;
+  }).length;
 }
 
 interface BoardTask {
@@ -107,16 +145,32 @@ function cfg(): { root: string; headers: Record<string, string> } | null {
  * Oldest first on purpose: a 36-day-old task is the one most likely to be dead,
  * and clearing the tail is where the board actually shrinks.
  *
- * The two-tier order is what makes "it comes back at the END of the queue" true.
+ * The tiered order is what makes "it comes back at the END of the queue" true.
  * Cards go out oldest-first, so the card Zaal just skipped was by definition the
  * oldest unasked one - simply un-asking it put it straight back at the FRONT and
  * the next tick re-sent the same card, forever, and no other task could ever
  * surface behind it. A requeued task therefore keeps its `asked` mark and waits
  * behind every task that has not been seen at all.
+ *
+ * TIER 3, THE RE-ASK (2026-08-14). An asked-but-unanswered card used to match
+ * neither tier: `fresh` excludes it (it is in `asked`) and `requeued` excludes
+ * it (no `requeuedAt`). So it was sent exactly ONCE, ever. Scroll past it and it
+ * was gone - while still holding a cap slot forever. Twenty of those is what
+ * froze the drip for five days.
+ *
+ * Eligibility is grill.ts's ladder, imported unchanged: 3h fresh, 2h after a
+ * day, 1.5h after three, 45m after a week. Age is measured from `firstAskedAt`,
+ * so a card nags HARDER the longer it has gone unanswered rather than expiring.
+ *
+ * It sits LAST on purpose. The 324 tasks that have never been seen once are the
+ * pile Zaal actually wants moving, and a re-ask tier in front of them would
+ * recreate the starvation this whole change exists to undo - just with a
+ * different set of twenty at the front.
  */
 async function nextTask(
   s: BacklogGrillState,
   fetchImpl: typeof fetch,
+  now: number,
 ): Promise<{ task: BoardTask; remaining: number; unasked: number } | null> {
   const c = cfg();
   if (!c) return null;
@@ -132,7 +186,20 @@ async function nextTask(
     .sort((a, b) =>
       String(s.asked[a.id].requeuedAt).localeCompare(String(s.asked[b.id].requeuedAt)),
     );
-  const queue = [...fresh, ...requeued];
+  const reask = rows
+    .filter((t) => {
+      const a = s.asked[t.id];
+      if (!a || a.requeuedAt || s.answered[t.id]) return false;
+      const sentAt = Date.parse(a.at);
+      if (!Number.isFinite(sentAt)) return false;
+      const firstAt = Date.parse(a.firstAskedAt ?? a.at);
+      const age = now - (Number.isFinite(firstAt) ? firstAt : sentAt);
+      return now - sentAt >= askCooldownMs(age);
+    })
+    // Longest since its last card goes first, so the ladder's "nag the old ones
+    // harder" survives contact with a tier that holds more than one card.
+    .sort((a, b) => Date.parse(s.asked[a.id].at) - Date.parse(s.asked[b.id].at));
+  const queue = [...fresh, ...requeued, ...reask];
   if (queue.length === 0) return null;
   return { task: queue[0], remaining: queue.length, unasked: fresh.length };
 }
@@ -159,14 +226,14 @@ export async function runBacklogGrillTick(
   if (!cfg()) return { sent: false, reason: 'tracker not configured' };
 
   const state = await readState();
-  const next = await nextTask(state, fetchImpl);
+  const next = await nextTask(state, fetchImpl, now);
   if (!next) return { sent: false, reason: 'nothing left to ask about' };
 
   const gate = shouldSendNext({
     nowMs: now,
     localHour: deps.localHour,
     lastSentMs: state.lastSentMs,
-    outstanding: outstandingCount(state),
+    outstanding: outstandingCount(state, now, DRIP_DEFAULT.capWindowMs),
     remainingInQueue: next.remaining,
     cfg: DRIP_DEFAULT,
   });
@@ -187,7 +254,16 @@ export async function runBacklogGrillTick(
 
   // Rewritten wholesale, which clears any `requeuedAt`: it has now come round
   // again, so it is an ordinary open card until it is answered a second time.
-  state.asked[next.task.id] = { at: new Date(now).toISOString(), title: next.task.title };
+  // `firstAskedAt` is the one thing carried across, because it is what makes an
+  // old card nag harder - reset it on every re-send and the ladder would read
+  // every card as brand new and never climb.
+  const prior = state.asked[next.task.id];
+  const sentAt = new Date(now).toISOString();
+  state.asked[next.task.id] = {
+    at: sentAt,
+    title: next.task.title,
+    firstAskedAt: prior?.firstAskedAt ?? prior?.at ?? sentAt,
+  };
   state.activeTaskId = next.task.id;
   state.lastSentMs = now;
   await writeState(state);
@@ -272,6 +348,7 @@ export async function applyBacklogAnswer(
     state.asked[taskId] = {
       at: state.asked[taskId]?.at ?? new Date().toISOString(),
       title: state.asked[taskId]?.title ?? '',
+      firstAskedAt: state.asked[taskId]?.firstAskedAt ?? state.asked[taskId]?.at,
       requeuedAt: new Date().toISOString(),
     };
     delete state.answered[taskId];

--- a/bot/src/zoe/backlog-grill.ts
+++ b/bot/src/zoe/backlog-grill.ts
@@ -170,6 +170,11 @@ export interface DripConfig {
   everyMinutes: number;
   /** Most unanswered cards allowed to pile up before we stop adding. */
   maxOutstanding: number;
+  /**
+   * How long a sent card counts against `maxOutstanding`. Past this it is no
+   * longer "on his phone" and stops holding a slot - see DRIP_DEFAULT.
+   */
+  capWindowMs: number;
   /** Local hours (Zaal's) in which cards may be sent. */
   startHour: number;
   endHour: number;
@@ -182,10 +187,29 @@ export interface DripConfig {
  * unbounded they become a wall he never opens, and a check nobody reads is
  * worth nothing. 20 is roughly one sweep's worth at the pace he cleared them
  * today.
+ *
+ * WHY THE CAP NEEDS A WINDOW (2026-08-14)
+ * --------------------------------------
+ * Without one, `maxOutstanding` counted every card ever sent and never
+ * answered - including cards sent days ago and buried under a week of
+ * Telegram. Twenty of those pinned the cap on 2026-08-09 and the drip stopped
+ * for five days: 324 open board tasks frozen behind 20 cards Zaal could no
+ * longer scroll back to. The count could only fall if he answered cards he
+ * could not find, so it could never reach zero, and `grill JAMMED 20/20`
+ * printed the identical string on every lane until it stopped being read
+ * (noisy-signal-guard.md).
+ *
+ * The cap was always trying to measure "how much is in front of him right
+ * now". 12h says that plainly: a card sent this morning is pressure, a card
+ * sent on Saturday is not. Releasing the slot does NOT release the card -
+ * nothing here removes anything, and the re-ask ladder in grill.ts brings old
+ * cards back HARDER as they age (Zaal, 2026-08-11: "older cards must nag MORE
+ * frequently, not expire").
  */
 export const DRIP_DEFAULT: DripConfig = {
   everyMinutes: 2,
   maxOutstanding: 20,
+  capWindowMs: 12 * 60 * 60 * 1000,
   startHour: 6,
   endHour: 22,
 };


### PR DESCRIPTION
Zaal's call, 2026-08-14: "324 frozen behind 20 is the problem, so no - an unanswered card must NOT keep holding a slot. Keep the re-send ladder exactly as it is AND release the cap slot after 12h, so maxOutstanding means 'sent in the last 12h', which is what it was always trying to measure."

## The jam

The drip stopped on 2026-08-09 13:10 UTC and did not send another card for five days. `journalctl` has been printing the same line ever since:

```
Aug 14 14:12:01 tsx[191356]: [zoe/ran] backlog-grill - 20 already unanswered - let him catch up
```

Board state at the time of writing: **364 open todo, 40 ever asked, 324 never surfaced once** - all frozen behind 20 cards sent on Aug 8-9 and never answered.

## Two defects, one cause

A card counted as pressure forever, and could never be seen again.

**1. The cap had no notion of when.** `maxOutstanding` counted every card ever sent and never answered. The only thing that could lower the count was Zaal answering cards buried five days deep in Telegram, so it could never fall on its own - a latch, not backpressure. `grill JAMMED 20/20` then printed the identical string on every lane for five days until it stopped being read (`noisy-signal-guard.md`).

`outstandingCount` now ignores cards older than `capWindowMs` (12h). Three things do not count, all for the same reason - none is sitting on his phone waiting for a thumb: answered, requeued, or aged out.

**2. An unanswered card was sent exactly once, ever.** It matched neither queue tier - `fresh` excludes it (it is in `asked`), `requeued` excludes it (no `requeuedAt`). Scroll past it and it was gone, while it went on holding a cap slot. `nextTask` gains a third tier that re-sends it.

## What was deliberately not touched

The ladder. `askCooldownMs` is **imported from `grill.ts` unchanged** - 3h fresh, 2h after a day, 1.5h after three, 45m after a week - not copied. The last time this class of policy got a second implementation (the status line's inline copy of `outstandingCount`) the copy silently drifted and painted a jam over a healthy grill.

`everyMinutes`, `maxOutstanding`, `startHour`, `endHour` are all unchanged.

Age is measured from a new `firstAskedAt` that survives re-sends, the same split `grill.ts` documents on `GrillItemState` - reset it on every send and the ladder would read every card as brand new and never climb. So an old card nags **harder** rather than expiring, per Zaal 2026-08-11.

**Ageing out of the CAP is not ageing out of the QUEUE.** Nothing here removes anything. `asked` still grows and only a `done`/`drop` closes a task.

## The count against the real on-disk state

Not a fixture - the live VPS `/home/zaal/.zao/zoe/backlog-grill-state.json` (40 asked, 20 answered, unanswered cards 123.6-126.7h old):

```
asked               40
answered            20
capWindow h         12
outstanding BEFORE  20   gate: SHUT
outstanding AFTER    0   gate: open
```

The number reaches zero. There is also a test that walks a pile of 20 from held to released **with nothing answered**, which is the property Zaal asked for.

## Ordering, stated plainly

The re-ask tier sits **last**, behind every never-seen task. The 324 are the pile that needs to move, and putting re-asks in front of them would recreate this starvation with a different twenty at the front. Practical effect: the stranded 20 come back once the fresh pool drains rather than immediately. If you want them interleaved sooner, that is a separate call.

Throughput is now bounded by the window rather than latched by it: at most `maxOutstanding` per `capWindowMs`, so **~40 cards/day if you answer nothing**, against 0/day for the last five.

## Blast radius

Both in-repo consumers go through the one windowed `outstandingCount`:

- the drip gate (`shouldSendNext`)
- the pinned Telegram brief's `grillDepth()` - which had the same permanent false "stuck at 20", and now releases stale cards too, so the phone and the terminal cannot disagree

The third consumer is the status line, in bettercallzaal/zaal-dotfiles#39.

`pinned-brief-runner.test.ts` needed its fixture timestamp changed from a hardcoded `2026-08-09` to a relative one: the depth is time-relative now, so a fixed calendar date would quietly age past the window and leave assertions passing for the wrong reason.

## Verification

| | before | after |
|---|---|---|
| `npm run typecheck` | clean | clean |
| bot vitest | 2407 passing, 185 files | **2415 passing, 185 files, 0 failing** |
| outstanding, real state | 20 (gate shut) | **0 (gate open)** |

Eight tests added: the 12h window boundary, a 20-card pile ageing to zero unanswered, the undateable-timestamp fallback, the re-ask firing only after its cooldown, `firstAskedAt` surviving a re-send, unseen-before-re-ask ordering, and the brief releasing aged-out cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)