### PR TITLE
feat: grill unification + Park verdict (cards 6b6875d1 + 1b7fe7c9)

### DIFF
--- a/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
@@ -172,6 +172,35 @@ describe('applyBacklogAnswer - the answer follows the card, not the cursor', () 
     expect(patched).toHaveLength(1);
   });
 
+  // Park (card 1b7fe7c9): the task stays OPEN - the PATCH carries a resurface
+  // note and NO status change. A drop that destroyed the row is off the menu.
+  it('park appends a resurface note and never touches status', async () => {
+    const r = await applyBacklogAnswer('4', fakeFetch, OLD);
+
+    expect(r.ok).toBe(true);
+    expect(r.message).toContain('Parked');
+    expect(patched).toHaveLength(1);
+    expect(patched[0].url).toContain(`id=eq.${OLD}`);
+    const body = patched[0].body as { status?: string; notes?: string };
+    expect(body.status).toBeUndefined();
+    expect(body.notes).toContain('parked - stays on the board');
+    expect((await readState()).answered[OLD]?.verdict).toBe('park');
+  });
+
+  it('does not park - or overwrite notes - when the notes read fails', async () => {
+    const failingRead = (async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PATCH') {
+        patched.push({ url: String(url), body: JSON.parse(String(init.body)) });
+        return { ok: true, status: 200 } as unknown as Response;
+      }
+      return { ok: false, status: 500 } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const r = await applyBacklogAnswer('4', failingRead, OLD);
+    expect(r.ok).toBe(false);
+    expect(patched).toHaveLength(0);
+    expect((await readState()).answered[OLD]).toBeUndefined();
+  });
+
   /**
    * Closing REPLACES `notes`, so it has to read them first. When that read
    * fails there is nothing to preserve, and writing anyway replaced the whole

--- a/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill-runner.test.ts
@@ -21,6 +21,7 @@ import {
   applyBacklogAnswer,
   outstandingCount,
   readState,
+  reconcileBacklogState,
   runBacklogGrillTick,
   writeState,
   type BacklogGrillState,
@@ -227,6 +228,16 @@ describe('runBacklogGrillTick - a skipped card goes to the back, not the front',
     if (String(url).includes('order=created_at.asc')) {
       return { ok: true, status: 200, json: async () => rows } as unknown as Response;
     }
+    // The reconcile pass asks for the asked-entries' board rows; everything in
+    // these tests is a live todo task, so answer accordingly.
+    if (String(url).includes('id=in.(')) {
+      const ids = /id=in\.\(([^)]*)\)/.exec(String(url))?.[1]?.split(',') ?? [];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ids.map((id) => ({ id, status: 'todo', archived_at: null, notes: '' })),
+      } as unknown as Response;
+    }
     return { ok: true, status: 200, json: async () => [{ notes: '' }] } as unknown as Response;
   }) as unknown as typeof fetch;
 
@@ -323,5 +334,112 @@ describe('runBacklogGrillTick - a skipped card goes to the back, not the front',
     expect((await tick(week)).title).toBe('Middle');
     expect((await tick(week + 2 * 60_000)).title).toBe('Newest');
     expect((await tick(week + 4 * 60_000)).title).toBe('Oldest');
+  });
+});
+
+// ── grill unification (card 6b6875d1): both ends, one count ─────────────────
+
+describe('reconcileBacklogState - the terminal end settles phone cards', () => {
+  const NOW = Date.UTC(2026, 7, 19, 14, 0, 0);
+
+  const askedThree = (): BacklogGrillState =>
+    st({
+      asked: {
+        closed: { at: new Date(NOW - 3_600_000).toISOString(), title: 'Closed in terminal' },
+        ruled: { at: new Date(NOW - 3_600_000).toISOString(), title: 'Verdict in notes' },
+        open: { at: new Date(NOW - 3_600_000).toISOString(), title: 'Still open' },
+      },
+    });
+
+  const boardWith =
+    (rows: Array<{ id: string; status?: string; archived_at?: string | null; notes?: string }>) =>
+    (async () =>
+      ({ ok: true, status: 200, json: async () => rows }) as unknown as Response) as unknown as typeof fetch;
+
+  beforeEach(() => {
+    files.clear();
+    process.env.COWORK_TRACKER_URL = 'https://tracker.test';
+    process.env.COWORK_TRACKER_KEY = 'k';
+  });
+
+  it('marks board-closed and verdict-synced entries answered; the count reaches zero-able', async () => {
+    const s = askedThree();
+    expect(outstandingCount(s, NOW)).toBe(3);
+    const rec = await reconcileBacklogState(
+      s,
+      boardWith([
+        { id: 'closed', status: 'done', archived_at: null, notes: '' },
+        { id: 'ruled', status: 'todo', archived_at: null, notes: 'context\nGRILL 2026-08-19 (Zaal): route to AGENT.' },
+        { id: 'open', status: 'todo', archived_at: null, notes: 'nothing decided' },
+      ]),
+      NOW,
+    );
+    expect(rec).toEqual({ boardClosed: 1, verdictSynced: 1 });
+    expect(s.answered.closed?.verdict).toBe('board-closed');
+    expect(s.answered.ruled?.verdict).toBe('verdict-synced');
+    expect(s.answered.open).toBeUndefined();
+    // Spec point 4: the count now agrees with what would actually still send.
+    expect(outstandingCount(s, NOW)).toBe(1);
+  });
+
+  it('treats a deleted task as board-closed', async () => {
+    const s = st({ asked: { gone: { at: new Date(NOW).toISOString(), title: 'Deleted' } } });
+    const rec = await reconcileBacklogState(s, boardWith([]), NOW);
+    expect(rec.boardClosed).toBe(1);
+    expect(s.answered.gone?.verdict).toBe('board-closed');
+  });
+
+  it('marks NOTHING when the board read fails - over-counting is the safe error', async () => {
+    const s = askedThree();
+    const failing = (async () => ({ ok: false, status: 500 }) as unknown as Response) as unknown as typeof fetch;
+    const rec = await reconcileBacklogState(s, failing, NOW);
+    expect(rec).toEqual({ boardClosed: 0, verdictSynced: 0 });
+    expect(Object.keys(s.answered)).toHaveLength(0);
+    expect(outstandingCount(s, NOW)).toBe(3);
+  });
+
+  it('settles a parked (requeued) card the terminal closed, clearing the park mark', async () => {
+    const s = st({
+      asked: { parked: { at: new Date(NOW).toISOString(), title: 'Parked', requeuedAt: new Date(NOW).toISOString() } },
+    });
+    await reconcileBacklogState(s, boardWith([{ id: 'parked', status: 'done', archived_at: null }]), NOW);
+    expect(s.answered.parked?.verdict).toBe('board-closed');
+    expect(s.asked.parked?.requeuedAt).toBeUndefined();
+  });
+});
+
+describe('grill unification - the tick side', () => {
+  beforeEach(() => {
+    files.clear();
+    process.env.COWORK_TRACKER_URL = 'https://tracker.test';
+    process.env.COWORK_TRACKER_KEY = 'k';
+  });
+
+  it('never sends a fresh card for a task already carrying a terminal verdict, and queries ALL routes', async () => {
+    const seenUrls: string[] = [];
+    const rows = [
+      { id: 'v', title: 'Already ruled', created_at: '2026-01-01T00:00:00Z', notes: 'ZAAL VERDICT 2026-08-19: do X.' },
+      { id: 'n', title: 'Genuinely open', created_at: '2026-02-01T00:00:00Z', notes: '' },
+    ];
+    const f = (async (url: string) => {
+      seenUrls.push(String(url));
+      if (String(url).includes('order=created_at.asc')) {
+        return { ok: true, status: 200, json: async () => rows } as unknown as Response;
+      }
+      return { ok: true, status: 200, json: async () => [] } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const result = await runBacklogGrillTick({
+      sendDM: async () => ({ message_id: 1 }),
+      localHour: 10,
+      now: Date.UTC(2026, 7, 19, 14, 0, 0),
+      fetchImpl: f,
+    });
+    expect(result.sent).toBe(true);
+    expect(result.title).toBe('Genuinely open');
+    // Spec point 3: Zaal grills ALL routes - the board query must not filter one.
+    const boardUrl = seenUrls.find((u) => u.includes('order=created_at.asc'));
+    expect(boardUrl).toBeDefined();
+    expect(boardUrl).not.toContain('route');
   });
 });

--- a/bot/src/zoe/__tests__/backlog-grill.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  classifyReconcile,
   DRIP_DEFAULT,
   parseVerdict,
   renderCard,
   shouldSendNext,
+  TERMINAL_VERDICT_RE,
   verdictButtons,
   verdictNote,
   VERDICTS,
@@ -197,5 +199,42 @@ describe('verdictNote - every change explains itself', () => {
 
   it('never claims done for a drop', () => {
     expect(verdictNote(parseVerdict('4')!, '2026-08-08')).not.toContain('confirmed done');
+  });
+});
+
+// ── grill unification (card 6b6875d1) ───────────────────────────────────────
+
+describe('TERMINAL_VERDICT_RE - the verdict forms measured on the live board', () => {
+  it('matches every form actually found in task notes (2026-08-19 audit)', () => {
+    expect(TERMINAL_VERDICT_RE.test('GRILL 2026-08-19 (Zaal): route to AGENT.')).toBe(true);
+    expect(TERMINAL_VERDICT_RE.test('ZAAL VERDICT 2026-08-19: combine the grills.')).toBe(true);
+    expect(TERMINAL_VERDICT_RE.test('GRILL 2026-08-18 (Telegram): confirmed done.')).toBe(true);
+    expect(TERMINAL_VERDICT_RE.test('context above\n  GRILL 2026-08-19 (Zaal): mid-notes.')).toBe(true);
+  });
+
+  it('does not fire on prose that merely mentions the grill', () => {
+    expect(TERMINAL_VERDICT_RE.test('add this to the grill queue later')).toBe(false);
+    expect(TERMINAL_VERDICT_RE.test('the GRILL ran on some date')).toBe(false);
+    expect(TERMINAL_VERDICT_RE.test('')).toBe(false);
+  });
+});
+
+describe('classifyReconcile - what the other end settled', () => {
+  it('board-closed for a missing, done, or archived row', () => {
+    expect(classifyReconcile(undefined)).toBe('board-closed');
+    expect(classifyReconcile({ status: 'done', archived_at: null })).toBe('board-closed');
+    expect(classifyReconcile({ status: 'in_progress', archived_at: null })).toBe('board-closed');
+    expect(classifyReconcile({ status: 'todo', archived_at: '2026-08-19T00:00:00Z' })).toBe('board-closed');
+  });
+
+  it('verdict-synced for a still-todo row carrying a terminal verdict', () => {
+    expect(
+      classifyReconcile({ status: 'todo', archived_at: null, notes: 'GRILL 2026-08-19 (Zaal): keep.' }),
+    ).toBe('verdict-synced');
+  });
+
+  it('null for a genuinely open row - reconcile must be able to touch nothing', () => {
+    expect(classifyReconcile({ status: 'todo', archived_at: null, notes: 'no ruling yet' })).toBeNull();
+    expect(classifyReconcile({ status: 'todo', archived_at: null })).toBeNull();
   });
 });

--- a/bot/src/zoe/__tests__/backlog-grill.test.ts
+++ b/bot/src/zoe/__tests__/backlog-grill.test.ts
@@ -16,7 +16,7 @@ describe('parseVerdict - a thumb at a traffic light', () => {
     ['1', 'done'],
     ['2', 'keep'],
     ['3', 'work'],
-    ['4', 'drop'],
+    ['4', 'park'],
     ['5', 'skip'],
   ])('a bare "%s" is %s', (reply, key) => {
     expect(parseVerdict(reply)?.key).toBe(key);
@@ -28,8 +28,16 @@ describe('parseVerdict - a thumb at a traffic light', () => {
 
   it('accepts the word instead of the number', () => {
     expect(parseVerdict('done')?.key).toBe('done');
-    expect(parseVerdict('drop')?.key).toBe('drop');
+    expect(parseVerdict('park')?.key).toBe('park');
     expect(parseVerdict('work on it')?.key).toBe('work');
+  });
+
+  // Triage never offers a drop (feedback_never_drop_always_park); a typed
+  // "drop" - or a tap on a pre-swap card's Drop button - reads as park.
+  it('maps a typed drop to park, never to a destroy', () => {
+    expect(parseVerdict('drop')?.key).toBe('park');
+    expect(parseVerdict('drop not relevant anymore')?.key).toBe('park');
+    expect(parseVerdict('drop')?.closesTask).toBe(false);
   });
 
   // "1" and "1 but ask iman first" mean different things, and the second is the
@@ -67,19 +75,19 @@ describe('the verdict shape', () => {
     expect(parseVerdict('5')?.requeue).toBe(true);
   });
 
-  it('done, keep and drop do not requeue', () => {
+  it('done, keep and park do not requeue', () => {
     for (const r of ['1', '2', '4']) expect(parseVerdict(r)?.requeue).toBe(false);
   });
 
-  it('only done and drop close the task', () => {
+  it('only done closes the task - park leaves it open', () => {
     expect(parseVerdict('1')?.closesTask).toBe(true);
-    expect(parseVerdict('4')?.closesTask).toBe(true);
+    expect(parseVerdict('4')?.closesTask).toBe(false);
     expect(parseVerdict('2')?.closesTask).toBe(false);
     expect(parseVerdict('3')?.closesTask).toBe(false);
   });
 
   it('the five never reorder - the numbers are muscle memory', () => {
-    expect(VERDICTS.map((v) => v.key)).toEqual(['done', 'keep', 'work', 'drop', 'skip']);
+    expect(VERDICTS.map((v) => v.key)).toEqual(['done', 'keep', 'work', 'park', 'skip']);
   });
 });
 
@@ -189,7 +197,7 @@ describe('shouldSendNext - a pile is the feature, a flood is not', () => {
 describe('verdictNote - every change explains itself', () => {
   it('records what was chosen', () => {
     expect(verdictNote(parseVerdict('1')!, '2026-08-08')).toContain('confirmed done');
-    expect(verdictNote(parseVerdict('4')!, '2026-08-08')).toContain('dropped');
+    expect(verdictNote(parseVerdict('4')!, '2026-08-08')).toContain('parked');
   });
 
   it('quotes what he typed', () => {
@@ -197,8 +205,12 @@ describe('verdictNote - every change explains itself', () => {
     expect(note).toContain('ask iman to verify');
   });
 
-  it('never claims done for a drop', () => {
+  it('never claims done for a park', () => {
     expect(verdictNote(parseVerdict('4')!, '2026-08-08')).not.toContain('confirmed done');
+  });
+
+  it('a park note says it resurfaces - the whole point of not dropping', () => {
+    expect(verdictNote(parseVerdict('4')!, '2026-08-20')).toContain('resurfaces later');
   });
 });
 

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -482,6 +482,24 @@ export async function applyBacklogAnswer(
     }
   } else if (v.key === 'skip') {
     message = 'Skipped - it returns later.';
+  } else if (v.key === 'park') {
+    // Park (card 1b7fe7c9): the task stays OPEN on the board - only a resurface
+    // note is appended. Same read-modify-write + fail-closed guard as the close
+    // path: notes are replaced wholesale by PATCH, so writing over a failed
+    // read would destroy the task's note history.
+    const cur = await fetchImpl(`${c.root}/rest/v1/tasks?id=eq.${taskId}&select=notes`, {
+      headers: c.headers,
+    });
+    if (!cur.ok) return { ok: false, message: `could not read that task (${cur.status}) - not parking` };
+    const rows = (await cur.json()) as Array<{ notes?: string }>;
+    const notes = `${(rows[0]?.notes || '').trim()}\n\n${verdictNote(v, new Date().toISOString().slice(0, 10))}`.trim();
+    const patch = await fetchImpl(`${c.root}/rest/v1/tasks?id=eq.${taskId}`, {
+      method: 'PATCH',
+      headers: { ...c.headers, Prefer: 'return=minimal' },
+      body: JSON.stringify({ notes }),
+    });
+    if (!patch.ok) return { ok: false, message: `park failed (${patch.status})` };
+    message = 'Parked - stays on the board, resurfaces later.';
   } else {
     message = 'Kept open.';
   }

--- a/bot/src/zoe/backlog-grill-runner.ts
+++ b/bot/src/zoe/backlog-grill-runner.ts
@@ -29,6 +29,8 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { featureRan } from './feature-ran';
 import {
+  classifyReconcile,
+  TERMINAL_VERDICT_RE,
   DRIP_DEFAULT,
   parseVerdict,
   renderCard,
@@ -187,7 +189,11 @@ async function nextTask(
   const r = await fetchImpl(url, { headers: c.headers, cache: 'no-store' });
   if (!r.ok) return null;
   const rows = (await r.json()) as BoardTask[];
-  const fresh = rows.filter((t) => !s.asked[t.id]);
+  // A never-asked task whose notes already carry a terminal grill verdict was
+  // ruled on from the other end - sending it a phone card would be the exact
+  // both-ends dupe this card exists to kill (6b6875d1). It still shows up here
+  // if the verdict line is ever removed, so nothing is permanently hidden.
+  const fresh = rows.filter((t) => !s.asked[t.id] && !TERMINAL_VERDICT_RE.test(t.notes || ''));
   const requeued = rows
     .filter((t) => s.asked[t.id]?.requeuedAt && !s.answered[t.id])
     .sort((a, b) =>
@@ -234,6 +240,67 @@ function getOldestUnansweredTaskId(s: BacklogGrillState): string | null {
 }
 
 /**
+ * Reconcile the state file with the board (grill unification, card 6b6875d1).
+ *
+ * Zaal grills from both ends: this drip AND terminal sessions that close tasks
+ * or stamp verdict lines directly into notes. Without reconcile the state file
+ * keeps counting those as "in front of him" - 23 stale entries were
+ * hand-reconciled on 2026-08-19 and the count could never reach zero on its
+ * own (noisy-signal-guard: a number that cannot fall is a latch, not a signal).
+ *
+ * Every unanswered asked-entry (requeued ones included - a terminal close ends
+ * a parked card too) is checked against the board in chunks:
+ *  - task closed / archived / deleted -> answered {verdict: 'board-closed'}
+ *  - still todo but notes carry a terminal verdict -> {verdict: 'verdict-synced'}
+ *
+ * A failed chunk fetch marks NOTHING from that chunk - a card we could not
+ * check is a card we cannot prove is dealt with, and between over-counting and
+ * silently dropping a live card, over-counting is the safe error (same call as
+ * outstandingCount's undateable-`at` case). Mutates `state`; the caller writes.
+ */
+export async function reconcileBacklogState(
+  state: BacklogGrillState,
+  fetchImpl: typeof fetch,
+  now: number,
+): Promise<{ boardClosed: number; verdictSynced: number }> {
+  const c = cfg();
+  const result = { boardClosed: 0, verdictSynced: 0 };
+  if (!c) return result;
+  const pending = Object.keys(state.asked).filter((id) => !state.answered[id]);
+  if (pending.length === 0) return result;
+
+  const at = new Date(now).toISOString();
+  const CHUNK = 50;
+  for (let i = 0; i < pending.length; i += CHUNK) {
+    const ids = pending.slice(i, i + CHUNK);
+    const url =
+      `${c.root}/rest/v1/tasks?id=in.(${ids.join(',')})` +
+      `&select=id,status,archived_at,notes`;
+    let rows: Array<{ id: string; status?: string; archived_at?: string | null; notes?: string | null }>;
+    try {
+      const r = await fetchImpl(url, { headers: c.headers, cache: 'no-store' });
+      if (!r.ok) continue;
+      rows = await r.json();
+    } catch {
+      continue;
+    }
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    for (const id of ids) {
+      const verdict = classifyReconcile(byId.get(id));
+      if (!verdict) continue;
+      state.answered[id] = { at, verdict };
+      // A parked (requeued) card that the board settled is settled - clear the
+      // park mark so applyBacklogAnswer's requeue bookkeeping never revives it.
+      if (state.asked[id]?.requeuedAt) delete state.asked[id].requeuedAt;
+      if (state.activeTaskId === id) state.activeTaskId = null;
+      if (verdict === 'board-closed') result.boardClosed++;
+      else result.verdictSynced++;
+    }
+  }
+  return result;
+}
+
+/**
  * One tick. Sends at most ONE card, or nothing.
  *
  * Returns what it did so the scheduler can log it - a silent tick that did
@@ -247,6 +314,16 @@ export async function runBacklogGrillTick(
   if (!cfg()) return { sent: false, reason: 'tracker not configured' };
 
   const state = await readState();
+  // Reconcile BEFORE the gate: outstandingCount must reflect what would
+  // actually still be sent, or a terminal sweep leaves the drip jammed on
+  // cards the board already closed.
+  const rec = await reconcileBacklogState(state, fetchImpl, now);
+  if (rec.boardClosed || rec.verdictSynced) {
+    await writeState(state);
+    console.log(
+      `[zoe/backlog-grill] reconciled: ${rec.boardClosed} board-closed, ${rec.verdictSynced} verdict-synced`,
+    );
+  }
   const next = await nextTask(state, fetchImpl, now);
   if (!next) return { sent: false, reason: 'nothing left to ask about' };
 

--- a/bot/src/zoe/backlog-grill.ts
+++ b/bot/src/zoe/backlog-grill.ts
@@ -37,12 +37,15 @@
  * part of the verdict shape rather than an afterthought.
  */
 
-/** The five, in the order they are pressed. Stable - do not reorder. */
+/** The five, in the order they are pressed. Stable - do not reorder.
+ * 4 was "Drop it" until 2026-08-20 (card 1b7fe7c9): triage never offers a drop
+ * option (feedback_never_drop_always_park). Park leaves the task OPEN on the
+ * board with a resurface note; nothing is destroyed. */
 export const VERDICTS = [
   { n: 1, key: 'done', label: 'Done - close it' },
   { n: 2, key: 'keep', label: 'Keep open' },
   { n: 3, key: 'work', label: 'Work on it now' },
-  { n: 4, key: 'drop', label: 'Drop it' },
+  { n: 4, key: 'park', label: 'Park it - resurfaces later' },
   { n: 5, key: 'skip', label: 'Skip for now' },
 ] as const;
 
@@ -79,7 +82,7 @@ export function parseVerdict(reply: string): Verdict | null {
     if (v) return build(v.key, m[2].trim() || undefined);
   }
 
-  // The word itself: "done", "keep", "drop", "skip", "work on it".
+  // The word itself: "done", "keep", "park", "skip", "work on it".
   const lower = raw.toLowerCase();
   for (const v of VERDICTS) {
     if (lower === v.key || lower.startsWith(`${v.key} `)) {
@@ -87,6 +90,11 @@ export function parseVerdict(reply: string): Verdict | null {
     }
   }
   if (/^work on it/i.test(lower)) return build('work', raw.slice(10).trim() || undefined);
+  // A typed "drop" maps to park - the standing rule reads it as intent to shelve,
+  // and destroying is never on the menu (never-drop-always-park).
+  if (lower === 'drop' || lower.startsWith('drop ')) {
+    return build('park', raw.slice(4).trim() || undefined);
+  }
 
   // Anything else is a real instruction. Treat it as "work on it" with the
   // typed text as the brief - a sentence is a richer answer than a number, and
@@ -100,7 +108,8 @@ function build(key: VerdictKey, note?: string): Verdict {
     note,
     // Work re-enters the queue: a task is never done because work STARTED.
     requeue: key === 'work' || key === 'skip',
-    closesTask: key === 'done' || key === 'drop',
+    // Only done closes now - park replaced drop and leaves the task open.
+    closesTask: key === 'done',
   };
 }
 
@@ -159,7 +168,7 @@ export function verdictButtons(taskId: string): { text: string; data: string }[]
       { text: '3 Work', data: d('work') },
     ],
     [
-      { text: '4 Drop', data: d('drop') },
+      { text: '4 Park', data: d('park') },
       { text: '5 Skip', data: d('skip') },
     ],
   ];
@@ -252,7 +261,7 @@ export function verdictNote(v: Verdict, date: string): string {
     done: 'confirmed done',
     keep: 'still wanted - kept open',
     work: 'sent to be worked on',
-    drop: 'dropped - not doing it',
+    park: 'parked - stays on the board, resurfaces later',
     skip: 'skipped for now',
   }[v.key];
   const note = v.note ? ` Zaal added: "${v.note}"` : '';

--- a/bot/src/zoe/backlog-grill.ts
+++ b/bot/src/zoe/backlog-grill.ts
@@ -258,3 +258,39 @@ export function verdictNote(v: Verdict, date: string): string {
   const note = v.note ? ` Zaal added: "${v.note}"` : '';
   return `GRILL ${date} (Telegram): ${base}.${note}`;
 }
+
+// ── reconcile (grill unification, card 6b6875d1) ────────────────────────────
+// Zaal grills from BOTH ends - this Telegram drip and terminal grill sessions.
+// The terminal end closes tasks and writes verdict lines into notes, and the
+// Telegram state file has no idea: 23 stale asked-entries were hand-reconciled
+// on 2026-08-19 (209 -> 186 outstanding). These helpers make that automatic.
+
+/**
+ * A terminal grill verdict as it actually appears in task notes, measured on
+ * the live board 2026-08-19 (14/346 todo tasks): a line starting
+ * "GRILL <date>" (terminal sessions stamp "(Zaal)", this file's own close path
+ * stamps "(Telegram)") or "ZAAL VERDICT <date>". The Telegram variant only
+ * ever lands on tasks this runner ALREADY answered, so matching it here is
+ * harmless - reconcile only looks at unanswered entries.
+ */
+export const TERMINAL_VERDICT_RE =
+  /(^|\n)\s*(GRILL \d{4}-\d{2}-\d{2}|ZAAL VERDICT \d{4}-\d{2}-\d{2})/;
+
+/**
+ * Classify one asked-entry's board row for reconcile.
+ *
+ *  - row missing (task deleted): 'board-closed' - there is nothing left to ask.
+ *  - status no longer todo, or archived: 'board-closed' - the other end dealt
+ *    with it; the card must stop counting and stop re-asking.
+ *  - still todo but notes carry a terminal verdict: 'verdict-synced' - Zaal
+ *    already ruled on it in a terminal; asking again on the phone is a dupe.
+ *  - otherwise null: a genuinely open card, leave it alone.
+ */
+export function classifyReconcile(
+  row: { status?: string; archived_at?: string | null; notes?: string | null } | undefined,
+): 'board-closed' | 'verdict-synced' | null {
+  if (!row) return 'board-closed';
+  if (row.status !== 'todo' || row.archived_at) return 'board-closed';
+  if (row.notes && TERMINAL_VERDICT_RE.test(row.notes)) return 'verdict-synced';
+  return null;
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -3458,8 +3458,10 @@ bot.callbackQuery(/^grill:ans:(.+)$/, async (ctx) => {
 // are outstanding at once - without it a tap on card 3 would be applied to
 // whichever card was sent last. Cards sent before this shipped carry no id and
 // still fall back to the card in play.
-bot.callbackQuery(/^bg:(done|keep|work|drop|skip)(?::(.+))?$/, async (ctx) => {
-  const [, key, taskId] = /^bg:(done|keep|work|drop|skip)(?::(.+))?$/.exec(
+// `drop` stays accepted for cards sent before the 2026-08-20 Park swap
+// (card 1b7fe7c9) - parseVerdict maps a tapped/typed drop to park.
+bot.callbackQuery(/^bg:(done|keep|work|park|drop|skip)(?::(.+))?$/, async (ctx) => {
+  const [, key, taskId] = /^bg:(done|keep|work|park|drop|skip)(?::(.+))?$/.exec(
     ctx.callbackQuery.data || '',
   ) ?? [];
   if (!key) return;


### PR DESCRIPTION
Grill unification (board card 6b6875d1, Zaal verdict 2026-08-19): one queue, grilled from both ends, state reconciled. The Telegram drip's state file now learns what terminal grill sessions did - 23 stale entries were hand-reconciled on 2026-08-19 (209 -> 186); this makes that automatic.

## What changed (per the card's 4-point spec)

1. **AUTO-RECONCILE** - `reconcileBacklogState()` runs at the start of every tick, before the send gate. Every unanswered asked-entry (requeued included) is checked against the board in chunks of 50: task closed/archived/deleted -> `answered = {verdict: 'board-closed'}`; parked cards get their `requeuedAt` cleared so nothing revives them. A failed chunk read marks NOTHING from that chunk - over-counting is the safe error, silently dropping a live card is not.
2. **VERDICT-SYNC** - a still-todo task whose notes carry a terminal verdict line counts as answered (`verdict: 'verdict-synced'`). The marker regex was measured against the live board first: 14/346 todo tasks match, spot-checked real ("GRILL <date> (Zaal):", "ZAAL VERDICT <date>:", plus this runner's own "(Telegram)" form). Bonus from the same spirit: the fresh tier skips a never-asked task already carrying a terminal verdict - sending it a phone card would be the exact both-ends dupe the card exists to kill.
3. **ALL routes kept** - the board query has no route filter (it never had one; a test now pins that so one cannot creep in).
4. **Count agreement** - reconcile runs BEFORE `outstandingCount` feeds the send gate, and the reconciled state is written immediately, so the statusline number (which imports `outstandingCount`) reflects what would actually still send. Reconciles are logged: `[zoe/backlog-grill] reconciled: N board-closed, M verdict-synced`.

## Notes

- `classifyReconcile` treats `in_progress` as board-closed (spec: "no longer status=todo"). This matches existing behavior: `nextTask` only queries `status=eq.todo`, so an in_progress task already never re-surfaces as a card.
- Pure policy (`TERMINAL_VERDICT_RE`, `classifyReconcile`) lives in backlog-grill.ts; IO stays in the runner - same split the two files already document.

## Evidence (loop-evals gates)

- A. `tsc --noEmit`: 0 errors. esbuild bundle of src/zoe/index.ts: clean.
- B. Full bot suite: 188 files, 2466 tests, all pass (2456 on main; +10 from this PR, no regression). The existing runner tests' board mock was extended to answer the reconcile query with live-todo rows - without that, reconcile would have (correctly) flagged their fixtures as deleted.
- C. Anti-bloat: 271 insertions / 1 deletion across 4 files; reuses cfg/readState/writeState/outstandingCount; biome clean on all touched files.
- D. Scope: only the card's spec (+ the fresh-tier dupe guard it implies, called out above).
- E. Safety: fail-closed on every board read; no auth or env behavior changed.
- F. Secret scan of diff: clean (case-insensitive, standalone step).

Deploy: PR-only; lands via the gated zoe-autodeploy flow per the card.

Board card: 6b6875d1 (Grill unification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
