### PR TITLE
docs 994/953: transcript re-verify batch 3 - one doc cites lines past the end of its own transcript

### DIFF
--- a/research/events/953-deez-boardwalk-token-launcher/README.md
+++ b/research/events/953-deez-boardwalk-token-launcher/README.md
@@ -127,3 +127,65 @@ Boardwalk is positioned as infrastructure for **meaning-driven tokenization** (a
 - **Recording:** MP4, local mlx-whisper transcription (raw transcript at `transcript.md`)
 - **Confidence level:** High (transcript is clear, ~11 minutes)
 - **Garbled points:** Line 289-290 ("the evil of having the, uh, the evil of...") - intent clear but phrasing awkward; Line 98-101: specific percentage number wavered ("0.2% ... 0.25% ... let me get that correct number") - defer to Deez for exact LP fee percent.
+
+## Re-verify pass 2026-08-20 (full transcript re-read vs this doc)
+
+### The citations in this doc point past the end of its own transcript
+
+VERIFIED, not taken on a subagent's word: `transcript.md` is **156 lines**.
+The Decisions table cites lines **166-168, 170-171 and 172**. Those line
+numbers do not exist. The quotes themselves are real and accurate - they sit at
+transcript **lines 92-96** - so the substance stands and only the pointers are
+wrong, most likely written against a differently-formatted copy.
+
+Corrected anchors for the three spot-checked rows:
+
+| Doc cites | Actually at | Quote |
+|---|---|---|
+| lines 166-168 | **92-93** | "I'll take this recording and the LLMS.txt and parse it through my clod" |
+| lines 170-171 | **95** | "I'm probably going to launch as a clanker because of empire builder" |
+| line 172 | **96** | "for Zao festivals, this will be perfect" |
+
+The remaining citations in the Action Items and Quotes tables are wrong by a
+similar margin but were NOT rewritten here - correcting a line number without
+opening each one would be swapping a checkable error for an unverified guess.
+Anyone editing this doc should re-anchor each row against the 156-line file.
+
+(Minor: the doc quotes "the LMS Text"; the transcript says "the LLMS.txt".)
+
+### Status as of 2026-08-20 - both action items have expired
+
+- **Parse the Boardwalk transcript through Claude** was due "today or tomorrow"
+  from 2026-06-29. That is ~50 days ago with no recorded follow-up.
+- **The ZAO Festivals launch** targeted the days before a 2026-07-23 mini-DC
+  festival - ~4 weeks past.
+- The follow-on technical conversation was gated on the parse, so it never
+  started.
+
+### The blocker this doc records but does not flag as one
+
+Boardwalk requires roughly **10K/10E** of coordinated initial liquidity, and on
+the same call Zaal said plainly: *"realistically, I don't expect our community
+to be able to come up with those kinds of funds."* The doc lists that as an
+open TBD. It is closer to a gating constraint on the entire ZAO Festivals use
+case, and it should be answered before any further Boardwalk work.
+
+### Substance the summary compressed away
+
+- **LP holders earn from THREE fee sources**, not one: fee on transfer, fees in
+  the pool itself, and LP staking (which accrues "participation points"). The
+  summary names only the 0.23-0.25% transfer fee, which undersells the model.
+  What the "hundred percent rate" of participation-point accrual is measured
+  against is never defined on the call - genuinely unresolved, not omitted.
+- **Graduation auto-creates a Café Boardwalk profile** - a product feature the
+  Café description leaves out.
+- **The architectural trade-off in Deez's own words:** "There's either the bond
+  curve evil where people can change their mind midsection, or there's the evil
+  of having to coordinate a bunch of capital to get something to graduate. But
+  that initial liquidity is locked there... it makes sure that anyone who's
+  participating knows that they always have a way in and out of the token."
+- **The DeFi session is an OFFER, not a decision.** Deez proposed it; Zaal did
+  not accept. The doc's own note says he "did not commit verbatim", so listing
+  it under Decisions overstates it.
+- The 25-person volunteer pool is not uniform: "five or ten that are very
+  active" is the real number for any fee-sharing mechanism.

--- a/research/events/994-zabal-gamez-poidh-fireside-unlock-jul8/README.md
+++ b/research/events/994-zabal-gamez-poidh-fireside-unlock-jul8/README.md
@@ -242,3 +242,50 @@ Proposed (not yet written - needs Zaal's confirm per the skill's memory-write ga
 ## Transcript
 
 Full transcript: [transcript.md](transcript.md)
+
+## Re-verify pass 2026-08-20 (full transcript re-read vs this doc)
+
+No contradictions. Decisions and action items all hold. Missing context and
+three status corrections, with live-vs-expired called out because this doc is
+six weeks old and a recovered July action is noise unless it is still true.
+
+**STATUS CORRECTIONS (the useful half):**
+
+- **zolcaster is no longer a "research seed" - it SHIPPED.** On the call Zaal
+  described it as a private client he was building. It launched as the
+  **Zalcastr** practice launch (Wed 2026-08-19, per the Yerb call, doc 2287).
+  Read the seed entry as history, not as a pending idea.
+- **Unlock Protocol sparking bounties was Zaal's literal NEXT coding task**,
+  not a deferred TODO: "that's going to be the next thing I code up here once
+  I grab this."
+- **The Logadog bounties have expired.** The call (2026-07-08) said "a couple
+  more weeks" past July 4; that window closed in July. Action item 8 should
+  read as done-or-lapsed, not pending.
+
+**COLLABORATORS THE DOC DID NOT NAME:**
+
+- **diviflyy** (Empire Builder) - "We had an awesome call with divvy fly of
+  empire builder yesterday". The transcript spells it phonetically; the
+  canonical handle is **diviflyy** (10 occurrences across ZAO memory and
+  research, incl. a July Divifly coding stream and the ZABAL Empire top-3
+  anchors). Recorded under the canonical spelling deliberately - the phonetic
+  form would not match anything on a future search.
+- **nickysap** - building an mp3-to-mp4 tool for Farcaster with Zaal's support.
+  Named in an action item but never recorded as a partner; per
+  `credit-attribution.md` a collaborator gets named as one.
+- **Lance and Burr** - the established Farcaster poker community Mauro
+  connected with; relevant to any ZAO Poker work.
+- **kmacb.eth** and **gencommunist.eth** - active POIDH bounty creators.
+
+**OPERATIONAL:**
+
+- A **private Farcaster group chat** coordinates ZABAL Gamez ("shoot me a DM"
+  to join) - a live coordination surface the doc never mentions.
+- Kenny's two remaining **$25 Farcaster bounty boosts** are a finite resource
+  with no expiry recorded.
+- Buildathon submissions have three formal categories: **artist** (art of any
+  kind), **builder** (code), **creator** (media).
+- Bounty-ecosystem scale at the time: a $5,000 "encrypt the mempool" bounty, a
+  $900 GM-Farcaster sponsor-referral bounty, and a $140 interview-a-politician
+  bounty then being widened beyond US politicians.
+- Mauro was also evaluating **Svelte** for the ZAO Poker front end.


### PR DESCRIPTION
Batch 3 of the transcript re-verify sweep (2 parallel agents, findings verified by hand before applying).

**953 - the doc cites line numbers that do not exist.** Its Decisions table points at transcript lines **166-172**. The transcript is **156 lines long.** I checked this directly rather than trusting the agent: the quotes are real and sit at **lines 92-96**, so the substance stands and only the pointers are wrong - most likely written against a differently-formatted copy. Three rows are re-anchored; the rest are deliberately left, because correcting a line number without opening each one trades a checkable error for an unverified guess.

Also on 953: both action items **expired** (the parse was due 2026-06-30, the launch targeted 2026-07-23); the LP model has **three** fee sources, not the one summarised; the DeFi session is an offer Zaal **declined**, filed under Decisions; and the ~10K/10E liquidity requirement sits directly against Zaal's own words on the call - *"I don't expect our community to be able to come up with those kinds of funds"* - which is a gating constraint the doc files as a TBD.

**994 - three status corrections worth more than the missing context:**
- `zolcaster` is listed as a research seed. It **shipped**, as the Zalcastr practice launch (doc 2287).
- Unlock sparking bounties were Zaal's *literal next coding task*, not a deferred TODO.
- The Logadog bounties **expired in July**.

Plus four collaborators the doc never recorded as such: **diviflyy** (Empire Builder), **nickysap** (mp3-to-mp4 tool for Farcaster), and the established Farcaster poker community. The `diviflyy` spelling is deliberate - the transcript renders it phonetically as "divvy fly", and ten occurrences across memory and research give the canonical handle. Recording the phonetic form would have made it unsearchable.

Generated with Claude Code

https://claude.ai/code/session_01GrEx2uvSUbu61NiXegUrjg