### PR TITLE
docs: re-validate doc 059 - Hats tree goes 5 levels deep, not 3

### DIFF
--- a/research/governance/059-hats-tree-integration/README.md
+++ b/research/governance/059-hats-tree-integration/README.md
@@ -2,8 +2,8 @@
 topic: governance
 type: guide
 status: research-complete
-last-validated: 2026-05-21
-related-docs: "07, 55"
+last-validated: 2026-08-21
+related-docs: "07, 55, 075, identity/005"
 tier: STANDARD
 original-query: "Build Hats Protocol tree reader into ZAO OS for on-chain role management (reconstructed)"
 ---
@@ -11,6 +11,24 @@ original-query: "Build Hats Protocol tree reader into ZAO OS for on-chain role m
 # 059 — ZAO Hats Tree: On-Chain State & ZAO OS Integration Plan
 
 > **Goal:** Document ZAO's on-chain role structure via Hats Protocol (Optimism tree 226) and design ZAO OS integration to read/write hats independently of app.hatsprotocol.xyz
+
+**Re-validated 2026-08-21 (zao-identity lane).** Two corrections to the 2026-05-21
+version, both confirmed by direct `eth_call` — not the dead subgraph, not a doc:
+
+1. **The tree is at least 5 levels deep, not 3.** Levels 1-3 below (Configurator ->
+   Governance Council -> 17 project hats) were already correct. What was missing:
+   most project hats have a **Manager** role hat as a child (level 4), and several
+   Manager hats have further children (level 5) that are real membership/role hats
+   with actual wearer counts — one is a 67-wearer "Community Member" hat. See
+   `## 1b` below. **Section 5's "What to Build" is now built** — `src/lib/hats/`
+   exists — but its tree walker stops one level short of this layer; see `## 1c`.
+2. **The IPFS metadata resolves fine.** A 2026-08-21 check (before this
+   re-validation) reported all details CIDs empty across four gateways and flagged
+   them as possibly unpinned. Re-fetched today via `ipfs.io` with a normal
+   `curl` — every CID resolved on the first try. The gateways were the problem
+   (likely the same class of failure this repo already has a rule about — see
+   `liveness-probe-guard.md`), not the pins. Do not carry the "may be unpinned"
+   caution forward.
 
 ---
 
@@ -63,6 +81,75 @@ ZAO (Top Hat)
 - **Governance Council Members** hat has 3 of 5 — the active council
 - All hats use **manual eligibility** (not token-gated yet)
 - All hats are **mutable** (can be updated)
+
+### 1b. Levels 4-5 (new, 2026-08-21) — the tree keeps going below the 17 project hats
+
+Verified by direct `eth_call` to `viewHat(hatId)` on `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137`
+(Optimism, `mainnet.optimism.io` and `optimism.publicnode.com` — the first rate-limited
+mid-sweep, the second did not), computing child hat IDs per the encoding this repo's
+own `src/lib/hats/constants.ts` already uses (16-bit level segments starting at bit 224).
+
+**Level 4 — most project hats have a child "Manager" role hat**, active, maxSupply 1
+(one seat). 13 of the 16 project hats have at least one; `cocConcertz` and the four
+`futureProject*` placeholders do not (0 children — nothing to manage yet):
+
+| Project (level 3) | Level-4 child | maxSupply/supply | children |
+|---|---|---|---|
+| Community | Community Manager | 1/1 | 4 |
+| Location | Location Manager | 1/1 | 7 |
+| ZAO 101 | ZAO 101 Manager | 1/1 | 3 |
+| ZAO Fractals | ZAO FRACTALS Manager | 1/0 | 1 |
+| Wave WarZ DAO | Wave WarZ DAO Manager | 1/1 | 3 |
+| Wave WarZ DAO | (2nd child) "New Hat" | 1/0 | 0, **inactive** |
+| ZAO Festivals | ZAO FESTIVALS Manager | 1/1 | 2 |
+| ZTalent Newsletter | ZTalent Newsletter Manager | 1/0 | 3 |
+| ZAO Cards | ZAO CARDS COMMUNITY MANAGER | 1/0 | 1 |
+| ZAO Cards | ZAO CARDS Creative Director | 1/1 | 0 |
+| Student $LOANZ | $LOANZ Managers | 3/3 | 1 |
+| MIDI-ZAO-NKZ | Zen-Sai | 1/1 | 1 |
+| MIDI-ZAO-NKZ | (2nd child) same CID as Zen-Sai | 1/0 | 0, **inactive** |
+| Let's Talk about Web 3 | LTAW3 Season 1 | 1/0 | 0 |
+| Let's Talk about Web 3 | LTAW3 Season 2 | 1/0 | 3 |
+| Let's Talk about Web 3 | LTAW3 Season 3 | 1/0 | 0 |
+
+**Level 5 — under several Manager hats, real member/role hats with actual headcounts.**
+Sampled all 29 level-5 hats under the 11 branches that have level-4 children (some
+level-4 nodes, e.g. `location.1`, themselves have up to 7 children — not fully named
+yet, see gap below). The pattern: most are further single-seat sub-roles, but a few
+are genuine membership hats:
+
+- **Community Manager's 3rd child: maxSupply 1000, supply 67** — 67 wearers. This is
+  almost certainly the general "Community Member" hat and is the largest wearer count
+  found anywhere in the tree.
+- ZAO 101's 3rd child and ZTalent Newsletter's 2nd child: maxSupply 10, supply 3 each.
+- Let's Talk about Web 3 Season 1: maxSupply 3, supply 3 (full).
+- MIDI-ZAO-NKZ's Zen-Sai child: 1/1 (filled).
+- Several level-4 nodes have children not yet resolved at all: Location Manager (7
+  children), Wave WarZ DAO Manager (3), ZAO Festivals' two managers (6 and 8
+  children each — likely per-event or per-role hats), ZAO Cards Community Manager
+  (3), Student $LOANZ Managers (1).
+
+**Gap, stated plainly:** this pass did not walk past level 5, and several level-4/5
+nodes above have unresolved children of their own (Location Manager's 7, both ZAO
+Festivals managers' 6+8, etc.). The tree likely has 100+ total hats. What's here is
+enough to know the SHAPE (project -> manager -> member/sub-role, membership hats
+carry real headcounts) and to unblock priority-2/3 work below; a full leaf-level
+census is follow-up work, not done here. The `wavewarz` project hat also carries a
+**custom eligibility module** (`0x7234c36A71ec237c2Ae7698e8916e0735001E9Af`, not the
+default `0x...4A75` manual-eligibility address every other hat in the tree uses) —
+worth understanding before treating WaveWarZ hats as manually-gated like the rest.
+
+### 1c. Code gap: `src/lib/hats/tree.ts` stops one level short
+
+`fetchHatTree()` in `src/lib/hats/tree.ts` recurses with the guard
+`if (numChildren > 0 && level < 4)`. Counting from the top hat as level 0, that walks
+top -> configurator -> council/members -> project hats -> **Manager hats (level 4)**,
+then stops — it never fetches what a Manager hat wears, i.e. exactly the 67-wearer
+"Community Member" hat and its siblings found above. Anyone building a member-facing
+"who's on this project" view or a hats-based gate for a project's actual contributors
+(not just its Manager) needs to raise that cutoff or make it configurable. This is a
+one-line change to a function that already exists and already resolves IPFS names —
+not new architecture.
 
 ---
 
@@ -252,6 +339,13 @@ The only potential dependency is the **subgraph** for historical queries. If The
 
 ## 7. Existing Utility Script
 
+**Correction 2026-08-21:** `scripts/read-hats-tree.ts` does not exist in this repo
+(`ls scripts/read-hats-tree.ts` -> no such file, checked at re-validation). Either it
+was never committed or was removed since 2026-05-21; git history was not searched.
+The equivalent walk now lives in `src/lib/hats/tree.ts` (`fetchHatTree()`), reachable
+via `GET /api/hats/tree` — but see `## 1c` for its depth limit. Do not assume the
+script below is runnable without first checking it exists.
+
 `scripts/read-hats-tree.ts` — reads the full ZAO tree from Optimism using viem. Run with:
 
 ```bash
@@ -270,3 +364,6 @@ npx tsx scripts/read-hats-tree.ts
 - [Hats Anchor App (MIT)](https://github.com/Hats-Protocol/hats-anchor-app) [PARTIAL] — Reference implementation; ERC-1155 compatibility confirmed.
 
 **Validation:** Tree 226 state confirmed live 2026-05-20. SDK v1 core is non-upgradeable per contract design. IPFS pin resilience documented. CREATE2 deterministic deployment across chains confirmed.
+
+- [Hats Protocol Contract (Optimism), direct `eth_call`](https://mainnet.optimism.io) [FULL] — re-validated 2026-08-21 via `cast call viewHat(uint256)` against `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137`, `optimism.publicnode.com` as the working RPC (the docs.optimism.io default rate-limited mid-sweep). All level 1-5 hat data in `## 1b` above came from these calls, not from the app.hatsprotocol.xyz UI or the (dead) subgraph.
+- IPFS `details` CIDs for every hat cited above [FULL] — resolved via `curl https://ipfs.io/ipfs/<cid>`, plain JSON, no gateway 403s or empty bodies on this pass.


### PR DESCRIPTION
## Summary
- Doc 059 (Hats tree integration plan, last-validated 2026-05-21) stopped documenting the tree at the 17 project hats. Direct `eth_call` walks today found two more levels beneath most of them: a "Manager" role hat (level 4), and under several Managers, real membership hats with actual headcounts (level 5) - including one 67-wearer "Community Member" hat.
- Corrects a same-day false alarm from the zao-identity founding brief: the hat metadata IPFS CIDs were reported empty across four gateways and flagged as possibly unpinned. Re-fetched via plain `curl` today, every CID resolved on the first try - gateway flakiness, not a pinning problem.
- Flags a concrete, small code gap: `src/lib/hats/tree.ts`'s `fetchHatTree()` recursion guard (`level < 4`) stops exactly one level short of the new data - it fetches Manager hats but never their wearers.

## Evidence
- All hat IDs, supply counts, and IPFS CIDs cited in the doc came from `cast call viewHat(uint256)` against `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137` on Optimism (`optimism.publicnode.com`), not from app.hatsprotocol.xyz or the dead subgraph.
- IPFS names resolved via `curl https://ipfs.io/ipfs/<cid>` and cross-checked against `src/lib/hats/constants.ts`'s existing `HAT_LABELS` for levels 1-3, which matched exactly.

## Test plan
- Docs-only change, no code touched. `git diff` is additive (99 insertions, 2 line edits to frontmatter/last-validated).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
