### PR TITLE
fix(zao-spend): sync repo copy with the 2026-08-17 PR-counter hotfix

### DIFF
--- a/scripts/agents/zao-spend
+++ b/scripts/agents/zao-spend
@@ -137,23 +137,45 @@ def scan(since: datetime):
 
 
 def outputs(since: datetime):
-    """PRs opened in the window, per repo. The 'what did it buy' half."""
+    """PRs opened in the window, per repo. The 'what did it buy' half.
+
+    2026-08-17 rewrite: this silently reported 0 PRs on a 16-merge day.
+    Three causes, each now fixed: (1) `gh pr list` rides the shared GraphQL
+    bucket that drains and 503s - use the REST pulls endpoint (separate
+    core bucket, doc 887); (2) two of three repo slugs did not exist
+    (ZAODEVZ/zabalgames, ZAODEVZ/ZAOstock) so 404s were eaten; (3) failures
+    hit a silent `continue`, so a broken meter read as a quiet day
+    (silent-failure-guard.md). Failures now print a warning line."""
     found = []
+    errs = []
     iso = since.strftime("%Y-%m-%dT%H:%M:%SZ")
-    for repo in ("bettercallzaal/ZAOOS", "ZAODEVZ/zabalgames", "ZAODEVZ/ZAOstock"):
+    repos = (
+        "bettercallzaal/ZAOOS",
+        "ZAODEVZ/ZAOcowork",
+        "ZAODEVZ/zabalgames",
+        "bettercallzaal/zaostock",
+        "bettercallzaal/zao-floor",
+        "bettercallzaal/zao-website",
+    )
+    for repo in repos:
         try:
             out = subprocess.run(
-                ["gh", "pr", "list", "--repo", repo, "--state", "all",
-                 "--limit", "40", "--json", "number,title,createdAt,state"],
+                ["gh", "api",
+                 f"repos/{repo}/pulls?state=all&sort=created&direction=desc&per_page=50",
+                 "--jq", "[.[] | {number, title, created_at, state}]"],
                 capture_output=True, text=True, timeout=25,
             )
             if out.returncode != 0:
+                errs.append(repo)
                 continue
             for pr in json.loads(out.stdout or "[]"):
-                if pr.get("createdAt", "") >= iso:
+                if pr.get("created_at", "") >= iso:
                     found.append((repo.split("/")[-1], pr["number"], pr["state"], pr["title"]))
         except Exception:
+            errs.append(repo)
             continue
+    if errs:
+        print(f"  WARNING: PR count incomplete - query failed for: {', '.join(errs)}", file=sys.stderr)
     return found
 
 


### PR DESCRIPTION
## Summary

Card a7020adc. `zao-spend --days 1` on 2026-08-17 showed $1,293 consumed
and "0 PR(s) opened" while 10+ PRs shipped - the what-it-bought half was
silently broken (silent-failure-guard.md shape: green output, wrong number).

Root cause was already found and fixed in the DEPLOYED copy
(`~/bin/zao-spend`, symlinked into zaal-dotfiles, run hourly by cron) via
dotfiles commit `37ab6d1` on 2026-08-17 - but that fix never landed back
into this repo. `scripts/agents/zao-spend` here was still the pre-fix
version. Confirmed live-diverged: `diff scripts/agents/zao-spend
~/bin/zao-spend` showed the two versions of `outputs()` differ, nothing
else.

Three causes, all fixed by the sync:
1. `gh pr list` rides the shared GraphQL rate-limit bucket, which drains
   and 503s - switched to the REST `pulls` endpoint (separate bucket).
2. Two of the three monitored repo slugs (`ZAODEVZ/zabalgames`,
   `ZAODEVZ/ZAOstock`) didn't exist at the time and 404'd silently -
   repo list expanded to 6 real slugs (adds ZAOcowork, zao-floor,
   zao-website).
3. A failed query hit a silent `continue` - now prints a stderr warning
   naming which repo failed.

## Evidence

Reproduced today (2026-08-21) against both versions - the specific
zero-PR failure mode from 8/17 no longer reproduces because the repos
that 404'd back then exist now, so this PR is landing the already-proven
fix (live on cron since 8/17), not re-discovering a live bug:

```
BEFORE (git HEAD, this repo's stale copy) --days 1: 41 PR/session lines, $63.71/PR
AFTER  (synced from deployed ~/bin/zao-spend) --days 1: 40 PR/session lines, $65.49/PR
```

`diff scripts/agents/zao-spend ~/bin/zao-spend` after sync: no output (identical).
`python3 -m py_compile scripts/agents/zao-spend`: clean.
Secret scan (standalone, case-insensitive, not chained to commit): 0 matches.

## Test plan

- [x] py_compile clean
- [x] `--days 1` runs against real gh data, no crash
- [x] diff against the deployed/cron copy is empty post-sync
- [x] secret scan clean
- [ ] Zaal: confirm `~/bin/zao-spend` (symlink target) stays the source of
      truth going forward - this PR just stops the repo copy from
      drifting from it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmYX7gR6KQL5ZLQb4cJf5j
