### PR TITLE
fix(bot): add start:zai - the ZAO voice-capture bot had no way to be started

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -9,6 +9,8 @@
     "start": "tsx src/index.ts",
     "dev:devz": "tsx watch src/devz/index.ts",
     "start:devz": "tsx src/devz/index.ts",
+    "dev:zai": "tsx watch src/zai/index.ts",
+    "start:zai": "tsx src/zai/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## What this is

Two npm scripts. `bot/src/zai/` has held a complete Discord voice-capture bot since 2026-07-17 - 942 lines across six modules, with `@discordjs/voice`, `@discordjs/opus`, `discord.js` and `prism-media` all already in `dependencies` - and there has never been a way to start it.

`bot/package.json` had `start` and `start:devz`. It had no `start:zai`. So the bot that doc 2088 decided to build, and that was then built, could not be run by anyone who did not know to type the tsx invocation by hand.

```
"dev:zai":   "tsx watch src/zai/index.ts",
"start:zai": "tsx src/zai/index.ts",
```

Same shape as the existing `dev:devz` / `start:devz` pair. Nothing else changed.

## Why now

Zaal asked this morning how we would build "our own ZAO Craig bot to capture coworking meetings and more." The honest answer is that we already decided and already built it, and the reason it does not feel built is that it was never wired up or deployed:

- **Doc 2088** (2026-07-27, DEEP) is the decision doc, and its `original-query` is almost word-for-word the same question. The call: copy an open-source `@discordjs/voice` recorder rather than adopt a SaaS meeting-bot or fork Craig, Discord voice only.
- **Doc 674** supersedes 673 with the Discord-over-Telegram architecture, on the grounds that per-speaker streams give diarization for free.
- **Doc 1187** describes the shipped ZAI capture + Q&A bot.
- **`bot/src/zai/voice-capture.ts`** implements exactly that: subscribes per speaker, decodes Opus to PCM, sends to Groq Whisper, flushes transcripts to `~/.zao/private/`.
- **Board card `e6145a0d`** - "TOP BUILD: deploy the ZAI Discord voice-capture bot" - has been open and overdue since 2026-07-21.

## What still blocks the deploy, and it is not this PR

`bot/src/zai/index.ts:20` loads env from `~/.zao/private/discord.env` (overridable with `ZAI_ENV_FILE`). **That file does not exist on this machine.** `config.ts` Zod-validates five values and refuses to start without them: a Discord token (`DISCORD_CAPTURE_TOKEN` or `ZAI_DISCORD_TOKEN`), `ZAAL_GUILD_ID`, `ZAAL_USER_ID`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`.

Creating a Discord bot application, minting its token, and inviting it to the server are Zaal's actions, not a lane's. This PR removes the wiring excuse so that when the token exists, `npm run start:zai` is the whole command.

## Verification

- `npx tsc --noEmit` in `bot/`: **exit 0, 0 errors**. `bot/node_modules` confirmed populated (239 entries) first, so this is a real pass and not the empty-`node_modules` phantom result that `noisy-signal-guard.md` warns about.
- `package.json` re-parsed as JSON after the edit.
- The entrypoint was **not** run. `agent-loops.md` rule 21 forbids boot-verifying a poller entrypoint by executing it, and this one calls `client.login()` at line 382.

Scope is two lines in one file. No behaviour changes for any currently running bot.
