### PR TITLE
docs 2279/2310/2316: transcript re-verify batch 2 - Baraza deadlock fixed, team structure recovered

### DIFF
--- a/research/events/2279-ellsworth-promo-marketing-chesnee-aug13/README.md
+++ b/research/events/2279-ellsworth-promo-marketing-chesnee-aug13/README.md
@@ -119,3 +119,34 @@ Flagged rather than guessed. Do not treat any of these as settled.
 - PR #35 on ZAODEVZ/ZAOstock - removes the unapproved Heart of Ellsworth partner claims and adds the approved partners.
 
 Full transcript: [transcript.md](transcript.md)
+
+## Re-verify pass 2026-08-19 (full transcript re-read vs this doc)
+
+No contradictions; the doc's handling of open questions held up. Two
+operational items were missing:
+
+**1. Zaal's lodging for the festival window** - not recorded anywhere:
+
+> "i'm actually going to be staying at the bed and breakfast on church that
+> i guess paul is a partner with a guy by the name of bill um it's the
+> victorian... just a couple blocks from downtown"
+
+The Victorian B&B on Church Street, a couple of blocks from downtown; Bill
+runs it and Paul (Star 97.7) is a partner. That connection also explains
+part of the Star 97.7 relationship.
+
+**2. The consultant meeting did not happen** on 2026-08-13 - Chesnee: "We
+had a meeting today and the meeting didn't happen." That is the reason the
+YouTube/Gmail migration is still open and the video stays unpublished; it
+is a delay with a cause, not a stalled decision.
+
+**3. Scope note on the radio booking:** the constraint is Zaal taking a day
+off, not Paul's willingness - "I need to get a day where I can take off and
+go on the radio." Paul is already on board.
+
+**4. Spectrum Reach** is the umbrella REGIONAL campaign (video + digital
+assets) that the Maine Craft Weekend listing feeds into, rather than a
+standalone channel.
+
+Still open, unchanged: whether Cara (director) and Karen (clay workshop)
+are the same person, and Eric Marisha's current vs former board status.

--- a/research/events/2310-zaostock-standup-aug17/README.md
+++ b/research/events/2310-zaostock-standup-aug17/README.md
@@ -139,3 +139,46 @@ Zaal's confirmation.
 - Diarization attempted (sherpa-onnx), discarded: 150 speakers detected on a
   ~5-voice call - labels unusable, content attribution used instead
 - Doc 2295 + doc 1045 + the 2026-08-17 standup artifact page - [FULL, internal]
+
+## Re-verify pass 2026-08-19 (full transcript re-read vs this doc)
+
+No contradictions found; three material omissions and one attribution fix.
+
+**1. THE TEAM STRUCTURE was missing entirely** - the standup assigned it
+explicitly and this doc did not carry it:
+
+> "we got Steve here and Katina, who are the owners of Black Moon... Then
+> we got Paper and Candy on the design side... Then we got music set up.
+> That's going to be Philems D. Coop helping support when I have AV
+> questions."
+
+- Venue / logistics: **Steve Peer + Katina (Black Moon)**
+- Design: **Paper + Candy**
+- Music + AV: **Dcoop**
+Each supports Zaal outside the standup itself.
+
+**2. ATTRIBUTION FIX.** The VERIFY item "I've been performing 15 years,
+strict on sets" is **Steve Peer**, not Dcoop - it sits inside Steve's own
+monologue on set discipline and the 45-minute structure. Resolved.
+
+**3. Dcoop's personal bridge loan** (material, not just "willing to buy
+gear"):
+
+> "i'm gonna have money coming in in january and february specifically for
+> zao festivals so even if i have to be the one that allocates like a
+> four-month portion you know loan and that it's getting paid back into...
+> for a zao festivals purchase I'm willing to do that."
+
+A four-month personal bridge repaid from Jan/Feb ZAO Festivals revenue.
+Treat as an offer on the record, not an accepted commitment - Zaal decides.
+
+**4. Steve's hip-hop crew has TWO slots**, not one: an afternoon teaser gig
+as well as the after-party anchor ("ideal for a little spot in the
+afternoon, like a little teaser gig... they clearly would be a great anchor
+for like the after party"). Steve also intends to book one of his own bands.
+
+**5. Still unresolved** (transcript does not settle them): whether the
+Momentify question came from Paper rather than Dcoop, and who recommended
+the brag/watch skills. The doc's MEDIUM flags on both were correct.
+Separately, the deck reference transcribes as "len" and reads as Fellenz -
+worth a one-word confirm.

--- a/research/events/2316-motomoto-zaostock-virtual-catchup-aug18/README.md
+++ b/research/events/2316-motomoto-zaostock-virtual-catchup-aug18/README.md
@@ -77,3 +77,30 @@ Full transcript: [transcript.md](transcript.md) (in this doc's folder: `research
 | Baraza test done and result noted on the board card | @Zaal | board card | 2026-08-22 |
 | Paste stakeholder recap reply to Aziz + Iman | @Zaal | tap | 2026-08-18 |
 | CRM merge Aziz/Motomoto rows (within completeness review) | @Zaal | board card | 2026-08-25 |
+
+## Re-verify pass 2026-08-19 - REVERSED ACTION CORRECTED (was blocking the test)
+
+Full transcript re-read. Everything else in this doc verified accurate
+(team lead, test-this-week, 12-6pm window, 5-10 crew, desktop + VPS/Pi
+fallback, TG coordination, LiDAR, fractal ping to Iman, Slack parked).
+
+**The one error, and it was a deadlock.** This doc recorded the plugin/spec
+exchange backwards. Transcript 05:23, AZIZ TO ZAAL:
+
+> "If you can send me the specs for your device, I can share with you some
+> plugins that you will need to run the live stream so that you can start
+> installing them meanwhile."
+
+Zaal: "just send it to me."
+
+CORRECT ORDER: **Zaal sends the desktop specs FIRST; Aziz then sends the
+plugin list.** The doc's action row ("Aziz sends plugin list + specs") had
+both sides waiting on each other, which is why nothing moved between 8/18
+and 8/19 with the test due 8/22. Board card 654b9aba corrected and raised
+to P1 on 2026-08-19; a specs message is clipboarded for Zaal.
+
+Independent of the exchange, the ZAO-side install list is already known
+from the baraza-tv repo: OBS 28+, Advanced Scene Switcher plugin plus
+obs/advss/baraza-advss-v2.json macros, the scenes/Baraza_Live.json
+collection, Python 3.12 + requirements.txt for baraza-bridge.py, 64-bit
+VLC for the playout scenes, OBS WebSocket on 4455.


### PR DESCRIPTION
## Summary
Batch 2 of the transcript re-verify sweep (3 parallel agents). One finding was blocking live work: doc 2316 recorded the Aziz spec/plugin exchange backwards, so both sides were waiting on each other with the Baraza test due 8/22. Also recovers the ZAOstock team structure (absent from 2310 entirely), fixes a speaker attribution, and records Dcoop's bridge-loan offer and Zaal's lodging.

## Tier
Verification pass (append-only, no renumbering)

## Sources
Each doc folder transcript.md read in full by its own agent; unresolved attributions left flagged rather than guessed.

## Next Actions
Board card 654b9aba corrected to P1 with the right direction + specs message clipboarded. Team-structure and bridge-loan items boarded separately.