### PR TITLE
feat: add General topic to ZAAL BOTZ fleet group (doc 2314 phase 1a)

### DIFF
--- a/bot/src/zoe/__tests__/topics.test.ts
+++ b/bot/src/zoe/__tests__/topics.test.ts
@@ -13,7 +13,14 @@ vi.mock('node:fs', () => ({
   },
 }));
 
-import { getTopicThread, readTopics, STANDARD_TOPICS, writeTopics } from '../topics';
+import {
+  GENERAL_THREAD_SENTINEL,
+  GENERAL_TOPIC,
+  getTopicThread,
+  readTopics,
+  STANDARD_TOPICS,
+  writeTopics,
+} from '../topics';
 
 afterEach(() => vi.clearAllMocks());
 
@@ -26,6 +33,40 @@ describe('STANDARD_TOPICS', () => {
 
   it('contains at least 5 topics', () => {
     expect(STANDARD_TOPICS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('contains General (fleet-wide flows, doc 2314)', () => {
+    expect(STANDARD_TOPICS).toContain(GENERAL_TOPIC);
+  });
+});
+
+// ── General sentinel ─────────────────────────────────────────────────────────
+
+describe('General topic sentinel', () => {
+  it('sentinel is falsy so senders omit message_thread_id', () => {
+    expect(GENERAL_THREAD_SENTINEL).toBe(0);
+    expect(Boolean(GENERAL_THREAD_SENTINEL)).toBe(false);
+  });
+
+  it('getTopicThread returns the sentinel for a mapped General', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({ Research: 101, [GENERAL_TOPIC]: GENERAL_THREAD_SENTINEL }),
+    );
+    expect(await getTopicThread(GENERAL_TOPIC)).toBe(GENERAL_THREAD_SENTINEL);
+  });
+});
+
+// ── roundtrip (doc 2314 phase 1a: read, write, read) ─────────────────────────
+
+describe('topics.json roundtrip', () => {
+  it('writeTopics output parses back to the same map via readTopics', async () => {
+    const map = { Research: 101, [GENERAL_TOPIC]: GENERAL_THREAD_SENTINEL };
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    await writeTopics(map);
+    const written = mockWriteFile.mock.calls[0][1] as string;
+    mockReadFile.mockResolvedValue(written);
+    expect(await readTopics()).toEqual(map);
   });
 });
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -158,7 +158,13 @@ import {
 } from './commands';
 import { formatSpendStatus } from './cost-governance';
 import { enqueueWork, queueDepth, runWorkTick } from './work-loop';
-import { STANDARD_TOPICS, readTopics, writeTopics } from './topics';
+import {
+  GENERAL_THREAD_SENTINEL,
+  GENERAL_TOPIC,
+  STANDARD_TOPICS,
+  readTopics,
+  writeTopics,
+} from './topics';
 import { routeTopic, topicNameForThread } from './topic-router';
 import { brandBoxFor, fetchIcmBrain, brandSystemPreamble } from './brand-brain';
 import { appendApproved } from './outbox';
@@ -546,6 +552,13 @@ bot.command('inittopics', async (ctx) => {
 
   const results: string[] = [];
   for (const name of STANDARD_TOPICS) {
+    // The native General topic cannot be created via createForumTopic; record
+    // the sentinel so senders know to omit message_thread_id (doc 2314).
+    if (name === GENERAL_TOPIC) {
+      topics[name] = GENERAL_THREAD_SENTINEL;
+      results.push(`${name}: group root (native, not created)`);
+      continue;
+    }
     if (topics[name]) {
       results.push(`${name}: ${topics[name]} (exists)`);
       continue;

--- a/bot/src/zoe/topics.ts
+++ b/bot/src/zoe/topics.ts
@@ -11,6 +11,16 @@ import { homedir } from 'node:os';
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
 const TOPICS_PATH = join(ZOE_HOME, 'topics.json');
 
+/**
+ * The group's built-in General topic (fleet-wide flows: morning digest,
+ * stale-capture nudges - doc 2314). Telegram forums ship with a native General
+ * topic that createForumTopic cannot create; posting WITHOUT message_thread_id
+ * lands there. So General maps to GENERAL_THREAD_SENTINEL (0) in topics.json: a
+ * falsy thread id that tells senders to omit message_thread_id.
+ */
+export const GENERAL_TOPIC = 'General';
+export const GENERAL_THREAD_SENTINEL = 0;
+
 /** The standard ZAAL BOTZ topics ZOE manages. Order is the create order.
  * Each has a behavior in topic-router.ts (topic = intent). */
 export const STANDARD_TOPICS = [
@@ -25,6 +35,7 @@ export const STANDARD_TOPICS = [
   'Newsletter',
   'WaveWarZ',
   'ZABAL Games',
+  GENERAL_TOPIC,
 ] as const;
 
 /** name -> message_thread_id */


### PR DESCRIPTION
Phase 1a of doc 2314 (ZAAL BOTZ fleet interface): add the General topic for fleet-wide flows (morning digest, stale-capture nudges).

## What changed

- `bot/src/zoe/topics.ts`: `GENERAL_TOPIC` ("General") added to `STANDARD_TOPICS`, plus `GENERAL_THREAD_SENTINEL` (0).
- `bot/src/zoe/index.ts` `/inittopics`: special-cases General - records the sentinel instead of calling `createForumTopic`.
- `bot/src/zoe/__tests__/topics.test.ts`: 4 new tests - General in STANDARD_TOPICS, sentinel is falsy, `getTopicThread` returns sentinel, topics.json write-then-read roundtrip.

## Design correction vs doc 2314

Doc 2314 planned `createForumTopic(chatId, "General")` with an assumed thread id 13. Telegram forums ship with a NATIVE General topic that `createForumTopic` cannot create - creating one would produce a duplicate topic named General next to the real one. `topic-router.ts:76` already documents "the group's General thread (no id)". So General maps to sentinel 0 in topics.json: falsy, which means every existing `message_thread_id ? ... : {}` send pattern automatically omits the thread id and lands in the native General. Fails safe by construction.

## Evidence (loop-evals gates)

- A. `tsc --noEmit`: 0 errors. `esbuild src/zoe/index.ts --bundle`: bundles clean (13.3mb, exit 0).
- B. Full bot suite: 187 files, 2445 tests, all pass (was 2441 before this PR's 4 additions; no regression).
- C. Anti-bloat: 67 insertions across 3 files; no duplication (reuses existing readTopics/writeTopics/getTopicThread; no new function). No dead code.
- D. Scope: only the Phase 1a deliverables named in doc 2314.
- E. Safety: `isFromZaal` guard and group-id check on `/inittopics` untouched.
- F. Secret scan of the diff: clean (case-insensitive, standalone step).

## Follow-on (not this PR)

Phase 1b: needs-you question routing per topic + reactions. Phase 1c: zao-tg CLI + handoffs topic + zj unread indicator. The founding brief's must-include (Zaal messaging from phone into terminals per lane) rides the qid bridge in 1b/1c, never a command bus (doc 2314 doctrine).

Doc: research/agents/2314-zaal-botz-fleet-interface-design

🤖 Generated with [Claude Code](https://claude.com/claude-code)
