### PR TITLE
Apply doc 977 fractal correction catalogue to the research library (card 944b3325)

### DIFF
--- a/research/governance/696-respect-fractal-lineage-summary/README.md
+++ b/research/governance/696-respect-fractal-lineage-summary/README.md
@@ -126,7 +126,7 @@ Respect is the primitive the whole system rests on.
 - **OG (ERC-20) vs ZOR (ERC-1155):** OG is fungible, cumulative, used for one-time awards and the historical ledger. ZOR is a non-transferable token-type (NTT) where each award is its own ERC-1155 id, distributed by ORDAO consensus for weekly scoring.
 - **Optional decay.** ZAO applies 2% weekly decay: `R(t) = R(t-1) * 0.98 + earned(t)`. Equilibrium under constant earning is `R_eq = earned / 0.02`; 2% gives a ~34-week half-life. Decay keeps governance weight tied to *recent* contribution, not a one-time burst years ago.
 - **Voting weight.** OREC reads OG Respect balances during a voting window. A proposal passes when `yesWeight > 2 x noWeight` (the 2/3+1 rule) and a minimum Respect threshold votes yes; 1/3 of participating Respect can veto.
-- **Equality.** A single Fibonacci round produces a Gini coefficient around 0.23 - dramatically more equal than typical token-voting DAOs (often 0.97-0.99). *See Doc 56, Doc 58, Doc 306.*
+- **Equality.** A single 6-person Fibonacci round computes to a Gini of about 0.41, and ZAO's cumulative OG distribution measures ~0.73 (top 10 hold ~53% - contribution concentrates in the core). Still more equal than typical token-voting DAOs (often 0.97-0.99), but the honest comparison is "meaningfully concentrated, transparently earned," not near-egalitarian. On-chain numbers: doc 975. *See Doc 56, Doc 58, Doc 306.*
 
 ## 6. ORDAO / OREC / frapps / Optimystics
 

--- a/research/governance/705-fractal-governance-external-deep-research/README.md
+++ b/research/governance/705-fractal-governance-external-deep-research/README.md
@@ -242,9 +242,9 @@ Practical ORDAO defaults:
 
 | Parameter | Suggested default | Basis |
 |---|---|---|
-| Voting period | 48 hours | Common OREC examples and ZAO usage |
-| Veto period | 48 hours | Same |
-| Minimum yes-weight threshold | 5-10% of total Respect | OREC is designed for low-turnout execution; ZAO docs use 10% as a typical framing |
+| Voting period | 72 hours | ZAO on-chain `voteLen` = 259,200s (doc 975) |
+| Veto period | 72 hours | ZAO on-chain `vetoLen` = 259,200s (doc 975) |
+| Minimum yes-weight threshold | 1,000 Respect (~2.6% of OG supply) | ZAO on-chain `minWeight` (doc 975); OREC is designed for low-turnout execution |
 | Max live yes votes per account | 10 | Matches documented anti-spam pattern |
 | Respect token standard | Respect1155 | Best-aligned with current ecosystem practice |
 | SDK | `@ordao/orclient` | Best-documented integration path |

--- a/research/governance/718-zao-fractal-whitepaper-foundations/718b-respect-game-mechanism-design.md
+++ b/research/governance/718-zao-fractal-whitepaper-foundations/718b-respect-game-mechanism-design.md
@@ -3,6 +3,7 @@ topic: governance
 type: guide
 status: research-complete
 last-validated: 2026-05-22
+superseded-by: "975 (for its numeric parameters only - structure/mechanism prose remains current)"
 related-docs: 56, 58, 103, 306, 696, 718
 original-query: "Keep studying [Respect Game mechanism design, for the ZAO Fractal Whitepaper]"
 tier: DEEP

--- a/research/governance/718-zao-fractal-whitepaper-foundations/718c-ordao-onchain-architecture.md
+++ b/research/governance/718-zao-fractal-whitepaper-foundations/718c-ordao-onchain-architecture.md
@@ -19,7 +19,7 @@ parent-doc: 718
 
 | Dimension | Finding | Implication for Whitepaper |
 |-----------|---------|---------------------------|
-| **OREC Mechanism** | Three-phase: voting (48h YES/NO) + veto (48h NO-only) + execution. Passes if YES weight >= threshold AND YES > 2x NO. | "Optimistic" = security via fraud-proof window, not active majority. Solves voter apathy. |
+| **OREC Mechanism** | Three-phase: voting (72h YES/NO) + veto (72h NO-only) + execution. Passes if YES weight >= threshold AND YES > 2x NO. | "Optimistic" = security via fraud-proof window, not active majority. Solves voter apathy. |
 | **Soulbound Design** | OG (ERC-20) frozen, historical ledger. ZOR (ERC-1155) active, living ledger. Both block transfers at contract level using `_beforeTokenTransfer` hooks. | Two-ledger model: historical preservation + democratic future. Transfer reversion = simple code, strong enforcement. |
 | **Vote Weight Source** | Reads OG Respect (ERC-20, frozen) at proposal block number for voting power. New Respect minted to ZOR (ERC-1155) post-execution. | Legacy votes remain valid; new distribution is democratic. Decouples vote rights from ongoing earnings. |
 | **Chain Choice** | Optimism OP Mainnet: EVM-equivalent, 100x lower gas than Ethereum, 2-second blocks, Superchain ecosystem ready. | Optimism enables affordable, scalable fractal governance. Base addition (2026) enables Superchain expansion. |
@@ -40,7 +40,7 @@ OREC inverts this model: **assume consensus exists, let the minority veto**. Thi
 
 OREC proposals move through three explicit phases:
 
-#### Phase 1: Voting Period (48 hours typical)
+#### Phase 1: Voting Period (72 hours - ZAO on-chain `voteLen`)
 
 - Proposal is open for YES and NO votes.
 - Vote weight = Respect balance at proposal start block (historical snapshot).
@@ -48,7 +48,7 @@ OREC proposals move through three explicit phases:
 - Votes are on-chain transactions; each vote costs gas (~$0.02-0.05 on Optimism).
 - Proposer's wallet auto-votes YES with their Respect weight upon submission.
 
-#### Phase 2: Veto Period (48 hours typical)
+#### Phase 2: Veto Period (72 hours - ZAO on-chain `vetoLen`)
 
 - Voting period has closed; no new YES votes accepted.
 - ONLY NO votes accepted (challenge window).
@@ -61,7 +61,7 @@ OREC proposals move through three explicit phases:
 - Both periods have elapsed.
 - Check passing conditions:
   - `voting_period_duration + veto_period_duration` time elapsed
-  - `yes_weight >= min_weight_threshold` (e.g., 10% of total Respect)
+  - `yes_weight >= min_weight_threshold` (ZAO on-chain `minWeight` = 1,000 Respect, ~2.6% of OG supply - see doc 975)
   - `yes_weight > 2 * no_weight` (supermajority: YES exceeds double the NO)
 - If conditions met, anyone calls `execute(propId)`.
 - OREC triggers minting in the Respect contract (or other actions, depending on proposal type).
@@ -233,7 +233,7 @@ This is cheaper than active majority voting because most proposals need no respo
 
 ### 4.2 Time-Window Reorg Risk
 
-On Optimism, blocks arrive ~2 seconds apart. A 48-hour veto window = 86,400 seconds = ~43,200 blocks. 
+On Optimism, blocks arrive ~2 seconds apart. A 72-hour veto window = 259,200 seconds = ~129,600 blocks. 
 
 **Low risk scenario:** An adversary cannot trigger a deep reorg (>12 blocks) on Optimism OP Mainnet without compromising Ethereum L1 itself (which secures Optimism via fraud-proofs). Optimism's security model inherits Ethereum's finality.
 
@@ -406,7 +406,7 @@ For the whitepaper, cite Nethermind audit results once finalized (expected June 
 2. **OREC: Optimistic Consent-Based Voting**
    - Problem: voter apathy in traditional DAOs.
    - Solution: optimistic execution (assume consensus, allow veto).
-   - Three phases: voting (48h, YES/NO) + veto (48h, NO-only) + execution.
+   - Three phases: voting (72h, YES/NO) + veto (72h, NO-only) + execution.
    - Passing criteria: quorum met + YES > 2x NO.
    - Security: 1/3 can veto, 2/3 can execute.
 
@@ -451,11 +451,11 @@ Respect Game (off-chain consensus)
 proposeBreakoutResult() to OREC
   ↓ OREC executes 3-phase cycle
 ┌─────────────────────────────────┐
-│ Phase 1: Voting (48h)           │
+│ Phase 1: Voting (72h)           │
 │ YES votes: 50 Respect            │
 │ NO votes: 5 Respect              │
 │ ↓                               │
-│ Phase 2: Veto (48h)             │
+│ Phase 2: Veto (72h)             │
 │ NO votes: 0 Respect (no change)  │
 │ ↓                               │
 │ Phase 3: Execution              │

--- a/research/governance/977-fix-fractals-documentation/README.md
+++ b/research/governance/977-fix-fractals-documentation/README.md
@@ -78,6 +78,20 @@ Wherever any fractal doc says "~200 members / ~200 holders", correct to **156 un
 | Edit `696`/`114`/`102`: "90+ weeks" -> "100+ weeks (~101)" everywhere | @Zaal | PR | 2026-07-13 |
 | Add `superseded-by: 975` to doc 718b frontmatter (its numbers, not its structure) | @Zaal | Edit | 2026-07-13 |
 
+## Applied (2026-08-20, fractal lane)
+
+All research-library corrections above are now applied in one PR (branch
+ws/research-977-apply-fractal-doc-fixes): 718c (48h->72h everywhere incl.
+the block math and the two diagram boxes, 10%->minWeight 1,000 Respect ~2.6%),
+705 (params table: 72h/72h + 1,000 Respect), 696 (Gini 0.23 -> 0.41 single
+round / 0.73 cumulative, honest framing), 718b (frontmatter superseded-by:
+975 for numbers). The "90+ weeks" and "~200 members" fixes were already
+applied on main before this pass. The ZAOfractal whitepaper repo side was
+fixed and deployed 2026-07-21/22 (two accuracy passes; see
+fractal-whitepaper-accuracy memory). Remaining open items need Zaal: the
+fractal numbering/date overlap (OG freeze vs ZOR start), and the dashboard
+OG+ZOR weight display (a ZAOOS surface, not a doc).
+
 ## Sources
 
 - [FULL] `718c-ordao-onchain-architecture.md`, `705-.../README.md`, `696-.../README.md`, `114-.../README.md`, `102-.../README.md` (ZAOOS working tree, grepped 2026-07-06) - the exact stale lines are cited above.


### PR DESCRIPTION
## What

Applies the remaining corrections from doc 977 (the 2026-07-06 fix-list grounded in doc 975's on-chain pull) to the research library:

- **718c**: every 48h -> 72h (8 instances, including the 86,400s block math -> 259,200s and both phase-diagram boxes); "10% of total Respect" -> on-chain `minWeight` = 1,000 Respect (~2.6% of OG supply)
- **705**: OREC params table -> measured 72h/72h + 1,000 Respect
- **696**: Gini 0.23 -> 0.41 (single 6-person round) / 0.73 (cumulative OG, top 10 = 53%), framing kept honest per the whitepaper Chapter 9 rule
- **718b**: frontmatter `superseded-by: 975` for its numeric parameters only
- **977**: applied-note appended recording what landed where

## Verification (what was already done vs not)

Checked before editing: the catalogue's "90+ weeks" and "~200 members" fixes were already applied on main; the ZAOfractal whitepaper repo was fixed and deployed 2026-07-21/22 (two accuracy passes). The four files above were the only remaining stale surfaces. Still open and Zaal-gated: the OG-freeze vs ZOR-start date overlap, and the dashboard's OG+ZOR weight display (ZAOOS surface, not a doc).

Board card: 944b3325 (Fix Fractal documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)