### PR TITLE
rules: liveness-probe-guard - busy is not dead (the rule owed since instance 1)

### DIFF
--- a/.claude/rules/liveness-probe-guard.md
+++ b/.claude/rules/liveness-probe-guard.md
@@ -1,0 +1,111 @@
+# Liveness Probe Guard - busy is not dead
+
+A health check that cannot tell a **busy** service from a **dead** one will
+eventually kill a healthy one. Then it will kill the replacement. The symptom
+never looks like "the probe was wrong" - it looks like the service crash-looping.
+
+This rule exists because the same bug was diagnosed three times across three
+lanes before anyone wrote it down.
+
+## The three instances (all confirmed, ZAOOS#3065)
+
+`gstack browse` - the headless browser the fleet uses for client-rendered pages.
+
+1. **2026-07-13** (zao-artizen). `browse restart` on an already-healthy session
+    repeatedly triggered "crashed twice in a row". Worked around at the call site:
+    `ZAOartizen/scripts/refresh-fund.mjs` stopped calling `restart` and started
+    verifying the URL after `goto` instead.
+2. **2026-08-12** (zao-artizen). The same crash-loop, *without* anything calling
+    `restart` - it happened inside the binary's own retry logic during a plain
+    `goto`. Same signature, different trigger path.
+3. **2026-08-14** (ignite-radio) - **root-caused.** Nothing was crashing.
+    `ensureServer()` probes `/health` with a single `AbortSignal.timeout(2000)`.
+    Measured latency on the *same* server: **0.007s idle vs 2.02s and 3.92s while
+    a heavy page loads** - a ~150x degradation that crosses the budget. On probe
+    failure it calls `startServer()`, which `unlinkSync`s the state file and
+    spawns a replacement **without killing the original**. So: busy server
+    misread as dead -> state file deleted -> second server spawns on a new port
+    at `about:blank` -> the page silently vanishes -> the original keeps running,
+    orphaned, holding its Chromium. Repeat per command. Falsifiable prediction,
+    confirmed: **7 orphaned servers and 36 headless Chromium** before cleanup.
+4. **2026-08-17** (zao-artizen). Reproduced with **0 orphans on the machine
+    beforehand**, which settles that orphans are downstream of the bug, not a
+    precondition for it.
+
+Upstream fixed it in gstack 1.62.0.0 (`probeHealthWithBackoff`, their issue
+\#1781); local is 0.9.2.0. Their own code comment describes this exact failure -
+independent confirmation of the diagnosis.
+
+## The one principle
+
+**A single short-timeout probe measures load, not liveness.** "No answer within
+N ms" and "dead" are different claims, and only the second one justifies killing
+something.
+
+## Rules (behavior-changing)
+
+1. **A liveness probe retries with backoff before declaring death.** One timed
+    probe is a load measurement. Use several attempts spaced apart (upstream's
+    `probeHealthWithBackoff(port, attempts=3, backoffMs=250)` is the reference
+    shape). If you are writing the probe, this is the whole fix.
+
+2. **Never spawn a replacement without killing the original.** If a supervisor
+    concludes a process is dead and it is wrong, the cost must be one wasted
+    check, not an orphan holding a browser. Kill-then-start, or do not start.
+
+3. **Deleting shared state on a failed probe is how you lose the thing you were
+    checking on.** `unlinkSync(stateFile)` before the old process is confirmed
+    gone destroys the only handle to a service that is still running fine.
+
+4. **When a tool reports "crashed", check whether anything actually crashed.**
+    Instance 3 was titled "crash-loops" for two days. Nothing crashed. Look for
+    changing PIDs, accumulating processes, and a working first command followed
+    by a failing second - that pattern is a supervisor problem, not a crash.
+
+5. **Do not tune the timeout up and call it fixed.** A bigger budget moves the
+    threshold; it does not make the probe able to distinguish the two states.
+    The number was never the bug.
+
+## The companion clause: an empty result is a failure
+
+Adjacent shape, same session. A fetch can return **HTTP 200, a real final URL,
+no exception, and zero content.** Code that trusts the status records "the source
+has no data" instead of "I could not read the source" - and that lie propagates
+into a dashboard or a research doc as a fact.
+
+**Assert on content, not on status.** For any scrape or fetch whose output feeds
+a number someone will act on, treat `length == 0` (or below a sane floor) as a
+hard failure. The guard is one line and it is correct regardless of cause.
+
+Honest scope: on 2026-08-17 one lane observed a zero-length 200 from
+`artizen.fund` and **could not reproduce it in six subsequent runs across three
+configurations**, while a second lane never reproduced it at all. So this is
+**not** recorded as a property of that site - it is recorded because the guard
+costs nothing and the failure mode is real wherever it occurs.
+`silent-failure-guard.md` rule 2 states the general form ("assert the thing it
+was supposed to produce exists and is non-empty"); this is that rule pointed
+specifically at fetches that feed figures.
+
+## Guards
+
+- This does not ban short probes for cheap, local, uncontended things. It binds
+  where a probe's failure triggers a **destructive** action - a kill, a respawn,
+  a state-file delete, a failover.
+- Do not patch a vendored dependency to fix this if an upstream release already
+  has. The 2026-08-14 lane attempted a minimal backport of
+  `probeHealthWithBackoff`, measured that it **regressed the working case**, and
+  deliberately shipped nothing. That was the right call. Upgrade, or leave it and
+  route around at the call site.
+- Routing around at the call site is legitimate and was the right move twice
+  here - but log it as a workaround, or instance N+1 gets diagnosed from scratch.
+
+## Source
+
+Written 2026-08-17 by the zao-artizen lane at ignite-radio's request, after that
+lane root-caused instance 3 and stopped for a fleet refresh. Three prior
+instances, two of them fully diagnosed, zero rules - which is exactly the failure
+`agentic-issue` exists to prevent, recurring inside the tooling that skill
+monitors. Tracking issue: bettercallzaal/ZAOOS#3065. Siblings:
+`silent-failure-guard.md` (green while broken - the general form of the companion
+clause), `noisy-signal-guard.md` (red while fine), `anti-fabrication.md`
+(evidence or UNVERIFIED), `vanishing-dependencies.md`.

--- a/.claude/rules/liveness-probe-guard.md
+++ b/.claude/rules/liveness-probe-guard.md
@@ -86,6 +86,40 @@ costs nothing and the failure mode is real wherever it occurs.
 was supposed to produce exists and is non-empty"); this is that rule pointed
 specifically at fetches that feed figures.
 
+## Measure three times before it becomes an artifact
+
+The strongest argument for this rule is not either finding above. It is what
+happened to both of them.
+
+Investigating instance 4, the two lanes produced **one unreproduced one-off
+each**, and each was caught only because the other lane re-ran the measurement
+instead of accepting the report:
+
+- zao-artizen reported a zero-length 200 as site behavior. One observation. Six
+  later runs across three configs: not reproducible.
+- ignite-radio reported that a desktop-UA recipe yielded **41% more content**,
+  superseded their own published advice on it, and credited the other lane. One
+  run per config. Re-measured at three runs each: **26,178-26,191 on defaults vs
+  26,190-26,191 with the UA** - about 13 characters. Not reproducible.
+
+Both had already been written into durable artifacts - a tracking issue and a
+research doc - before anyone re-ran anything.
+
+6. **A single run is an anecdote. Three runs is a measurement.** Anything headed
+    for an issue, a rule, a research doc, or a recipe other people will follow
+    gets repeated first. Report the spread, not one number.
+
+7. **Apply the same scepticism to your own number as to the one you are
+    challenging.** ignite-radio named this asymmetry themselves: they correctly
+    refused to accept the incoming zero-length claim without testing it, and in
+    the same message published their own single-run 41% figure. Challenging
+    someone else's data is exactly the moment your own is least examined.
+
+What survived both retractions was the one variable each lane had independently
+measured more than once: the settle window (~23,034 chars at 3s vs ~26,185 at
+25s). That holds because they measured separately, **not** because they agreed -
+convergence is not proof (`research-grounding.md` rule 3).
+
 ## Guards
 
 - This does not ban short probes for cheap, local, uncontended things. It binds
@@ -105,7 +139,10 @@ Written 2026-08-17 by the zao-artizen lane at ignite-radio's request, after that
 lane root-caused instance 3 and stopped for a fleet refresh. Three prior
 instances, two of them fully diagnosed, zero rules - which is exactly the failure
 `agentic-issue` exists to prevent, recurring inside the tooling that skill
-monitors. Tracking issue: bettercallzaal/ZAOOS#3065. Siblings:
+monitors. The "measure three times" section was added after both lanes retracted
+an unreproduced one-off during the same investigation - each caught by the other,
+neither caught by its author. Tracking issue: bettercallzaal/ZAOOS#3065.
+Siblings:
 `silent-failure-guard.md` (green while broken - the general form of the companion
 clause), `noisy-signal-guard.md` (red while fine), `anti-fabrication.md`
 (evidence or UNVERIFIED), `vanishing-dependencies.md`.

--- a/.claude/rules/liveness-probe-guard.md
+++ b/.claude/rules/liveness-probe-guard.md
@@ -4,33 +4,35 @@ A health check that cannot tell a **busy** service from a **dead** one will
 eventually kill a healthy one. Then it will kill the replacement. The symptom
 never looks like "the probe was wrong" - it looks like the service crash-looping.
 
-This rule exists because the same bug was diagnosed three times across three
-lanes before anyone wrote it down.
+This rule exists because the same bug was hit three times over five weeks, and
+fully root-caused a month in, before anyone wrote it down.
 
 ## The three instances (all confirmed, ZAOOS#3065)
 
 `gstack browse` - the headless browser the fleet uses for client-rendered pages.
+All three were hit by the zao-artizen lane, in `ZAOartizen/scripts/refresh-fund.mjs`.
 
-1. **2026-07-13** (zao-artizen). `browse restart` on an already-healthy session
-    repeatedly triggered "crashed twice in a row". Worked around at the call site:
-    `ZAOartizen/scripts/refresh-fund.mjs` stopped calling `restart` and started
-    verifying the URL after `goto` instead.
-2. **2026-08-12** (zao-artizen). The same crash-loop, *without* anything calling
-    `restart` - it happened inside the binary's own retry logic during a plain
-    `goto`. Same signature, different trigger path.
-3. **2026-08-14** (ignite-radio) - **root-caused.** Nothing was crashing.
-    `ensureServer()` probes `/health` with a single `AbortSignal.timeout(2000)`.
-    Measured latency on the *same* server: **0.007s idle vs 2.02s and 3.92s while
-    a heavy page loads** - a ~150x degradation that crosses the budget. On probe
-    failure it calls `startServer()`, which `unlinkSync`s the state file and
-    spawns a replacement **without killing the original**. So: busy server
-    misread as dead -> state file deleted -> second server spawns on a new port
-    at `about:blank` -> the page silently vanishes -> the original keeps running,
-    orphaned, holding its Chromium. Repeat per command. Falsifiable prediction,
-    confirmed: **7 orphaned servers and 36 headless Chromium** before cleanup.
-4. **2026-08-17** (zao-artizen). Reproduced with **0 orphans on the machine
-    beforehand**, which settles that orphans are downstream of the bug, not a
-    precondition for it.
+1. **2026-07-13.** `browse restart` on an already-healthy session repeatedly
+    triggered "crashed twice in a row". Worked around at the call site:
+    `refresh-fund.mjs` stopped calling `restart` and started verifying the URL
+    after `goto` instead.
+2. **2026-08-12.** The same crash-loop, *without* anything calling `restart` - it
+    happened inside the binary's own retry logic during a plain `goto`. Same
+    signature, different trigger path. Issue filed.
+3. **2026-08-17.** Reproduced with **0 orphans on the machine beforehand**, which
+    settles that orphans are downstream of the bug, not a precondition for it.
+
+**Root-caused 2026-08-14 by the ignite-radio lane** (investigating instance 2 -
+analysis, not a fourth occurrence). Nothing was crashing. `ensureServer()` probes
+`/health` with a single `AbortSignal.timeout(2000)`. Measured latency on the
+*same* server: **0.007s idle vs 2.02s and 3.92s while a heavy page loads** - a
+~150x degradation that crosses the budget. On probe failure it calls
+`startServer()`, which `unlinkSync`s the state file and spawns a replacement
+**without killing the original**. So: busy server misread as dead -> state file
+deleted -> second server spawns on a new port at `about:blank` -> the page
+silently vanishes -> the original keeps running, orphaned, holding its Chromium.
+Repeat per command. Falsifiable prediction, confirmed: **7 orphaned servers and
+36 headless Chromium** before cleanup.
 
 Upstream fixed it in gstack 1.62.0.0 (`probeHealthWithBackoff`, their issue
 \#1781); local is 0.9.2.0. Their own code comment describes this exact failure -
@@ -91,7 +93,7 @@ specifically at fetches that feed figures.
 The strongest argument for this rule is not either finding above. It is what
 happened to both of them.
 
-Investigating instance 4, the two lanes produced **one unreproduced one-off
+Investigating instance 3, the two lanes produced **one unreproduced one-off
 each**, and each was caught only because the other lane re-ran the measurement
 instead of accepting the report:
 
@@ -136,10 +138,11 @@ convergence is not proof (`research-grounding.md` rule 3).
 ## Source
 
 Written 2026-08-17 by the zao-artizen lane at ignite-radio's request, after that
-lane root-caused instance 3 and stopped for a fleet refresh. Three prior
-instances, two of them fully diagnosed, zero rules - which is exactly the failure
-`agentic-issue` exists to prevent, recurring inside the tooling that skill
-monitors. The "measure three times" section was added after both lanes retracted
+lane root-caused the bug on 2026-08-14 and then stopped for a fleet refresh.
+Three instances, fully root-caused a month in, and still zero rules - which is
+exactly the failure `agentic-issue` exists to prevent, recurring inside the
+tooling that skill monitors. The "measure three times" section was added after
+both lanes retracted
 an unreproduced one-off during the same investigation - each caught by the other,
 neither caught by its author. Tracking issue: bettercallzaal/ZAOOS#3065.
 Siblings:


### PR DESCRIPTION
Writes the rule that ZAOOS#3065 has owed since it reached two instances. It is now at **three**, over five weeks, fully root-caused a month in, with nothing auto-loaded into sessions to prevent the fourth. That is precisely the failure the `agentic-issue` skill exists to stop, recurring inside the tooling that skill monitors.

Written at ignite-radio's explicit request - that lane root-caused the bug on 2026-08-14 and then stopped for a fleet refresh, and said so rather than leaving an "I'll get to it" that would have made this the third silent handoff.

## The shape

A health check that cannot distinguish a **busy** service from a **dead** one will eventually kill a healthy one, then kill its replacement.

`gstack browse` probes `/health` with a single `AbortSignal.timeout(2000)`. Measured on the same server: **0.007s idle vs 2.02s and 3.92s under load** - a ~150x degradation that crosses the budget. On probe failure it `unlinkSync`s the state file and spawns a replacement **without killing the original**, so the loaded page silently vanishes and orphans accumulate (7 servers / 36 Chromium at peak). It presents as a crash-loop. **Nothing crashes.** Fixed upstream in gstack 1.62.0.0 (`probeHealthWithBackoff`, upstream #1781); local is 0.9.2.0.

All three occurrences (2026-07-13, 2026-08-12, 2026-08-17) were hit by the zao-artizen lane in `ZAOartizen/scripts/refresh-fund.mjs`. The 2026-08-17 one reproduced with **0 orphans on the machine beforehand**, settling that orphans are downstream of the bug rather than a precondition.

## The seven rules

Core: retry with backoff before declaring death; never spawn a replacement without killing the original; don't delete shared state on a failed probe; when a tool says "crashed", check whether anything crashed; and **don't tune the timeout up and call it fixed - the number was never the bug.**

Then two added after this investigation produced **one unreproduced one-off per lane**, each caught only because the other lane re-ran the measurement:

- **A single run is an anecdote. Three runs is a measurement.** zao-artizen reported a zero-length HTTP 200 as site behavior (six later runs: not reproducible). ignite-radio reported a 41% content gain from a desktop-UA recipe and superseded their own published advice on it (three runs per config on re-measure: ~13 characters, not reproducible). Both were already in durable artifacts before anyone repeated anything.
- **Apply the same scepticism to your own number as to the one you are challenging.** ignite-radio identified this asymmetry in themselves - they correctly refused the incoming claim without testing it, and published their own single run in the same message.

What survived is the one variable both lanes measured independently more than once (a 25s settle window: ~23,034 chars at 3s vs ~26,185 at 25s) - and the rule says it holds because they measured, **not** because they agreed, pointing at `research-grounding.md` rule 3 so two-lane agreement is not later read as verification.

## Scope kept honest

- The companion clause (an empty result is a failure, not a result) is deliberately **not** recorded as a property of artizen.fund, since it did not reproduce. It is in because the guard costs one line and is correct regardless of cause - and it points at `silent-failure-guard.md` rule 2 rather than restating it.
- Explicit guard against the obvious wrong fix: the 2026-08-14 lane attempted a minimal backport of the upstream probe, **measured that it regressed the working case, and shipped nothing.** The rule records that as correct behavior so the next lane doesn't "helpfully" land it.
- Does not ban short probes generally - it binds only where a probe's failure triggers something destructive (kill, respawn, state delete, failover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)