### PR TITLE
feat(zoe): featureRan batch 2 - four modules, and a correction to the count

### DIFF
--- a/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
+++ b/bot/src/zoe/__tests__/feature-ran-coverage.test.ts
@@ -61,6 +61,14 @@ const AUTONOMOUS_FEATURES = [
   'dispatch.ts',
   'proactive.ts',
   'team-tracker.ts',
+  // Batch 2, 2026-08-15. Only four, because re-reading the candidates found
+  // curator.ts, task-teammate-ack.ts and task-comment-replies.ts already log
+  // their counts on the success path - they never needed one, and the audit
+  // classifier had mislabelled them.
+  'daily-note.ts',
+  'reflexion.ts',
+  'relay-bridge.ts',
+  'bonfire-queue.ts',
 ];
 
 function sourceOf(file: string): string {

--- a/bot/src/zoe/bonfire-queue.ts
+++ b/bot/src/zoe/bonfire-queue.ts
@@ -17,6 +17,7 @@
  */
 
 import { remember, type RememberResult } from './recall';
+import { featureRan } from './feature-ran';
 
 const QUEUE_KEY = 'zg:bonfire:pending';
 const REST_URL = process.env.ZG_UPSTASH_REST_URL ?? '';
@@ -149,7 +150,11 @@ export function buildEpisode(item: BonfireSubmission): {
 
 /** Promote a submission into the canonical graph (episode/create). */
 export async function promoteSubmission(item: BonfireSubmission): Promise<RememberResult> {
-  return remember(buildEpisode(item));
+  const r = await remember(buildEpisode(item));
+  // remember() can return ok:false (Bonfire down) or skipped:true (secret or
+  // PII scan). Neither is a promotion, so neither announces.
+  if (r.ok) featureRan('bonfire-promote', item.type);
+  return r;
 }
 
 /** Telegram render of a submission under review. */

--- a/bot/src/zoe/daily-note.ts
+++ b/bot/src/zoe/daily-note.ts
@@ -13,6 +13,7 @@
  */
 
 import { db } from '../supabase';
+import { featureRan } from './feature-ran';
 
 export interface DailyNoteItem {
   id: string;
@@ -152,6 +153,7 @@ export async function appendItem(ownerId: string, text: string): Promise<DailyNo
       return null;
     }
 
+    featureRan('daily-note', 'item appended');
     return item;
   } catch (err) {
     console.error('[zoe/daily-note] appendItem error:', (err as Error)?.message ?? err);

--- a/bot/src/zoe/reflexion.ts
+++ b/bot/src/zoe/reflexion.ts
@@ -26,6 +26,7 @@
 import { callClaudeCli } from '../hermes/claude-cli';
 import { ZOE_DEFAULT_MODEL, ZOE_HARD_MODEL } from './types';
 import type { ZoeContext } from './types';
+import { featureRan } from './feature-ran';
 
 export type MemoryFile = 'human.md' | 'persona.md';
 export type Confidence = 'high' | 'medium' | 'low';
@@ -332,6 +333,7 @@ export async function runReflexion(input: ReflexionInput): Promise<ReflexionResu
     voice_note_request: needsVoiceNote.length > 0 ? renderVoiceNoteRequest(needsVoiceNote) : null,
   };
 
+  featureRan('reflexion', `${highConfidence.length} high-confidence`);
   return {
     plan,
     model: result.model,

--- a/bot/src/zoe/relay-bridge.ts
+++ b/bot/src/zoe/relay-bridge.ts
@@ -24,6 +24,7 @@
  */
 
 import { sendChunkedToTelegram } from './tg-chunk';
+import { featureRan } from './feature-ran';
 
 const HUB_LEGACY_ID = '9000';
 
@@ -158,7 +159,10 @@ export async function saveHubRelays(_id: string, relays: RelayMsg[]): Promise<bo
 export async function sendRelayReply(lane: string, msg: string, ts: string): Promise<boolean> {
   const hub = await fetchHub();
   if (!hub) return false;
-  return saveHubRelays(hub.id, appendReply(hub.relays, lane, msg, ts));
+  const saved = await saveHubRelays(hub.id, appendReply(hub.relays, lane, msg, ts));
+  // Only when the write LANDED. A failed save is not a relay.
+  if (saved) featureRan('relay-bridge', lane);
+  return saved;
 }
 
 /**


### PR DESCRIPTION
## Executive summary

Batch 2 of the `featureRan` work from #3084. I set out to instrument eight modules and instrumented **four** - because re-reading the candidates found three that never needed it, and that exposed a bug in the audit classifier behind #3084's own table.

**SUCCESS 30 → 34. SILENT 60 → 57. CATCH-ONLY 0.**

## The correction, first

`curator.ts:372`, `task-teammate-ack.ts:574` and `task-comment-replies.ts:348` already log their counts on the success path. They were listed as `ERR-ONLY` - "speaks only when it fails" - and that was wrong.

The classifier had a branch bug: a module with **both** `console.error` and `console.log` fell through to a line that returned `ERR-ONLY` whenever `errs` was non-empty. So every module that already reports success was counted as silent-on-success.

| category | #3084 said | actually |
|---|---:|---:|
| ERR-ONLY | 37 | **22** |
| LOGS-OK (new - already reports success) | - | **16** |

**#3084's table over-counted the problem by 15 modules.** Saying so here rather than quietly re-baselining, because the table is what anyone would use to pick the next batch.

## What was instrumented

| module | announces when |
|---|---|
| `daily-note` | an item was appended to the note |
| `reflexion` | a plan was produced, with its high-confidence count |
| `relay-bridge` | **only when the hub write landed** - a failed save is not a relay |
| `bonfire-queue` | **only on `r.ok`** - `remember()` also returns `skipped: true` on a secret or PII hit, and a blocked write is not a promotion |

The last two are conditional for the same reason as batch 1: "it ran" and "it worked" are different questions. Announcing on a failed write would make the line mean "the function was called", which is the confusion this whole mechanism exists to remove.

## Evidence

PROVEN by mutation, restored: stripping `relay-bridge`'s call fails the coverage test by name - `cannot say they ran: relay-bridge.ts`.

Coverage list 18 → 22 modules, so this cannot shrink back silently.

`tsc --noEmit` 0 errors. Full bot suite green.

## Restraint note

Three candidates were dropped on inspection rather than instrumented. `featureRan` in a module that already reports success is duplicate noise, and `noisy-signal-guard.md` is the reason the whole exercise is selective rather than a sweep over all 129.
