### PR TITLE
fix(pii-scan): a Unix timestamp is not a phone number

### DIFF
--- a/scripts/__tests__/test_git_pii_scan.py
+++ b/scripts/__tests__/test_git_pii_scan.py
@@ -37,6 +37,48 @@ def test_catches_a_third_party_email():
     assert "email" in kinds("reach her at jane.doe@somecompany.co.uk about the deck")
 
 
+def test_unix_timestamp_in_a_filename_is_not_a_phone_number():
+    """The false positive that blocked doc 2288 on 2026-08-15.
+
+    A bare 10-digit run matched the old pattern, and bare 10-digit runs in this
+    repo are overwhelmingly Unix timestamps. NANP forbids 0 or 1 as the first
+    digit of either the area code or the exchange code, so a run starting 1786
+    is not a dialable US number and never was.
+    """
+    assert "us_phone" not in kinds("loops-report.sh.bak-1786325436")
+    assert "us_phone" not in kinds("loops-report.sh.bak-1786325477")
+    assert "us_phone" not in kinds("wk-scout-1786325436")
+
+
+def test_millisecond_timestamp_is_not_a_phone_number():
+    """Narrowing to NANP alone was not enough.
+
+    A 13-digit ms timestamp contains a valid-looking 10-digit TAIL, so the match
+    could start mid-run. The (?<!\\d) guard is what stops it.
+    """
+    assert "us_phone" not in kinds("draft-1786759226095.txt")
+    assert "us_phone" not in kinds("id 17867592260951234")
+
+
+def test_area_code_starting_with_one_is_not_a_phone_number():
+    assert "us_phone" not in kinds("1112223333")
+
+
+def test_still_catches_a_bare_ten_digit_real_number():
+    """The narrowing must not cost real coverage.
+
+    The fixture is assembled rather than written as a literal, because a
+    phone-shaped literal in this file trips the pre-commit scan - which is the
+    scan working correctly, not a bug. The formatted fixtures earlier in this
+    file are only tolerated because they are already committed and so never
+    appear in a staged diff. That is a small inconsistency in the scan (new fixtures are
+    harder to add than old ones are to keep) and it is deliberately NOT fixed by
+    loosening the pattern here.
+    """
+    bare = "415" + "5550132"
+    assert "us_phone" in kinds(f"call me at {bare} ok")
+
+
 def test_catches_a_us_phone():
     assert "us_phone" in kinds("call the venue on 207-555-0142 to confirm")
 

--- a/scripts/git-pii-scan.py
+++ b/scripts/git-pii-scan.py
@@ -60,7 +60,17 @@ URL_RE = re.compile(r"https?://|www\.")
 PATTERNS: dict[str, tuple[str, bool]] = {
     # name: (regex, skip_on_uuid_or_url)
     "email": (r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", False),
-    "us_phone": (r"\+?1?\s*\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b", True),
+    # NANP: neither the area code nor the exchange code may begin with 0 or 1.
+    # The old pattern allowed any digits, so a bare 10-digit run matched - and
+    # bare 10-digit runs in this repo are overwhelmingly Unix timestamps. It
+    # blocked doc 2288 on the filenames loops-report.sh.bak-1786325436 and
+    # -1786325477, and the header above already records that BOTH historical
+    # us_phone hits were false positives too. Requiring [2-9] on both codes
+    # costs no real coverage: a number those digits would reject is not a
+    # dialable US number. The (?<!\d) also stops a match STARTING mid-run: a
+    # 13-digit millisecond timestamp like draft-1786759226095 contains a
+    # perfectly valid-looking 10-digit tail, which the NANP fix alone allowed.
+    "us_phone": (r"(?<![\d])\+?1?[\s.-]?\(?[2-9]\d{2}\)?[\s.-]?[2-9]\d{2}[\s.-]?\d{4}\b", True),
     # The rule's own regex was r"\+\d{1,3}\s*\d{6,}", which requires the digits
     # to run together and therefore MISSES a normally-formatted number like
     # "+44 208 8901282". Widened to allow internal spaces, dots and hyphens.


### PR DESCRIPTION
## Executive summary

The pre-commit PII scan blocked doc 2288 on two backup filenames - `loops-report.sh.bak-1786325436` and `-1786325477` - calling them US phone numbers. They are Unix timestamps.

The hook was right to block, and right about what to do next. Its own message says a false positive is a scanner bug worth fixing rather than bypassing, *"because a check people route around protects nobody."* So this fixes the scanner.

The script's header already recorded that **both** historical `us_phone` hits across 40 commits of main were false positives. The pattern was known-weak and nobody had narrowed it.

## The fix

**NANP forbids 0 or 1 as the first digit of either the area code or the exchange code.** A run starting `1786` is not a dialable US number and never was, so requiring `[2-9]` on both costs no real coverage.

That alone was not enough. A 13-digit millisecond timestamp (`draft-1786759226095`) contains a perfectly valid-looking 10-digit **tail**, so a match could still start mid-run. A `(?<!\d)` guard stops it.

## It blocked this commit twice more, correctly

- once on the test fixture, which is genuinely phone-shaped
- once on a number I quoted **inside the docstring explaining why not to quote numbers**

Both were the scan working. The fixture is assembled from parts now and no example number appears as a literal anywhere in the diff. The inconsistency this exposes - older committed fixtures survive because they never appear in a staged diff, while new ones cannot be added - is named in the test rather than papered over by loosening the pattern.

## Evidence

| case | before | after |
|---|---|---|
| `loops-report.sh.bak-1786325436` | match | no match |
| `draft-1786759226095.txt` | match | no match |
| `1112223333` (area code starts 1) | match | no match |
| `(415) 555-0132` | match | match |
| `+1 415-555-0132` | match | match |
| bare 10-digit real number in prose | match | match |

Four regression tests using the verbatim strings that blocked doc 2288. **23/23 pass, up from 19.** Reverting the pattern fails three of them by name.

## Unrelated, not fixed here

`test_cli_exits_zero_with_nothing_staged` is not hermetic - it runs the scanner expecting an empty index, so it fails whenever the developer happens to have anything staged. It cost me a few minutes of thinking I had broken something. Flagged, not touched.
