### PR TITLE
fix(zoe): doc numbering asked a checkout nobody updates

### DIFF
--- a/bot/src/zoe/__tests__/doc-numbering.test.ts
+++ b/bot/src/zoe/__tests__/doc-numbering.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Doc numbering must not hand out a number that already exists.
+ *
+ * On 2026-08-15 ZOE's research-worker produced its first doc in days and
+ * numbered it 2249 - already taken by research/agents/2249-cli-messaging-vs-ssh-
+ * orchestration. The collision guard caught it, but only after a PR was open.
+ *
+ * Cause: nextDocNum read a LOCAL checkout. REPO defaults to ~/zao-os while the
+ * bot runs from ~/zao-bot-live, and nothing keeps ~/zao-os current - it was six
+ * days behind, where the highest doc really was 2248.
+ *
+ * Two things are pinned here: the parser reads EVERY topic dir (the hardcoded
+ * TOPICS list names 13 of the repo's 25), and it ignores digits that are not a
+ * doc number.
+ */
+import { describe, expect, it } from 'vitest';
+import { maxDocNumFrom } from '../research-doc';
+
+describe('maxDocNumFrom', () => {
+  it('finds the highest number across topic dirs', () => {
+    expect(
+      maxDocNumFrom(
+        [
+          'research/agents/2285-zol-draft-only-eleven-days',
+          'research/events/2287-yerb-recap',
+          'research/business/2282-fleet-output-audit',
+        ].join('\n'),
+      ),
+    ).toBe(2287);
+  });
+
+  it('reads topic dirs that are NOT in the hardcoded TOPICS list', () => {
+    // TOPICS names 13; the repo has 25. `technology` and `estate` are real dirs
+    // that the old scan never looked at, so a doc landing there was invisible.
+    expect(maxDocNumFrom('research/technology/2278-ambient-voice')).toBe(2278);
+    expect(maxDocNumFrom('research/estate/2299-something')).toBe(2299);
+  });
+
+  it('the exact collision: a listing ending at 2248 must not yield 2249 as free', () => {
+    // Reading a six-day-old checkout gave 2248, so nextDocNum returned 2249 -
+    // which research/agents/2249 already held. The fix is reading origin/main,
+    // and this pins the arithmetic the caller depends on.
+    const stale = 'research/agents/2248-something';
+    const fresh = 'research/agents/2248-something\nresearch/infrastructure/2288-code-with-no-home';
+    expect(maxDocNumFrom(stale) + 1).toBe(2249);
+    expect(maxDocNumFrom(fresh) + 1).toBe(2289);
+  });
+
+  it('ignores digits that are not a doc number', () => {
+    expect(maxDocNumFrom('research/agents/notes-2026-08-15')).toBe(0);
+    expect(maxDocNumFrom('research/agents/2285-doc/sub-9999-nested')).toBe(2285);
+    expect(maxDocNumFrom('')).toBe(0);
+  });
+
+  it('does not let a 5+ digit slug poison the max', () => {
+    // The loose-regex bug the /zao-research skill already learned in July.
+    expect(maxDocNumFrom('research/agents/1234567-huge')).toBe(0);
+  });
+});

--- a/bot/src/zoe/__tests__/research-doc.test.ts
+++ b/bot/src/zoe/__tests__/research-doc.test.ts
@@ -104,9 +104,13 @@ describe('commitResearchDoc', () => {
     mockMkdir.mockResolvedValue(undefined);
     mockWriteFile.mockResolvedValue(undefined);
     mockAppendFile.mockResolvedValue(undefined);
-    // gh api returns PR titles with doc numbers
+    // Call order matters now: nextDocNum asks origin/main FIRST (fetch, then
+    // ls-tree), and only falls back to the disk scan and PR titles when the
+    // remote read yields nothing. An empty ls-tree here exercises that fallback.
     mockExec
-      .mockResolvedValueOnce(execOk('doc 750: some research\ndoc 755: more research\n'))
+      .mockResolvedValueOnce(execOk(''))  // git fetch origin main
+      .mockResolvedValueOnce(execOk(''))  // git ls-tree origin/main research/ - empty
+      .mockResolvedValueOnce(execOk('doc 750: some research\ndoc 755: more research\n'))  // gh api PR titles
       .mockResolvedValue(execOk('https://github.com/org/repo/pull/756\n'));
     const r = await commitResearchDoc({ question: 'Another question', findings: '...' });
     expect(r.ok).toBe(true);

--- a/bot/src/zoe/research-doc.ts
+++ b/bot/src/zoe/research-doc.ts
@@ -29,12 +29,46 @@ async function git(args: string[]): Promise<string> {
 }
 
 /** Highest doc number across merged dirs + open PR titles + in-flight branches, +1. */
+/** Highest doc number in a `git ls-tree` listing of research/. Exported for tests. */
+export function maxDocNumFrom(lines: string): number {
+  let max = 0;
+  for (const line of lines.split('\n')) {
+    // research/<topic>/<NNNN>-slug  - topic is NOT constrained to the TOPICS
+    // list, because the repo has 25 topic dirs and TOPICS names 13. Reading only
+    // the known ones would miss whichever dir happens to hold the highest number.
+    const m = line.match(/^research\/[^/]+\/(\d{3,4})-/);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max;
+}
+
 async function nextDocNum(): Promise<number> {
   let max = 0;
-  for (const t of TOPICS) {
-    let entries: string[] = [];
-    try { entries = await fs.readdir(join(REPO, 'research', t)); } catch { /* topic dir may not exist */ }
-    for (const e of entries) { const m = e.match(/^(\d+)-/); if (m) max = Math.max(max, Number(m[1])); }
+
+  // Ask the REMOTE, not a local checkout.
+  //
+  // This used to read `REPO` off disk, and REPO defaults to ~/zao-os while the
+  // bot actually runs from ~/zao-bot-live. Nothing keeps ~/zao-os current, so on
+  // 2026-08-15 it was ~6 days behind and numbering picked 2249 - a number
+  // already taken by research/agents/2249-cli-messaging-vs-ssh-orchestration.
+  // The collision guard caught it, but only after a PR had been opened.
+  let sawRemote = false;
+  try {
+    await exec('git', ['-C', REPO, 'fetch', 'origin', 'main', '--quiet'], { maxBuffer: 1024 * 1024 });
+    const { stdout } = await exec('git', ['-C', REPO, 'ls-tree', '-r', '-d', '--name-only', 'origin/main', 'research/'], { maxBuffer: 8 * 1024 * 1024 });
+    max = Math.max(max, maxDocNumFrom(stdout));
+    sawRemote = max > 0;
+  } catch { /* fall through to the disk scan below */ }
+
+  // Disk fallback, and LOUD about it. A silent fallback here is how a stale
+  // checkout produced a duplicate number without anyone noticing.
+  if (!sawRemote) {
+    console.log('[zoe/research-doc] WARNING: could not read origin/main for doc numbering - falling back to the local checkout, which may be stale');
+    for (const t of TOPICS) {
+      let entries: string[] = [];
+      try { entries = await fs.readdir(join(REPO, 'research', t)); } catch { /* topic dir may not exist */ }
+      for (const e of entries) { const m = e.match(/^(\d+)-/); if (m) max = Math.max(max, Number(m[1])); }
+    }
   }
   try {
     const { stdout } = await exec('gh', ['api', 'repos/bettercallzaal/ZAOOS/pulls?state=open&per_page=80', '--jq', '.[].title'], { maxBuffer: 1024 * 1024 });


### PR DESCRIPTION
## Executive summary

ZOE's research-worker produced its **first doc in five days** overnight and numbered it **2249** - a number already taken by `research/agents/2249-cli-messaging-vs-ssh-orchestration`. The `collision` check caught it, but only after PR #3101 was already open.

The arithmetic was never wrong. **`nextDocNum` was asking a checkout nobody updates.**

## The cause

`REPO` defaults to `~/zao-os`. The bot actually runs from `~/zao-bot-live`. `zoe-autodeploy.sh` keeps the live one current every ten minutes; **nothing keeps `~/zao-os` current.**

Measured today:

| checkout | HEAD | highest doc on disk |
|---|---|---:|
| `~/zao-os` (what numbering read) | #3099 | 2286 |
| `~/zao-bot-live` (what runs) | #3104 | 2288 |

At 04:14Z it was roughly six days behind, where the highest doc really was 2248 - so 2249 looked free.

## The fix

Ask **origin/main**: `git fetch`, then `git ls-tree`. That is what a human does by hand every time a doc is numbered.

The local scan survives only as a fallback, and it now **says out loud** that it is falling back. A silent fallback to a stale checkout is precisely how this produced a duplicate with nobody noticing.

## A second, latent version of the same blindness

The old scan iterated a hardcoded `TOPICS` list of **13** entries. The repo has **25** topic dirs. A doc landing in `technology/`, `estate/`, `brand/` or `zabal/` was invisible to numbering entirely - it just had not bitten yet. The new parser reads every topic dir.

## Evidence

Five tests, including the exact collision:

```
maxDocNumFrom('research/agents/2248-something') + 1        === 2249
same listing + research/infrastructure/2288-...  + 1        === 2289
maxDocNumFrom('research/technology/2278-...')               === 2278   (dir not in TOPICS)
maxDocNumFrom('research/agents/1234567-huge')               === 0      (no 7-digit poisoning)
```

Full bot suite **2441 passed, exit 0**.

One existing test needed updating and it is worth naming: it mocked `exec` **positionally**, assuming the first call was the `gh api` PR-title fetch. Two calls now precede it, so the once-mock fed PR titles to `git fetch` and the test returned 1 instead of 756. The mock now names each call rather than depending on order. The test's intent is unchanged.

## Flagged, not fixed

While tracing this, `systemctl --user show zoe-bot` printed a **bot token in the unit's `Environment=` line**, readable by anything that can run that command. It belongs in an `EnvironmentFile` with `0600`, and the token is worth rotating. Not touched here - that is a credential action.
