### PR TITLE
rules: thread-discipline told every session to run `todo`, which is gone

### DIFF
--- a/.claude/rules/thread-discipline.md
+++ b/.claude/rules/thread-discipline.md
@@ -18,11 +18,22 @@ don't hold them in working memory or the transcript alone.
    truth for "what's still open," not the chat scrollback.
 
 2. **PARK-ON-PIVOT - when Zaal jumps threads before the current one is done,
-   capture the leaving thread to the inbox FIRST, then follow.** Run
-   `todo "<the parked thread + its next step>"` so it lands in the cowork inbox
-   and enters triage->crush. Never let a pivot leave a thread living only in the
-   conversation. A one-line `todo` is cheap; a lost thread is not. (If `todo` is
-   unavailable, mark it parked in the ledger and surface it in the end recap.)
+   capture the leaving thread FIRST, then follow.** Never let a pivot leave a
+   thread living only in the conversation. Capturing is cheap; a lost thread is
+   not.
+
+   > **TOOL STATUS 2026-08-19: `todo` IS NOT PRESENT on this Mac.** Verified four
+   > ways - absent from `~/bin` and `~/zaal-dotfiles/bin`, never in dotfiles git
+   > history (so git cannot restore it), and not a shell alias or function.
+   > `crush`, `cockpit`, `zao-triage`, `morning-pick` and `ztui` are gone with it.
+   > Board card 78f3279f tracks restore-or-retire.
+   >
+   > **Until it returns, the fallback IS the path:** write the parked thread into
+   > the session's task ledger AND straight onto the cowork board (the board is
+   > untouched and reachable), or send it to ZOE on Telegram, which is still a
+   > live capture door. Then surface it in the end recap. Do NOT invoke `todo`
+   > and assume it landed - it exits "command not found", which is a silent drop
+   > if nobody reads the shell output.
 
 3. **END RECAP - on a natural stop, a `/compact`, or when asked, surface the
    ledger in three buckets:** DONE (shipped, with proof - PR#/file), PARKED


### PR DESCRIPTION
A rules-vs-reality audit across all 30 rule files found this one **instructing a command that does not exist on this Mac.**

`todo` is the capture door in PARK-ON-PIVOT - the step that stops a thread evaporating when Zaal jumps mid-work. A session following the rule literally would run it, get `command not found`, and **silently drop the very thread it was trying to save.**

Verified four ways before changing anything: absent from `~/bin` and `~/zaal-dotfiles/bin`, **never present in dotfiles git history** (untracked-and-vanished, not a deletion git can undo), and not a shell alias or function - `.zshrc` only puts `~/bin` on PATH. `crush`, `cockpit`, `zao-triage`, `morning-pick` and `ztui` are gone the same way. Board card `78f3279f` tracks restore-or-retire.

The rule already carried a fallback clause; this promotes it to **the** path while the tool is missing, and names the two capture doors that still work: the cowork board directly, and ZOE on Telegram.

**Two false positives, checked and deliberately not changed:** CLAUDE.md's `icm` hit is inside a box id (`icm_-hsPHePpq...`), and workflow-discipline.md only references the `icm-grounding.md` filename.

**The rest of the rules' paths are clean.** The remaining unresolved ones are prose examples: `rm ~/x/*` in no-rm-rf, the `gmail-`/`gcal-` naming templates in pii-hygiene, and the `foo` route in tests.md.

Generated with Claude Code

https://claude.ai/code/session_01GrEx2uvSUbu61NiXegUrjg