### PR TITLE
fix(zaostock-bot): reconcile the VPS deploy into git - git is canonical, nothing lost

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -2,7 +2,7 @@ import { config as loadEnv } from 'dotenv';
 loadEnv();
 
 import { Bot, Context } from 'grammy';
-import { startHeartbeat } from './lib/cowork';
+import { startHeartbeat, reportEvent, startCommandPoller } from './lib/cowork';
 import {
   resolveMember,
   linkUsernameToMember,
@@ -43,6 +43,24 @@ const ADMIN_IDS = (process.env.BOT_ADMIN_TELEGRAM_IDS ?? '')
   .filter((n) => Number.isFinite(n) && n > 0);
 
 const bot = new Bot<Context>(token);
+
+// ---- Cowork control plane ---------------------------------------------------
+// Reconciled from the VPS deploy, 2026-08-17. This wiring ran in production for
+// weeks while existing nowhere in git, so the board could pause this bot and the
+// repo had no record of it. lib/cowork.ts already anticipated this consumer - its
+// restart comment names `zaostock-bot Restart=always` - so only the wiring was
+// missing, not the capability.
+const COWORK_BOOT_TS = Date.now();
+let coworkTask = 'booting';
+let coworkLastError: string | null = null;
+let coworkPaused = false;
+
+// A `pause` command from the board drops incoming Telegram updates. Registered
+// before every other handler so pausing is total rather than partial.
+bot.use(async (_ctx, next) => {
+  if (coworkPaused) return;
+  await next();
+});
 
 // Routing policy: bot must NEVER post in the ZAO Festivals General topic.
 // Anything that lacks an explicit message_thread_id when targeting that
@@ -592,6 +610,8 @@ bot.on('message:text', async (ctx) => {
 
 bot.catch((err) => {
   console.error('[zaostock-bot] error:', err);
+  coworkLastError = err?.message ?? String(err);
+  void reportEvent('error', coworkLastError, { unit: 'zaostock-bot' });
   alertDevops(bot, `error: ${err?.message ?? String(err)}`).catch(() => undefined);
 });
 
@@ -621,11 +641,19 @@ process.on('uncaughtException', (err) => {
 
 console.log('[zaostock-bot] starting...');
 // Heartbeat to the coworking status board (dormant unless COWORK_API_URL/TOKEN set).
-startHeartbeat(60_000, () => 'up', { unit: 'zaostock-bot' });
+// The 4th argument is evaluated per tick, so the board shows what the bot is
+// doing now rather than only that it is alive.
+startHeartbeat(60_000, () => 'up', { unit: 'zaostock-bot' }, () => ({
+  current_task: coworkTask,
+  last_error: coworkLastError,
+  uptime_s: Math.round((Date.now() - COWORK_BOOT_TS) / 1000),
+}));
 bot.start({
   onStart: async (info) => {
     console.log(`[zaostock-bot] running as @${info.username}`);
     cachedUsername = info.username.toLowerCase();
+    coworkTask = 'idle (polling)';
+    void reportEvent('startup', `online as @${info.username}`, { unit: 'zaostock-bot' });
     scheduleAll(bot, (err, label) => {
       console.error(`[schedule] ${label} failed:`, err);
       alertDevops(bot, `${label} digest failed: ${err instanceof Error ? err.message : 'unknown'}`).catch(
@@ -643,4 +671,21 @@ process.on('SIGTERM', () => {
 process.on('SIGINT', () => {
   alertDevops(bot, 'bot stopping (SIGINT)').catch(() => undefined);
   bot.stop();
+});
+
+// ---- Cowork control-plane poller --------------------------------------------
+// Lifecycle only (pause/resume). onRunTask/onAsk are deliberately omitted:
+// lib/cowork.ts reports unsupported commands as a clear error result rather than
+// dropping them, so the board shows an honest outcome instead of silence.
+startCommandPoller({
+  onPause: () => {
+    coworkPaused = true;
+    coworkTask = 'paused';
+    void reportEvent('paused', 'paused via control plane', { unit: 'zaostock-bot' });
+  },
+  onResume: () => {
+    coworkPaused = false;
+    coworkTask = 'idle (polling)';
+    void reportEvent('resumed', 'resumed via control plane', { unit: 'zaostock-bot' });
+  },
 });


### PR DESCRIPTION
fix(zaostock-bot): reconcile the VPS deploy into git - git is canonical, nothing lost

Zaal's call, relayed via zaoos-infra 2026-08-17: **git is canonical**.

THE PROBLEM. /home/zaal/zaostock-bot on the VPS is not a git repo - no .git, no
remote, no history - and the service is active. It runs the festival. Production
and git had diverged in BOTH directions:

  on the box, not in git : the cowork control plane. startCommandPoller wired with
                           onPause/onResume, plus a middleware that DROPS every
                           incoming Telegram update while paused. Something could
                           remotely pause the festival bot and git had no record
                           that the capability existed.
  in git, not on the box : the process-level crash safety net
                           (unhandledRejection + uncaughtException -> alertDevops)
                           and the /board command.

WHAT "GIT IS CANONICAL" MEANT HERE, and why it is not "discard the box's work".
lib/cowork.ts in git already anticipated this consumer - its restart handler
comment names `zaostock-bot Restart=always` - and both startHeartbeat (4-arg, with
a per-tick metaFn) and reportEvent already had the exact signatures the box calls.
The capability was designed for this bot; only the WIRING was missing from git.
Discarding it would have deleted a live board capability that git's own library
was built to serve. So git becomes the single source of truth by ABSORBING the
control plane, not by dropping it.

THE CHANGE, six edits to bot/src/index.ts:
  - widen the ./lib/cowork import to reportEvent + startCommandPoller
  - control-plane state (COWORK_BOOT_TS, coworkTask, coworkLastError, coworkPaused)
    and the pause middleware, registered before every other handler so a pause is
    total rather than partial
  - bot.catch records the error and reports it, WITHOUT removing git's alertDevops
  - startHeartbeat gains the 4th argument so the board shows current_task,
    last_error and uptime_s rather than only that the process is alive
  - onStart reports 'startup' and sets the task to idle
  - startCommandPoller wired for lifecycle only. onRunTask/onAsk are deliberately
    omitted: lib/cowork.ts reports unsupported commands as an explicit error result
    rather than dropping them, so the board shows an honest outcome.

NOTHING FROM PRODUCTION WAS LOST, verified by presence rather than by reading diff
hunks: startCommandPoller, coworkPaused, COWORK_BOOT_TS, current_task, uptime_s and
all three reportEvent calls are present. Git's crash handlers, /board and the
error alertDevops are also all still present. The reconciled file is the union.

VERIFIED
  tsc --noEmit ......... exit 0, 0 errors absolute, 0 in the edited file
  vitest run ........... 2441 passed / 187 files, exit 0
  esbuild .............. bundles bot/src/index.ts (the ZAOstock entrypoint) exit 0
  index.ts was NOT imported or executed - agent-loops rule 21; esbuild bundles the
  boot graph without running it, and a second poller would collide with the live one.

THIS PR DOES NOT DEPLOY. It makes git correct. The box is still an untracked copy
until someone redeploys it FROM this commit and deletes the loose stale files at
the deploy root (actions.ts, activity.ts, auth.ts, capture.ts sit beside src/ and
are old copies of it - they are not what runs, and they are what made an earlier
audit of mine report a drift that did not exist). Redeploying is a live change to
the bot that runs the festival, 47 days out, so it stays Zaal's.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N3znCy4Xk7L8XDneB9Lnkf
