### PR TITLE
fix(zoe): the research loop was discarding paid work and lying about why

### DIFF
--- a/bot/src/zoe/__tests__/work-park.test.ts
+++ b/bot/src/zoe/__tests__/work-park.test.ts
@@ -21,6 +21,8 @@ const receipts: Array<Record<string, unknown>> = [];
 const reported: string[] = [];
 let researchOutput = '';
 let dispatchThrows = false;
+let workerStatus: 'completed' | 'failed' | 'needs-revision' = 'completed';
+let workerError: string | undefined;
 let docResult: { ok: boolean; num?: number; prUrl?: string; error?: string } = { ok: true, num: 9999, prUrl: 'http://pr/1' };
 
 vi.mock('../dispatch', () => ({
@@ -28,7 +30,7 @@ vi.mock('../dispatch', () => ({
     if (dispatchThrows) throw new Error('dispatch exploded');
     await hooks?.onSubtaskDone?.(
       { worker: 'research-worker' },
-      { status: 'completed', output: researchOutput },
+      { status: workerStatus, output: researchOutput, error: workerError },
     );
   }),
 }));
@@ -67,6 +69,8 @@ describe('work-park', () => {
     reported.length = 0;
     researchOutput = '';
     dispatchThrows = false;
+    workerStatus = 'completed';
+    workerError = undefined;
     docResult = { ok: true, num: 9999, prUrl: 'http://pr/1' };
   });
   afterEach(async () => {
@@ -116,6 +120,54 @@ describe('work-park', () => {
     expect(parked[0].item?.input).toBe('a topic that explodes');
     expect(receipts[0].resultType).toBe('error');
     expect(receipts[0].inputDigest).toBeTruthy(); // WHICH topic, not just "a tick"
+  });
+
+  it('a FAILED worker parks with its real reason, not "empty-output"', async () => {
+    // 16 of 20 research runs on 2026-08-14 failed with a real reason -
+    // rate_limit, timeout, unclassified - and every one would have been filed as
+    // 'empty-output', a category that describes the symptom and hides the cause.
+    await enqueueWork('a topic the CLI rate-limits');
+    researchOutput = '';
+    workerStatus = 'failed';
+    workerError = 'claude CLI exited 1 [rate_limit: rate-limited/overloaded]';
+
+    await runWorkTick(deps);
+
+    const parked = await parkedWork();
+    expect(parked).toHaveLength(1);
+    expect(parked[0].reason).toBe('error');
+    expect(parked[0].reason).not.toBe('empty-output');
+    expect(parked[0].error).toContain('rate_limit');
+    expect(reported.join(' ')).toContain('rate_limit');
+  });
+
+  it('a genuinely empty result is still "empty-output" - the two stay distinct', async () => {
+    await enqueueWork('a topic that returns nothing at all');
+    researchOutput = '';
+    workerStatus = 'completed'; // succeeded, produced nothing
+
+    await runWorkTick(deps);
+
+    const parked = await parkedWork();
+    expect(parked[0].reason).toBe('empty-output');
+    expect(parked[0].error).toBeUndefined();
+  });
+
+  it('needs-revision output is USED, not thrown away', async () => {
+    // workers.ts sets `status: passed ? 'completed' : 'needs-revision'`, so a
+    // needs-revision result is the full research - the critic flagged it, the
+    // worker still produced it. Two such runs cost $0.93 and $0.97 on
+    // 2026-08-14 and were discarded, then reported as empty. verify-replan is
+    // the layer meant to judge them, and it never ran because out stayed ''.
+    await enqueueWork('a topic the critic is unhappy with');
+    researchOutput = 'real findings the critic flagged but which exist';
+    workerStatus = 'needs-revision';
+
+    await runWorkTick(deps);
+
+    expect(await parkedWork()).toHaveLength(0); // committed, not parked
+    expect(receipts[0].resultType).toBe('success');
+    expect(reported.join(' ')).toContain('doc');
   });
 
   it('a successful tick still reports success and parks nothing', async () => {

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -26,7 +26,7 @@ import { commitResearchDoc } from './research-doc';
 import { emitReceipt } from './receipts';
 import { callClaudeCli } from '../hermes/claude-cli';
 import { verifyReplanResearch } from './verify-replan';
-import { parkWork, resumeWork } from './work-park';
+import { parkWork, resumeWork, type ParkReason } from './work-park';
 import type { ZoeContext } from './types';
 
 const dir = (): string => process.env.ZOE_HOME || join(homedir(), '.zao', 'zoe');
@@ -160,6 +160,11 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
     const item = q[0];
     // Captured from the research-doc hook so the receipt can point at the PR (R1b).
     let evidenceUrl: string | null = null;
+    // The worker's own failure text. Without this, a FAILED worker and a
+    // worker that returned nothing are indistinguishable downstream, and the
+    // item gets parked as 'empty-output' - which is a lie when the truth was
+    // 'claude CLI exited 1 [rate_limit]'.
+    let lastWorkerError = '';
     const ctx: ZoeContext = {
       zaal_tg_id: deps.zaalTgId,
       workspace_dir: deps.repoDir,
@@ -207,7 +212,19 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
           zaalTgId: deps.zaalTgId,
           hooks: {
             onSubtaskDone: async (st, r) => {
-              if (st.worker === 'research-worker' && r.status === 'completed' && r.output) out = r.output;
+              if (st.worker !== 'research-worker') return;
+              // needs-revision IS the full output - the critic flagged it, the
+              // worker still produced it (workers.ts sets
+              // `status: passed ? 'completed' : 'needs-revision'`). Discarding it
+              // threw away a paid research pass - measured at $0.93 and $0.97 on
+              // 2026-08-14 - and then reported the item as 'empty-output'.
+              //
+              // It also meant verifyReplanResearch below NEVER RAN, because `out`
+              // stayed empty. That judge is exactly the layer meant to decide
+              // whether a critic-flagged result is good enough, so this hands it
+              // back its job rather than pre-empting it here.
+              if (r.output && (r.status === 'completed' || r.status === 'needs-revision')) out = r.output;
+              if (r.status === 'failed') lastWorkerError = r.error ?? 'worker failed, no reason recorded';
             },
           },
         });
@@ -265,10 +282,20 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
         // THE SILENT PATH. reportFor lives inside the branch above, so an empty
         // research result used to send nothing anywhere, delete the item, charge
         // it against the daily cap, and emit a 'success' receipt. Park it, say so.
-        await parkWork(item, 'empty-output', { stage: 'research' });
+        // Say WHICH failure this was. 16 of 20 research runs on 2026-08-14
+        // failed with a real reason (rate_limit, timeout, unclassified) and all
+        // of them would have been filed as 'empty-output' - a category that
+        // describes the symptom and hides the cause.
+        const reason: ParkReason = lastWorkerError ? 'error' : 'empty-output';
+        await parkWork(item, reason, {
+          stage: 'research',
+          ...(lastWorkerError ? { error: lastWorkerError } : {}),
+        });
         resultType = 'error';
         await reportFor(item, deps)(
-          `Work-loop: "${item.input.slice(0, 60)}" produced no research output - parked, not lost. Ask ZOE for parked work.`,
+          lastWorkerError
+            ? `Work-loop: "${item.input.slice(0, 60)}" failed - ${lastWorkerError.slice(0, 120)}. Parked, not lost.`
+            : `Work-loop: "${item.input.slice(0, 60)}" produced no research output - parked, not lost. Ask ZOE for parked work.`,
         ).catch(() => {});
       }
       await writeQueue((await readQueue()).filter((x) => x.id !== item.id));


### PR DESCRIPTION
## Executive summary

Doc 2282 (#3091) found the Pi scout pipeline producing nothing for five days. This is the cause, and **it is not the one that doc guessed at.**

ZOE's own run records, 2026-08-11 to 08-14: **20 research-worker runs - 16 failed, 4 needs-revision, zero completed.**

Two separate bugs, both living in one line of `work-loop.ts`:

```ts
if (st.worker === 'research-worker' && r.status === 'completed' && r.output) out = r.output;
```

## Bug 1: paid work was thrown away

`workers.ts:441` sets `status: passed ? 'completed' : 'needs-revision'`. So a **needs-revision result is the full research** - the critic flagged it, the worker still produced it.

Those four runs cost **$0.93 and $0.97** each. Every one was discarded by the `=== 'completed'` filter, and then reported to Zaal as *"produced no research output"*. Money spent, work done, deleted, and mislabelled.

It also meant **`verifyReplanResearch` never ran**, because `out` stayed empty. That judge is precisely the layer meant to decide whether a critic-flagged result is good enough. The filter was pre-empting it with a silent discard.

## Bug 2: a failed worker was indistinguishable from an empty one

`WorkerResult` carries `error`. The real ones look like:

```
claude CLI exited 1 [rate_limit: rate-limited/overloaded - retry short]
claude CLI exited 1 [unknown: unclassified claude CLI failure]
claude CLI timed out after 600000ms
```

None of it survived the hook. All 16 failures would have been filed as `empty-output` - a category that names the symptom and buries the cause. A parked item now carries reason `error` plus the worker's own text, and the Telegram line says which failure it was.

A genuinely empty result is **still** `empty-output`. A test keeps the two distinct, because collapsing them is how this hid.

## Correcting doc 2282

That doc named `cheap-loop.pause` and the daily spend cap as the likely cause, marked **not proven**. It was wrong. The failed runs cost **$0** - they never reached the model. The rate limit and the 600-second timeout are the real story.

Worth noting the sequencing: this was only findable because #3076 shipped parking. Before it, all 20 runs would have been deleted with a `success` receipt.

## Evidence

PROVEN by mutation, both restored:

| Mutation | Result |
|---|---|
| restore the `=== 'completed'` filter | FAILS: `needs-revision output is USED, not thrown away` |
| drop the worker-error capture | FAILS: `a FAILED worker parks with its real reason, not "empty-output"` |

`tsc --noEmit` 0 errors. **185 files / 2410 tests pass, exit 0** (3 added).

## What this does not fix

The rate limits and the 600s timeouts are real and still there - this makes them **visible and attributable** rather than silently filed as "empty". Whether the research worker needs a longer timeout, a backoff, or a cheaper model is a separate decision with its own evidence, and it should be made against the park records this now produces.
