### PR TITLE
fix(pii-scan): a transaction hash is not a phone number

### DIFF
--- a/scripts/__tests__/test_git_pii_scan.py
+++ b/scripts/__tests__/test_git_pii_scan.py
@@ -170,6 +170,46 @@ def test_only_added_lines_are_scanned():
     assert pii.scan(rows) == []
 
 
+# The fixtures below are ASSEMBLED AT RUNTIME rather than written as literals.
+# A test that proves this scanner catches phone numbers must contain something
+# phone-shaped, and a comment explaining a hash false-positive must contain the
+# digits - both of which make the file unstageable by the very scanner it tests.
+# Concatenating the pieces keeps the guard strict (no allowlist widening, no
+# bypass) while letting its own tests live in the repo.
+_HASH = "0xdb707582bd56df81570befe8b5c0cf324ce4887e5740332141df7d" + "294" + "6639595"
+_PHONE = "415" + "-555-" + "0123"   # NANP-valid shape, reserved-fictional range
+
+
+def test_transaction_hash_is_not_a_phone_number():
+    """The exact line that blocked doc 2301 on 2026-08-17.
+
+    The hash ends in ten decimal digits that satisfy the NANP pattern. The
+    lookbehind does not save it: the run is preceded by a hex LETTER, not a
+    digit.
+    """
+    assert "us_phone" not in kinds(f'  "tx": "{_HASH}",')
+
+
+def test_bare_long_hex_token_is_not_a_phone_number():
+    bare = "0000000a000000000000006c7234c36a71ec" + "294" + "6639595" + "e0735001e9af"
+    assert "us_phone" not in kinds(f"token_id {bare}")
+
+
+def test_a_real_phone_still_fires_on_an_ordinary_line():
+    assert "us_phone" in kinds(f"his cell is {_PHONE}, call after 6")
+
+
+def test_a_phone_sharing_a_line_with_a_hash_is_NOT_caught():
+    """Pins the cost of the line-skip approach honestly.
+
+    The hex guard skips the whole line, exactly as the UUID and URL guards
+    already do, so a phone number next to a hash is missed. This is a real
+    limitation, not the ideal. If it ever matters, mask hex spans instead of
+    skipping the line - and this test is where you find out you changed it.
+    """
+    assert "us_phone" not in kinds(f"tx {_HASH} call {_PHONE}")
+
+
 def test_cli_exits_zero_with_nothing_staged():
     r = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True,
                        cwd=str(SCRIPT.resolve().parents[1]))

--- a/scripts/git-pii-scan.py
+++ b/scripts/git-pii-scan.py
@@ -56,6 +56,17 @@ ZAO_DOMAINS = ("thezao.com", "bettercallzaal.com", "zabalgamez.com", "zaofestiva
 # Lines that produced every observed false positive. A UUID is not a phone number.
 UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}", re.I)
 URL_RE = re.compile(r"https?://|www\.")
+# Long hex tokens - a transaction hash, an address, a token id - contain runs of
+# ten consecutive decimal digits by pure chance, and such a run satisfies the
+# NANP phone pattern. Real case, 2026-08-17: the on-chain evidence for the
+# fractal weekly record was blocked because an Optimism tx hash ended in a
+# ten-digit decimal run. The (?<![\d]) lookbehind does not help, because those
+# digits are preceded by a hex LETTER rather than a digit. Same false-positive
+# class the header already records for a UUID, so it joins the same guard.
+# (The offending hash is not reproduced here - a literal digit run in this file
+# would trip the scanner it belongs to. It is pinned in the tests, assembled at
+# runtime, alongside the pre-existing fixtures that do the same.)
+HEX_RE = re.compile(r"0x[0-9a-fA-F]{16,}|\b[0-9a-fA-F]{32,}\b")
 
 PATTERNS: dict[str, tuple[str, bool]] = {
     # name: (regex, skip_on_uuid_or_url)
@@ -110,7 +121,9 @@ def scan(rows: list[tuple[str, str]]) -> list[tuple[str, str, str, str]]:
     """-> [(kind, file, match, line)]"""
     found: list[tuple[str, str, str, str]] = []
     for path, line in rows:
-        skip_numeric = bool(UUID_RE.search(line) or URL_RE.search(line))
+        skip_numeric = bool(
+            UUID_RE.search(line) or URL_RE.search(line) or HEX_RE.search(line)
+        )
         for kind, (pat, guarded) in PATTERNS.items():
             if guarded and skip_numeric:
                 continue


### PR DESCRIPTION
## What broke

The staged-diff PII scanner blocked a commit of on-chain evidence. The offending "personal data" was a 64-character Optimism transaction hash that happens to end in ten consecutive decimal digits - a run which satisfies the North American numbering plan pattern.

The existing `(?<![\d])` lookbehind does not save it, because those digits are preceded by a hex **letter**, not a digit.

## Why it is fixed rather than bypassed

The hook's own refusal message says it, and it is right:

> If this is a false positive, that is a bug in the scanner worth fixing - say so rather than bypassing, because a check people route around protects nobody.

A guard that blocks legitimate work teaches people to disable it. This is `noisy-signal-guard.md` exactly: a check that fires on the normal case stops being read. On-chain hashes are about to become ordinary content in `research/governance/`, so this would have fired repeatedly.

## The fix

`HEX_RE` matches a `0x`-prefixed token of 16+ hex chars, or a bare 32+ char hex run. Its presence makes the numeric patterns skip that line - the identical mechanism `UUID_RE` and `URL_RE` already use, for the identical reason. The script header already documented a UUID producing this same false positive; a transaction hash is the same class.

No pattern was loosened. No allowlist was widened.

## Evidence

27/27 tests pass (`python3 scripts/__tests__/test_git_pii_scan.py`), four of them new:

| Test | Asserts |
|---|---|
| `test_transaction_hash_is_not_a_phone_number` | the exact line that blocked the fractal record stays silent |
| `test_bare_long_hex_token_is_not_a_phone_number` | an unprefixed 64-char token stays silent |
| `test_a_real_phone_still_fires_on_an_ordinary_line` | **coverage is not lost** - the scanner still catches real numbers |
| `test_a_phone_sharing_a_line_with_a_hash_is_NOT_caught` | pins the real cost of the line-skip approach |

That last test asserts a limitation rather than an ideal, deliberately. The hex guard skips the whole line, so a phone number next to a hash is missed - the same tradeoff the UUID and URL guards already make. If that ever matters the fix is to mask hex spans instead of skipping the line, and that test is where someone would discover they had changed the behaviour.

## One thing worth knowing

Fixtures are assembled at runtime (`"415" + "-555-" + "0123"`) rather than written as literals. A test proving the scanner catches phone numbers must contain something phone-shaped, which makes the file unstageable by the very scanner it tests. This file had already hit that and established the convention for its bare-ten-digit fixture; the new fixtures follow it. The alternative - allowlisting the scanner's own test file - would have punched a hole in the guard to fix a test ergonomics problem.

## Scope

The scanner and its tests, nothing else. The on-chain data that hit the false positive ships in its own PR.

Generated with [Claude Code](https://claude.com/claude-code)
