### PR TITLE
feat: capture quality gate - no card born without who/why (card b8cba711)

### DIFF
--- a/.claude/rules/capture-quality.md
+++ b/.claude/rules/capture-quality.md
@@ -1,0 +1,40 @@
+# Capture Quality - no card born without WHO / WHY / DONE-WHEN
+
+Adopted 2026-08-20 from card b8cba711 (approved 2026-08-19). WHY: Sparq
+(closed unidentifiable), Colleen (no context), NEXUS (zero notes) each burned
+a grill round on 2026-08-19. Five seconds of context at capture time beats
+six weeks of amnesia and a wasted grill card.
+
+## The rule (behavior-changing, both capture ends)
+
+1. **ZOE capture (phone end):** a DM capture with no why/who context does not
+   board silently. ZOE holds it and asks ONE button question - "Add a why" /
+   "Board it bare" (the gate prompts, never blocks; bare-on-purpose is one
+   tap). Implementation: `splitCapturesByQuality` in
+   `bot/src/zoe/team-tracker.ts` + the `capq:` callback in `bot/src/zoe/index.ts`.
+
+2. **Organizer / any lane routing cards to the board (terminal end):** a card
+   routed to the board carries WHY + DONE-WHEN synthesized from the context it
+   came from. A card where NEITHER is derivable goes to GRILL-QUEUE.md
+   instead of the board - a grill question is the right home for "what even
+   is this", the board is not.
+
+3. **Tooling floor:** `zao-tracker` create subcommands already take `--why`
+   and `--done-when` - use them on every card a session creates. A card
+   without them should be the exception a human chose, never the default a
+   pipeline produced.
+
+## Guards
+
+- This gates BOARD writes, not capture itself - capture stays frictionless
+  (one thought, one line, never lost). The gate runs where the thought
+  becomes a card.
+- Never DROP a capture for missing context (feedback: never drop, always
+  park) - the choices are enrich, board-bare-on-purpose, or grill-queue.
+
+## Source
+
+Card b8cba711; incidents of 2026-08-19 (Sparq / Colleen / NEXUS grill
+rounds). Siblings: `thread-discipline.md` (capture is sacred),
+`noisy-signal-guard.md` (a board full of context-free cards is a wall nobody
+reads), feedback_never_drop_always_park.

--- a/bot/src/zoe/__tests__/team-tracker.test.ts
+++ b/bot/src/zoe/__tests__/team-tracker.test.ts
@@ -1,5 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, capturePriority, formatTeamDigest, buildPrioritiesEpisode, buildTeamContextBlock, formatOwnerDigest, type TeamTask } from '../team-tracker';
+import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, capturePriority, formatTeamDigest, buildPrioritiesEpisode, buildTeamContextBlock, formatOwnerDigest, isBareCapture, splitCapturesByQuality, type TeamTask } from '../team-tracker';
+
+// ── capture quality gate (card b8cba711) ────────────────────────────────────
+
+describe('isBareCapture - flags empty context, does not grade prose', () => {
+  it('bare: no description, empty, whitespace, or too short to carry a why', () => {
+    expect(isBareCapture({ title: 'Sparq' })).toBe(true);
+    expect(isBareCapture({ title: 'Colleen', description: '' })).toBe(true);
+    expect(isBareCapture({ title: 'NEXUS', description: '   ' })).toBe(true);
+    expect(isBareCapture({ title: 'x', description: 'call him' })).toBe(true);
+  });
+
+  it('ok: any description long enough to carry a why', () => {
+    expect(
+      isBareCapture({ title: 'x', description: 'Sparq asked about ZAOstock sponsorship tiers' }),
+    ).toBe(false);
+  });
+});
+
+describe('splitCapturesByQuality', () => {
+  it('partitions without losing or reordering anything', () => {
+    const a = { title: 'a', description: 'why: follow up on the artizen submission' };
+    const b = { title: 'b' };
+    const c = { title: 'c', description: 'done when the deck v2 is in the vault' };
+    const { ok, bare } = splitCapturesByQuality([a, b, c]);
+    expect(ok).toEqual([a, c]);
+    expect(bare).toEqual([b]);
+    expect(ok.length + bare.length).toBe(3);
+  });
+});
 
 describe('formatOwnerDigest', () => {
   const members = new Map([['u1', 'zaal'], ['u2', 'iman']]);

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -68,7 +68,7 @@ import { readFleetStatus, formatLoopsStatus, formatLoopDetail } from './loops-st
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
 import { runCrmOps, summarizeCrmResults } from './crm';
-import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured, addTeamTask, mirrorCapturesToTracker, runTeamDigest, getTeamMemberMap, formatOwnerDigest } from './team-tracker';
+import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured, addTeamTask, mirrorCapturesToTracker, splitCapturesByQuality, runTeamDigest, getTeamMemberMap, formatOwnerDigest } from './team-tracker';
 import { decomposeGoal, renderPlanForApproval, shouldDecompose } from './decompose';
 import {
   buildMemoryBlocks,
@@ -631,6 +631,13 @@ bot.command('zoldraft', async (ctx) => {
 // tapped one does (Fable audit fix - without this, typed answers were untagged).
 const pendingTypeAnswers = new Map<number, string>();
 
+// Capture quality gate (card b8cba711): a DM capture with no why/who context is
+// held here instead of boarding silently; ZOE asks ONE button question. Keyed by
+// a short id riding in "capq:<w|b>:<key>" callbacks. pendingWhyReplies mirrors
+// pendingTypeAnswers: after an "Add a why" tap, Zaal's next DM text IS the why.
+const pendingBareCaptures = new Map<string, { title: string; description?: string; priority?: string }>();
+const pendingWhyReplies = new Map<number, string>();
+
 bot.on('callback_query:data', async (ctx, next) => {
   if (!isFromZaal(ctx)) {
     await ctx.answerCallbackQuery();
@@ -714,6 +721,42 @@ bot.on('callback_query:data', async (ctx, next) => {
       { from: 'zaal', text: `[answer:${r.qid}] ${r.reaction}`, sender: 'zaalbotz-btn' },
       String(gid),
     ).catch((e) => console.error('[zoe/index] r-answer log failed:', (e as Error)?.message));
+    return;
+  }
+
+  // Capture quality gate buttons ("capq:<w|b>:<key>", card b8cba711).
+  // w = Add a why: his next DM text becomes the capture's why, then it boards.
+  // b = Board it bare anyway: boards as-is - the gate prompts, never blocks.
+  const capq = /^capq:([wb]):(.+)$/.exec(ctx.callbackQuery.data);
+  if (capq) {
+    const [, action, key] = capq;
+    const held = pendingBareCaptures.get(key);
+    if (!held) {
+      await ctx.answerCallbackQuery({ text: 'That capture already resolved.' });
+      return;
+    }
+    if (action === 'b') {
+      pendingBareCaptures.delete(key);
+      await ctx.answerCallbackQuery({ text: 'Boarding bare.' });
+      const n = await mirrorCapturesToTracker([held]).catch(() => 0);
+      await ctx
+        .editMessageText(
+          n
+            ? `Boarded bare: "${held.title.slice(0, 80)}"`
+            : `Board write failed for "${held.title.slice(0, 60)}" - it stays in ZOE's local tasks`,
+          { reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {});
+    } else {
+      const cbChat = ctx.callbackQuery.message?.chat?.id;
+      if (cbChat) pendingWhyReplies.set(cbChat, key);
+      await ctx.answerCallbackQuery({ text: 'Reply with the why.' });
+      await ctx
+        .editMessageText(`Adding a why to "${held.title.slice(0, 80)}" - reply with one line.`, {
+          reply_markup: { inline_keyboard: [] },
+        })
+        .catch(() => {});
+    }
     return;
   }
 
@@ -2641,6 +2684,32 @@ async function dispatchConcierge(
   // was answered as ordinary chat. bus-bridge.ts has had parseBusReply() for
   // exactly this and was left deliberately unwired; this is that wiring step.
   //
+  // Capture-quality why reply (card b8cba711): Zaal just tapped "Add a why" on a
+  // bare capture, so this DM text IS the why. Checked FIRST in the private scope
+  // - the pending state is explicit, set only by that tap, and cleared here
+  // (first-handler-wins: a claiming branch must name exactly what it claims).
+  if (scope === 'private') {
+    const whyKey = pendingWhyReplies.get(chatId);
+    if (whyKey) {
+      pendingWhyReplies.delete(chatId);
+      const held = pendingBareCaptures.get(whyKey);
+      pendingBareCaptures.delete(whyKey);
+      if (held) {
+        held.description = text.trim();
+        const n = await mirrorCapturesToTracker([held]).catch(() => 0);
+        await ctx
+          .reply(
+            n
+              ? `Boarded with why: "${held.title.slice(0, 60)}" - ${text.trim().slice(0, 80)}`
+              : `Board write failed - "${held.title.slice(0, 60)}" stays in ZOE's local tasks`,
+          )
+          .catch(() => {});
+        return;
+      }
+      // Held capture evaporated (restart) - fall through so the text is not lost.
+    }
+  }
+
   // Checked BEFORE the build classifier, because "reply ab12cd fix the api" must
   // be a bus reply, not a build request - the prefix is explicit and wins.
   if (scope === 'private') {
@@ -2785,10 +2854,33 @@ async function dispatchConcierge(
       const { added } = await applyTaskOps(result.task_ops);
       // Mirror new captures into the Supabase tracker WITH context, so a voice/
       // forward/DM capture becomes a self-explaining grill card (not a bare title).
+      // Quality gate (card b8cba711): a capture with no why/who is HELD behind a
+      // one-button prompt instead of boarding silently - 5 seconds at capture
+      // time beats a wasted grill round six weeks later. Local ZoeTask store is
+      // untouched either way; only the board mirror is gated.
       if (added.length > 0) {
-        await mirrorCapturesToTracker(added).catch((e) =>
-          console.warn('[zoe/index] capture->tracker mirror failed (nbd):', (e as Error).message),
-        );
+        const { ok, bare } = splitCapturesByQuality(added);
+        if (ok.length > 0) {
+          await mirrorCapturesToTracker(ok).catch((e) =>
+            console.warn('[zoe/index] capture->tracker mirror failed (nbd):', (e as Error).message),
+          );
+        }
+        for (const t of bare) {
+          const key = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+          pendingBareCaptures.set(key, t);
+          await ctx
+            .reply(`"${t.title.slice(0, 100)}" has no why - board it anyway?`, {
+              reply_markup: {
+                inline_keyboard: [
+                  [
+                    { text: 'Add a why', callback_data: `capq:w:${key}` },
+                    { text: 'Board it bare', callback_data: `capq:b:${key}` },
+                  ],
+                ],
+              },
+            })
+            .catch(() => {});
+        }
       }
     }
 

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -227,6 +227,35 @@ export function capturePriority(p: 'high' | 'med' | 'low' | string): string {
   return p === 'high' ? 'P1' : p === 'low' ? 'P3' : 'P2';
 }
 
+/** A concierge-captured task on its way to the board. */
+export interface CapturedTask {
+  title: string;
+  description?: string;
+  priority?: string;
+}
+
+/**
+ * Capture quality gate (card b8cba711): a card born without WHO/WHY context
+ * burns a grill round six weeks later (Sparq, Colleen, NEXUS - 2026-08-19).
+ * "Bare" = no description, or one too short to carry a why. The threshold is
+ * deliberately low: this flags EMPTY context, it does not grade prose.
+ */
+export const BARE_CAPTURE_MIN_CHARS = 12;
+
+export function isBareCapture(t: CapturedTask): boolean {
+  return (t.description ?? '').trim().length < BARE_CAPTURE_MIN_CHARS;
+}
+
+export function splitCapturesByQuality(added: CapturedTask[]): {
+  ok: CapturedTask[];
+  bare: CapturedTask[];
+} {
+  const ok: CapturedTask[] = [];
+  const bare: CapturedTask[] = [];
+  for (const t of added) (isBareCapture(t) ? bare : ok).push(t);
+  return { ok, bare };
+}
+
 /**
  * Mirror concierge-captured tasks into the Supabase tracker (what the grill +
  * board read) WITH the description as notes, so a voice/forward capture becomes


### PR DESCRIPTION
Card b8cba711 (approved 2026-08-19): capture quality gate - no card born without WHO/WHY/DONE-WHEN. WHY on the card: Sparq (closed unidentifiable), Colleen (no context), NEXUS (zero notes) each burned a grill round on 2026-08-19. Both halves of the card's spec:

## Half 1 - ZOE capture prompt (bot)

- `bot/src/zoe/team-tracker.ts`: `isBareCapture` (no description or under 12 chars - flags EMPTY context, does not grade prose) + `splitCapturesByQuality`. Pure, tested.
- `bot/src/zoe/index.ts`: the DM concierge mirror site now splits captures. Contextful ones board exactly as before; a bare one is HELD and ZOE asks ONE button question: "Add a why" / "Board it bare". The gate prompts, never blocks - bare-on-purpose is one tap.
  - `capq:<w|b>:<key>` callback: `b` boards as-is; `w` arms `pendingWhyReplies` so Zaal's next DM text becomes the why (exact `pendingTypeAnswers` pattern), then boards.
  - The why-catch sits FIRST in the private-scope text path, before the bus-reply parse and the build classifier - the pending state is explicit, set only by the tap, cleared on use, and falls through (text not lost) if the held capture evaporated over a restart (first-handler-wins: the claiming branch names exactly what it claims).
  - The ctx-less board-dispatch mirror site (control-plane path) is NOT gated - no chat to ask in; those come from the board, not from a fresh capture.
  - ZOE's local ZoeTask store is untouched either way - only the board mirror is gated, so capture itself stays frictionless and nothing is ever dropped.

## Half 2 - organizer standing rule

- `.claude/rules/capture-quality.md`: cards routed to the board carry WHY + DONE-WHEN synthesized from context; cards where neither is derivable go to GRILL-QUEUE instead of the board; `zao-tracker --why/--done-when` on every session-created card. Auto-loads every session like the other rules.

## Evidence (loop-evals gates)

- A. `tsc --noEmit` 0 errors; esbuild bundle of src/zoe/index.ts clean.
- B. Full bot suite: 188 files, 2463 tests, all pass (2460 on main; +3 from this PR).
- C. Anti-bloat: 195 insertions / 5 deletions; reuses mirrorCapturesToTracker, the pendingTypeAnswers pattern, and the existing callback pipeline; biome clean on touched files.
- D. Scope: exactly the card's two halves.
- E. Safety: capq handler sits inside the existing `isFromZaal`-guarded callback handler; no auth/env change; never drops a capture (never-drop-always-park).
- F. Secret scan of staged diff: clean (standalone step).

Board card: b8cba711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
