### PR TITLE
feat: wire hats gating into track-of-day select - first real hats consumer

### DIFF
--- a/src/app/api/music/track-of-day/select/__tests__/route.test.ts
+++ b/src/app/api/music/track-of-day/select/__tests__/route.test.ts
@@ -10,6 +10,9 @@ vi.mock('@/lib/auth/session', () => ({ getSessionData: mockGetSessionData }));
 
 vi.mock('@/lib/publish/auto-cast', () => ({ autoCastToZao: vi.fn().mockResolvedValue(undefined) }));
 
+const mockHasPermission = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+vi.mock('@/lib/hats/gating', () => ({ hasPermission: mockHasPermission }));
+
 const mockMaybySingle = vi.hoisted(() => vi.fn());
 const mockMaybyTopNomination = vi.hoisted(() => vi.fn());
 const mockUpdate = vi.hoisted(() => vi.fn());
@@ -40,10 +43,15 @@ import { POST } from '../route';
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.useRealTimers();
   callCount = 0;
 });
 
 const ADMIN_SESSION = { fid: 1, isAdmin: true };
+const WALLET = '0x1234567890123456789012345678901234567890';
+const HAT_WEARER_SESSION = { fid: 2, isAdmin: false, walletAddress: WALLET };
+const PLAIN_SESSION = { fid: 3, isAdmin: false, walletAddress: WALLET };
+const BEFORE_CUTOFF = new Date('2026-07-17T10:00:00.000Z'); // 6pm EST cutoff is 23:00 UTC
 
 describe('POST /api/music/track-of-day/select', () => {
   it('returns 401 when no session', async () => {
@@ -86,5 +94,39 @@ describe('POST /api/music/track-of-day/select', () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.selected.title).toBe('ZAO Anthem');
+  });
+
+  it('returns 403 before cutoff for a non-admin wallet with no feature_tracks hat', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BEFORE_CUTOFF);
+    mockGetSessionData.mockResolvedValue(PLAIN_SESSION);
+    mockHasPermission.mockResolvedValue(false);
+    mockMaybySingle.mockResolvedValue({ data: null, error: null });
+    const res = await POST();
+    expect(res.status).toBe(403);
+    expect(mockHasPermission).toHaveBeenCalledWith(WALLET, 'feature_tracks');
+  });
+
+  it('allows a non-admin wallet wearing the feature_tracks hat to select before cutoff', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BEFORE_CUTOFF);
+    mockGetSessionData.mockResolvedValue(HAT_WEARER_SESSION);
+    mockHasPermission.mockResolvedValue(true);
+    mockMaybySingle.mockResolvedValue({ data: null, error: null });
+    const mockNomination = { id: 'nom-2', title: 'Hat Pick', artist: 'ZAO' };
+    mockMaybyTopNomination.mockResolvedValue({ data: mockNomination, error: null });
+    const mockSingle = vi.fn().mockResolvedValue({
+      data: { ...mockNomination, selected_date: '2026-07-17' },
+      error: null,
+    });
+    mockUpdate.mockReturnValue({
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: mockSingle,
+    });
+    const res = await POST();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.selected.title).toBe('Hat Pick');
   });
 });

--- a/src/app/api/music/track-of-day/select/route.ts
+++ b/src/app/api/music/track-of-day/select/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { hasPermission } from '@/lib/hats/gating';
 import { logger } from '@/lib/logger';
 import { autoCastToZao } from '@/lib/publish/auto-cast';
+
+const WALLET_ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 
 // POST — select today's Track of the Day
 // Admin-only manual selection, OR auto-select if past cutoff (6pm EST)
@@ -29,14 +32,22 @@ export async function POST() {
       );
     }
 
-    // Determine if this is admin manual select or auto-select
+    // Determine if this is admin manual select or auto-select.
+    // Augmented with the Hats Protocol 'feature_tracks' permission (the
+    // ZTalent Newsletter hat) so a hat wearer can select without also being
+    // a session admin - the first real consumer of src/lib/hats/gating.ts.
     const isAdmin = session.isAdmin;
+    const isHatFeaturer =
+      !isAdmin && session.walletAddress && WALLET_ADDRESS_RE.test(session.walletAddress)
+        ? await hasPermission(session.walletAddress as `0x${string}`, 'feature_tracks')
+        : false;
+    const canSelect = isAdmin || isHatFeaturer;
     const cutoffHour = 23; // 6pm EST ~ 23:00 UTC
     const now = new Date();
     const cutoffToday = new Date(`${today}T${String(cutoffHour).padStart(2, '0')}:00:00.000Z`);
     const isPastCutoff = now >= cutoffToday;
 
-    if (!isAdmin && !isPastCutoff) {
+    if (!canSelect && !isPastCutoff) {
       return NextResponse.json(
         { error: 'Only admins can select before the cutoff time (6pm EST)' },
         { status: 403 },


### PR DESCRIPTION
## Summary
- `src/lib/hats/gating.ts` (474 lines across `src/lib/hats/`) has existed since it was built but had zero consumers - no UI, no route, no component called it (confirmed via `grep -r "lib/hats"` returning only its own routes/tests). This is the zao-identity lane's priority-2 item: prove the layer end to end with one genuine, cheap use.
- Wires `hasPermission(wallet, 'feature_tracks')` into `POST /api/music/track-of-day/select`. The permission mapping already existed in `gating.ts` (ZTalent Newsletter project hat -> `feature_tracks`) - this just calls it. A wallet wearing that hat can now select the daily track before the 6pm EST cutoff without also being a session admin.
- Purely additive: the existing `session.isAdmin` check, and the 401/409/404 paths, are unchanged. This only widens who passes the pre-cutoff 403 - it does not remove or weaken any existing guard (`pre-merge-security-and-suite.md`).

## Evidence
- Two new tests: a non-admin wallet with no `feature_tracks` hat still gets 403 pre-cutoff; a wallet with the hat passes. 6/6 tests green (`npx vitest run src/app/api/music/track-of-day/select`).
- `npm run typecheck`: 0 errors (ran on the full repo before this PR was split into its own worktree).
- `npx biome check` on both touched files: clean, no fixes needed.
- `hasPermission` fails closed to `false` on any RPC error (wrapped in `Promise.allSettled` inside `gating.ts`), so an Optimism RPC outage degrades this to admin-only behavior, not a crash or an open gate.

## Test plan
- [x] `npx vitest run src/app/api/music/track-of-day/select` - 6/6 pass
- [x] `npm run typecheck` - 0 errors
- [x] `npx biome check` on both files - clean
- [ ] Zaal: confirm the ZTalent Newsletter hat -> feature_tracks mapping is the right first pairing (it was already in `gating.ts` before this PR, not invented here)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
