### PR TITLE
fix(vercel): ignore-build guard failed open on shallow clones (docs-only builds = 94% of Vercel bill)

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -4,13 +4,52 @@
 # (a longer inline value fails vercel.json schema validation and errors EVERY
 # deploy - see the 2026-07-27 incident).
 #
+# 2026-08-18: the previous version built EVERY docs-only main commit (~$22/mo
+# of Build CPU, 94% of the project's Vercel bill) because Vercel's shallow
+# clone rarely contains VERCEL_GIT_PREVIOUS_SHA, and "SHA missing -> build"
+# fired on nearly every deploy. This version fetches the missing SHA, falls
+# back to diffing the commit itself, and logs its decision so the build log
+# shows WHY it built or skipped.
+
+BUILD_PATHS=(src public package.json package-lock.json next.config.ts tsconfig.json community.config.ts vercel.json scripts/vercel-ignore.sh)
+
 # 1. Only ever build production. Preview/branch deploys skip entirely - saves
-#    the (over-budget) Vercel spend and stops failing-preview emails.
-[ "${VERCEL_ENV:-}" = "production" ] || exit 0
-# 2. Production: if the previous deploy's SHA is missing from the shallow clone,
-#    build (safe default - can't diff, so don't risk skipping a real change).
-git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null || exit 1
-# 3. Build only if a build-relevant file changed since that SHA. git diff --quiet
-#    exits 0 (no change -> SKIP) or 1 (changed -> BUILD); that becomes our exit.
-git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" -- \
-  src public package.json package-lock.json next.config.ts tsconfig.json community.config.ts vercel.json
+#    the Vercel spend and stops failing-preview emails.
+if [ "${VERCEL_ENV:-}" != "production" ]; then
+  echo "[vercel-ignore] non-production (${VERCEL_ENV:-unset}) -> SKIP"
+  exit 0
+fi
+
+# 2. Make the previous deploy's SHA reachable. The clone is shallow, so the
+#    SHA is usually absent - fetch just that object before giving up on it.
+PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -n "$PREV" ] && ! git cat-file -e "$PREV" 2>/dev/null; then
+  git fetch --depth=1 origin "$PREV" 2>/dev/null || true
+fi
+
+# 3. Diff base: the previous deploy's SHA when reachable, else this commit's
+#    parent (deepen by one if the shallow clone lacks it). Only when NO base
+#    exists do we fall through to the safe default of building.
+BASE=""
+if [ -n "$PREV" ] && git cat-file -e "$PREV" 2>/dev/null; then
+  BASE="$PREV"
+else
+  git rev-parse --verify -q HEAD^ >/dev/null 2>&1 || git fetch --deepen=1 origin 2>/dev/null || true
+  if git rev-parse --verify -q HEAD^ >/dev/null 2>&1; then
+    BASE="HEAD^"
+  fi
+fi
+if [ -z "$BASE" ]; then
+  echo "[vercel-ignore] no diff base reachable (prev=${PREV:-unset}) -> BUILD (safe default)"
+  exit 1
+fi
+
+# 4. Build only if a build-relevant file changed since the base. git diff
+#    --quiet exits 0 (no change -> SKIP) or 1 (changed -> BUILD).
+if git diff --quiet "$BASE" HEAD -- "${BUILD_PATHS[@]}"; then
+  echo "[vercel-ignore] no build-relevant change vs $BASE -> SKIP"
+  exit 0
+else
+  echo "[vercel-ignore] build-relevant change vs $BASE -> BUILD"
+  exit 1
+fi


### PR DESCRIPTION
## What

`scripts/vercel-ignore.sh` was building every docs-only main commit. Vercel's shallow clone almost never contains `VERCEL_GIT_PREVIOUS_SHA`, so the script's "SHA missing -> build" safe default fired on nearly every deploy, silently.

## Evidence (measured 2026-08-18)

- Vercel usage, current cycle: zaoos project = $23.43 of the account's ~$39.56; **Build CPU Minutes = 108 hours = $21.93 (94%)**. Runtime products are cents.
- `git rev-list --count --since="7 days ago" origin/main` = 89 commits; commits touching build paths in the same window = **0**. Deployments list shows those docs commits all Ready with full builds (8-core machine, ~1m30s wall = ~12 CPU-min each).
- Build log of deployment 79Ug5qhVK (docs: doc 2310/2311): `Running "bash scripts/vercel-ignore.sh"` immediately followed by `Running "vercel build"`, no output - the silent exit-1 path.
- Reproduced locally: a depth-1 clone with the OLD script and unset `VERCEL_GIT_PREVIOUS_SHA` exits 1 (BUILD) with no output. Same clone with the new script picks the `HEAD^` fallback and decides from the actual diff.

## Fix

1. If `VERCEL_GIT_PREVIOUS_SHA` is set but unreachable, `git fetch --depth=1 origin <sha>` before giving up on it.
2. If still no previous SHA, fall back to diffing `HEAD^` (deepening the clone by 1 if needed) - a docs-only commit skips instead of building.
3. Only when NO diff base is reachable at all does it build unconditionally (kept as the fail-safe, per workflow-discipline rule 3).
4. Every decision is echoed (`[vercel-ignore] ... -> SKIP/BUILD`) so the build log shows why - the old script was undiagnosable from the log (state-claims: silence is not evidence).
5. `scripts/vercel-ignore.sh` added to BUILD_PATHS so guard changes themselves deploy.

## Verification

| Case | Old | New |
|---|---|---|
| preview env | SKIP | SKIP |
| docs-only commit, prev SHA unset/unreachable | **BUILD (the bug)** | SKIP |
| prev SHA reachable, docs-only span | SKIP | SKIP |
| prev SHA garbage | BUILD | HEAD^ fallback -> SKIP |
| src-touching change | BUILD | BUILD |
| no diff base at all (depth-1, no deepen possible) | BUILD | BUILD (safe default, now logged) |

`bash -n` clean. No app code touched; loop-evals gates A/B/D/E n/a beyond that (deploy-config-only diff).

## Expected effect

Docs merges (the overwhelming majority of main traffic) stop consuming ~12 build-CPU-min each. Projected saving on current merge rate: roughly $20/mo of the $19.56 on-demand overage on the bettercallzaal Vercel account.

Note: this project deploys from a `vercel.json` `ignoreCommand`; no dashboard settings change needed. First deploy after merge WILL build (this file is build-relevant) - expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
