### PR TITLE
feat: wire needs-you flow through topic routing (doc 2314 phase 1b, PR 2/2)

### DIFF
--- a/bot/src/zoe/__tests__/question-routing.test.ts
+++ b/bot/src/zoe/__tests__/question-routing.test.ts
@@ -16,6 +16,7 @@ import {
   REACTION_TYPES,
 } from '../questions';
 import {
+  openQuestionCapReport,
   resolveQuestionTopic,
   routeQuestionToTopic,
   type TelegramRoutingDeps,
@@ -138,5 +139,49 @@ describe('reaction callbacks', () => {
 
   it('throws when callback_data would exceed the 64-byte cap', () => {
     expect(() => encodeReaction('x'.repeat(60), 'approve')).toThrow(/64/);
+  });
+});
+
+// ── open-question caps (doc 2314 flow 2b) ───────────────────────────────────
+
+describe('openQuestionCapReport', () => {
+  const q = (n: number, topic: string, lane?: string) => ({ qid: `q${n}`, topic, lane });
+
+  it('stays quiet at or under the warn threshold', () => {
+    const report = openQuestionCapReport([q(1, 'Coding'), q(2, 'Coding'), q(3, 'Coding')]);
+    expect(report.warnings).toEqual([]);
+    expect(report.alerts).toEqual([]);
+  });
+
+  it('warns per topic past the warn threshold', () => {
+    const report = openQuestionCapReport([
+      q(1, 'Coding'),
+      q(2, 'Coding'),
+      q(3, 'Coding'),
+      q(4, 'Coding'),
+      q(5, 'Research'),
+    ]);
+    expect(report.warnings).toEqual(['topic "Coding" has 4 open questions']);
+    expect(report.alerts).toEqual([]);
+  });
+
+  it('alerts when a topic is jammed by enough distinct lanes', () => {
+    const report = openQuestionCapReport([
+      q(1, 'Coding', 'lane-a'),
+      q(2, 'Coding', 'lane-a'),
+      q(3, 'Coding', 'lane-b'),
+      q(4, 'Coding', 'lane-b'),
+      q(5, 'Coding', 'lane-c'),
+      q(6, 'Coding', 'lane-c'),
+    ]);
+    expect(report.alerts).toEqual(['topic "Coding" looks jammed: 6 unanswered from 3 lanes']);
+  });
+
+  it('never alerts without lane data, even past the alert threshold', () => {
+    const report = openQuestionCapReport(
+      Array.from({ length: 7 }, (_, i) => q(i, 'Coding')),
+    );
+    expect(report.warnings).toHaveLength(1);
+    expect(report.alerts).toEqual([]);
   });
 });

--- a/bot/src/zoe/__tests__/question-routing.test.ts
+++ b/bot/src/zoe/__tests__/question-routing.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+// doc 2314 phase 1b: per-topic needs-you question routing + reaction callbacks.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetTopicThread = vi.hoisted(() => vi.fn());
+
+vi.mock('../topics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../topics')>();
+  return { ...actual, getTopicThread: mockGetTopicThread };
+});
+
+import {
+  encodeReaction,
+  parseReactionCallback,
+  reactionKeyboard,
+  REACTION_TYPES,
+} from '../questions';
+import {
+  resolveQuestionTopic,
+  routeQuestionToTopic,
+  type TelegramRoutingDeps,
+} from '../telegram-routing';
+
+afterEach(() => vi.clearAllMocks());
+
+function makeDeps(overrides: Partial<TelegramRoutingDeps> = {}): TelegramRoutingDeps & {
+  sendMessage: ReturnType<typeof vi.fn>;
+} {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    zaalId: 111,
+    groupId: 222,
+    ...overrides,
+  } as TelegramRoutingDeps & { sendMessage: ReturnType<typeof vi.fn> };
+}
+
+// ── resolveQuestionTopic ─────────────────────────────────────────────────────
+
+describe('resolveQuestionTopic', () => {
+  it('routes a brand that is a standard topic to that topic', () => {
+    expect(resolveQuestionTopic('ZABAL Games')).toBe('ZABAL Games');
+    expect(resolveQuestionTopic('WaveWarZ')).toBe('WaveWarZ');
+  });
+
+  it('routes unbranded and unknown brands to Claude Code', () => {
+    expect(resolveQuestionTopic(undefined)).toBe('Claude Code');
+    expect(resolveQuestionTopic('')).toBe('Claude Code');
+    expect(resolveQuestionTopic('Not A Topic')).toBe('Claude Code');
+  });
+});
+
+// ── routeQuestionToTopic ─────────────────────────────────────────────────────
+
+describe('routeQuestionToTopic', () => {
+  const q = { qid: 'qb1', text: 'Ship it?', options: ['Yes', 'No'] };
+
+  it('posts to the mapped thread with a question keyboard', async () => {
+    mockGetTopicThread.mockResolvedValue(12);
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'ZABAL Games', q);
+    expect(mockGetTopicThread).toHaveBeenCalledWith('ZABAL Games');
+    const [chatId, text, opts] = deps.sendMessage.mock.calls[0];
+    expect(chatId).toBe(222);
+    expect(text).toBe('Ship it?');
+    expect(opts.message_thread_id).toBe(12);
+    const labels = opts.reply_markup.inline_keyboard.flat().map((b: { text: string }) => b.text);
+    expect(labels).toEqual(['Yes', 'No', 'Type my own']);
+  });
+
+  it('posts an unmapped topic to the group root and logs loud', async () => {
+    mockGetTopicThread.mockResolvedValue(undefined);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'ZABAL Games', q);
+    const [chatId, , opts] = deps.sendMessage.mock.calls[0];
+    expect(chatId).toBe(222);
+    expect(opts.message_thread_id).toBeUndefined();
+    expect(err).toHaveBeenCalledWith(expect.stringContaining('not in topics.json'));
+    err.mockRestore();
+  });
+
+  it('posts General (sentinel 0) to the group root without an error', async () => {
+    mockGetTopicThread.mockResolvedValue(0);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'General', q);
+    const [, , opts] = deps.sendMessage.mock.calls[0];
+    expect(opts.message_thread_id).toBeUndefined();
+    expect(err).not.toHaveBeenCalled();
+    err.mockRestore();
+  });
+
+  it('falls back to the DM when no groupId is configured', async () => {
+    const deps = makeDeps({ groupId: undefined });
+    await routeQuestionToTopic(deps, 'ZABAL Games', q);
+    const [chatId, , opts] = deps.sendMessage.mock.calls[0];
+    expect(chatId).toBe(111);
+    expect(opts.message_thread_id).toBeUndefined();
+    expect(mockGetTopicThread).not.toHaveBeenCalled();
+  });
+
+  it('uses the reaction keyboard when options is empty', async () => {
+    mockGetTopicThread.mockResolvedValue(12);
+    const deps = makeDeps();
+    await routeQuestionToTopic(deps, 'ZABAL Games', { qid: 'qb2', text: 'PR up.', options: [] });
+    const [, , opts] = deps.sendMessage.mock.calls[0];
+    const labels = opts.reply_markup.inline_keyboard.flat().map((b: { text: string }) => b.text);
+    expect(labels).toEqual(['Approve', 'Done']);
+  });
+});
+
+// ── reaction callbacks ───────────────────────────────────────────────────────
+
+describe('reaction callbacks', () => {
+  it('encode/parse roundtrips every reaction type', () => {
+    for (const r of REACTION_TYPES) {
+      expect(parseReactionCallback(encodeReaction('qb1', r))).toEqual({ qid: 'qb1', reaction: r });
+    }
+  });
+
+  it('rejects non-reaction callbacks and unknown reaction values', () => {
+    expect(parseReactionCallback('q:qb1:eWVz')).toBeNull();
+    expect(parseReactionCallback('r:qb1')).toBeNull();
+    expect(parseReactionCallback('r::YXBwcm92ZQ')).toBeNull();
+    expect(
+      parseReactionCallback(`r:qb1:${Buffer.from('explode', 'utf8').toString('base64url')}`),
+    ).toBeNull();
+  });
+
+  it('reactionKeyboard puts Approve + Done on one row with r: callbacks', () => {
+    const kb = reactionKeyboard('qb1');
+    expect(kb.inline_keyboard).toHaveLength(1);
+    const [approve, done] = kb.inline_keyboard[0];
+    expect(approve.text).toBe('Approve');
+    expect(approve.callback_data.startsWith('r:qb1:')).toBe(true);
+    expect(done.text).toBe('Done');
+  });
+
+  it('throws when callback_data would exceed the 64-byte cap', () => {
+    expect(() => encodeReaction('x'.repeat(60), 'approve')).toThrow(/64/);
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -173,7 +173,7 @@ import { dispatchHermesRun } from '../hermes/runner';
 import { shadowSummary } from '../hermes/critic';
 import { logTopicThreadId } from './curator';
 import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
-import { parseQuestionCallback } from './questions';
+import { parseQuestionCallback, parseReactionCallback } from './questions';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
 import { loadThreads, deleteThread, renderOpenThreadsBlock } from './threads';
 import { ackPush } from './proactive';
@@ -690,6 +690,30 @@ bot.on('callback_query:data', async (ctx, next) => {
         String(gid),
       ).catch((e) => console.error('[zoe/index] q-answer log failed:', (e as Error)?.message));
     }
+    return;
+  }
+
+  // Reaction buttons ("r:<qid>:<b64>", doc 2314 phase 1b) - Approve/Done pair.
+  // Same qid bridge as q: answers: log to recent/ so the session reads it; the
+  // reaction value rides in the same [answer:<qid>] shape so downstream answer
+  // detection needs no second path.
+  const r = parseReactionCallback(ctx.callbackQuery.data);
+  if (r) {
+    const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    await ctx.answerCallbackQuery({ text: 'Got it.' });
+    await ctx
+      .editMessageText(`Answered (${r.qid}): ${r.reaction}`, {
+        reply_markup: { inline_keyboard: [] },
+      })
+      .catch(() => {});
+    const mid = ctx.callbackQuery.message?.message_id;
+    if (mid) {
+      await ctx.api.unpinChatMessage(gid, mid).catch(() => {});
+    }
+    await pushRecent(
+      { from: 'zaal', text: `[answer:${r.qid}] ${r.reaction}`, sender: 'zaalbotz-btn' },
+      String(gid),
+    ).catch((e) => console.error('[zoe/index] r-answer log failed:', (e as Error)?.message));
     return;
   }
 

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -33,13 +33,14 @@ import { promises as fs } from 'node:fs';
 import { acquireTickLock, releaseTickLock } from './tick-lock';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQuestion } from './questions';
+import { parseQuestionCallback, encodeQuestion, type ParsedQuestion } from './questions';
+import { routeQuestionToTopic, resolveQuestionTopic, openQuestionCapReport } from './telegram-routing';
 import { pushRecent, ZOE_PATHS } from './memory';
 import { enqueueWork } from './work-loop';
 import { pushInboundRelays, sendRelayReply, laneFromReplyQid } from './relay-bridge';
 import { recordMessageContext } from './message-context';
 import { armPendingAnswer } from './pending-answers';
-import { startNudge, stopNudge, markPinged, dueTracks, nudgeLadderEnabled } from './nudge-ladder';
+import { startNudge, stopNudge, markPinged, dueTracks, nudgeLadderEnabled, openTracks } from './nudge-ladder';
 import { refillOpenThings, clearOpenThing, topicFromQid, type TopicOpenThingState } from './always-open-topics';
 import { topicNameForThread } from './topic-router';
 import { featureRan } from './feature-ran';
@@ -476,9 +477,14 @@ export async function runNudgePing(deps: {
       const advanced = await markPinged(t.qid, nowMs);
       if (!advanced) continue;
       try {
-        await deps.bot.api.sendMessage(deps.groupId, `Still need your answer: ${t.label}`, {
-          reply_markup: questionKeyboard(t.qid, t.options),
-        });
+        // Re-ping into the question's topic (doc 2314 phase 1b): topic from the
+        // qid prefix where one is encoded, Claude Code for neutral questions.
+        // zaalId is the DM fallback slot only - groupId is always set here.
+        await routeQuestionToTopic(
+          { sendMessage: deps.bot.api.sendMessage, zaalId: deps.groupId, groupId: deps.groupId },
+          resolveQuestionTopic(topicFromQid(t.qid) ?? undefined),
+          { qid: t.qid, text: `Still need your answer: ${t.label}`, options: t.options },
+        );
       } catch (err) {
         console.error('[zoe/nudge-ladder] re-ping failed:', (err as Error)?.message);
       }
@@ -593,9 +599,21 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
           }
 
           try {
-            await deps.bot.api.sendMessage(deps.groupId, qText, {
-              reply_markup: questionKeyboard(action.nextQuestion.qid, action.nextQuestion.options),
-            });
+            // Post into the question's topic (doc 2314 phase 1b): topic from the
+            // qid prefix where one is encoded, Claude Code for neutral questions.
+            await routeQuestionToTopic(
+              {
+                sendMessage: deps.bot.api.sendMessage,
+                zaalId: deps.zaalTgId,
+                groupId: deps.groupId,
+              },
+              resolveQuestionTopic(topicFromQid(action.nextQuestion.qid) ?? undefined),
+              {
+                qid: action.nextQuestion.qid,
+                text: qText,
+                options: action.nextQuestion.options,
+              },
+            );
             // arm General: Zaal's next plain typed message answers this question
             armPendingAnswer(deps.groupId, action.nextQuestion.qid);
             // Nudge ladder: begin the escalating->decaying ping for this open question.
@@ -606,6 +624,16 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
                 action.nextQuestion.options,
                 deps.now.getTime(),
               );
+              // Doc 2314 flow 2b caps: warn (never block) when a topic piles up.
+              const open = await openTracks();
+              const report = openQuestionCapReport(
+                open.map((tr) => ({
+                  qid: tr.qid,
+                  topic: resolveQuestionTopic(topicFromQid(tr.qid) ?? undefined),
+                })),
+              );
+              for (const w of report.warnings) console.warn(`[zoe/orchestrator] ${w}`);
+              for (const a of report.alerts) console.error(`[zoe/orchestrator] ALERT: ${a}`);
             }
             actioned++;
             console.log(

--- a/bot/src/zoe/questions.ts
+++ b/bot/src/zoe/questions.ts
@@ -65,3 +65,60 @@ export function parseQuestionCallback(data: string): ParsedQuestion | null {
   }
   return { qid, value, isType: value === TYPE_SENTINEL };
 }
+
+// ── reactions (doc 2314 phase 1b) ───────────────────────────────────────────
+// Approve/done answers as their own callback family ("r:") so a reaction tap
+// never collides with a q: option whose text happens to be "Approve". Buttons,
+// not the Telegram reactions API - the doc's fallback path, chosen because
+// reactions arrive as message_reaction updates with no qid to parse.
+
+export const REACTION_TYPES = ['approve', 'done'] as const;
+export type ReactionType = (typeof REACTION_TYPES)[number];
+
+/** A tapped reaction: the question id + which reaction. */
+export interface ParsedReaction {
+  qid: string;
+  reaction: ReactionType;
+}
+
+/** Build the callback_data for one reaction. Same 64-byte cap as questions. */
+export function encodeReaction(qid: string, reaction: ReactionType): string {
+  const data = `r:${qid}:${b64urlEncode(reaction)}`;
+  if (Buffer.byteLength(data, 'utf8') > 64) {
+    throw new Error(`callback_data too long (${Buffer.byteLength(data)}B > 64): shorten qid for reaction "${reaction}"`);
+  }
+  return data;
+}
+
+/** Inline keyboard for the reaction pair: Approve + Done on one row. */
+export function reactionKeyboard(
+  qid: string,
+): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [
+      [
+        { text: 'Approve', callback_data: encodeReaction(qid, 'approve') },
+        { text: 'Done', callback_data: encodeReaction(qid, 'done') },
+      ],
+    ],
+  };
+}
+
+/** Parse an "r:<qid>:<b64>" callback, or null if not a reaction callback or the
+ *  decoded value is not a known reaction type. */
+export function parseReactionCallback(data: string): ParsedReaction | null {
+  if (!data.startsWith('r:')) return null;
+  const rest = data.slice(2);
+  const sep = rest.indexOf(':');
+  if (sep < 0) return null;
+  const qid = rest.slice(0, sep);
+  if (!qid) return null;
+  let value: string;
+  try {
+    value = Buffer.from(rest.slice(sep + 1), 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+  if (!(REACTION_TYPES as readonly string[]).includes(value)) return null;
+  return { qid, reaction: value as ReactionType };
+}

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -180,3 +180,50 @@ export async function routeQuestionToTopic(
   }
   await deps.sendMessage(chatId, q.text, sendOpts);
 }
+
+/** One open (unanswered) needs-you question, for cap accounting. */
+export interface OpenQuestion {
+  qid: string;
+  topic: string;
+  /** Lane that asked. Optional until phase 1c's unread-replies log carries it. */
+  lane?: string;
+}
+
+/** Doc 2314 flow 2b caps: warn (never block) past this many open questions in
+ *  one topic; alert the operator when a topic looks jammed. */
+export const OPEN_QUESTION_WARN_THRESHOLD = 3;
+export const OPEN_QUESTION_ALERT_THRESHOLD = 5;
+export const OPEN_QUESTION_ALERT_MIN_LANES = 2;
+
+/**
+ * Pure cap report over the open-question set. Warnings fire per topic past the
+ * warn threshold. Alerts fire only when a topic is past the alert threshold AND
+ * the questions come from more than OPEN_QUESTION_ALERT_MIN_LANES distinct
+ * KNOWN lanes - with no lane data the alert stays quiet rather than guessing
+ * (anti-fabrication; lane data arrives with the phase 1c unread-replies log).
+ */
+export function openQuestionCapReport(open: OpenQuestion[]): {
+  warnings: string[];
+  alerts: string[];
+} {
+  const byTopic = new Map<string, OpenQuestion[]>();
+  for (const q of open) {
+    const list = byTopic.get(q.topic) ?? [];
+    list.push(q);
+    byTopic.set(q.topic, list);
+  }
+  const warnings: string[] = [];
+  const alerts: string[] = [];
+  for (const [topic, qs] of byTopic) {
+    if (qs.length > OPEN_QUESTION_WARN_THRESHOLD) {
+      warnings.push(`topic "${topic}" has ${qs.length} open questions`);
+    }
+    const lanes = new Set(qs.map((q) => q.lane).filter(Boolean));
+    if (qs.length > OPEN_QUESTION_ALERT_THRESHOLD && lanes.size > OPEN_QUESTION_ALERT_MIN_LANES) {
+      alerts.push(
+        `topic "${topic}" looks jammed: ${qs.length} unanswered from ${lanes.size} lanes`,
+      );
+    }
+  }
+  return { warnings, alerts };
+}

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -20,6 +20,8 @@
  */
 
 import { ZAAL_DM_ID, ZAAL_BOTZ_GROUP_ID, ZAAL_BOTZ_RESEARCH_THREAD } from './env';
+import { GENERAL_TOPIC, STANDARD_TOPICS, getTopicThread } from './topics';
+import { questionKeyboard, reactionKeyboard } from './questions';
 
 // Chunking is shared with every other long-send path (tg-chunk.ts) so the
 // boundary logic can never drift between the router and direct sends.
@@ -123,4 +125,58 @@ export function constructRoutingDeps(sendMessageImpl: TelegramRoutingDeps['sendM
     groupId: ZAAL_BOTZ_GROUP_ID,
     groupThreadId: ZAAL_BOTZ_RESEARCH_THREAD,
   };
+}
+
+// ── per-topic question routing (doc 2314 phase 1b) ──────────────────────────
+
+/**
+ * Resolve which ZAAL BOTZ topic a question belongs in. A lane declares its
+ * BRAND context (doc 2314 decision 2: routing by brand, not assignment); a
+ * brand that is a standard topic routes there, anything else - unbranded,
+ * unknown, or a non-topic brand - falls back to the Claude Code topic.
+ */
+export function resolveQuestionTopic(brand?: string): string {
+  if (brand && (STANDARD_TOPICS as readonly string[]).includes(brand)) return brand;
+  return 'Claude Code';
+}
+
+export interface TopicQuestion {
+  qid: string;
+  text: string;
+  /** Answer options; empty array = reaction pair (Approve/Done) instead. */
+  options: string[];
+  includeType?: boolean;
+}
+
+/**
+ * Post a needs-you question into a ZAAL BOTZ topic thread. Replies come back
+ * through the existing qid bridge (parseQuestionCallback / parseReactionCallback)
+ * - topics are never a command bus (doc 2314 doctrine).
+ *
+ * Thread resolution: topics.json via getTopicThread. General's sentinel (0) and
+ * any unmapped topic both post to the group root so the question stays VISIBLE;
+ * an unmapped topic additionally logs loud (stale topics.json - run /inittopics).
+ * No groupId configured: falls back to Zaal's DM, same as sendToZaal.
+ */
+export async function routeQuestionToTopic(
+  deps: TelegramRoutingDeps,
+  topicName: string,
+  q: TopicQuestion,
+): Promise<void> {
+  const keyboard = q.options.length
+    ? questionKeyboard(q.qid, q.options, q.includeType ?? true)
+    : reactionKeyboard(q.qid);
+  const chatId = deps.groupId ?? deps.zaalId;
+  const sendOpts: any = { reply_markup: keyboard };
+  if (deps.groupId) {
+    const threadId = await getTopicThread(topicName);
+    if (threadId) {
+      sendOpts.message_thread_id = threadId;
+    } else if (topicName !== GENERAL_TOPIC) {
+      console.error(
+        `[zoe/telegram-routing] topic "${topicName}" not in topics.json; posting question ${q.qid} to group root (run /inittopics)`,
+      );
+    }
+  }
+  await deps.sendMessage(chatId, q.text, sendOpts);
 }


### PR DESCRIPTION
Phase 1b (PR 2 of 2) of doc 2314: wire the needs-you flow through the routing layer PR #3159 added. Stacked on `ws/fleet-2314-phase1b-routing` - merge #3159 first; this PR's diff is only the wiring delta.

## What changed

- `bot/src/zoe/index.ts`: `r:` reaction callback handler registered after the `q:` block (first-handler-wins: `r:` prefix collides with nothing). A tapped Approve/Done logs `[answer:<qid>] approve|done` to recent/ via the SAME qid bridge as q: answers - no second answer-detection path.
- `bot/src/zoe/orchestrator-tick.ts`: both question post sites (next-question + nudge re-ping) now go through `routeQuestionToTopic`, resolving the topic from the qid prefix (`topicFromQid`) with Claude Code fallback for neutral questions. Previously both posted to the group root.
- `bot/src/zoe/telegram-routing.ts`: `openQuestionCapReport()` - pure cap helper per doc 2314 flow 2b. Warn past 3 open questions in a topic (console.warn, never blocks); alert only past 5 unanswered AND more than 2 distinct KNOWN lanes. With no lane data the alert stays quiet rather than guessing - lane data arrives with phase 1c's unread-replies log. Wired after each question post from live `openTracks()`.
- `bot/src/zoe/__tests__/question-routing.test.ts`: 4 new tests for the cap report (quiet under threshold, per-topic warn, lane-aware alert, no-alert-without-lane-data).

## Evidence (loop-evals gates)

- A. `tsc --noEmit`: 0 errors. esbuild bundle of src/zoe/index.ts: clean.
- B. Full bot suite: 188 files, 2460 tests, all pass (2456 before; +4 from this PR, no regression).
- C. Anti-bloat: 153 insertions / 9 deletions across 4 files; `questionKeyboard` import removed from orchestrator-tick (now unused there); biome check on all touched files: clean.
- D. Scope: only the phase 1b wiring named in doc 2314 + the caps from flow 2b.
- E. Safety: `isFromZaal` gate covers the new r: handler (it sits inside the existing guarded callback_query handler); no auth or env behavior changed.
- F. Secret scan of diff: clean (case-insensitive, standalone step).

## Phase 1b exit criteria (doc 2314)

Tests pass (done). Manual test after deploy: ask a question with a topic-prefixed qid, verify it lands in that topic with buttons; tap Approve on a reaction pair, verify `[answer:<qid>] approve` reaches recent/.

Doc: research/agents/2314-zaal-botz-fleet-interface-design

🤖 Generated with [Claude Code](https://claude.com/claude-code)
