### PR TITLE
ci: the collision guard must report on every PR, or it can never be required

### DIFF
--- a/.github/workflows/doc-collision-guard.yml
+++ b/.github/workflows/doc-collision-guard.yml
@@ -23,10 +23,24 @@ name: Doc number collision guard
 # (renaming them would break the cross-reference link graph), so this guard
 # compares added directories against main rather than auditing main itself.
 
+# WHY THERE IS NO `paths:` FILTER
+#
+# There was one, scoped to research/**, and it made this check impossible to
+# REQUIRE. A required check that does not report leaves a PR blocked forever
+# rather than failing it, so a path-filtered check can never be mandatory - it
+# simply does not run on a code-only PR.
+#
+# That was not theoretical. On 2026-08-15 PR #3101 carried `collision: fail`
+# for a genuine duplicate (doc 2249) and `automerge` still read green, because
+# collision was not among the required checks and could not be made one.
+#
+# The job is already cheap and safe to run on every PR: if the diff adds no new
+# research doc directories it prints "Nothing to check" and exits 0. Removing
+# the filter costs one checkout per PR and buys a check that can actually be
+# binding.
+
 on:
   pull_request:
-    paths:
-      - "research/**"
 
 jobs:
   collision:


### PR DESCRIPTION
## Executive summary

PR #3101 carried **`collision: fail`** for a genuine duplicate - doc 2249, already held by `research/agents/2249-cli-messaging-vs-ssh-orchestration` - and **`automerge` still read green.** It could have landed the duplicate.

The reason is structural, not a missing setting.

## Why it could not simply be "made required"

The guard was path-filtered to `research/**`, so it **does not report at all** on a code-only PR. Confirmed on the current open PRs:

| PR | collision |
|---|---|
| #3101 (docs) | fail |
| #3104 (docs) | pass |
| #3100, #3103, #3106 (code) | **NOT REPORTED** |

A required check that never reports leaves a PR **blocked forever** rather than failing it. So a path-filtered check can never be mandatory - requiring it as it stood would have blocked every code PR. That is the same footgun that makes `Build` unrequireable, since `Build` is skipped whenever a job it `needs` fails.

## The change

Remove the `paths:` filter. That is all.

The job was **already** safe to run everywhere: with no new research doc directories in the diff it prints `No new research doc directories in this PR. Nothing to check.` and exits 0. The filter bought nothing except unrequireability.

Cost: one checkout per PR. Buys: a check that can actually be binding.

## The follow-up, which is yours

Once this is on main and reporting on every PR, `collision` can join `Lint & Typecheck`, `Test` and `Bot Tests` as a required status check. That is a branch-protection change.

**Do not require it before this merges** - it would block every open code PR on a check that never arrives.

## Why this one matters more than the bug it fixes

It is the shape of most of today's findings. `collision` failed and nothing stopped. `loop-health` reported "17 stalled" so reliably nobody read it, and a broken pipeline sat five days behind the noise. The PII scanner carried a pattern its own header recorded as producing only false positives. #3059 was automerged over red Bot Tests.

Every one of those checks was correct in principle and toothless in practice. The gap was never detection - it was that detection did not stop anything.
