### PR TITLE
feat: per-topic question routing + reaction callbacks (doc 2314 phase 1b, PR 1/2)

### DIFF
--- a/bot/src/zoe/__tests__/question-routing.test.ts
+++ b/bot/src/zoe/__tests__/question-routing.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+// doc 2314 phase 1b: per-topic needs-you question routing + reaction callbacks.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetTopicThread = vi.hoisted(() => vi.fn());
+
+vi.mock('../topics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../topics')>();
+  return { ...actual, getTopicThread: mockGetTopicThread };
+});
+
+import {
+  encodeReaction,
+  parseReactionCallback,
+  reactionKeyboard,
+  REACTION_TYPES,
+} from '../questions';
+import {
+  resolveQuestionTopic,
+  routeQuestionToTopic,
+  type TelegramRoutingDeps,
+} from '../telegram-routing';
+
+afterEach(() => vi.clearAllMocks());
+
+function makeDeps(overrides: Partial<TelegramRoutingDeps> = {}): TelegramRoutingDeps & {
+  sendMessage: ReturnType<typeof vi.fn>;
+} {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    zaalId: 111,
+    groupId: 222,
+    ...overrides,
+  } as TelegramRoutingDeps & { sendMessage: ReturnType<typeof vi.fn> };
+}
+
+// ── resolveQuestionTopic ─────────────────────────────────────────────────────
+
+describe('resolveQuestionTopic', () => {
+  it('routes a brand that is a standard topic to that topic', () => {
+    expect(resolveQuestionTopic('ZABAL Games')).toBe('ZABAL Games');
+    expect(resolveQuestionTopic('WaveWarZ')).toBe('WaveWarZ');
+  });
+
+  it('routes unbranded and unknown brands to Claude Code', () => {
+    expect(resolveQuestionTopic(undefined)).toBe('Claude Code');
+    expect(resolveQuestionTopic('')).toBe('Claude Code');
+    expect(resolveQuestionTopic('Not A Topic')).toBe('Claude Code');
+  });
+});
+
+// ── routeQuestionToTopic ─────────────────────────────────────────────────────
+
+describe('routeQuestionToTopic', () => {
+  const q = { qid: 'qb1', text: 'Ship it?', options: ['Yes', 'No'] };
+
+  it('posts to the mapped thread with a question keyboard', async () => {
+    mockGetTopicThread.mockResolvedValue(12);
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'ZABAL Games', q);
+    expect(mockGetTopicThread).toHaveBeenCalledWith('ZABAL Games');
+    const [chatId, text, opts] = deps.sendMessage.mock.calls[0];
+    expect(chatId).toBe(222);
+    expect(text).toBe('Ship it?');
+    expect(opts.message_thread_id).toBe(12);
+    const labels = opts.reply_markup.inline_keyboard.flat().map((b: { text: string }) => b.text);
+    expect(labels).toEqual(['Yes', 'No', 'Type my own']);
+  });
+
+  it('posts an unmapped topic to the group root and logs loud', async () => {
+    mockGetTopicThread.mockResolvedValue(undefined);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'ZABAL Games', q);
+    const [chatId, , opts] = deps.sendMessage.mock.calls[0];
+    expect(chatId).toBe(222);
+    expect(opts.message_thread_id).toBeUndefined();
+    expect(err).toHaveBeenCalledWith(expect.stringContaining('not in topics.json'));
+    err.mockRestore();
+  });
+
+  it('posts General (sentinel 0) to the group root without an error', async () => {
+    mockGetTopicThread.mockResolvedValue(0);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'General', q);
+    const [, , opts] = deps.sendMessage.mock.calls[0];
+    expect(opts.message_thread_id).toBeUndefined();
+    expect(err).not.toHaveBeenCalled();
+    err.mockRestore();
+  });
+
+  it('falls back to the DM when no groupId is configured', async () => {
+    const deps = makeDeps({ groupId: undefined });
+    await routeQuestionToTopic(deps, 'ZABAL Games', q);
+    const [chatId, , opts] = deps.sendMessage.mock.calls[0];
+    expect(chatId).toBe(111);
+    expect(opts.message_thread_id).toBeUndefined();
+    expect(mockGetTopicThread).not.toHaveBeenCalled();
+  });
+
+  it('uses the reaction keyboard when options is empty', async () => {
+    mockGetTopicThread.mockResolvedValue(12);
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'ZABAL Games', { qid: 'qb2', text: 'PR up.', options: [] });
+    const [, , opts] = deps.sendMessage.mock.calls[0];
+    const labels = opts.reply_markup.inline_keyboard.flat().map((b: { text: string }) => b.text);
+    expect(labels).toEqual(['Approve', 'Done']);
+  });
+});
+
+// ── reaction callbacks ───────────────────────────────────────────────────────
+
+describe('reaction callbacks', () => {
+  it('encode/parse roundtrips every reaction type', () => {
+    for (const r of REACTION_TYPES) {
+      expect(parseReactionCallback(encodeReaction('qb1', r))).toEqual({ qid: 'qb1', reaction: r });
+    }
+  });
+
+  it('rejects non-reaction callbacks and unknown reaction values', () => {
+    expect(parseReactionCallback('q:qb1:eWVz')).toBeNull();
+    expect(parseReactionCallback('r:qb1')).toBeNull();
+    expect(parseReactionCallback('r::YXBwcm92ZQ')).toBeNull();
+    expect(
+      parseReactionCallback(`r:qb1:${Buffer.from('explode', 'utf8').toString('base64url')}`),
+    ).toBeNull();
+  });
+
+  it('reactionKeyboard puts Approve + Done on one row with r: callbacks', () => {
+    const kb = reactionKeyboard('qb1');
+    expect(kb.inline_keyboard).toHaveLength(1);
+    const [approve, done] = kb.inline_keyboard[0];
+    expect(approve.text).toBe('Approve');
+    expect(approve.callback_data.startsWith('r:qb1:')).toBe(true);
+    expect(done.text).toBe('Done');
+  });
+
+  it('throws when callback_data would exceed the 64-byte cap', () => {
+    expect(() => encodeReaction('x'.repeat(60), 'approve')).toThrow(/64/);
+  });
+});

--- a/bot/src/zoe/questions.ts
+++ b/bot/src/zoe/questions.ts
@@ -65,3 +65,60 @@ export function parseQuestionCallback(data: string): ParsedQuestion | null {
   }
   return { qid, value, isType: value === TYPE_SENTINEL };
 }
+
+// ── reactions (doc 2314 phase 1b) ───────────────────────────────────────────
+// Approve/done answers as their own callback family ("r:") so a reaction tap
+// never collides with a q: option whose text happens to be "Approve". Buttons,
+// not the Telegram reactions API - the doc's fallback path, chosen because
+// reactions arrive as message_reaction updates with no qid to parse.
+
+export const REACTION_TYPES = ['approve', 'done'] as const;
+export type ReactionType = (typeof REACTION_TYPES)[number];
+
+/** A tapped reaction: the question id + which reaction. */
+export interface ParsedReaction {
+  qid: string;
+  reaction: ReactionType;
+}
+
+/** Build the callback_data for one reaction. Same 64-byte cap as questions. */
+export function encodeReaction(qid: string, reaction: ReactionType): string {
+  const data = `r:${qid}:${b64urlEncode(reaction)}`;
+  if (Buffer.byteLength(data, 'utf8') > 64) {
+    throw new Error(`callback_data too long (${Buffer.byteLength(data)}B > 64): shorten qid for reaction "${reaction}"`);
+  }
+  return data;
+}
+
+/** Inline keyboard for the reaction pair: Approve + Done on one row. */
+export function reactionKeyboard(
+  qid: string,
+): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [
+      [
+        { text: 'Approve', callback_data: encodeReaction(qid, 'approve') },
+        { text: 'Done', callback_data: encodeReaction(qid, 'done') },
+      ],
+    ],
+  };
+}
+
+/** Parse an "r:<qid>:<b64>" callback, or null if not a reaction callback or the
+ *  decoded value is not a known reaction type. */
+export function parseReactionCallback(data: string): ParsedReaction | null {
+  if (!data.startsWith('r:')) return null;
+  const rest = data.slice(2);
+  const sep = rest.indexOf(':');
+  if (sep < 0) return null;
+  const qid = rest.slice(0, sep);
+  if (!qid) return null;
+  let value: string;
+  try {
+    value = Buffer.from(rest.slice(sep + 1), 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+  if (!(REACTION_TYPES as readonly string[]).includes(value)) return null;
+  return { qid, reaction: value as ReactionType };
+}

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -20,6 +20,8 @@
  */
 
 import { ZAAL_DM_ID, ZAAL_BOTZ_GROUP_ID, ZAAL_BOTZ_RESEARCH_THREAD } from './env';
+import { GENERAL_TOPIC, STANDARD_TOPICS, getTopicThread } from './topics';
+import { questionKeyboard, reactionKeyboard } from './questions';
 
 // Chunking is shared with every other long-send path (tg-chunk.ts) so the
 // boundary logic can never drift between the router and direct sends.
@@ -123,4 +125,58 @@ export function constructRoutingDeps(sendMessageImpl: TelegramRoutingDeps['sendM
     groupId: ZAAL_BOTZ_GROUP_ID,
     groupThreadId: ZAAL_BOTZ_RESEARCH_THREAD,
   };
+}
+
+// ── per-topic question routing (doc 2314 phase 1b) ──────────────────────────
+
+/**
+ * Resolve which ZAAL BOTZ topic a question belongs in. A lane declares its
+ * BRAND context (doc 2314 decision 2: routing by brand, not assignment); a
+ * brand that is a standard topic routes there, anything else - unbranded,
+ * unknown, or a non-topic brand - falls back to the Claude Code topic.
+ */
+export function resolveQuestionTopic(brand?: string): string {
+  if (brand && (STANDARD_TOPICS as readonly string[]).includes(brand)) return brand;
+  return 'Claude Code';
+}
+
+export interface TopicQuestion {
+  qid: string;
+  text: string;
+  /** Answer options; empty array = reaction pair (Approve/Done) instead. */
+  options: string[];
+  includeType?: boolean;
+}
+
+/**
+ * Post a needs-you question into a ZAAL BOTZ topic thread. Replies come back
+ * through the existing qid bridge (parseQuestionCallback / parseReactionCallback)
+ * - topics are never a command bus (doc 2314 doctrine).
+ *
+ * Thread resolution: topics.json via getTopicThread. General's sentinel (0) and
+ * any unmapped topic both post to the group root so the question stays VISIBLE;
+ * an unmapped topic additionally logs loud (stale topics.json - run /inittopics).
+ * No groupId configured: falls back to Zaal's DM, same as sendToZaal.
+ */
+export async function routeQuestionToTopic(
+  deps: TelegramRoutingDeps,
+  topicName: string,
+  q: TopicQuestion,
+): Promise<void> {
+  const keyboard = q.options.length
+    ? questionKeyboard(q.qid, q.options, q.includeType ?? true)
+    : reactionKeyboard(q.qid);
+  const chatId = deps.groupId ?? deps.zaalId;
+  const sendOpts: any = { reply_markup: keyboard };
+  if (deps.groupId) {
+    const threadId = await getTopicThread(topicName);
+    if (threadId) {
+      sendOpts.message_thread_id = threadId;
+    } else if (topicName !== GENERAL_TOPIC) {
+      console.error(
+        `[zoe/telegram-routing] topic "${topicName}" not in topics.json; posting question ${q.qid} to group root (run /inittopics)`,
+      );
+    }
+  }
+  await deps.sendMessage(chatId, q.text, sendOpts);
 }


### PR DESCRIPTION
Phase 1b (PR 1 of 2) of doc 2314: the per-topic question routing layer + reaction callbacks. Pure additive - no call sites change in this PR; PR 2 wires the needs-you flow through it.

## What changed

- `bot/src/zoe/telegram-routing.ts`: `resolveQuestionTopic(brand)` (brand that is a standard topic routes there, everything else falls back to Claude Code - doc 2314 decision 2) and `routeQuestionToTopic(deps, topicName, q)` (resolves thread via topics.json, posts question or reaction keyboard). Extends the existing routing module instead of creating a parallel one.
- `bot/src/zoe/questions.ts`: reaction callback family `r:<qid>:<b64url(reaction)>` - `encodeReaction`, `reactionKeyboard` (Approve + Done buttons), `parseReactionCallback`. Same 64-byte cap and parse shape as the q: family. The `r:` prefix is unused by any existing callback handler (checked: q:, veto:, skip:, bc:, grill:, approve:, post:, edit:, done:, ans:).
- `bot/src/zoe/__tests__/question-routing.test.ts`: 11 tests - brand resolution, mapped-thread post, unmapped-topic loud fallback to group root, General sentinel (no error), DM fallback when groupId unset, reaction keyboard path, encode/parse roundtrip, invalid-input rejection, 64-byte cap.

## Design notes

- Buttons, not the Telegram reactions API: reactions arrive as message_reaction updates with no qid to parse. This is the doc's own risk-table fallback for phase 1b.
- Unmapped topic posts to group root with a loud console.error (stale topics.json, run /inittopics) instead of throwing - the question stays visible rather than lost, and the failure is never silent.
- Replies ride the existing qid bridge only; topics are never a command bus (doc 2314 doctrine).

## Evidence (loop-evals gates)

- A. `tsc --noEmit`: 0 errors. esbuild bundle of src/zoe/index.ts: clean.
- B. Full bot suite: 188 files, 2456 tests, all pass (2445 before; +11 from this PR, no regression).
- C. Anti-bloat: 113 insertions, 0 deletions, 2 source files; reuses questionKeyboard, b64urlEncode, getTopicThread, TelegramRoutingDeps - no duplicated logic, no dead code.
- D. Scope: only the phase 1b routing-layer deliverables; wiring call sites deferred to PR 2.
- E. Safety: no auth paths, env handling, or existing behavior touched (additive exports only).
- F. Secret scan of diff: clean (case-insensitive, standalone step).

## Next (PR 2 of phase 1b)

Wire the needs-you flow (orchestrator-tick + zao-ask receiver) through `routeQuestionToTopic`, add the open-question caps (warn at 3, alert at 5+ from 2+ lanes), register the `r:` callback handler in index.ts.

Doc: research/agents/2314-zaal-botz-fleet-interface-design

🤖 Generated with [Claude Code](https://claude.com/claude-code)
