### PR TITLE
icm: box drafts for one approval pass - zabalgamez replacement + magnetiq retirement + zoe/zai/zol verify (card 7f0af85c)

### DIFF
--- a/research/identity/icm-boxes/drafts/README.md
+++ b/research/identity/icm-boxes/drafts/README.md
@@ -18,3 +18,22 @@ The registry is a stale mirror; `https://useicm.com/api/objects/<id>/llm.txt` is
 source of truth, and reading it is unauthenticated.
 
 Written in the overnight build loop 2026-07-30. Source lines are in each draft.
+
+## Added 2026-08-20 (card 7f0af85c, one approval pass - doc 2241 actions)
+
+- `zabalgamez.draft.llm.txt` - proposed REPLACEMENT for the live box (live 2139c,
+  unchanged since the 8/7 snapshot, verified by fresh fetch 2026-08-20). Three
+  changes vs live: (1) August arc updated to reality - six finalists announced
+  2026-08-17, finals week Aug 24-30, no finalist names (kit still unmerged in
+  zabalgamez PR #624); (2) ALL Magnetiq references removed (entry + Find it) per
+  the retirement; (3) submissions URL restored from the repo copy. OPEN QUESTION
+  for Zaal in the approval sheet: what replaces Magnetiq for signup/collectibles?
+- **Magnetiq retirement** (doc 2241 item 4): no draft needed - the action is
+  deleting/archiving live box icm_ObVlvn960SvOLc-W-IV3wQ (817c, byte-identical to
+  `live-snapshots/magnetiq.llm.txt`, which stays as the permanent archive). Needs
+  Zaal's owner key. The zabalgamez draft above already drops its Magnetiq lines,
+  so no live box references Magnetiq after both actions.
+- The three new-box drafts (`../zoe.draft.llm.txt`, `../zai.draft.llm.txt`,
+  `../zol.draft.llm.txt`) verified still repo-only (registry = 23 live boxes,
+  none of the three present) and fact-checked 2026-08-20; publish-ready as
+  written. Approval sheet: zao-vault notes/icm-approval-sheet.md.

--- a/research/identity/icm-boxes/drafts/zabalgamez.draft.llm.txt
+++ b/research/identity/icm-boxes/drafts/zabalgamez.draft.llm.txt
@@ -1,0 +1,30 @@
+# ICM: ZABAL Games (ZABAL Gamez)
+
+ZABAL Games is The ZAO's 3-month build-a-thon. Free to join, anyone welcome. It is a Farcaster-native onboarding event: ship something real in public, with a ZAO mentor in your corner, and earn Respect plus an on-chain credential. Build for a real 100+ member community, not a weekend you forget.
+
+## Three tracks
+- Artist - musical / visual builds
+- Builder - developer / aspiring-coder builds
+- Creator - media / distribution / content builds
+
+## The arc (2026)
+- June: recorded workshops (ZAO teachers + ecosystem partners on governance, Respect, tools like Claude Code, Empire Builder, POIDH, Juke, SongJam). Watchable live or async at zabalgamez.com/recordings.
+- July: open build month. Goal set by Zaal (2026-07-04): 200 distinct builders, multiple submissions each. Ship a live URL + open-source repo + short demo + a cast to /zabal. Every build that clears the bar earns Respect. Partial and WIP drafts count.
+- August: Finals. Six finalists announced 2026-08-17; finals week runs August 24-30 with a 24h build + promote + Respect-weighted vote + live reveal stream. Finalists paid in USDC (tiered). WaveWarZ-Base integration and on-chain settlement.
+
+## How it works
+- Entry: register on the site (/enter) with a wallet + GitHub repo.
+- Mentors: open roster (not a fixed panel) - each mentor defines the builder archetype they want and pairs with an open-submission builder; they get a Hats Protocol "ZAO Mentor" role.
+- Submissions: a public GitHub-backed board at zabalgamez.com/submissions; Bonfire (knowledge graph) is the system of record.
+- Empire Builder + Clanker are optional tools (leaderboards, token launch), not requirements.
+- What you walk away with: a live artifact + open repo; Respect for July finishers; a Hats Protocol collectible NFT on Base as a universal "I shipped at ZABAL Games" credential.
+
+## Find it
+- Site: zabalgamez.com (with a Z; old zabalgames.com redirects here)
+- Farcaster: the /zabal channel; tag posts "zabal gamez"
+- Stream overlay for workshops/finals: zaoos.com/overlay/zabal-games
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- WaveWarZ (wavewarz)


### PR DESCRIPTION
## Summary
Card 7f0af85c: doc 2241's gated ICM actions folded into one approval pass. Stages a zabalgamez replacement draft (finals-week arc, Magnetiq stripped, submissions URL restored) and documents the Magnetiq retirement prep. The three new-box drafts (zoe/zai/zol) were verified still repo-only and fact-checked; they ship unchanged. Publishing is NOT done here - gated on Zaal per icm-grounding.md.

## What Zaal approves (5 taps, sheet in zao-vault notes/icm-approval-sheet.md)
1. Publish zoe box (draft ready)
2. Publish zai box (draft ready)
3. Publish zol box (draft ready)
4. Retire magnetiq box (delete via owner key; snapshot archived)
5. Replace zabalgamez box body with the draft (open question: Magnetiq's signup/collectibles replacement)

## Grounding
Live fetches 2026-08-20: zabalgamez 2139c and magnetiq 817c both byte-identical to the 8/7 live-snapshots; registry confirms 23 live boxes, zoe/zai/zol absent.