### PR TITLE
fix: AGENTS.md route-count drift (322/55 -> 324/62) - unblocks the guardrail check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ npx biome check src/lib/agents        # lint specific module
 ## Project Structure
 
 ```
-src/app/api/         # 322 route handlers across 55 domains: /api/[feature]/[action]/route.ts
+src/app/api/         # 324 route handlers across 62 domains: /api/[feature]/[action]/route.ts
 src/components/      # 296 components organized by feature
 src/hooks/           # 18 custom hooks (useAuth, useChat, useRadio, etc.)
 src/lib/             # Utilities across 42 domains (auth, db, farcaster, music, publish, agents)


### PR DESCRIPTION
One line. The estate drift guard fails because AGENTS.md claims **322 route handlers across 55 domains**; the repo has **324 across 62**.

Counted directly rather than trusting the guard: `find src/app/api -name route.ts | wc -l` = 324, `ls -d src/app/api/*/ | wc -l` = 62. CLAUDE.md already carries 324/62, so AGENTS.md was the stale half of the pair it mirrors.

Found by the shepherd loop's PR merge-readiness pass while diagnosing why #3133 was red. Separately, #3126's guardrail failure is unrelated: a GitHub 429 while downloading actions/github-script on Aug 17, an infra flake that just needs a re-run.

Generated with Claude Code

https://claude.ai/code/session_01GrEx2uvSUbu61NiXegUrjg