### PR TITLE
docs 949/948/947: transcript re-verify batch 5 - split-speaker quote, mistranslated chain, three unhonoured promises

### DIFF
--- a/research/events/947-marie-zaal-zao-fund-intake/README.md
+++ b/research/events/947-marie-zaal-zao-fund-intake/README.md
@@ -85,3 +85,52 @@ Zaal called Marie after she applied to the ZAO Fund via Artisan to discuss colla
 ## Sources
 
 - Local recording transcribed via mlx-whisper (whisper-large-v3-turbo), 2026-07-03. Full transcript in transcript.md. [FULL]
+
+## Re-verify pass 2026-08-20 (full 355-line transcript re-read)
+
+Every citation checked and every figure traced: Marie's 15,000 EUR goal, the
+~3,000 raised, the 12,000 two-week sprint, the fund's ~$10.5K/$10,000/$433, the
+$1,000 Artizen pool, her $600 unlocked and $300 remaining, and the $500 ZAO match
+making $1,500. **Nothing fabricated** - unusually clean on numbers.
+
+### The hedge that got upgraded to certainty
+
+The action item records "Add Marie's project to ZAO Fund Discord voting by end of
+Wednesday" at **High confidence**. What was actually said (155-159) is firm about
+the doing and uncertain about the outcome:
+
+> "I'll make sure on Wednesday, at the end of the day on Wednesday, even though
+> I think the timer will end on Wednesday... And we can both look at it then and
+> go check that same place on your fund, on your website, and we'll **hopefully**
+> see Artisan Endowment and then also the Zao."
+
+Plus "the way the funding, my understanding it works is..." - someone describing
+a mechanism they are still learning. The commitment is real; the confidence that
+it would display correctly was not.
+
+### Three promises to a third party, 59 days old, no recorded outcome
+
+This doc was last validated 2026-07-03 - eleven days after the call and **before
+the Wednesday deadline it tracks could even resolve**. It is frozen at the moment
+of promising, which is exactly when a doc is least useful for accountability.
+
+| Promised to Marie | Source | Recorded outcome |
+|---|---|---|
+| Add her project to the ZAO Fund vote by Wed 2026-06-26 | 155-159 | none |
+| Introduce her to Civil Monkey | 63 | none |
+| Send the Maine music-events URL on WhatsApp | 237 | none |
+
+The Maine URL was **contingent and the doc does not say so**: at 235-236 Zaal
+says "I don't have any projects up. I will be" - the link could not be sent until
+he created the thing. An action item that omits its own precondition reads as
+neglected when it was actually blocked.
+
+On the Civil Monkey introduction, one nuance worth keeping before anyone treats
+it as a broken promise: at 64 the reply is "he's in Berlin. I know him also...
+he's a close collaborator of mine." The speaker labels here are inferred, so it
+is genuinely unclear whether Marie already knew him - in which case the
+introduction was courtesy rather than access. Recorded as **unresolved**, because
+guessing either way changes what is owed.
+
+These are commitments to someone outside ZAO who was mid-crowdfund at the time.
+Carded for Zaal rather than left in a doc, since only he can say what happened.

--- a/research/events/948-empire-builder-zabal-gamez-build-sesh/README.md
+++ b/research/events/948-empire-builder-zabal-gamez-build-sesh/README.md
@@ -69,3 +69,51 @@ Three interleaved threads: (1) token strategy - Person A will wait for Clanker v
 ## Sources
 
 - Local recording transcribed via mlx-whisper (whisper-large-v3-turbo), 2026-07-03. Full transcript in transcript.md. [PARTIAL - Whisper single-block with heavy padding; speaker attribution medium-confidence, softer-item owners marked low]
+
+## Re-verify pass 2026-08-20 (full 817-line transcript re-read)
+
+All four quotes verified verbatim at their cited lines; every technical claim
+(splits, audited contracts, leaderboard, boosters, droids-on-legacy-tokens,
+self-serve API-key portal, ZOL under ZOE) traced to source. No fabricated
+numbers. Four corrections.
+
+### "zavall" should be ZABAL
+
+The brand appears as `zavall` three times here. The transcript says "Zabal"; the
+canonical form is **ZABAL** (all caps - `CLAUDE.md` brand glossary). Left in
+place rather than silently rewritten, because a doc's own text is evidence of
+what a transcript produced - but any copy taken from this doc should use ZABAL.
+
+### "eth-Seoul bridge" is almost certainly eth-SOLANA
+
+The transcript renders it "eth to soul" (385). WaveWarZ runs on **Solana + Base**
+(memory `project_wavewarz_canonical`, doc 743), and no Seoul/Korea context
+appears anywhere in the call. "Seoul" looks like a plausible-sounding cleanup of
+a phonetic transcription, which is the more dangerous kind of error - it reads as
+a fact. Treat as **Solana**, unverified against the audio.
+
+### A ~90-line legal/regulatory block is missing entirely
+
+Transcript ~440-530 carries a substantial discussion of WaveWarZ smart-contract
+decentralisation, enforcement risk and liability structure. It is absent from
+this recap - not summarised, not seeded, not flagged. That matters more than
+usual because it is the same subject as **doc 951** (the Greg/Autonomous legal
+call), and a future decision that reads only one of the two gets half the
+picture. Anyone re-opening the WaveWarZ legal question should read both.
+
+Two other under-covered blocks: the live Iceberg territory-game demo (~111-260)
+and the game/point/leaderboard mechanics (~260-353). The recap represents roughly
+a tenth of the transcript, which is fine for decisions and thin for mechanics.
+
+### Confidence inconsistency
+
+The live-build stream is Medium in the decisions table and High in the action
+items, for the same commitment - and the transcript settles a concrete slot
+("tuesday 9 00 p.m", with the Melbourne conversion). The action item has it
+right.
+
+### Status 2026-08-20
+
+Every dated action here has passed: the API-key rotation (same-day), the Tuesday
+live-build, the Glonky image-gen fix (June), and the create-Empire step. None
+carries a completion record. Read them as history unless separately revived.

--- a/research/events/949-brandon-wavewarz-zabal-gamez-intro/README.md
+++ b/research/events/949-brandon-wavewarz-zabal-gamez-intro/README.md
@@ -142,3 +142,39 @@ Broader context: Zaal positioned ZAO as a 188-member music/tech collective on Ba
 - **Filename:** Garbled during transcription ("gho-st m-in tops")
 - **Transcript:** Raw text in `transcript.md` (this directory)
 - **Extract:** Structured analysis provided pre-recap
+
+## Re-verify pass 2026-08-20 (full 280-line transcript re-read)
+
+All eight quotes verified verbatim; Brandon's background, handle, the 102
+mini-apps figure, and both parties' locations all trace to source.
+
+### Attribution error - one speaker's thought split across two people
+
+This doc reads "Brandon acknowledged 'so many cleaner ways'" and separately
+"Zaal framed the challenge: 'there's so many better things we could show.'"
+Transcript 224-232 is a single continuous passage from **one** speaker, who owns
+the work throughout - "so i made this and i would love for your help to improve
+this", "this is our wave wars dev wallet", "our operational wallet as well as the
+three founders". Both phrases belong to that speaker. Presenting them as a
+back-and-forth invents an exchange that did not happen.
+
+### "3.5 SOL operational payout" is a threshold, not a rate
+
+Transcript 230: "at 3.5 soul we're paying out our operational wallet as well as
+the three founders." That describes the point at which payouts trigger. Read as
+an ongoing payout rate it would misstate the economics.
+
+### "Franklin St Parklet" - true, but not from this call
+
+The venue does not appear anywhere in these 280 lines. It is nonetheless
+**correct** - Franklin Street Parklet is the confirmed ZAOstock venue across ZAO
+sources. So this is enrichment from outside knowledge, not invention, and it is
+kept. Flagged only so nobody later "verifies" it against this transcript, finds
+nothing, and deletes a true fact. What the call does confirm is the date:
+"october 3rd put it in your calendar" (59).
+
+### Status 2026-08-20
+
+All three action items - calendar add, sending Empire Builder documentation,
+exploring the monorepo - were due within a fortnight of 2026-07-03 and carry no
+completion record. Treat as expired unless revived.


### PR DESCRIPTION
Batch 5 (3 agents; every load-bearing claim re-checked at source, and **two agent claims were themselves wrong** - see below).

**947 (Marie / ZAO Fund intake) is the one that matters.** Its numbers are unusually clean - every figure traced. But it records "add Marie's project to the fund vote by Wednesday" at **High confidence** when what was said is firm about the doing and uncertain about the outcome: *"we'll **hopefully** see Artisan Endowment"*, and *"the way the funding, my understanding it works is..."*

The bigger issue is timing. The doc was last validated **eleven days after the call - before the deadline it tracks could resolve** - so it is frozen at the moment of promising. Three commitments to someone **outside ZAO** have no recorded outcome 59 days on: the fund-vote add, a Civil Monkey introduction, and a Maine music-events URL. The URL was **contingent and the doc does not say so** (*"I don't have any projects up. I will be"*), which makes a blocked item read as a neglected one. Carded for Zaal - only he knows what happened.

On the introduction, line 64 reads *"he's in Berlin. I know him also... close collaborator of mine"* - which may mean Marie already knew him, making it courtesy rather than access. Speaker labels are inferred, so it is recorded **UNRESOLVED** rather than guessed. The guess changes what is owed.

**949 (Brandon intro) - an invented exchange.** The doc splits one continuous passage across two speakers. Transcript 224-232 is a single speaker throughout, who owns the work: *"so i made this"*, *"our wave wars dev wallet"*, *"our operational wallet as well as the three founders"*. Also, "3.5 SOL operational payout" is the **threshold at which payouts trigger**, not a rate.

**948 (Empire Builder, 817 lines) - a mistranslated chain.** "eth-Seoul bridge" is almost certainly **eth-Solana**: the transcript says "eth to soul", WaveWarZ runs Solana + Base, and no Korea context exists in the call. A phonetic transcription cleaned into a real place name is the dangerous kind of error - it reads as a fact. Also `zavall` three times where the brand is **ZABAL**, and a **~90-line block on WaveWarZ smart-contract decentralisation, enforcement risk and liability is missing from the recap entirely** - the same subject as doc 951, so a decision informed by only one of the two gets half the picture.

**Two agent claims corrected before writing.** One flagged "Franklin St Parklet" in 949 as invented because it is absent from the transcript. It is absent - **and correct**, being the confirmed ZAOstock venue. Kept, and flagged as outside enrichment precisely so a later pass does not verify it against this one file, find nothing, and delete a true fact. A second claimed a 948 confidence rating was understated; the transcript settles a concrete slot, so the action item had it right and the decisions table did not.

Generated with Claude Code

https://claude.ai/code/session_01GrEx2uvSUbu61NiXegUrjg