### PR TITLE
docs 952/951/950: transcript re-verify batch 4 - a legal hedge restored, an invented number flagged

### DIFF
--- a/research/events/950-ohnahji-zaal-strat-sesh/README.md
+++ b/research/events/950-ohnahji-zaal-strat-sesh/README.md
@@ -162,3 +162,47 @@ Renee (Artisan lead, weekly fund-manager mtgs), Gabe Covington / Hip Hop Crypto 
 ## Sources
 
 Raw transcript captured via mp4 recording and transcribed locally using mlx-whisper. Extract processed from transcript 2026-07-02.
+
+## Re-verify pass 2026-08-20 (full 1,245-line transcript re-read)
+
+### The bad number is still sitting in the decisions table
+
+This doc's own Deep Dive already caught it: "Buy side volume: 383,364 SOL" is
+impossible against ~500 SOL lifetime volume. But the figure is still presented as
+fact in the table above, where a reader will hit it first and the correction last.
+
+Verified at source (transcript 514): Zaal, reading a Dune dashboard aloud, says
+the buy side "is three, eight, three 64." That is a spoken string a transcript
+cannot disambiguate - it could be 383.64, 383,64 in a European decimal, or
+something else entirely. **Treat the table entry as UNVERIFIED**; the number
+needs re-reading off the dashboard, not off this doc.
+
+### Citation offsets
+
+Two quotes sit a few lines from where they are cited - the transcript is 1,245
+lines and both quotes exist, so this is drift rather than fabrication:
+
+- "There's so much in here..." is cited at 183-185; it begins at **186**.
+- "The goal here is to create like project management Kanban style boards..." is
+  cited at 36-38; it begins at **39**.
+
+### Expired actions
+
+- Review Zao.xyz board task #562 - due 2026-07-03, ~7 weeks past.
+- The 24-hour stream event targeted ~2026-08-07 and the transcript shows planning
+  only, no booking. Separately, the 24-hour stream idea was CLOSED on 2026-08-19
+  as never-happened (board card 082da183), so this one is settled: it did not run.
+
+The rest (whitepaper, Solana bridge test, Flow Stage review, Sam coordination,
+Artizen study, Twitch API) carry no dates and remain open.
+
+### On coverage - a deliberate non-finding
+
+An automated pass graded this doc as covering only ~30-40% of the transcript and
+flagged the compressed personal material - work shifts, family time, health,
+decompression - as under-representation. **That compression is correct and should
+not be "fixed."** A research doc records decisions and commitments; a colleague's
+and Zaal's personal circumstances are not repo content, and expanding them here
+would be a PII regression, not an improvement (`pii-hygiene.md`). The genuine
+coverage gap is elsewhere: the long Zao.xyz demo walkthrough (~377 lines) is
+summarised thinly, and that is the part worth expanding if anyone revisits.

--- a/research/events/951-greg-autonomous-wavewarz-legal/README.md
+++ b/research/events/951-greg-autonomous-wavewarz-legal/README.md
@@ -115,3 +115,61 @@ Greg advised: risk-first entity planning (identify liability exposure before pic
 
 - Raw transcript: `/research/events/951-greg-autonomous-wavewarz-legal/transcript.md`
 - Transcription method: mlx-whisper (local) from mp4 recording (2026-07-01)
+
+## Re-verify pass 2026-08-20 - two corrections that affect legal decisions
+
+All six quoted passages verified verbatim against the transcript, attendees and
+every number (33/33/33, 50/50, 1.5 years, 18+ jurisdictions) traced. Citations
+are accurate. Two things in this doc could still mislead a decision.
+
+### 1. The CC0 line inverts Greg's actual position
+
+This doc records CC0 as a "fallback to traditional IP registration." Greg said
+close to the opposite. In his words (transcript 146-153):
+
+> "the ones that will win for sure are the cooperative ones... as an excellent
+> proof that you own that piece of music for example... creative commons is
+> very able to do it"
+
+and immediately after:
+
+> "the reality is that if you face a court or a legal suit well you will need
+> the proper tools not like this easygoing and accessible way of registering
+> intellectual property"
+
+So CC0 is **proof of authorship, and explicitly NOT court-ready**. Traditional
+filings are what he expects to win. Reading this doc's phrasing as permission to
+prioritise CC0 over trademark/IP filings would be reading it against the source.
+
+### 2. "May be worth 5-10% of deal" is not Greg's number
+
+The Deep Dive line "Offshore for friction, not safety... May be worth 5-10% of
+deal" carries a figure Greg never gave. The only percentages in the transcript
+are "hundred percent protectable/covered" (about liability, not valuation) and
+"one percent fees" (about the platform). Treat the 5-10% as the earlier author's
+own estimate, not legal advice received - it is unattributed either way.
+
+### Elevated from Research Seeds - two decision-level facts
+
+- **Nominee directors remove you from the public registry.** Greg (235-237):
+  "you won't be registered in any specific like public residency in caiman or
+  panama or whatever because we have nominee services that is a person that will
+  be representing you guys." That is a material privacy/liability property of the
+  offshore option, not background reading.
+- **The US pass-through buys bank-loan access.** Greg (224-231) gives that as a
+  specific reason for the hybrid structure - capital access, not just tax
+  simplicity. It is currently one item in a comma list.
+
+### Context that changes how to read the TBDs
+
+The call was time-boxed - "actually we're only on for seven more minutes"
+(line 167) - and one attendee said he was distracted in the closing stretch. The
+open TBD items were agreed under time pressure, so treat them as intentions
+rather than firm commitments. All action items are now ~50 days old with no
+recorded closure.
+
+### Actionability defect
+
+The follow-up action points at "otomos.com" (elsewhere "otomós.com"). On the call
+Greg spells it aloud as "o-t-o-m-o-s" while the screen shows a different domain
+(254-256). Confirm the real URL before anyone tries to action it.

--- a/research/events/952-viniapp-brainstorm/README.md
+++ b/research/events/952-viniapp-brainstorm/README.md
@@ -85,3 +85,46 @@ useicm.com / ICM (Chris's context tool, 129, 178), Nicky Sap (Chris's dev collab
 - [FULL] Re-transcribed recording (mlx-whisper turbo, anti-hallucination flags), `transcript.md` in this folder - 2026-07-05, ~6,000 words, verified loop-free.
 - Cross-ref: doc 950 (Ohnahji strat sesh) names "Chris Dolinsky / Vinny app / ICM".
 - Method note: the prior 2026-07-03 recap is superseded - it was written off a corrupted (~90% lost) transcript. Token name corrected ZOL -> ZABAL against transcript line 20.
+
+## Re-verify pass 2026-08-20 (full transcript re-read vs this doc)
+
+### ICM stands for "identifier context and mail" - the ambiguity was an artefact
+
+This doc records the acronym as `identifier context [mail/mgmt], line 178 - last
+word not fully audible`. The source is not ambiguous. The transcript simply wraps
+mid-sentence:
+
+- line 178: `a big piece of the ICM too is that so ICM stands for identifier context and`
+- line 179: `mail. So for instance, your Claude code and my Claude code,`
+
+Read across the line break it is plainly **"identifier context and mail"**, from
+Chris, who built useicm.com. Worth carrying beyond this doc: `icm-grounding.md`
+governs 24+ ZAO boxes and never states what the acronym expands to.
+
+The general lesson is cheap and repeatable: a quote cut at a line boundary can
+manufacture an ambiguity the speaker never had. Read one line further before
+recording uncertainty.
+
+### Staleness - this recap is ~7 weeks old and its actions have passed
+
+Every near-term action item here was due in early-to-mid July: try useicm.com and
+report back, draft the summary, share mentor evaluation criteria, build the GitHub
+integration. As of 2026-08-20 they are 38-52 days past. Read them as history
+unless separately revived; the ICM box work did continue (three ZAO boxes were
+published 2026-08-19).
+
+### Context the recap dropped
+
+- **Zaal was already building the thing Viniapp scaffolds.** "I've been on a
+  light tear just like sending my clod off to just like make basic small games
+  for the Zibal games" (11-13). That makes Viniapp a personal use case rather
+  than an abstract product discussion, which is the whole reason the beginner
+  tier matters to him.
+- **The beginner gap is specific, and it is the product's problem statement**
+  (23-40): never coded, does not know what a database is, does not know iOS from
+  Android, does not know how an app reaches the store or how a game gets "onto
+  your screen."
+- **Chris is his own first user** - a separate context box per project (himself,
+  Aware AI, ViniApp, API now.fun, ICM), which is the model demonstrating itself.
+- One small action never recorded: Zaal asked Chris for his bio to build him a
+  box (465).


### PR DESCRIPTION
Batch 4 of the transcript re-verify sweep (3 agents; every load-bearing claim re-checked against the transcript before writing).

**951 (Greg / Autonomous, legal) - two things that could push a decision the wrong way.**

1. The doc records CC0 as a *"fallback to traditional IP registration."* Greg said close to the opposite. CC0 is excellent **proof of authorship**, but *"if you face a court or a legal suit well you will need the proper tools not like this easygoing and accessible way of registering intellectual property"* - and the lawyers who file conventionally *"will win for sure."* Someone reading the doc alone could deprioritise trademark filings on the strength of a hedge that had been removed.
2. The Deep Dive asserts offshore structure *"May be worth 5-10% of deal."* **Greg never gave that figure.** The only percentages in the transcript are "hundred percent protectable/covered" (liability) and "one percent fees" (the platform). Now marked as the earlier author's estimate rather than advice received.

Also elevated two decision-level facts buried in Research Seeds - nominee directors keep you off the public registry, and the US pass-through buys bank-loan access - and noted the call was time-boxed to seven closing minutes, which is how much weight its TBD items can carry.

**952 (Viniapp) - an ambiguity that was never in the source.** The doc records `ICM = identifier context [mail/mgmt], last word not fully audible`. The transcript simply **wraps mid-sentence**: line 178 ends `"...identifier context and"`, line 179 begins `"mail."` So **ICM is "identifier context and mail"**, from the person who built useicm.com. Worth carrying beyond this doc - `icm-grounding.md` governs 24+ boxes and never expands the acronym. General lesson: a quote cut at a line boundary manufactures ambiguity the speaker never had.

**950 (Ohnahji strat, 1,245 lines) - the bad number outranks its own correction.** The impossible `383,364 SOL` buy-side figure still sits in the decisions table, while the doc's own Deep Dive debunks it further down - so a reader meets the error first and the correction last. Now marked UNVERIFIED at the point of first contact. Two citations drift ~3 lines. The 24-hour stream action is settled: closed 2026-08-19 as never-happened.

**One finding deliberately NOT acted on.** An automated pass flagged 950's compressed personal material - work shifts, family time, health - as under-representation. That compression is **correct**. A research doc records decisions; expanding personal circumstances into the repo would be a PII regression, not an improvement. Recorded in-doc as a non-finding so a future pass does not "fix" it.

Generated with Claude Code

https://claude.ai/code/session_01GrEx2uvSUbu61NiXegUrjg