### PR TITLE
bus: Candy partner onboarding kit + deployed-state capture (bus.zaoos.com live)

### DIFF
--- a/infra/bus/PARTNER-ONBOARDING.md
+++ b/infra/bus/PARTNER-ONBOARDING.md
@@ -1,0 +1,43 @@
+# ZAO Bus - partner agent onboarding (one page)
+
+For any partner agent that speaks HTTP (first partner: Candy's bot). The bus is
+transport only - the tasern wire contract, credit Jim / Meme for Trees (spec
+shared 2026-08-06). Base URL: https://bus.zaoos.com/bus (LIVE since 2026-08-20).
+
+## You get
+- A partner token (delivered out-of-band by Zaal - never committed, never in argv).
+  It maps you to your agent name. You can ONLY message "coordinator" and read
+  your own thread + files. Everything is enforced server-side.
+
+## The whole API
+```
+# health (no auth)
+curl -s $BUS/health
+
+# poll your new messages (do this hourly, or on your own cadence)
+curl -s -H "Authorization: Bearer $TOKEN" "$BUS/messages?status=new"
+
+# send to the coordinator
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"to":"coordinator","subject":"hello","body":"..."}' "$BUS/send"
+
+# mark handled
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -d '{"status":"read"}' "$BUS/messages/<id>"
+
+# files shared with you (the ZAOstock pitch pack lands here as pack.json)
+curl -s -H "Authorization: Bearer $TOKEN" "$BUS/files"
+curl -s -H "Authorization: Bearer $TOKEN" -o pack.json "$BUS/files/<name>"
+
+# upload (auto-prefixed with your name)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "X-Filename: report.md" \
+  --data-binary @report.md "$BUS/files/upload"
+```
+Wire shape: `{id, from, to, subject, body, status: "new"|"read", created}`. JSON
+caps at 50KB per message; files at 50MB. Keep the token in env or a chmod-600
+file. Rotation is one env edit + restart on our side - tell us if it leaks.
+
+## What flows on day one
+- ZAO -> partner: `zaostock-pack.json` (the public pitch pack) + internal
+  ZAOstock ops notes addressed to your thread.
+- Partner -> coordinator: anything; ZOE renders it to Zaal's phone in full
+  (bot/src/zoe/bus-bridge.ts) and he replies from Telegram.

--- a/infra/bus/deploy/DEPLOYED.md
+++ b/infra/bus/deploy/DEPLOYED.md
@@ -1,0 +1,22 @@
+# zao-bus - deployed state (2026-08-20)
+
+- Host: VPS 1 (31.97.148.88), user `zaal`, systemd user unit `zao-bus.service`
+  (this directory holds the tracked copy of the live unit).
+- Binary: `/home/zaal/zao-bus/bus.js` = a copy of `infra/bus/bus.js` (scp on
+  deploy; re-scp + `systemctl --user restart zao-bus` to upgrade).
+- Env: `/home/zaal/.zao/private/bus.env` (chmod 600). Tokens minted 2026-08-20
+  with `openssl rand -hex 32`: admin, guest (zoe), partners CANDY / JIM /
+  BRANDON. Values live only there. Rotate = edit env + restart.
+- Public URL: https://bus.zaoos.com/bus (cloudflared ingress -> localhost:3099,
+  DNS route added 2026-08-20; config backup at ~/.cloudflared/config.yml.bak-20260820).
+- Wire contract + partner instructions: ../PARTNER-ONBOARDING.md. Spec credit:
+  Jim / Meme for Trees (tasern coordinator), shared 2026-08-06.
+- History: an Aug-4 localhost-only prototype (`~/.zao/private/zao-bus-server.js`,
+  https://127.0.0.1:8790, partners zao/jim/brandon/sam, 5 setup-day messages)
+  ran under this unit until 2026-08-20. File + store preserved in place; unit
+  backup at `~/.config/systemd/user/zao-bus.service.bak-20260820`.
+- First traffic on the new bus: coordinator -> candy welcome message +
+  `coordinator-zaostock-pack.json` in /bus/files.
+- NOT yet wired: ZOE polling OUR bus (cron polls tasern.quest only - see
+  bus-poll-run.sh on the VPS) and ZOE bus-bridge env. One cron line + bot env,
+  both operator steps.

--- a/infra/bus/deploy/zao-bus.service
+++ b/infra/bus/deploy/zao-bus.service
@@ -1,0 +1,23 @@
+# The LIVE unit on VPS 1 (~zaal/.config/systemd/user/zao-bus.service), captured
+# 2026-08-20 when the unit was swapped from the Aug-4 localhost prototype
+# (~/.zao/private/zao-bus-server.js, preserved untouched) to the canonical
+# tested infra/bus/bus.js. Git-tracked per vanishing-dependencies.md.
+# Env: /home/zaal/.zao/private/bus.env (chmod 600; BUS_PORT=3099, BUS_DATA_DIR,
+# BUS_ADMIN_TOKEN, BUS_GUEST_TOKEN[+_CANDY,_JIM,_BRANDON]) - values never in git.
+# Public: bus.zaoos.com -> localhost:3099 via the zaal cloudflared tunnel.
+[Unit]
+Description=ZAO Agent-to-Agent Message Bus (canonical infra/bus/bus.js, tasern wire contract)
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/home/zaal/.zao/private/bus.env
+ExecStart=/usr/bin/node /home/zaal/zao-bus/bus.js
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+Environment="NODE_ENV=production"
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

The Candy data bus is LIVE. This PR records it and ships the partner kit:

- `infra/bus/PARTNER-ONBOARDING.md` - one-page kit for any HTTP partner agent: the full wire contract (tasern shape, credit Jim / Meme for Trees), curl for poll/send/read/files, token hygiene. Base URL https://bus.zaoos.com/bus.
- `infra/bus/deploy/zao-bus.service` - tracked copy of the live systemd user unit (vanishing-dependencies.md: if something depends on it, git holds it).
- `infra/bus/deploy/DEPLOYED.md` - deployed state: what runs where, token names (never values), the preserved Aug-4 prototype, config backups, and what is deliberately NOT yet wired (ZOE's poll cron still points at tasern.quest; bus-bridge env unset - both one-line operator steps).

## Verification (all measured 2026-08-20)

- Swap: unit now execs the canonical `bus.js` (11/11 node tests pass locally); `systemctl --user is-active` = active; `GET /bus/health` = `{"status":"ok"}` locally AND from the public internet via bus.zaoos.com (HTTP 200).
- Auth: unauthenticated `/bus/messages` from outside -> 401. Coordinator -> candy welcome message sent; Candy's partner token polled it back (thread scoping enforced server-side).
- Files: `zaostock-pack.json` uploaded to the bus file share.
- cloudflared: ingress validated before restart; DNS route added; zoe.zaoos.com unaffected (200). portal/ao/claude were ALREADY 502 before the restart - caddy is up but its upstreams (auth-server :3005, spawn-server :3004, ttyd) are dead; flagged to Zaal, not restarted blind.
- Old prototype (`zao-bus-server.js`, 127.0.0.1:8790, 5 setup-day messages, partners zao/jim/brandon/sam): stopped with the unit swap, file + store + unit backup preserved. Localhost-only bind means no external party ever held a working token to it.

## Zaal taps

1. Hand Candy her token: `ssh vps` then read `BUS_GUEST_TOKEN_CANDY` from `~/.zao/private/bus.env` (your eyes only) and send it to her out-of-band with `infra/bus/PARTNER-ONBOARDING.md`.
2. Optional wiring: point a second bus-poll cron at our bus + set ZOE's bus env (exact lines in DEPLOYED.md).
3. Portal upstreams (auth-server/spawn-server/ttyd) are down - your call whether that was intentional this morning.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBR5N1HHr6L6XPTVeJKHek
