### PR TITLE
research: doc 1659 addendum v4 - OpenMatter agent is live, what to actually do with it

### DIFF
--- a/research/agents/1659-openmatter-network-agent-platform-eval.md
+++ b/research/agents/1659-openmatter-network-agent-platform-eval.md
@@ -302,3 +302,332 @@ Zaal, not yet asked directly.
 Sources: `https://www.openmatter.network/` (FULL, raw fetch 2026-08-21),
 `https://www.openmatter.network/platform` (FULL, raw fetch 2026-08-21).
 `datavizor.openmatter.network` (FAILED - requires login, not attempted here).
+
+---
+
+## Addendum v4 - 2026-08-22: the agent is deployed and Running, so the question is now operational
+
+The July eval asked whether to adopt OpenMatter. The August 21 addendum
+corrected its "no compute" finding. This addendum answers a different question,
+because the situation moved again: **a container is deployed on OpenMatter and
+running right now, on our credits.** What follows is what it is, what it costs,
+what it can safely do, and what we should actually put on it.
+
+Ground truth for this addendum comes from Zaal's own dashboard screenshot
+(2026-08-22). It is his eyes, not an inference:
+
+| Fact | Value |
+|---|---|
+| Project | "The ZAO Newsletter", 1 deployment |
+| Container | `nousresearch/hermes-agent`, tag `latest` |
+| Ports | 8642/tcp, 9119/tcp |
+| Status | Running |
+| Credits | 12.3513 Cr |
+| Plan | Particle, 0% used, resets 2026-08-31 |
+| Deployments | Running 1, Completed 0, Errors 0 |
+
+### 1. What `nousresearch/hermes-agent` actually is
+
+Not a small thing, and not the same "Hermes" we already have.
+
+- **Nous Research's Hermes Agent**, self-hosted autonomous agent with a
+  built-in learning loop. Their own description: it "creates skills from
+  experience, improves them during use, nudges itself to persist knowledge, and
+  builds a deepening model of who you are across sessions."
+- `github.com/NousResearch/hermes-agent` - **234,260 stars**, pushed within the
+  hour of this measurement. An ecosystem of first-party satellites around it
+  (`hermes-agent-self-evolution` 5,115 stars, `autonovel` 1,505,
+  `hermes-paperclip-adapter` 1,826, `hermes-telegram-business` 28).
+- Docker Hub `nousresearch/hermes-agent` - **8,348,951 pulls**, 150 stars,
+  registered 2026-03-29. The `latest` tag was pushed 2026-08-22 11:08 UTC, the
+  same day as our deploy. Image is ~943 MB arm64 / ~955 MB amd64, multi-arch.
+- Docs at `hermes-agent.nousresearch.com`.
+
+**Naming collision, now operational rather than theoretical.** ZAO's
+`bot/src/hermes/` is our own auto-PR coder/critic pipeline, folded into ZOE
+2026-06-29. It has nothing to do with this. Doc 599c flagged the collision on
+2026-05-21 and recommended keeping our name internal-only; that recommendation
+now has teeth, because the estate contains both at once. Any sentence about
+"Hermes" from here on needs a qualifier.
+
+**Doc 599c also left an open item that this deploy answers by accident.** It
+said: "INVESTIGATE NousResearch Hermes Agent feature set - if it ships profiles
++ skills + memory + sessions out-of-the-box and is open source, it may be a
+better base than rolling our own." It does ship all four, plus cron, hooks, a
+web dashboard, multi-profile supervision, and an OpenAI-compatible API. That
+investigate-item sat for three months and is now closed by observation.
+
+### 2. What ports 8642 and 9119 are, exactly
+
+From Nous' own docker documentation (raw fetch, not a summary):
+
+- **8642** - the gateway's **OpenAI-compatible API server** and health endpoint.
+  Gated on `API_SERVER_ENABLED=true`. To reach it from outside the container it
+  also needs `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8
+  characters). Every profile binds 8642; a second profile needs its own
+  `API_SERVER_PORT`.
+- **9119** - the **web dashboard**, enabled by `HERMES_DASHBOARD=1`, bound
+  `0.0.0.0` by default inside the container.
+
+Useful endpoints on 8642, all bearer-authenticated:
+`POST /v1/chat/completions`, `POST /v1/responses` (server-side conversation
+state via `previous_response_id`), `GET /v1/models`, `GET /api/model/options`
+(provider inventory and per-model pricing), and `GET /v1/capabilities`, which
+returns a machine-readable description of what the running build supports.
+
+### 3. Running is not working
+
+This is the most important correction to make before anyone reports success.
+
+Nous' API server documentation says, verbatim: *"Hermes itself needs a
+configured provider and tool backends for the API server to be useful."* The
+provider credentials are written by an **interactive setup wizard**
+(`docker run -it ... nousresearch/hermes-agent setup`) into `/opt/data/.env`.
+
+So a container showing **Running** with no provider configured is an empty
+shell. It will hold a port and burn credits and answer nothing. "Running 1,
+Errors 0" is consistent with both a healthy configured agent and a completely
+unconfigured one, and the dashboard cannot tell them apart. Only a call to
+8642 can.
+
+Same for the ports: 8642 does not listen at all unless `API_SERVER_ENABLED` is
+true, and 9119 does not serve unless `HERMES_DASHBOARD=1`. That both ports are
+*published* tells us how the deploy was declared, not that either is answering.
+
+### 4. `/opt/data` is the entire agent, and it needs to be a persistent volume
+
+The container is stateless by design. Everything that makes it *our* agent
+lives in a single mounted directory at `/opt/data`:
+
+| Path | Contents |
+|---|---|
+| `.env` | API keys and secrets |
+| `config.yaml` | all configuration |
+| `SOUL.md` | agent personality/identity |
+| `sessions/` | conversation history |
+| `memories/` | persistent memory store |
+| `skills/` | installed skills |
+| `cron/`, `hooks/`, `logs/`, `home/` | jobs, event hooks, logs, subprocess HOME |
+
+`/opt/hermes` (the install tree) is root-owned and read-only to the runtime
+user in published images, so self-improvement is scoped to skills, memory,
+plugins and config under `/opt/data`.
+
+**Open question for Zaal, and it is load-bearing: does the OpenMatter
+deployment mount a persistent volume at `/opt/data`?** If it does not, then
+every redeploy or image upgrade silently destroys the configuration, the
+memories, and the learned skills - which is precisely the value proposition of
+this agent over a plain chat wrapper. The Datavizor navigation includes a "Data
+Storage" section, so the capability plausibly exists; whether this deployment
+uses it is not visible from outside.
+
+Nous also warn: never run two gateway containers against the same data
+directory - session files and memory stores are not safe for concurrent
+writes. That is the same shape as `agent-loops.md` rule 9 (one instance per
+resource), arrived at independently by another project.
+
+### 5. Security - the highest-stakes fact in this deploy
+
+Two internet-facing ports on a host running an autonomous agent that has a
+terminal tool. Nous' own documentation explains why they removed their
+`--insecure` escape hatch, verbatim:
+
+> "An unauthenticated public dashboard was the entry point for the June 2026
+> MCP-config persistence campaign: internet scanners reached exposed dashboards
+> (and OpenAI API servers) and drove the agent into planting an SSH-key
+> backdoor."
+
+Their hardening, and what it means for us:
+
+- The **dashboard fails closed** on a non-loopback bind with no auth provider
+  registered - it refuses to start and names the missing env var. Three
+  bundled providers: basic auth (`HERMES_DASHBOARD_BASIC_AUTH_USERNAME` +
+  `_PASSWORD` + `_SECRET`), Nous Portal OAuth, or self-hosted OIDC.
+  `HERMES_DASHBOARD_INSECURE=1` is a deprecated no-op and no longer bypasses
+  anything.
+- The **API server has no such fail-closed guarantee described**. It is gated
+  only on `API_SERVER_ENABLED`, and their docs state plainly: *"Opening any
+  port on an internet facing machine is a security risk. You should not do it
+  unless you understand the risks."*
+
+Therefore, before anything else is done with this deployment, three things need
+confirming from Zaal's session, and every one of them is a yes/no he can read
+off a settings page:
+
+1. Is `API_SERVER_KEY` set, and is it a real random value
+   (`openssl rand -hex 32`) rather than a placeholder?
+2. Which dashboard auth provider is configured on 9119? If the dashboard is
+   genuinely serving on a public bind, one of the three must be set, or it
+   would have failed to start - so "the dashboard loads" is itself evidence.
+3. Is `API_SERVER_CORS_ORIGINS` set to `*`? The Nous example uses `*` for
+   convenience; it should be narrowed or unset for a public deploy.
+
+This is not hypothetical hardening advice. It is the documented cause of a real
+campaign two months ago against exactly this container on exactly these ports.
+
+### 6. The credit math, and why it decides everything else
+
+**Method first, because the number is derived and not measured.** OpenMatter
+publishes no pricing: `openmatter.network/pricing` returns 404,
+`docs.openmatter.network` does not resolve, and the Datavizor dashboard renders
+the balance client-side behind a login. The only rate datum in existence for
+ZAO is the one Zaal relayed on 2026-08-14: **0.3932 credits described as ~0.47
+compute hours**. Everything below follows from that single point and inherits
+all of its uncertainty.
+
+- Implied rate: **~0.837 Cr per compute-hour** (1 Cr = ~1.195 compute-hours).
+- Current balance 12.3513 Cr = **~14.8 compute-hours**.
+- Continuously running, that is **under 15 hours - roughly 0.6 of a day.**
+- Running continuously from now to the 2026-08-31 plan reset is 9 days = 216
+  hours = **~181 Cr**. The balance covers **about 7%** of it.
+
+**The conclusion this forces:** at this balance, OpenMatter cannot host
+anything that needs to stay up. A persistent gateway is not affordable for even
+one full day. Any recommendation that treats it as a place to move a long-lived
+service is arithmetic-blind, and that includes the obvious-sounding one of
+moving ZOL there.
+
+Two things could change this and both are Zaal-session lookups, not research:
+
+- **The Particle plan may include an allowance consumed before credits.** The
+  screenshot reads "0% used, resets Aug 31" while a container is Running, which
+  is more consistent with a plan allowance absorbing the burn than with credits
+  being drawn down. If so the real runway is longer and currently unknown.
+- **The rate is likely instance-size dependent.** 0.837 Cr/hr may be the rate
+  for whatever shape was running on 2026-08-14, not this one.
+
+Until one of those is checked, treat ~15 hours as the working budget and do not
+spend it on anything that is not a proof.
+
+### 7. What we would actually run there - the honest answer is nothing, yet
+
+Evaluated against what ZAO already pays for, not against what would be
+interesting:
+
+| Candidate | Current cost | On OpenMatter | Verdict |
+|---|---|---|---|
+| ZOL (Farcaster agent) | Pi hardware we own, electricity | metered, ~0.84 Cr/hr | **No.** Converts a sunk fixed cost into a variable one, and `agent-loops.md` rule 9 means a move is a MOVE, never a second copy. ZOL is healthy on the Pi and its actual blocker is OpenRouter credits, not compute. |
+| Cheap-AI loops on the Hostinger VPS | flat monthly, already paid | metered | **No.** The VPS was measured at load 0.03/0.16/0.24 with 113 days uptime. Moving work off an idle box we already pay for onto a meter is a strict cost regression. |
+| Mac-bound loops | Claude Code weekly cap | metered | **No.** These are capped on the Claude tier, not on compute. Different constraint; OpenMatter does not relieve it. |
+| Overflow capacity generally | - | metered | **No** while a free-forever option is on the table. Doc 2284 already reasoned this through for Oracle Always Free, and the difference matters: Oracle is free-forever, this is metered. Metered compute is the wrong home for work whose defining property is that it is low-value enough to overflow. |
+
+**A clean "not worth it at 12 credits" is the result** (`anti-fabrication.md`
+rule 4: grade to the lowest severity the evidence supports). That is not the
+same as "OpenMatter is not worth it." The value here is in two places that have
+nothing to do with hosting cheap loops:
+
+1. **The relationship.** Chris B asked how the deployments went on 2026-08-18.
+   Nothing has gone back. The debt is now four days old and compounding, and it
+   is the single highest-value thing this lane can help close.
+2. **The architecture.** OpenMatter is the compute layer in the settled
+   ZOL/MIDAO design, and its verification story (QuantumGuard proofs, Datavizor
+   execution records) is exactly what a community-owned agent inside a legal
+   entity needs to prove it behaved. That is a 2027 concern at the earliest,
+   and it is unaffected by today's balance.
+
+So the July verdict splits rather than flips. **As infrastructure: still WATCH,
+now for a measured reason (the meter) rather than a wrong one ("no compute").
+As a relationship and as the compute layer of the ZOL legal-body design: live,
+funded, and owed a reply.**
+
+### 8. The one-curl proof, ready to fire
+
+Cheapest possible end-to-end proof, and deliberately not a chat completion:
+`/v1/capabilities` is a static description of the running build. It proves the
+port is open, the API server is enabled, and the bearer token is right, without
+invoking the model or burning a single token of inference.
+
+```bash
+curl -sS -H "Authorization: Bearer $API_SERVER_KEY" \
+  http://<DEPLOY_IP>:8642/v1/capabilities
+```
+
+A healthy response is a JSON object with `"object":
+"hermes.api_server.capabilities"` and a `features` map.
+
+Then, and only if that returns, the real proof that the agent is configured -
+this one does invoke the model:
+
+```bash
+curl -sS http://<DEPLOY_IP>:8642/v1/chat/completions \
+  -H "Authorization: Bearer $API_SERVER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"hermes-agent","messages":[{"role":"user","content":"Reply with the single word: online"}]}'
+```
+
+**Two things are missing and both are Zaal's**, per the brief's own tap stack:
+the deployment's public IP (the screenshot shows ports, not a host) and the
+`API_SERVER_KEY` value. Neither should be pasted into a transcript - see
+`secret-hygiene.md` and the `/secret` skill. The Pi can run both curls the
+moment it has them; `pi-research.md` already carries that instruction.
+
+Interpreting the outcomes honestly:
+
+- **Connection refused / timeout** - the API server is not enabled, or the port
+  is not actually published, or the platform firewalls it. Not a failure of the
+  agent.
+- **401** - the port is open and the server is up. The token is wrong. This is
+  a good failure; it proves reachability.
+- **200 on capabilities, error on chat** - reachable and authenticated, but no
+  model provider is configured. This is the "Running is not working" case from
+  section 3, and it is the outcome to expect if nobody ran the setup wizard.
+- **200 on both** - the deploy is genuinely end to end, and that is what goes
+  back to Chris B.
+
+### 9. What is still open, and who owns it
+
+Zaal-gated, unchanged and absolute: anything that spends credits, anything
+outbound to the OpenMatter Telegram group, any legal-entity commitment.
+
+| Open item | Owner | Note |
+|---|---|---|
+| Deploy IP + `API_SERVER_KEY` | Zaal | unblocks the one-curl proof; use `/secret`, never the transcript |
+| Is `/opt/data` on a persistent volume? | Zaal | if not, every redeploy wipes config, memory and skills |
+| `API_SERVER_KEY` real? dashboard auth provider? CORS `*`? | Zaal | section 5; documented attack path, not speculation |
+| Does the Particle plan include an allowance? | Zaal | decides whether the runway is 15 hours or much longer |
+| Reply to Chris B | Zaal | four days overdue as of this addendum |
+| 2026-08-13 meeting notes doc | Zaal | still not captured anywhere in `zao-vault` or `research/` |
+| Is OpenMatter's agent template literally Hermes Agent? | unverified | the Datavizor onboarding offers "deploy an agent from a template"; that hermes-agent is running suggests it is one, but this cannot be seen without a login |
+
+### Sources and method (v4)
+
+Per `research-grounding.md`, the method is stated so a reader can tell a
+verbatim quote from a reconstruction. **No WebFetch was used anywhere in this
+addendum** - every quotation below comes from raw bytes.
+
+- `https://hermes-agent.nousresearch.com/docs/user-guide/docker` - FULL, raw
+  `curl` + HTML strip, 2026-08-22. Source of the 8642/9119 definitions, the
+  `/opt/data` table, the s6 supervision behaviour, the auth-gate rules and the
+  June 2026 campaign quotation.
+- `NousResearch/hermes-agent` `website/docs/user-guide/features/api-server.md` -
+  FULL, read via `gh api` (raw file contents, not a rendered page), 2026-08-22.
+  Source of the endpoint list, the `/v1/capabilities` shape and the "needs a
+  configured provider" quotation.
+- `https://hub.docker.com/v2/repositories/nousresearch/hermes-agent/` and its
+  `/tags` - FULL, official JSON API, 2026-08-22. Pull count, star count,
+  registration date, image sizes, `latest` push timestamp.
+- GitHub search API via `gh` - FULL, 2026-08-22. Star counts and the satellite
+  repo list.
+- `https://www.openmatter.network/platform` - FULL, raw fetch, 2026-08-22.
+  Re-confirms the credit-network and distributed-orchestration framing.
+- `https://datavizor.openmatter.network/` - PARTIAL. Returns 200 but is a
+  client-rendered SPA; only the pre-hydration shell is readable. It yields the
+  navigation (Build / Deploy / Collaborate / Data Storage / Infrastructure /
+  Networking / Resources / Account / Billing / Activity / Organization), a
+  three-step onboarding ending in "Launch an agent from a template", and
+  "Available Balance: CONNECT TO VIEW". No pricing.
+- `https://www.openmatter.network/pricing` - **FAILED, 404.**
+  `https://docs.openmatter.network/` - **FAILED, does not resolve.** Probes of
+  `/api/health`, `/api/plans`, `/api/pricing`, `/api/deployments` on the
+  Datavizor host all returned 404. Public pricing does not exist; the rate used
+  in section 6 is derived from one figure Zaal relayed on 2026-08-14 and is
+  marked as such throughout.
+- Dashboard state (project, container, ports, credits, plan) - Zaal's
+  screenshot, 2026-08-22, relayed in `zao-vault/handoffs/openmatter.md` v4.
+
+Related in-repo prior art: doc 599c (the Nous Hermes naming collision and the
+now-closed investigate item), doc 2360 (which agent gets the legal body: ZOL),
+doc 2284 (Oracle Always Free, the free-forever comparison), doc 2154/2155 (the
+identity ladder). Rules that bind this addendum: `research-grounding.md`,
+`anti-fabrication.md`, `state-claims.md`, `secret-hygiene.md`,
+`agent-loops.md` rule 9.


### PR DESCRIPTION
Extends doc 1659 (per `feedback_always_extend_over_rebuild.md` and the lane brief's own caution) rather than opening a second OpenMatter eval. Answers the v4 mission in `zao-vault/handoffs/openmatter.md`: the `nousresearch/hermes-agent` container is deployed and Running on OpenMatter, so the open question is no longer whether to adopt but what to do with it.

## What it establishes

**What the container is.** Nous Research's Hermes Agent - 234k stars, 8.35M Docker pulls, `latest` pushed the same day as our deploy. Not our `bot/src/hermes/`. Doc 599c called that naming collision on 2026-05-21 and left an open "investigate the Nous feature set" item; this deploy closes it by observation.

**Running is not working.** Nous' docs, verbatim: "Hermes itself needs a configured provider and tool backends for the API server to be useful." Provider keys are written by an interactive setup wizard into `/opt/data/.env`. A container showing Running with no provider is an empty shell, and the dashboard cannot distinguish the two states. Only a call to 8642 can.

**Security, and it is the highest-stakes fact in the deploy.** Nous attribute a June 2026 compromise campaign to exactly these exposed surfaces: internet scanners reaching dashboards and OpenAI API servers and driving the agent into planting an SSH-key backdoor. Three yes/no checks for Zaal, all readable off a settings page.

**The credit math decides everything else.** Derived from the single rate datum that exists (0.3932 Cr = ~0.47 compute-hr, 2026-08-14, relayed by Zaal): ~0.837 Cr/hr, so 12.3513 Cr is ~14.8 compute-hours. Continuously running that is under a day, and covers ~7% of the span to the Aug 31 reset. Two things could change it, both Zaal-session lookups, both named.

**What we would run there: nothing production, yet** - and that clean negative is the result, not a dodge. ZOL is on Pi hardware we own and rule 9 makes a move a MOVE; the Hostinger VPS was measured at load 0.03 with 113 days uptime, so moving work onto a meter is a cost regression; Mac loops are cap-bound not compute-bound; and doc 2284's free-forever comparison beats metered for overflow. July's WATCH splits: still WATCH as infrastructure (now for a measured reason instead of a wrong one), live as a relationship and as the compute layer of the settled ZOL/MIDAO design.

**A one-curl proof, ready to fire**, with `/v1/capabilities` first because it proves reachability and auth without invoking the model or burning inference. All four outcomes interpreted honestly, including the 401-is-good-news case.

## Grounding

No WebFetch anywhere in this addendum - raw `curl` plus HTML strip, official Docker Hub JSON, and `gh api` reads of the repo's own doc files. Per-source FULL/PARTIAL/FAILED is in the addendum. OpenMatter publishes no pricing: `/pricing` 404s, `docs.openmatter.network` does not resolve, and Datavizor renders balance client-side behind login, so the rate is flagged as derived throughout rather than presented as measured.

## Gates respected

Nothing spent, nothing deployed, nothing sent. No credentials in the diff (case-insensitive secret scan run as its own step, clean). The deploy IP and `API_SERVER_KEY` are deliberately left as placeholders and flagged for `/secret` rather than the transcript.

## Zaal taps this surfaces

Deploy IP + API key (unblocks the proof); is `/opt/data` on a persistent volume; the three security checks; whether the Particle plan includes an allowance; the reply to Chris B, now four days overdue; the 8/13 meeting notes, still uncaptured.

Credits: Nous Research, `NousResearch/hermes-agent` and its documentation (public repo, read via the GitHub API); OpenMatter Network's own platform pages.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
