### PR TITLE
docs 2287-2298: transcript re-verify pass - missed items appended (5 calls)

### DIFF
--- a/research/events/2287-yerb-empire-tokenless-aug14/README.md
+++ b/research/events/2287-yerb-empire-tokenless-aug14/README.md
@@ -103,3 +103,30 @@ ZAO context: this call is ZAOstock (Oct 3, Franklin Street Parklet) sponsor/atte
 - [Empire Builder](https://empirebuilder.world) - the platform the Empire + leaderboard were created on. Facts about v3 tokenless, the 20/80 split, cross-chain boosters, and Robinhood/BNB/Monad chain support are as STATED ON THE CALL by Jordan (its founder), not re-verified against docs this run.
 - [Clanker](https://www.clanker.world) - deployment rail Empire uses; v5 "being audited" per Jordan, UNVERIFIED.
 - Not re-fetched this run: pump.fun, AutoBuy, Droid/Neynar, Trinity. All claims about them in this doc are call statements, graded accordingly.
+
+
+## Re-verify pass 2026-08-19 (full transcript re-read vs this doc)
+
+Verification agent re-read the complete transcript. Core decisions all held.
+Additions the first pass missed:
+
+- **FACTUAL FIX - supported chains:** Zaal confirmed on-call that Empire also
+  has **Polygon and Optimism** support ("we have polygon support we have
+  optimism") - the chain list above (Base, Arbitrum, Robinhood, BNB, Monad)
+  was incomplete. Solana remains the one gap.
+- **NEW ACTION - Wyoming DEX outreach:** beyond sending Jordan the material,
+  Zaal committed to his own follow-up: "I owe him a message... I definitely
+  want to collaborate with them more." (Boarded 2026-08-19.)
+- **Token distribution structure discussed** (not yet a decision): team
+  airdrop with vesting past the dump window + a crowdfund list ("pop in
+  twenty dollars... you are now on the list for getting the airdrop...
+  one to one... at a vesting schedule") seeding the LP.
+- **Zalcastr practice-launch ratio options:** "probably take 50% of the
+  tokens or 75 and then put 50% up against a USDC or ETH pool."
+- **Design assumption for ZAOstock:** "We're going to have more people on
+  the stream than we're going to have in person" - the virtual audience is
+  primary; reward design should assume it.
+- **Positioning note (Jordan):** "You don't have to call things tokens. You
+  can call them points" - friction-lowering framing for non-crypto audiences.
+- **WaveWarZ x Empire idea (Zaal):** a no-token Empire per battle,
+  distributing rewards cross-chain to Solana wallets via Farcaster.

--- a/research/events/2295-steve-peer-black-moon-logistics-aug15/README.md
+++ b/research/events/2295-steve-peer-black-moon-logistics-aug15/README.md
@@ -101,3 +101,24 @@ referral on this call ("He's a great guy... runs a van to Boston").
 ## Sources
 
 - [FULL] The recording: 30 min, transcribed + diarized locally. Transcripts preserved at `~/.zao/private/meetings/batch-aug17/`.
+
+
+## Re-verify pass 2026-08-19 (full transcript re-read vs this doc)
+
+Core partnership decisions all held. Actions the first pass missed (all
+boarded/folded 2026-08-19):
+
+- **Facebook event** - Zaal, same-day goal on the call: "my goal is to make
+  a Facebook event... that's important for getting the word out locally."
+- **Star 97.7 radio appearance** - "I'm trying to go on the radio with Paul
+  from Star 97.7... hopefully soon."
+- **Partner logos** - not just Black Moon: **Wallace Events and Star 97.7
+  logos** also need adding to the site and materials.
+- **Website photo gallery** - attendees post pictures to the site, "that's
+  what we did with our last one" (post-event engagement feature).
+- **Meal structure detail:** lunches + dinners Thu/Fri/Sat; Thu-Fri smaller,
+  Saturday peaks under ~20 people - feeds the Katina headcount.
+- **Showcase intent:** the WaveWarZ live-traded battles demo is THE thing to
+  show Black Moon in person ("that's kind of our big showcase").
+- **Contingencies:** local acts can fill schedule blanks; Steve suggests
+  ASSIGNING performers to stages rather than polling preferences.

--- a/research/events/2296-dylan-rizzle-clanker-v5-token-planning-aug4/README.md
+++ b/research/events/2296-dylan-rizzle-clanker-v5-token-planning-aug4/README.md
@@ -94,3 +94,23 @@ tier: STANDARD
 ## Sources
 
 - [FULL] The recording: 57 min, transcribed locally. Raw transcript preserved at `~/.zao/private/meetings/batch-aug17/dyl-raw.txt`. Diarization invalid (2-speaker run on a 4-voice call) - deliberately not used.
+
+
+## Re-verify pass 2026-08-19 (full transcript re-read vs this doc)
+
+Decision-complete; operational detail the first pass compressed away:
+
+- **Trinity pool architecture, exact:** 50% USDC primary pair, 15% ETH, 15%
+  Clanker, remainder bought/staked or feeding the **accumulator bot** that
+  compounds fees into new Trinity pairs.
+- **Implementation step:** Rizzle recommends a **Gnosis Safe as the Clanker
+  admin** before launch; he has tooling and offered a setup call.
+- **Airdrop alternative discussed:** stake prior ZAO tokens into a contract
+  for a time window = the airdrop list (participation-gated, not snapshot).
+- **Whipcoin offered as the working model** to replicate, not just an
+  anecdote - the ~$5k bonding-curve floor mechanism is the template.
+- **Open risk, unresolved on-call:** droid economics at Clanker's 10% fee
+  split - "I feel like it dies out too quickly"; whether fees can sustain a
+  droid is THE open question on the recursive design.
+- **FEF idea (exploratory):** "Farcaster Eats First" - post to Farcaster
+  first, auto-cascade to other platforms later; wants a repo if pursued.

--- a/research/events/2297-matteo-livepeer-web3radio-harberger-aug6/README.md
+++ b/research/events/2297-matteo-livepeer-web3radio-harberger-aug6/README.md
@@ -101,3 +101,17 @@ where the $0 YouTube-RTMP MVP was the standing decision.
 - Matteo's Medium articles on Pensy/Harberger ads: Cloudflare-blocked during
   the call; he is dropping links in the Telegram group - attach them here when
   they land rather than citing from memory.
+
+
+## Re-verify pass 2026-08-19 (full transcript re-read vs this doc)
+
+Complete on decisions and actions. Two context notes added:
+
+- **Credibility marker:** Matteo self-flagged his Livepeer knowledge as ~2
+  years stale ("It's been a while that I haven't been an active user...
+  a couple of years") - his Daydream/VST pointers are informed check-ins,
+  not hands-on experience. Verify current state before building on them.
+- **Why Harberger ads (his framing):** "on-chain advertising has big
+  potential especially to democratize the access... a way for people to
+  fund themselves" - the democratization lens, which is the ZAO-values fit,
+  not just the mechanism.

--- a/research/events/2298-paper-bomb-squad-collab-aug5/README.md
+++ b/research/events/2298-paper-bomb-squad-collab-aug5/README.md
@@ -99,3 +99,22 @@ people's secrets").
 ## Sources
 
 - [FULL] The recording: 36 min, transcribed + diarized locally. Preserved at `~/.zao/private/meetings/batch-aug17/`.
+
+
+## Re-verify pass 2026-08-19 - SPEAKER ATTRIBUTION FLAG (unresolved)
+
+A full transcript re-read flagged possible reversed attributions in "the
+exchange" section: the transcript's Speaker 1 says they use Firefly, found
+Audos (via Lu.ma), and run the ZABAL auto-like - and the verification pass
+read Speaker 1 as Paper, which would invert this doc.
+
+HELD AS UNVERIFIED, leaning original-correct: Zaal's standing tooling
+(Firefly-only posting rule, Audos usage, ZABAL is Zaal's brand, ICM keys are
+Zaal's) matches Speaker 1's statements, so Speaker 1 is more plausibly ZAAL
+and this doc's attribution stands. The transcript's speaker labels are the
+weak link, not the doc. Zaal can settle it in five seconds.
+
+Two items that hold regardless of speaker:
+- A shared **Obsidian project folder** for the collaboration was planned
+  (ICM material + ZAO Festivals info dropped in).
+- A **livestream demo of the Bomb Squad store** purchase flow was planned.


### PR DESCRIPTION
## Summary
Re-verification of five call docs against their full transcripts (5 parallel agents, one per call). Appends missed actions, one factual fix (2287 chain list: + Polygon, Optimism), compressed operational detail, and one HELD-UNVERIFIED speaker flag (2298) rather than a blind correction.

## Tier
Verification pass (append-only prose on existing docs, no renumbering)

## Sources
Each doc folder transcript.md read in full by its agent; findings spot-held against known Zaal tooling before applying (2298 corrections NOT applied - flagged instead).

## Next Actions
New board cards: Facebook event, Star 97.7 radio, Wyoming DEX outreach. Logos folded into the Sam brand-kit card.