### PR TITLE
feat(zoe): Surplus Intelligence as the second cheap cap-fallback rung

### DIFF
--- a/bot/src/zoe/README.md
+++ b/bot/src/zoe/README.md
@@ -95,6 +95,9 @@ Unconfigured groups log non-Zaal sender IDs to journal so Zaal can discover Tele
 | `BONFIRE_AGENT_ID` | no | agent UUID |
 | `ZOE_DEFAULT_MODEL` | no | default `sonnet` |
 | `ZOE_HARD_MODEL` | no | default `opus` |
+| `SURPLUS_API_KEY` | no | Surplus Intelligence - the second cheap cap-fallback rung, tried right after OpenRouter. Without it, an OpenRouter outage escalates straight to Grok/GPT, which are neither cheap nor always configured. On 2026-08-21 that gap took the whole fleet down: 17 loops, zero output. |
+| `SURPLUS_BASE_URL` | no | default `https://api.surplusintelligence.ai/v1`. Only set it if the endpoint moves. |
+| `SURPLUS_MODEL` | no | default `auto` - their router picks the cheapest healthy seller. |
 | `ZOE_QUICK_MODEL` | no | default `haiku` |
 
 ## Turn model (doc 872 - effectiveness)

--- a/bot/src/zoe/models/__tests__/router-failover.test.ts
+++ b/bot/src/zoe/models/__tests__/router-failover.test.ts
@@ -17,7 +17,7 @@ import {
  * (openrouter fails -> grok succeeds) without hitting any provider.
  */
 
-const KEYS = ['XAI_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'MODEL_ROUTING_ENABLED', 'OPENROUTER_MODEL', 'OPENROUTER_HIGH_MODEL'];
+const KEYS = ['XAI_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'MODEL_ROUTING_ENABLED', 'OPENROUTER_MODEL', 'OPENROUTER_HIGH_MODEL', 'SURPLUS_API_KEY', 'SURPLUS_BASE_URL', 'SURPLUS_MODEL'];
 const saved: Record<string, string | undefined> = {};
 const realFetch = globalThis.fetch;
 
@@ -172,5 +172,83 @@ describe('callCapFallback tier routing (high-tier escalation, doc 2217)', () => 
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     await callCapFallback('sys', 'msg');
     expect(bodyModelOf(fetchMock)).toBe('meta-llama/llama-4');
+  });
+});
+
+
+/**
+ * SURPLUS INTELLIGENCE - the second cheap rung, added 2026-08-21.
+ *
+ * The whole fleet went silent that morning - 17 loops, zero output - because
+ * OpenRouter ran out of credits and the next rung was Grok, which is neither
+ * cheap nor always configured. These tests pin the behaviour that prevents a
+ * repeat: a cheap provider must have a cheap provider behind it.
+ */
+describe('surplus intelligence fallback rung', () => {
+  it('counts as a cap-fallback provider on its own', () => {
+    setEnv({ OPENROUTER_API_KEY: undefined, XAI_API_KEY: undefined, OPENAI_API_KEY: undefined, SURPLUS_API_KEY: 'sk-surplus-test' });
+    expect(hasCapFallbackProvider()).toBe(true);
+  });
+
+  it('carries the call when OpenRouter is out of credits - the 2026-08-21 case', async () => {
+    setEnv({ OPENROUTER_API_KEY: 'sk-or-test', SURPLUS_API_KEY: 'sk-surplus-test', XAI_API_KEY: undefined, OPENAI_API_KEY: undefined });
+    const seen: string[] = [];
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      seen.push(href);
+      if (href.includes('openrouter.ai')) {
+        // What a drained OpenRouter key actually returns.
+        return { ok: false, status: 402, text: async () => 'insufficient credits', json: async () => ({}) } as unknown as Response;
+      }
+      return okResponse('answered by surplus') as unknown as Response;
+    }) as typeof fetch;
+
+    const { result, provider } = await callCapFallback('sys', 'hello');
+    expect(provider).toBe('surplus');
+    expect(result.text).toBe('answered by surplus');
+    expect(result.model).toMatch(/^surplus\//);
+    // Order matters: OpenRouter is still tried first, Surplus is the catch.
+    expect(seen[0]).toContain('openrouter.ai');
+    expect(seen[1]).toContain('surplusintelligence.ai');
+  });
+
+  it('is tried BEFORE grok, so an outage does not escalate to an expensive tier', async () => {
+    setEnv({ OPENROUTER_API_KEY: undefined, SURPLUS_API_KEY: 'sk-surplus-test', XAI_API_KEY: 'xai-test', OPENAI_API_KEY: undefined });
+    const seen: string[] = [];
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      seen.push(String(url));
+      return okResponse('ok') as unknown as Response;
+    }) as typeof fetch;
+
+    const { provider } = await callCapFallback('sys', 'hello');
+    expect(provider).toBe('surplus');
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('surplusintelligence.ai');
+  });
+
+  it('treats a 200 with an empty completion as a FAILURE, not an empty answer', async () => {
+    setEnv({ OPENROUTER_API_KEY: undefined, SURPLUS_API_KEY: 'sk-surplus-test', XAI_API_KEY: undefined, OPENAI_API_KEY: undefined });
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: '   ' } }], usage: {} }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    // Handing the caller a blank reply and calling it success is the silent
+    // failure this guard exists to stop.
+    await expect(callCapFallback('sys', 'hello')).rejects.toThrow(/empty completion/i);
+  });
+
+  it('honours SURPLUS_BASE_URL so the endpoint can be corrected without a deploy', async () => {
+    setEnv({ OPENROUTER_API_KEY: undefined, SURPLUS_API_KEY: 'sk-surplus-test', SURPLUS_BASE_URL: 'https://example.test/v9', XAI_API_KEY: undefined, OPENAI_API_KEY: undefined });
+    let called = '';
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      called = String(url);
+      return okResponse('ok') as unknown as Response;
+    }) as typeof fetch;
+
+    await callCapFallback('sys', 'hello');
+    expect(called).toBe('https://example.test/v9/chat/completions');
   });
 });

--- a/bot/src/zoe/models/router.ts
+++ b/bot/src/zoe/models/router.ts
@@ -333,15 +333,109 @@ async function callOpenRouter(
   }
 }
 
+
+/**
+ * Surplus Intelligence base URL. OpenAI-compatible: POST /chat/completions with
+ * a bearer token, same request and response shape as OpenRouter, which is why
+ * this rung is a near-copy rather than a new abstraction.
+ *
+ * SOURCED FROM THEIR DOCS PAGE VIA A SUMMARISING FETCH, not raw text, so treat
+ * the constant as unverified until the first live call succeeds
+ * (`research-grounding.md`). If it is wrong the call throws and the ladder falls
+ * through to the next provider - the cost of being wrong here is one wasted
+ * attempt, never a silent failure.
+ */
+const SURPLUS_DEFAULT_BASE = 'https://api.surplusintelligence.ai/v1';
+
+export function hasSurplusApiKey(): boolean {
+  return Boolean(process.env.SURPLUS_API_KEY?.trim());
+}
+
+async function callSurplus(
+  systemPrompt: string,
+  userMessage: string,
+  modelOverride?: string,
+): Promise<ClaudeCliResult> {
+  if (!hasSurplusApiKey()) {
+    throw new Error('SURPLUS_API_KEY not set');
+  }
+
+  const baseUrl = process.env.SURPLUS_BASE_URL?.trim() || SURPLUS_DEFAULT_BASE;
+  // Surplus routes "one API key, every model - to the cheapest healthy seller",
+  // so the model id is theirs to resolve. Left overridable because the catalogue
+  // is a marketplace and will move.
+  const model = modelOverride ?? process.env.SURPLUS_MODEL ?? 'auto';
+  const apiKey = process.env.SURPLUS_API_KEY;
+
+  const request: OpenAiRequest = {
+    model,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userMessage },
+    ],
+    temperature: 1,
+    max_tokens: FALLBACK_MAX_TOKENS,
+  };
+
+  const startMs = Date.now();
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'User-Agent': 'ZOE-bot/1.0',
+        'X-Title': 'ZOE',
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Surplus API error ${response.status}: ${errorText.slice(0, 300)}`);
+    }
+
+    const data = (await response.json()) as OpenAiResponse;
+    const text = data.choices[0]?.message?.content ?? '';
+    // A 200 carrying an empty completion is a FAILED call, not an empty answer.
+    // Treating it as success would hand the caller a blank reply and report it
+    // as working (`liveness-probe-guard.md`, the companion clause).
+    if (!text.trim()) {
+      throw new Error('Surplus returned empty completion');
+    }
+
+    return {
+      text,
+      inputTokens: data.usage?.prompt_tokens ?? 0,
+      outputTokens: data.usage?.completion_tokens ?? 0,
+      totalCostUsd: 0,
+      model: `surplus/${model}`,
+      durationMs: Date.now() - startMs,
+      numTurns: 1,
+      isError: false,
+      sessionId: `surplus-${startMs}`,
+    };
+  } catch (error: unknown) {
+    throw new Error(`Surplus call failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 /**
  * CAP FALLBACK: the Claude CLI is rate-limited or over its weekly cap, so run
  * this concierge turn on the best available non-Claude provider instead of
- * failing. Tries OpenRouter first (cheap, always-on), then Grok, then GPT.
+ * failing. Order: OpenRouter, then Surplus Intelligence, then Grok, then GPT.
+ *
+ * Surplus sits SECOND on purpose. On 2026-08-21 the entire fleet went silent -
+ * 17 loops, zero output - because OpenRouter ran out of credits and the next
+ * rung was Grok, which is neither cheap nor always configured. A cheap provider
+ * needs a cheap provider behind it, or an outage at the top is an outage for
+ * everything.
  * Throws only if NO non-Claude provider is configured (then the caller surfaces
  * the original Claude error).
  */
 export function hasCapFallbackProvider(): boolean {
-  return hasOpenRouterApiKey() || hasGrokApiKey() || hasGptApiKey();
+  return hasOpenRouterApiKey() || hasSurplusApiKey() || hasGrokApiKey() || hasGptApiKey();
 }
 
 export async function callCapFallback(
@@ -356,11 +450,12 @@ export async function callCapFallback(
   const orModel = opts?.tier === 'high' ? OPENROUTER_HIGH_MODEL : undefined;
   const attempts: Array<{ name: string; fn: () => Promise<ClaudeCliResult> }> = [];
   if (hasOpenRouterApiKey()) attempts.push({ name: 'openrouter', fn: () => callOpenRouter(systemPrompt, userMessage, orModel) });
+  if (hasSurplusApiKey()) attempts.push({ name: 'surplus', fn: () => callSurplus(systemPrompt, userMessage) });
   if (hasGrokApiKey()) attempts.push({ name: 'grok', fn: () => callGrok(systemPrompt, userMessage) });
   if (hasGptApiKey()) attempts.push({ name: 'gpt', fn: () => callGpt(systemPrompt, userMessage) });
 
   if (attempts.length === 0) {
-    throw new Error('no cap-fallback provider configured (set OPENROUTER_API_KEY, XAI_API_KEY, or OPENAI_API_KEY)');
+    throw new Error('no cap-fallback provider configured (set OPENROUTER_API_KEY, SURPLUS_API_KEY, XAI_API_KEY, or OPENAI_API_KEY)');
   }
 
   const errors: string[] = [];


### PR DESCRIPTION
feat(zoe): Surplus Intelligence as the second cheap cap-fallback rung

## Why now

This morning the entire fleet went silent. From the ZOE DM at 08:00:

```
FLEET BRAIN DOWN (NO_CREDITS). All cheap-loops are exiting at zero-spend - the fleet is IDLE.
FLEET OUTPUT - 20260821: 0 drafts produced, 0 escalated to build board
SILENT: zoe, ww, coc, human, zol, zaostock, fractal, sparkz, warpee, research,
        artizen, zabal, poidh, wwafrica, zoostr, bcz, maine
```

Seventeen loops, zero output, because OpenRouter ran out of credits.

The cap-fallback ladder was OpenRouter, then Grok, then GPT. Grok and GPT are neither cheap nor always configured, so in practice **there was nothing behind OpenRouter**. A cheap provider with no cheap provider behind it means an outage at the top is an outage for everything.

## What changed

Surplus Intelligence is added as the **second** rung, immediately after OpenRouter and before Grok. It is OpenAI-compatible (`/chat/completions`, bearer auth), so the caller is deliberately a near-copy of `callOpenRouter` rather than a new abstraction.

```
before:  openrouter -> grok -> gpt
after:   openrouter -> surplus -> grok -> gpt
```

Three env vars, all optional - absent key means the rung is simply skipped, exactly like the existing ones:

| Var | Default |
|---|---|
| `SURPLUS_API_KEY` | unset, rung skipped |
| `SURPLUS_BASE_URL` | `https://api.surplusintelligence.ai/v1` |
| `SURPLUS_MODEL` | `auto` - their router picks the cheapest healthy seller |

## Verification

`tsc --noEmit`: **0 errors.**

Router failover tests **16 to 21, all passing**. No existing test removed or weakened. The five new ones pin the behaviour that matters rather than the implementation:

- Surplus alone satisfies `hasCapFallbackProvider()`
- **A 402 from OpenRouter falls through to Surplus** - the stub returns exactly what a drained key returns, and the test asserts OpenRouter is still tried first
- Surplus is reached **before** Grok, so an outage does not escalate to an expensive tier
- **A 200 carrying an empty completion throws** rather than returning a blank reply as success (`liveness-probe-guard.md`, the companion clause)
- `SURPLUS_BASE_URL` is honoured, so a moved endpoint is a config change and not a deploy

## Honest caveat

The default base URL came from **a summarising fetch of their docs page, not raw text**, so treat the constant as unverified until the first live call succeeds (`research-grounding.md`). This is low-risk by construction: if it is wrong the call throws and the ladder falls through to the next provider. The cost of being wrong is one wasted attempt, never a silent failure. `SURPLUS_BASE_URL` exists precisely so it can be corrected without shipping.

The key itself is Zaal's to add - it is a purchase.
