### PR TITLE
feat: env-configurable grill unanswered cap (ZOE_GRILL_MAX_OUTSTANDING)

### DIFF
--- a/bot/src/zoe/backlog-grill.ts
+++ b/bot/src/zoe/backlog-grill.ts
@@ -208,7 +208,13 @@ export interface DripConfig {
  */
 export const DRIP_DEFAULT: DripConfig = {
   everyMinutes: 2,
-  maxOutstanding: 20,
+  // ZOE_GRILL_MAX_OUTSTANDING overrides the unanswered-card ceiling (Zaal,
+  // 2026-08-17: "make sure the grill doesn't only max at 20"). Falls back to
+  // 20 when unset or not a positive integer - never NaN into the gate.
+  maxOutstanding: (() => {
+    const raw = Number(process.env.ZOE_GRILL_MAX_OUTSTANDING);
+    return Number.isInteger(raw) && raw > 0 ? raw : 20;
+  })(),
   capWindowMs: 12 * 60 * 60 * 1000,
   startHour: 6,
   endHour: 22,


### PR DESCRIPTION
## Summary
Makes the backlog-grill unanswered-card ceiling env-configurable: ZOE_GRILL_MAX_OUTSTANDING (integer-guarded, falls back to 20 when unset/invalid). Zaal asked for the grill to not hard-cap at 20 (2026-08-17).

## Verification
- tsc --noEmit: 0 errors
- vitest backlog-grill: 39/39 pass
- Default behavior unchanged when env is unset

## Deploy note
After merge: set ZOE_GRILL_MAX_OUTSTANDING in the VPS bot .env (suggest 200) and deploy via the gated zoe-autodeploy path. Statusline GRILL_CEILING in zaal-dotfiles needs the matching bump in the same pass or it will paint JAMMED wrongly.
